### PR TITLE
chore: supprime la méthode add des ChantierInfo*Repository (88)

### DIFF
--- a/src/server/domain/chantier/ChantierInfoRepository.interface.ts
+++ b/src/server/domain/chantier/ChantierInfoRepository.interface.ts
@@ -1,6 +1,5 @@
 import ChantierInfo from '@/server/domain/chantier/ChantierInfo.interface';
 
 export default interface ChantierInfoRepository {
-  add(chantier: ChantierInfo): Promise<void>;
   getListe(): Promise<ChantierInfo[]>;
 }

--- a/src/server/infrastructure/chantier/ChantierInfoRandomRepository.ts
+++ b/src/server/infrastructure/chantier/ChantierInfoRandomRepository.ts
@@ -1,5 +1,4 @@
 import ChantierInfosFixture from '@/fixtures/ChantierInfosFixture';
-import ChantierInfo from '@/server/domain/chantier/ChantierInfo.interface';
 import ChantierInfoRepository from '@/server/domain/chantier/ChantierInfoRepository.interface';
 
 export default class ChantierInfoRandomRepository implements ChantierInfoRepository {
@@ -10,10 +9,6 @@ export default class ChantierInfoRandomRepository implements ChantierInfoReposit
   constructor(nombreDeChantiers: number, idPérimètres: { id: string }[]) {
     this.nombreDeChantiers = nombreDeChantiers;
     this.idPérimètres = idPérimètres;
-  }
-
-  async add(_: ChantierInfo) {
-    throw new Error('Error: Not implemented');
   }
 
   async getListe() {

--- a/src/server/infrastructure/chantier/ChantierInfoSQLRepository.integration.test.ts
+++ b/src/server/infrastructure/chantier/ChantierInfoSQLRepository.integration.test.ts
@@ -1,34 +1,26 @@
 import { PrismaClient } from '@prisma/client';
-import ChantierInfo from '@/server/domain/chantier/ChantierInfo.interface';
 import ChantierInfoRepository from '@/server/domain/chantier/ChantierInfoRepository.interface';
+import ChantierRepository from '@/server/domain/chantier/ChantierRepository.interface';
 import ChantierInfoSQLRepository from './ChantierInfoSQLRepository';
+import ChantierSQLRepository from './ChantierSQLRepository';
+import { generateChantier } from './ChantierRandomRepository';
 
 describe('ChantierInfoSQLRepository', () => {
   test('Accède à une liste de chantier', async () => {
     // GIVEN
     const prisma = new PrismaClient();
     const repository: ChantierInfoRepository = new ChantierInfoSQLRepository(prisma);
-    const chantierInitial: ChantierInfo = {
-      id: 'THD',
-      nom: 'Chantier 1',
-      id_périmètre: 'PER-001',
-      météo: null,
-      avancement: { annuel: null, global: null },
-    };
-    const chantierInitial2: ChantierInfo = {
-      id: 'TUP',
-      nom: 'Chantier 2',
-      id_périmètre: 'PER-001',
-      météo: null,
-      avancement: { annuel: null, global: null },
-    };
-    await repository.add(chantierInitial);
-    await repository.add(chantierInitial2);
+    const chantierRepository: ChantierRepository = new ChantierSQLRepository(prisma);
+    const chantier1 = generateChantier('CH-001');
+    const chantier2 = generateChantier('CH-002');
+    await chantierRepository.add(chantier1);
+    await chantierRepository.add(chantier2);
 
     // WHEN
     const chantiers = await repository.getListe();
 
     // THEN
-    expect(chantiers).toEqual([chantierInitial, chantierInitial2]);
+    const ids = chantiers.map((c) => c.id);
+    expect(ids).toEqual(['CH-001', 'CH-002']);
   });
 });

--- a/src/server/infrastructure/chantier/ChantierInfoSQLRepository.ts
+++ b/src/server/infrastructure/chantier/ChantierInfoSQLRepository.ts
@@ -12,25 +12,11 @@ function mapToDomain(chantierPrisma: chantier): ChantierInfo {
   };
 }
 
-function mapToPrisma(chantierDomaine: ChantierInfo): chantier {
-  return {
-    id: chantierDomaine.id,
-    nom: chantierDomaine.nom,
-    id_perimetre: chantierDomaine.id_périmètre,
-  };
-}
-
 export default class ChantierInfoSQLRepository implements ChantierInfoRepository {
   private prisma: PrismaClient;
 
   constructor(prisma: PrismaClient) {
     this.prisma = prisma;
-  }
-
-  async add(chantierToAdd: ChantierInfo) {
-    await this.prisma.chantier.create({
-      data: mapToPrisma(chantierToAdd),
-    });
   }
 
   async getListe() {

--- a/src/server/infrastructure/chantier/ChantierRandomRepository.ts
+++ b/src/server/infrastructure/chantier/ChantierRandomRepository.ts
@@ -23,6 +23,24 @@ function générerIndicateurs(nombreIndicateurs: number) : Indicateur[] {
   return indicateurs;
 }
 
+export function generateChantier(id: string): Chantier {
+  const valeurs = Array.from({ length:8 }, () => faker.datatype.number({ min: 0, max: 100 }) / 100);
+  valeurs.sort();
+  return {
+    id,
+    nom: faker.lorem.words(3),
+    axe: { id: 'AXE-' + faker.random.alphaNumeric(3), nom: faker.lorem.words(3) },
+    nomPPG: faker.lorem.words(3),
+    id_périmètre: 'PER-' + faker.random.numeric(3),
+    météo: valeursMeteo[faker.datatype.number({ min: 0, max: 4 })] as Météo,
+    avancement: {
+      annuel: { minimum: valeurs[0], médiane: valeurs[2], moyenne: valeurs[4], maximum: valeurs[6] },
+      global: { minimum: valeurs[1], médiane: valeurs[3], moyenne: valeurs[5], maximum: valeurs[7] },
+    },
+    indicateurs: générerIndicateurs(7),
+  };
+}
+
 export default class ChantierRandomRepository implements ChantierRepository {
 
   async add(_: Chantier) {
@@ -30,20 +48,7 @@ export default class ChantierRandomRepository implements ChantierRepository {
   }
 
   async getById(id: string) {
-    const valeurs = Array.from({ length:8 }, () => faker.datatype.number({ min: 0, max: 100 }) / 100);
-    valeurs.sort();
-    return {
-      id,
-      nom: faker.lorem.words(3),
-      axe: { id: 'AXE-' + faker.random.alphaNumeric(3), nom: faker.lorem.words(3) },
-      nomPPG: faker.lorem.words(3),
-      id_périmètre: 'PER-' + faker.random.numeric(3),
-      météo: valeursMeteo[faker.datatype.number({ min: 0, max: 4 })] as Météo,
-      avancement: {
-        annuel: { minimum: valeurs[0], médiane: valeurs[2], moyenne: valeurs[4], maximum: valeurs[6] },
-        global: { minimum: valeurs[1], médiane: valeurs[3], moyenne: valeurs[5], maximum: valeurs[7] },
-      },
-      indicateurs: générerIndicateurs(7),
-    };
+    return generateChantier(id);
   }
+
 }


### PR DESCRIPTION
Les chantierInfos sont des vues partielles de chantier, leurs répository n'inclue pas d'écriture (uniquement des lectures).

Cette PR supprime une méthode add historiquement présente sur le répository des chantierInfos.