### PR TITLE
fix: corrige l'affichage d'un chantier à la maille nationale avec les vraies données (107)

### DIFF
--- a/src/pages/chantier/[id].tsx
+++ b/src/pages/chantier/[id].tsx
@@ -12,9 +12,9 @@ export default function NextPageChantier({ chantier }: NextPageChantierProps) {
   );
 }
 
-export async function getServerSideProps({ params }: { params: { id: Chantier['id'], zoneNom: Chantier['zoneNom'] } }) {
+export async function getServerSideProps({ params }: { params: { id: Chantier['id'] } }) {
   const chantierRepository = dependencies.getChantierRepository();
-  const chantier: Chantier = await chantierRepository.getById(params.id, '');
+  const chantier: Chantier = await chantierRepository.getById(params.id, 'National');
 
   return {
     props: {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -22,7 +22,7 @@ export async function getServerSideProps() {
   const chantierInfoRepository = dependencies.getChantierInfoRepository();
 
   const périmètresMinistériels = await périmètreRepository.getListe();
-  const chantiers = await chantierInfoRepository.getListe();
+  const chantiers = await chantierInfoRepository.getListeMailleNationale();
 
   return {
     props: {

--- a/src/server/domain/chantier/ChantierInfoRepository.interface.ts
+++ b/src/server/domain/chantier/ChantierInfoRepository.interface.ts
@@ -1,5 +1,5 @@
 import ChantierInfo from '@/server/domain/chantier/ChantierInfo.interface';
 
 export default interface ChantierInfoRepository {
-  getListe(): Promise<ChantierInfo[]>;
+  getListeMailleNationale(): Promise<ChantierInfo[]>;
 }

--- a/src/server/infrastructure/chantier/ChantierInfoRandomRepository.ts
+++ b/src/server/infrastructure/chantier/ChantierInfoRandomRepository.ts
@@ -11,7 +11,7 @@ export default class ChantierInfoRandomRepository implements ChantierInfoReposit
     this.idPérimètres = idPérimètres;
   }
 
-  async getListe() {
+  async getListeMailleNationale() {
     const valeursFixes = [];
     const nbPérimètres = this.idPérimètres.length;
     for (let i = 0; i < this.nombreDeChantiers; i = i + 1) {

--- a/src/server/infrastructure/chantier/ChantierInfoSQLRepository.integration.test.ts
+++ b/src/server/infrastructure/chantier/ChantierInfoSQLRepository.integration.test.ts
@@ -13,11 +13,13 @@ describe('ChantierInfoSQLRepository', () => {
     const chantierRepository: ChantierRepository = new ChantierSQLRepository(prisma);
     const chantier1 = générerChantier('CH-001', 'National');
     const chantier2 = générerChantier('CH-002', 'National');
+    const chantier3 = générerChantier('CH-003', 'Normandie');
     await chantierRepository.add(chantier1);
     await chantierRepository.add(chantier2);
+    await chantierRepository.add(chantier3);
 
     // WHEN
-    const chantiers = await repository.getListe();
+    const chantiers = await repository.getListeMailleNationale();
 
     // THEN
     const ids = chantiers.map((c) => c.id);

--- a/src/server/infrastructure/chantier/ChantierInfoSQLRepository.ts
+++ b/src/server/infrastructure/chantier/ChantierInfoSQLRepository.ts
@@ -19,8 +19,10 @@ export default class ChantierInfoSQLRepository implements ChantierInfoRepository
     this.prisma = prisma;
   }
 
-  async getListe() {
-    const chantiersPrisma = await this.prisma.chantier.findMany();
+  async getListeMailleNationale() {
+    const chantiersPrisma = await this.prisma.chantier.findMany({
+      where: { zone_nom: 'National' },
+    });
     return chantiersPrisma.map(chantierPrisma => mapToDomain(chantierPrisma));
   }
 }


### PR DESCRIPTION
### Problème

Depuis l'apparition des zones dans la table chantier, la page d'un chantier ne s'affiche plus correctement, et la liste des chantiers remonte plus de 4000 lignes.

### Solution

Ajouter la zone 'National' dans la demande au répository depuis le front (getServerSideProps()), et ne conserver que les chantier à maille nationale dans la liste des chantiers.

### Observation

À date, seule la maille Nationale est sélectionnable, et l'information de zone n'est pas encore disponible à cet endroit du front donc on l'a mise en dur.