### PR TITLE
119 affichage des frontières des régions cartographie

### DIFF
--- a/src/client/components/PageChantiers/RépartitionGéographique/RépartitionGéographique.tsx
+++ b/src/client/components/PageChantiers/RépartitionGéographique/RépartitionGéographique.tsx
@@ -11,8 +11,8 @@ export default function RépartitionGéographique() {
         Répartition géographique
       </Titre>
       <Cartographie
-        maille='départementale'
-        périmètreTerritorial={{
+        niveauDeMailleAffiché='départementale'
+        territoireAffiché={{
           codeInsee: 'FR',
           divisionAdministrative: 'france',
         }}

--- a/src/client/components/PageChantiers/RépartitionGéographique/RépartitionGéographique.tsx
+++ b/src/client/components/PageChantiers/RépartitionGéographique/RépartitionGéographique.tsx
@@ -11,6 +11,7 @@ export default function RépartitionGéographique() {
         Répartition géographique
       </Titre>
       <Cartographie
+        maille='régionale'
         zone={{
           codeInsee: 'FR',
           divisionAdministrative: 'france',

--- a/src/client/components/PageChantiers/RépartitionGéographique/RépartitionGéographique.tsx
+++ b/src/client/components/PageChantiers/RépartitionGéographique/RépartitionGéographique.tsx
@@ -11,8 +11,8 @@ export default function RépartitionGéographique() {
         Répartition géographique
       </Titre>
       <Cartographie
-        maille='régionale'
-        zone={{
+        maille='départementale'
+        périmètreTerritorial={{
           codeInsee: 'FR',
           divisionAdministrative: 'france',
         }}

--- a/src/client/components/_commons/Cartographie/Cartographie.interface.tsx
+++ b/src/client/components/_commons/Cartographie/Cartographie.interface.tsx
@@ -4,16 +4,17 @@ export type Territoire = {
   // manque l'info : département ou région
 };
 
-export type TracéDépartement = Territoire & {
-  tracéSVG: string,
-  codeInseeRégion: string,
+export type TracéRégion = {
+  départements: {
+    tracéSVG: string;
+    codeInsee: string;
+    codeInseeRégion: string;
+    nom: string;
+  }[];
+  tracéSVG: string;
+  codeInsee: string;
+  nom: string;
 };
-
-export type TracéRégion = Territoire & {
-  tracéSVG: string,
-};
-
-export type TracéTerritoire = TracéDépartement | TracéRégion;
 
 export type IdentifiantTerritoire = {
   codeInsee: Exclude<string, 'FR'>,
@@ -24,5 +25,6 @@ export type IdentifiantTerritoire = {
 };
 
 export default interface CartographieProps {
-  zone: IdentifiantTerritoire
+  zone: IdentifiantTerritoire,
+  maille: 'régionale' | 'départementale',
 }

--- a/src/client/components/_commons/Cartographie/Cartographie.interface.tsx
+++ b/src/client/components/_commons/Cartographie/Cartographie.interface.tsx
@@ -1,18 +1,10 @@
-export type Territoire = {
+export type TracéRégionJSON = {
+  tracéSVG: string,
   codeInsee: string,
-  nom: string,
-  // manque l'info : département ou région
-};
+  nom: string
+}[];
 
-export type TracéRégion = Territoire & {
-  départements: (Territoire & {
-    tracéSVG: string;
-    codeInseeRégion: string;
-  })[];
-  tracéSVG: string;
-};
-
-export type PérimètreTerritorial = {
+export type TerritoireAffiché = {
   codeInsee: Exclude<string, 'FR'>,
   divisionAdministrative: 'région',
 } | {
@@ -21,6 +13,6 @@ export type PérimètreTerritorial = {
 };
 
 export default interface CartographieProps {
-  périmètreTerritorial: PérimètreTerritorial,
-  maille: 'régionale' | 'départementale',
+  territoireAffiché: TerritoireAffiché,
+  niveauDeMailleAffiché: 'régionale' | 'départementale',
 }

--- a/src/client/components/_commons/Cartographie/Cartographie.interface.tsx
+++ b/src/client/components/_commons/Cartographie/Cartographie.interface.tsx
@@ -4,27 +4,23 @@ export type Territoire = {
   // manque l'info : département ou région
 };
 
-export type TracéRégion = {
-  départements: {
+export type TracéRégion = Territoire & {
+  départements: (Territoire & {
     tracéSVG: string;
-    codeInsee: string;
     codeInseeRégion: string;
-    nom: string;
-  }[];
+  })[];
   tracéSVG: string;
-  codeInsee: string;
-  nom: string;
 };
 
-export type IdentifiantTerritoire = {
+export type PérimètreTerritorial = {
   codeInsee: Exclude<string, 'FR'>,
-  divisionAdministrative: 'région' | 'département',
+  divisionAdministrative: 'région',
 } | {
   codeInsee: 'FR',
   divisionAdministrative: 'france'
 };
 
 export default interface CartographieProps {
-  zone: IdentifiantTerritoire,
+  périmètreTerritorial: PérimètreTerritorial,
   maille: 'régionale' | 'départementale',
 }

--- a/src/client/components/_commons/Cartographie/Cartographie.tsx
+++ b/src/client/components/_commons/Cartographie/Cartographie.tsx
@@ -1,15 +1,27 @@
 import CartographieProps from '@/components/_commons/Cartographie/Cartographie.interface';
 import CartographieAffichage from '@/components/_commons/Cartographie/CartographieAffichage/CartographieAffichage';
 import tracésDépartements from './départements.json';
+import tracésRégions from './régions.json';
 
-export default function Cartographie({ zone }: CartographieProps) {
+
+export default function Cartographie({ zone, maille }: CartographieProps) {
+
+  const tracésTerritoires = (
+    zone.divisionAdministrative === 'région'
+      ? tracésRégions.filter(tracéRégion => tracéRégion.codeInsee === zone.codeInsee)
+      : tracésRégions
+  ).map(tracéRégion => (
+    {
+      ...tracéRégion,
+      départements: maille === 'départementale'
+        ? tracésDépartements.filter(tracéDépartement => tracéDépartement.codeInseeRégion === tracéRégion.codeInsee)
+        : [],
+    }
+  ));
+
   return (
     <CartographieAffichage
-      tracésTerritoires={
-            zone.divisionAdministrative === 'région'
-              ? tracésDépartements.filter(tracéDépartement => tracéDépartement.codeInseeRégion === zone.codeInsee)
-              : tracésDépartements
-        }
+      tracésTerritoires={tracésTerritoires}
     />
   );
 }

--- a/src/client/components/_commons/Cartographie/Cartographie.tsx
+++ b/src/client/components/_commons/Cartographie/Cartographie.tsx
@@ -4,11 +4,11 @@ import tracésDépartements from './départements.json';
 import tracésRégions from './régions.json';
 
 
-export default function Cartographie({ zone, maille }: CartographieProps) {
+export default function Cartographie({ périmètreTerritorial, maille }: CartographieProps) {
 
-  const tracésTerritoires = (
-    zone.divisionAdministrative === 'région'
-      ? tracésRégions.filter(tracéRégion => tracéRégion.codeInsee === zone.codeInsee)
+  const tracés = (
+    périmètreTerritorial.divisionAdministrative === 'région'
+      ? tracésRégions.filter(tracéRégion => tracéRégion.codeInsee === périmètreTerritorial.codeInsee)
       : tracésRégions
   ).map(tracéRégion => (
     {
@@ -21,7 +21,7 @@ export default function Cartographie({ zone, maille }: CartographieProps) {
 
   return (
     <CartographieAffichage
-      tracésTerritoires={tracésTerritoires}
+      tracésRégions={tracés}
     />
   );
 }

--- a/src/client/components/_commons/Cartographie/Cartographie.tsx
+++ b/src/client/components/_commons/Cartographie/Cartographie.tsx
@@ -1,27 +1,35 @@
-import CartographieProps from '@/components/_commons/Cartographie/Cartographie.interface';
+import CartographieProps, { TracéRégionJSON } from '@/components/_commons/Cartographie/Cartographie.interface';
 import CartographieAffichage from '@/components/_commons/Cartographie/CartographieAffichage/CartographieAffichage';
-import tracésDépartements from './départements.json';
-import tracésRégions from './régions.json';
+import { TracéRégion } from '@/components/_commons/Cartographie/CartographieAffichage/CartographieAffichage.interface';
+import départementsJSON from './départements.json';
+import régionsJSON from './régions.json';
 
-
-export default function Cartographie({ périmètreTerritorial, maille }: CartographieProps) {
-
-  const tracés = (
-    périmètreTerritorial.divisionAdministrative === 'région'
-      ? tracésRégions.filter(tracéRégion => tracéRégion.codeInsee === périmètreTerritorial.codeInsee)
-      : tracésRégions
-  ).map(tracéRégion => (
+function définirLesDépartementsÀTracer(régions: TracéRégionJSON, afficherDépartements: boolean): TracéRégion[] {
+  return régions.map(région => (
     {
-      ...tracéRégion,
-      départements: maille === 'départementale'
-        ? tracésDépartements.filter(tracéDépartement => tracéDépartement.codeInseeRégion === tracéRégion.codeInsee)
+      ...région,
+      départementsÀTracer: afficherDépartements
+        ? départementsJSON.filter(tracéDépartement => tracéDépartement.codeInseeRégion === région.codeInsee)
         : [],
-    }
-  ));
+    }),
+  );
+}
+
+function sélectionnerRégion(régions: TracéRégionJSON, codeInsee: string) {
+  return régions.filter(région => région.codeInsee === codeInsee);
+}
+
+export default function Cartographie({ territoireAffiché, niveauDeMailleAffiché }: CartographieProps) {
+  const tracésRégionsSansDépartement =
+    territoireAffiché.divisionAdministrative === 'région'
+      ? sélectionnerRégion(régionsJSON, territoireAffiché.codeInsee)
+      : régionsJSON;
+
+  const tracésRégions = définirLesDépartementsÀTracer(tracésRégionsSansDépartement, niveauDeMailleAffiché === 'départementale');
 
   return (
     <CartographieAffichage
-      tracésRégions={tracés}
+      tracésRégions={tracésRégions}
     />
   );
 }

--- a/src/client/components/_commons/Cartographie/CartographieAffichage/BulleDInfo/BulleDInfo.styled.ts
+++ b/src/client/components/_commons/Cartographie/CartographieAffichage/BulleDInfo/BulleDInfo.styled.ts
@@ -4,7 +4,6 @@ const BulleDInfoStyled = styled.div`
   position: fixed;
   z-index: 1;
   font-size: 0.75rem;
-  text-align: center;
   vertical-align: middle;
   pointer-events: none; /* supprime le flickering lorsque le curseur est sur la bulle d'info */
   background-color: var(--background-contrast-grey);

--- a/src/client/components/_commons/Cartographie/CartographieAffichage/CartographieAffichage.interface.tsx
+++ b/src/client/components/_commons/Cartographie/CartographieAffichage/CartographieAffichage.interface.tsx
@@ -1,5 +1,5 @@
-import { TracéTerritoire } from '@/components/_commons/Cartographie/Cartographie.interface';
+import { TracéRégion } from '@/components/_commons/Cartographie/Cartographie.interface';
 
 export default interface CartographieAffichageProps {
-  tracésTerritoires: TracéTerritoire[]
+  tracésRégions: TracéRégion[]
 }

--- a/src/client/components/_commons/Cartographie/CartographieAffichage/CartographieAffichage.interface.tsx
+++ b/src/client/components/_commons/Cartographie/CartographieAffichage/CartographieAffichage.interface.tsx
@@ -1,4 +1,16 @@
-import { TracéRégion } from '@/components/_commons/Cartographie/Cartographie.interface';
+export type Territoire = { // TODO /!\ même nom côté back
+  codeInsee: string,
+  nom: string,
+  // manque l'info : département ou région
+};
+
+export type TracéRégion = Territoire & {
+  départementsÀTracer: (Territoire & {
+    tracéSVG: string;
+    codeInseeRégion: string;
+  })[];
+  tracéSVG: string;
+};
 
 export default interface CartographieAffichageProps {
   tracésRégions: TracéRégion[]

--- a/src/client/components/_commons/Cartographie/CartographieAffichage/CartographieAffichage.tsx
+++ b/src/client/components/_commons/Cartographie/CartographieAffichage/CartographieAffichage.tsx
@@ -4,7 +4,7 @@ import CartographieAffichageProps from '@/components/_commons/Cartographie/Carto
 import BulleDInfo from '@/components/_commons/Cartographie/CartographieAffichage/BulleDInfo/BulleDInfo';
 import { Territoire } from '@/components/_commons/Cartographie/Cartographie.interface';
 
-export default function CartographieAffichage({ tracésTerritoires }: CartographieAffichageProps) {
+export default function CartographieAffichage({ tracésRégions }: CartographieAffichageProps) {
   const [sourisPosition, setSourisPosition] = useState({ x: 0, y: 0 });
   const [territoireSurvolé, setTerritoireSurvolé] = useState<Territoire | null>(null);
 
@@ -27,7 +27,7 @@ export default function CartographieAffichage({ tracésTerritoires }: Cartograph
         : null}
       <CartographieSVG
         setTerritoireSurvolé={setTerritoireSurvolé}
-        tracésTerritoires={tracésTerritoires}
+        tracésRégions={tracésRégions}
       />
     </div>
   );

--- a/src/client/components/_commons/Cartographie/CartographieAffichage/CartographieAffichage.tsx
+++ b/src/client/components/_commons/Cartographie/CartographieAffichage/CartographieAffichage.tsx
@@ -1,8 +1,9 @@
 import { useState } from 'react';
 import CartographieSVG from '@/components/_commons/Cartographie/CartographieAffichage/CartographieSVG/CartographieSVG';
-import CartographieAffichageProps from '@/components/_commons/Cartographie/CartographieAffichage/CartographieAffichage.interface';
+import CartographieAffichageProps, {
+  Territoire,
+} from '@/components/_commons/Cartographie/CartographieAffichage/CartographieAffichage.interface';
 import BulleDInfo from '@/components/_commons/Cartographie/CartographieAffichage/BulleDInfo/BulleDInfo';
-import { Territoire } from '@/components/_commons/Cartographie/Cartographie.interface';
 
 export default function CartographieAffichage({ tracésRégions }: CartographieAffichageProps) {
   const [sourisPosition, setSourisPosition] = useState({ x: 0, y: 0 });

--- a/src/client/components/_commons/Cartographie/CartographieAffichage/CartographieSVG/CartographieSVG.interface.tsx
+++ b/src/client/components/_commons/Cartographie/CartographieAffichage/CartographieSVG/CartographieSVG.interface.tsx
@@ -1,4 +1,4 @@
-import { Territoire, TracéTerritoire } from '@/components/_commons/Cartographie/Cartographie.interface';
+import { Territoire, TracéRégion } from '@/components/_commons/Cartographie/Cartographie.interface';
 
 export type Viewbox = {
   x: number,
@@ -8,6 +8,6 @@ export type Viewbox = {
 };
 
 export default interface CartographieSVGProps {
-  tracésTerritoires: TracéTerritoire[],
+  tracésTerritoires: TracéRégion[],
   setTerritoireSurvolé:  (state: Territoire | null) => void
 }

--- a/src/client/components/_commons/Cartographie/CartographieAffichage/CartographieSVG/CartographieSVG.interface.tsx
+++ b/src/client/components/_commons/Cartographie/CartographieAffichage/CartographieSVG/CartographieSVG.interface.tsx
@@ -8,6 +8,6 @@ export type Viewbox = {
 };
 
 export default interface CartographieSVGProps {
-  tracésTerritoires: TracéRégion[],
+  tracésRégions: TracéRégion[],
   setTerritoireSurvolé:  (state: Territoire | null) => void
 }

--- a/src/client/components/_commons/Cartographie/CartographieAffichage/CartographieSVG/CartographieSVG.interface.tsx
+++ b/src/client/components/_commons/Cartographie/CartographieAffichage/CartographieSVG/CartographieSVG.interface.tsx
@@ -1,4 +1,7 @@
-import { Territoire, TracéRégion } from '@/components/_commons/Cartographie/Cartographie.interface';
+import {
+  Territoire,
+  TracéRégion,
+} from '@/components/_commons/Cartographie/CartographieAffichage/CartographieAffichage.interface';
 
 export type Viewbox = {
   x: number,

--- a/src/client/components/_commons/Cartographie/CartographieAffichage/CartographieSVG/CartographieSVG.styled.ts
+++ b/src/client/components/_commons/Cartographie/CartographieAffichage/CartographieSVG/CartographieSVG.styled.ts
@@ -4,7 +4,7 @@ const CartographieSVGStyled = styled.div`
   position: relative;
   width: 100%;
 
-  .territoire {
+  .département {
     cursor: pointer;
     fill: #d0d0d0;
     stroke: #fff;
@@ -12,6 +12,12 @@ const CartographieSVGStyled = styled.div`
     &:hover {
       opacity: 0.72;
     }
+  }
+
+  .région {
+    fill: none;        
+    stroke: #FFFF;
+    stroke-width: 0.8
   }
 `;
 

--- a/src/client/components/_commons/Cartographie/CartographieAffichage/CartographieSVG/CartographieSVG.styled.ts
+++ b/src/client/components/_commons/Cartographie/CartographieAffichage/CartographieSVG/CartographieSVG.styled.ts
@@ -3,21 +3,21 @@ import styled from '@emotion/styled';
 const CartographieSVGStyled = styled.div`
   position: relative;
   width: 100%;
+  stroke: var(--grey-1000-50);
 
-  .département {
+  .frontière {
+    fill: none;
+    stroke-width: 0.6;
+  }
+
+  .territoire-rempli {
     cursor: pointer;
     fill: #d0d0d0;
-    stroke: #fff;
+    stroke-width: 0.2;
 
     &:hover {
       opacity: 0.72;
     }
-  }
-
-  .région {
-    fill: none;        
-    stroke: #FFFF;
-    stroke-width: 0.8
   }
 `;
 

--- a/src/client/components/_commons/Cartographie/CartographieAffichage/CartographieSVG/CartographieSVG.tsx
+++ b/src/client/components/_commons/Cartographie/CartographieAffichage/CartographieSVG/CartographieSVG.tsx
@@ -4,7 +4,7 @@ import CartographieZoomEtDéplacement
   from '@/components/_commons/Cartographie/CartographieZoomEtDéplacement/CartographieZoomEtDéplacement';
 import CartographieSVGStyled from './CartographieSVG.styled';
 
-function CartographieSVG({ tracésTerritoires, setTerritoireSurvolé }: CartographieSVGProps) {
+function CartographieSVG({ tracésRégions, setTerritoireSurvolé }: CartographieSVGProps) {
   const svgRef = useRef<SVGSVGElement | null>(null);
   const [viewbox, setViewbox] = useState<Viewbox>({
     x: 0,
@@ -26,7 +26,6 @@ function CartographieSVG({ tracésTerritoires, setTerritoireSurvolé }: Cartogra
       />
       <svg
         ref={svgRef}
-        strokeWidth="0.3"
         version="1.2"
         viewBox={`
           ${viewbox.x}
@@ -43,11 +42,11 @@ function CartographieSVG({ tracésTerritoires, setTerritoireSurvolé }: Cartogra
           }}
         >
           {
-            tracésTerritoires.map((tracéTerritoire) => (
-              <g key={tracéTerritoire.nom}>
-                {tracéTerritoire.départements.map(département => (
+            tracésRégions.map((tracéRégion) => (
+              <g key={tracéRégion.nom}>
+                {tracéRégion.départements.map(département => (
                   <path
-                    className="département"
+                    className="territoire-rempli"
                     d={département.tracéSVG}
                     key={département.nom}
                     onMouseEnter={() => {
@@ -55,10 +54,22 @@ function CartographieSVG({ tracésTerritoires, setTerritoireSurvolé }: Cartogra
                     }}
                   />
                 ))}
-                <path
-                  className='région'
-                  d={tracéTerritoire.tracéSVG}
-                />
+                {
+                  tracéRégion.départements.length === 0
+                    ?
+                      <path
+                        className='territoire-rempli'
+                        d={tracéRégion.tracéSVG}
+                        onMouseEnter={() => {
+                          setTerritoireSurvolé({ codeInsee: tracéRégion.codeInsee, nom: tracéRégion.nom });
+                        }}
+                      />
+                    :
+                      <path
+                        className='frontière'
+                        d={tracéRégion.tracéSVG}
+                      />
+                  }
               </g>
             ))
           }
@@ -69,6 +80,6 @@ function CartographieSVG({ tracésTerritoires, setTerritoireSurvolé }: Cartogra
 }
 
 export default memo(CartographieSVG, (prevProps, nextProps) => (
-  prevProps.tracésTerritoires === nextProps.tracésTerritoires &&
+  prevProps.tracésRégions === nextProps.tracésRégions &&
   prevProps.setTerritoireSurvolé === nextProps.setTerritoireSurvolé
 ));

--- a/src/client/components/_commons/Cartographie/CartographieAffichage/CartographieSVG/CartographieSVG.tsx
+++ b/src/client/components/_commons/Cartographie/CartographieAffichage/CartographieSVG/CartographieSVG.tsx
@@ -44,7 +44,7 @@ function CartographieSVG({ tracésRégions, setTerritoireSurvolé }: Cartographi
           {
             tracésRégions.map((tracéRégion) => (
               <g key={tracéRégion.nom}>
-                {tracéRégion.départements.map(département => (
+                {tracéRégion.départementsÀTracer.map(département => (
                   <path
                     className="territoire-rempli"
                     d={département.tracéSVG}
@@ -55,7 +55,7 @@ function CartographieSVG({ tracésRégions, setTerritoireSurvolé }: Cartographi
                   />
                 ))}
                 {
-                  tracéRégion.départements.length === 0
+                  tracéRégion.départementsÀTracer.length === 0
                     ?
                       <path
                         className='territoire-rempli'

--- a/src/client/components/_commons/Cartographie/CartographieAffichage/CartographieSVG/CartographieSVG.tsx
+++ b/src/client/components/_commons/Cartographie/CartographieAffichage/CartographieSVG/CartographieSVG.tsx
@@ -43,15 +43,23 @@ function CartographieSVG({ tracésTerritoires, setTerritoireSurvolé }: Cartogra
           }}
         >
           {
-            tracésTerritoires.map(tracéTerritoire => (
-              <path
-                className="territoire"
-                d={tracéTerritoire.tracéSVG}
-                key={tracéTerritoire.nom}
-                onMouseEnter={() => {
-                  setTerritoireSurvolé({ codeInsee: tracéTerritoire.codeInsee, nom: tracéTerritoire.nom });
-                }}
-              />
+            tracésTerritoires.map((tracéTerritoire) => (
+              <g key={tracéTerritoire.nom}>
+                {tracéTerritoire.départements.map(département => (
+                  <path
+                    className="département"
+                    d={département.tracéSVG}
+                    key={département.nom}
+                    onMouseEnter={() => {
+                      setTerritoireSurvolé({ codeInsee: département.codeInsee, nom: département.nom });
+                    }}
+                  />
+                ))}
+                <path
+                  className='région'
+                  d={tracéTerritoire.tracéSVG}
+                />
+              </g>
             ))
           }
         </g>


### PR DESCRIPTION
### Fonctionnalité

La carte est capable d'afficher pour la France entière : 

- ses départements avec ses frontières régionales
- ses régions seules

### Fonctionnement

Les données sont préparées de sorte à ce que la cartographie charge un objet contenant des régions avec ou non les départements (selon la maille choisie).

### Points d'attention

Nous avons eu à discuter certains termes métiers semblants similaires (territoire, division, maille,...) mais qui désignent en réalité des choses différentes. Côté Front, nous avons aboutis à ces définitions qui pourront être rediscutées si besoin:

- périmètre territorial : représente le territoire à afficher sur la carte
- territoire : terme générique pour désigner la France, une région ou un département précis
- maille :  Elle représente le niveau de découpage régional ou départemental
