### PR TITLE
feat: branchement des donnees des indicateurs maille nationale sur la page chantier (52)

### DIFF
--- a/src/client/components/PageChantier/PageChantier.interface.ts
+++ b/src/client/components/PageChantier/PageChantier.interface.ts
@@ -1,5 +1,7 @@
 import Chantier from '@/server/domain/chantier/Chantier.interface';
+import Indicateur from '@/server/domain/indicateur/Indicateur.interface';
 
 export default interface PageChantierProps {
   chantier: Chantier
+  indicateurs: Indicateur[]
 }

--- a/src/client/components/PageChantier/PageChantier.tsx
+++ b/src/client/components/PageChantier/PageChantier.tsx
@@ -19,7 +19,7 @@ const listeRubriques: Rubrique[] = [
   { nom: 'Commentaires', ancre: 'commentaires' },
 ];
 
-export default function PageChantier({ chantier }: PageChantierProps) {
+export default function PageChantier({ chantier, indicateurs }: PageChantierProps) {
   return (
     <PageChantierStyled>
       <PageChantierEnTête chantier={chantier} />
@@ -39,7 +39,7 @@ export default function PageChantier({ chantier }: PageChantierProps) {
           </div>
           <Cartes />
           <Indicateurs
-            indicateurs={chantier.indicateurs}
+            indicateurs={indicateurs}
           />
           <Commentaires />
         </div>

--- a/src/fixtures/ChantierFixture.ts
+++ b/src/fixtures/ChantierFixture.ts
@@ -1,7 +1,6 @@
 import { faker } from '@faker-js/faker';
 import Chantier, { Territoires } from '@/server/domain/chantier/Chantier.interface';
 import MétéoFixture from '@/fixtures/MétéoFixture';
-import IndicateurFixture from '@/fixtures/IndicateurFixture';
 import FixtureInterface from '@/fixtures/Fixture.interface';
 import { générerCaractèresSpéciaux, générerUnIdentifiantUnique } from './utils';
 
@@ -38,7 +37,6 @@ class ChantierFixture implements FixtureInterface<Chantier> {
       directeurProjet: 'DirProj',
       directeurAdministrationCentrale: ['DAC1', 'DAC2'],
       ministères: ['Min1', 'Min2'],
-      indicateurs: IndicateurFixture.générerPlusieurs(5),
       ...valeursFixes,
     };
   }

--- a/src/pages/chantier/[id].tsx
+++ b/src/pages/chantier/[id].tsx
@@ -20,7 +20,8 @@ export default function NextPageChantier({ chantier, indicateurs }: NextPageChan
 export async function getServerSideProps({ params }: { params: { id: Chantier['id'] } }) {
   const chantierRepository = dependencies.getChantierRepository();
   const chantier: Chantier = await chantierRepository.getById(params.id);
-  const indicateurs: Indicateur[] = chantier.indicateurs;
+  const indicateurRepository = dependencies.getIndicateurRepository();
+  const indicateurs: Indicateur[] = await indicateurRepository.getByChantierId(params.id);
 
   return {
     props: {

--- a/src/pages/chantier/[id].tsx
+++ b/src/pages/chantier/[id].tsx
@@ -1,24 +1,31 @@
 import Chantier from '@/server/domain/chantier/Chantier.interface';
 import PageChantier from '@/components/PageChantier/PageChantier';
 import { dependencies } from '@/server/infrastructure/Dependencies';
+import Indicateur from '@/server/domain/indicateur/Indicateur.interface';
 
 interface NextPageChantierProps {
   chantier: Chantier
+  indicateurs: Indicateur[]
 }
 
-export default function NextPageChantier({ chantier }: NextPageChantierProps) {
+export default function NextPageChantier({ chantier, indicateurs }: NextPageChantierProps) {
   return (
-    <PageChantier chantier={chantier} />
+    <PageChantier 
+      chantier={chantier} 
+      indicateurs={indicateurs}
+    />
   );
 }
 
 export async function getServerSideProps({ params }: { params: { id: Chantier['id'] } }) {
   const chantierRepository = dependencies.getChantierRepository();
   const chantier: Chantier = await chantierRepository.getById(params.id);
+  const indicateurs: Indicateur[] = chantier.indicateurs;
 
   return {
     props: {
       chantier,
+      indicateurs,
     },
   };
 }

--- a/src/server/domain/chantier/Chantier.interface.ts
+++ b/src/server/domain/chantier/Chantier.interface.ts
@@ -1,4 +1,3 @@
-import Indicateur from '@/server/domain/indicateur/Indicateur.interface';
 import Météo from './Météo.interface';
 
 export type Axe = { id: string, nom: string } | null;
@@ -28,5 +27,4 @@ export default interface Chantier {
   directeurAdministrationCentrale: string[],
   ministères: string[],
   météo: Météo;
-  indicateurs: Indicateur[];
 }

--- a/src/server/domain/indicateur/Indicateur.interface.ts
+++ b/src/server/domain/indicateur/Indicateur.interface.ts
@@ -8,7 +8,7 @@ export default interface Indicateur {
   id: string;
   nom: string;
   type: TypesAvancement;
-  estIndicateurDuBaromètre: boolean;
+  estIndicateurDuBaromètre: boolean | null;
   valeurInitiale: Valeur;
   valeurActuelle: Valeur;
   valeurCible: Valeur;

--- a/src/server/domain/indicateur/IndicateurRepository.interface.ts
+++ b/src/server/domain/indicateur/IndicateurRepository.interface.ts
@@ -1,0 +1,5 @@
+import Indicateur from '@/server/domain/indicateur/Indicateur.interface';
+
+export default interface IndicateurRepository {
+  getByChantierId(chantierId: string): Promise<Indicateur[]>;
+}

--- a/src/server/infrastructure/Dependencies.ts
+++ b/src/server/infrastructure/Dependencies.ts
@@ -5,17 +5,23 @@ import PérimètreMinistérielRandomRepository from '@/server/infrastructure/pé
 import ChantierRepository from '@/server/domain/chantier/ChantierRepository.interface';
 import PérimètreMinistérielRepository from '@/server/domain/périmètreMinistériel/PérimètreMinistérielRepository.interface';
 import ChantierRandomRepository from '@/server/infrastructure/chantier/ChantierRandomRepository';
+import IndicateurRepository from '@/server/domain/indicateur/IndicateurRepository.interface';
+import IndicateurSQLRepository from '@/server/infrastructure/indicateur/IndicateurSQLRepository';
+import IndicateurRandomRepository from '@/server/infrastructure/indicateur/IndicateurRandomRepository';
 
 class Dependencies {
   private readonly _chantierRepository: ChantierRepository;
 
   private readonly _périmètreMinistérielRepository: PérimètreMinistérielRepository;
 
+  private readonly _indicateurRepository: IndicateurRepository;
+
   constructor() {
     if (process.env.USE_DATABASE == 'true') {
       const prisma = new PrismaClient();
       this._périmètreMinistérielRepository = new PérimètreMinistérielSQLRepository(prisma);
       this._chantierRepository = new ChantierSQLRepository(prisma);
+      this._indicateurRepository = new IndicateurSQLRepository(prisma);
 
     } else {
       const nombreDeChantiers = 120;
@@ -28,6 +34,7 @@ class Dependencies {
 
       this._périmètreMinistérielRepository = new PérimètreMinistérielRandomRepository(idPérimètres);
       this._chantierRepository = new ChantierRandomRepository(valeursFixes);
+      this._indicateurRepository = new IndicateurRandomRepository();
     }
   }
 
@@ -37,6 +44,10 @@ class Dependencies {
 
   getPerimètreMinistérielRepository(): PérimètreMinistérielRepository {
     return this._périmètreMinistérielRepository;
+  }
+
+  getIndicateurRepository(): IndicateurRepository {
+    return this._indicateurRepository;
   }
 }
 

--- a/src/server/infrastructure/chantier/ChantierRandomRepository.unit.test.ts
+++ b/src/server/infrastructure/chantier/ChantierRandomRepository.unit.test.ts
@@ -11,7 +11,6 @@ describe('ChantierRandomRepository', () => {
 
     // THEN
     expect(chantier.id).toBe('abc1234');
-    expect(chantier.indicateurs).toHaveLength(5);
   });
 
   test('un chantier random contient une maille', async () => {

--- a/src/server/infrastructure/chantier/ChantierSQLRepository.ts
+++ b/src/server/infrastructure/chantier/ChantierSQLRepository.ts
@@ -59,7 +59,6 @@ function mapToDomain(chantiers: chantier[]): Chantier {
     directeurProjet: chantierNationale.directeur_projet,
     directeurAdministrationCentrale: chantierNationale.directeurs_administration_centrale,
     ministères: chantierNationale.ministeres,
-    indicateurs: [],
   };
 
   for (const chantierNonNational of chantiersNonNationales) {

--- a/src/server/infrastructure/indicateur/IndicateurRandomRepository.ts
+++ b/src/server/infrastructure/indicateur/IndicateurRandomRepository.ts
@@ -1,0 +1,10 @@
+import IndicateurRepository from '@/server/domain/indicateur/IndicateurRepository.interface';
+import Indicateur from '@/server/domain/indicateur/Indicateur.interface';
+import IndicateurFixture from '@/fixtures/IndicateurFixture';
+
+export default class IndicateurRandomRepository implements IndicateurRepository {
+
+  async getByChantierId(_chantierId: string): Promise<Indicateur[]> {
+    return IndicateurFixture.générerPlusieurs(5);
+  }
+}

--- a/src/server/infrastructure/indicateur/IndicateurSQLRepository.integration.test.ts
+++ b/src/server/infrastructure/indicateur/IndicateurSQLRepository.integration.test.ts
@@ -3,7 +3,6 @@ import IndicateurSQLRepository from './IndicateurSQLRepository';
 
 //   faciliter la lecture / écriture des tests (éventuellement une méthode de création des indicateurs ? fixture ?)
 //   d'autres choses à vérifier avec un test auto ?
-//   supprimer le champs Chantier.indicateurs
 //   où est-ce qu'on s'arrête ? implémentation des mailles non encore utilisées ou pas ? (nat, dept, reg ?)
 
 describe('IndicateurSQLRepository', () => {

--- a/src/server/infrastructure/indicateur/IndicateurSQLRepository.integration.test.ts
+++ b/src/server/infrastructure/indicateur/IndicateurSQLRepository.integration.test.ts
@@ -1,6 +1,11 @@
 import { indicateur, PrismaClient } from '@prisma/client';
 import IndicateurSQLRepository from './IndicateurSQLRepository';
 
+//   faciliter la lecture / écriture des tests (éventuellement une méthode de création des indicateurs ? fixture ?)
+//   d'autres choses à vérifier avec un test auto ?
+//   supprimer le champs Chantier.indicateurs
+//   où est-ce qu'on s'arrête ? implémentation des mailles non encore utilisées ou pas ? (nat, dept, reg ?)
+
 describe('IndicateurSQLRepository', () => {
   test('Récupérer une liste d\'indicateur via un ID de chantier', async () => {
     // GIVEN

--- a/src/server/infrastructure/indicateur/IndicateurSQLRepository.integration.test.ts
+++ b/src/server/infrastructure/indicateur/IndicateurSQLRepository.integration.test.ts
@@ -1,7 +1,6 @@
 import { indicateur, PrismaClient } from '@prisma/client';
+import IndicateurRowBuilder from '@/server/infrastructure/test/indicateur/IndicateurRowBuilder';
 import IndicateurSQLRepository from './IndicateurSQLRepository';
-
-//   faciliter la lecture / écriture des tests (éventuellement une méthode de création des indicateurs ? fixture ?)
 
 describe('IndicateurSQLRepository', () => {
   test("Récupère une liste vide quand il n'y a pas d'indicateurs", async () => {
@@ -24,63 +23,25 @@ describe('IndicateurSQLRepository', () => {
     const chantierId = 'CH-001';
     
     const indicateurs: indicateur[] = [
-      {
-        id: 'IND-001',
-        code_insee: 'FR',
-        maille: 'NAT',
-        nom: 'Indicateur 1',
-        chantier_id: chantierId,
-        objectif_valeur_cible: null,
-        objectif_taux_avancement: null,
-        objectif_date_valeur_cible: null,
-        type_id: null,
-        type_nom: null,
-        est_barometre: null,
-        est_phare: null,
-        valeur_initiale: null,
-        date_valeur_initiale: null,
-        valeur_actuelle: null,
-        date_valeur_actuelle: null,
-        territoire_nom: null,
-      },
-      {
-        id: 'IND-002',
-        code_insee: 'FR',
-        maille: 'NAT',
-        nom: 'Indicateur 2',
-        chantier_id: chantierId,
-        objectif_valeur_cible: null,
-        objectif_taux_avancement: null,
-        objectif_date_valeur_cible: null,
-        type_id: null,
-        type_nom: null,
-        est_barometre: null,
-        est_phare: null,
-        valeur_initiale: null,
-        date_valeur_initiale: null,
-        valeur_actuelle: null,
-        date_valeur_actuelle: null,
-        territoire_nom: null,
-      },
-      {
-        id: 'IND-003',
-        code_insee: '75',
-        maille: 'REG',
-        nom: 'Indicateur 3',
-        chantier_id: chantierId,
-        objectif_valeur_cible: null,
-        objectif_taux_avancement: null,
-        objectif_date_valeur_cible: null,
-        type_id: null,
-        type_nom: null,
-        est_barometre: null,
-        est_phare: null,
-        valeur_initiale: null,
-        date_valeur_initiale: null,
-        valeur_actuelle: null,
-        date_valeur_actuelle: null,
-        territoire_nom: null,
-      },
+      new IndicateurRowBuilder()
+        .withId('IND-001')
+        .withNom('Indicateur 1')
+        .withChantierId(chantierId)
+        .build(),
+
+      new IndicateurRowBuilder()
+        .withId('IND-001')
+        .withNom('Indicateur 1')
+        .withChantierId(chantierId)
+        .withCodeInsee('78')
+        .withMaille('REG')
+        .build(),
+
+      new IndicateurRowBuilder()
+        .withId('IND-002')
+        .withNom('Indicateur 2')
+        .withChantierId(chantierId)
+        .build(),
     ];
 
     await prisma.indicateur.createMany({ data: indicateurs });

--- a/src/server/infrastructure/indicateur/IndicateurSQLRepository.integration.test.ts
+++ b/src/server/infrastructure/indicateur/IndicateurSQLRepository.integration.test.ts
@@ -1,0 +1,83 @@
+import { indicateur, PrismaClient } from '@prisma/client';
+import IndicateurSQLRepository from './IndicateurSQLRepository';
+
+describe('IndicateurSQLRepository', () => {
+  test('Récupérer une liste d\'indicateur via un ID de chantier', async () => {
+    // GIVEN
+    const prisma = new PrismaClient();
+    const repository = new IndicateurSQLRepository(prisma);
+
+    const chantierId = 'CH-001';
+    
+    const indicateurs: indicateur[] = [
+      {
+        id: 'IND-001',
+        code_insee: 'FR',
+        maille: 'NAT',
+        nom: 'Indicateur 1',
+        chantier_id: chantierId,
+        objectif_valeur_cible: null,
+        objectif_taux_avancement: null,
+        objectif_date_valeur_cible: null,
+        type_id: null,
+        type_nom: null,
+        est_barometre: null,
+        est_phare: null,
+        valeur_initiale: null,
+        date_valeur_initiale: null,
+        valeur_actuelle: null,
+        date_valeur_actuelle: null,
+        territoire_nom: null,
+      },
+      {
+        id: 'IND-002',
+        code_insee: 'FR',
+        maille: 'NAT',
+        nom: 'Indicateur 2',
+        chantier_id: chantierId,
+        objectif_valeur_cible: null,
+        objectif_taux_avancement: null,
+        objectif_date_valeur_cible: null,
+        type_id: null,
+        type_nom: null,
+        est_barometre: null,
+        est_phare: null,
+        valeur_initiale: null,
+        date_valeur_initiale: null,
+        valeur_actuelle: null,
+        date_valeur_actuelle: null,
+        territoire_nom: null,
+      },
+      {
+        id: 'IND-003',
+        code_insee: '75',
+        maille: 'REG',
+        nom: 'Indicateur 3',
+        chantier_id: chantierId,
+        objectif_valeur_cible: null,
+        objectif_taux_avancement: null,
+        objectif_date_valeur_cible: null,
+        type_id: null,
+        type_nom: null,
+        est_barometre: null,
+        est_phare: null,
+        valeur_initiale: null,
+        date_valeur_initiale: null,
+        valeur_actuelle: null,
+        date_valeur_actuelle: null,
+        territoire_nom: null,
+      },
+    ];
+
+    await prisma.indicateur.createMany({ data: indicateurs });
+
+    // WHEN
+    const result = await repository.getByChantierId(chantierId);
+
+    // THEN
+    expect(result.length).toEqual(3);
+    expect(result[0].id).toEqual('IND-001');
+    expect(result[1].id).toEqual('IND-002');
+    expect(result[2].id).toEqual('IND-003');
+  });
+});

--- a/src/server/infrastructure/indicateur/IndicateurSQLRepository.integration.test.ts
+++ b/src/server/infrastructure/indicateur/IndicateurSQLRepository.integration.test.ts
@@ -2,10 +2,20 @@ import { indicateur, PrismaClient } from '@prisma/client';
 import IndicateurSQLRepository from './IndicateurSQLRepository';
 
 //   faciliter la lecture / écriture des tests (éventuellement une méthode de création des indicateurs ? fixture ?)
-//   d'autres choses à vérifier avec un test auto ?
-//   où est-ce qu'on s'arrête ? implémentation des mailles non encore utilisées ou pas ? (nat, dept, reg ?)
 
 describe('IndicateurSQLRepository', () => {
+  test("Récupère une liste vide quand il n'y a pas d'indicateurs", async () => {
+    // GIVEN
+    const prisma = new PrismaClient();
+    const repository = new IndicateurSQLRepository(prisma);
+
+    // WHEN
+    const result = await repository.getByChantierId('CH-001');
+
+    // THEN
+    expect(result).toStrictEqual([]);
+  });
+
   test('Récupérer une liste d\'indicateur via un ID de chantier', async () => {
     // GIVEN
     const prisma = new PrismaClient();
@@ -79,9 +89,8 @@ describe('IndicateurSQLRepository', () => {
     const result = await repository.getByChantierId(chantierId);
 
     // THEN
-    expect(result.length).toEqual(3);
+    expect(result.length).toEqual(2);
     expect(result[0].id).toEqual('IND-001');
     expect(result[1].id).toEqual('IND-002');
-    expect(result[2].id).toEqual('IND-003');
   });
 });

--- a/src/server/infrastructure/indicateur/IndicateurSQLRepository.ts
+++ b/src/server/infrastructure/indicateur/IndicateurSQLRepository.ts
@@ -24,7 +24,7 @@ export default class IndicateurSQLRepository implements IndicateurRepository {
 
   async getByChantierId(chantierId: string): Promise<Indicateur[]> {
     const indicateurs: indicateur[] = await this.prisma.indicateur.findMany({
-      where: { chantier_id: chantierId },
+      where: { chantier_id: chantierId, maille: 'NAT' },
     });
 
     return this.mapToDomain(indicateurs);

--- a/src/server/infrastructure/indicateur/IndicateurSQLRepository.ts
+++ b/src/server/infrastructure/indicateur/IndicateurSQLRepository.ts
@@ -1,0 +1,30 @@
+import { chantier, indicateur, PrismaClient } from '@prisma/client';
+
+export default class IndicateurSQLRepository {
+  private prisma: PrismaClient;
+
+  constructor(prisma: PrismaClient) {
+    this.prisma = prisma;
+  }
+
+  mapToDomain(indicateurs: indicateur[]) {
+    return indicateurs.map(row => ({
+      id: row.id,
+      nom: row.nom,
+      type: row.type_nom,
+      estIndicateurDuBaromètre: row.est_barometre,
+      valeurInitiale: row.valeur_initiale,
+      valeurActuelle: row.valeur_actuelle,
+      valeurCible: row.objectif_valeur_cible,
+      tauxAvancementGlobal: row.objectif_taux_avancement,
+    }));
+  }
+
+  async getByChantierId(chantierId: string) {
+    const indicateurs: indicateur[] = await this.prisma.indicateur.findMany({
+      where: { chantier_id: chantierId },
+    });
+
+    return this.mapToDomain(indicateurs);
+  }
+}

--- a/src/server/infrastructure/indicateur/IndicateurSQLRepository.ts
+++ b/src/server/infrastructure/indicateur/IndicateurSQLRepository.ts
@@ -1,17 +1,19 @@
-import { chantier, indicateur, PrismaClient } from '@prisma/client';
+import { indicateur, PrismaClient } from '@prisma/client';
+import IndicateurRepository from '@/server/domain/indicateur/IndicateurRepository.interface';
+import Indicateur, { TypesAvancement } from '@/server/domain/indicateur/Indicateur.interface';
 
-export default class IndicateurSQLRepository {
+export default class IndicateurSQLRepository implements IndicateurRepository {
   private prisma: PrismaClient;
 
   constructor(prisma: PrismaClient) {
     this.prisma = prisma;
   }
 
-  mapToDomain(indicateurs: indicateur[]) {
+  mapToDomain(indicateurs: indicateur[]): Indicateur[] {
     return indicateurs.map(row => ({
       id: row.id,
       nom: row.nom,
-      type: row.type_nom,
+      type: row.type_nom as TypesAvancement || 'CONTEXTE', // TODO: que fait-on des nulls, qui sont la majorité ?
       estIndicateurDuBaromètre: row.est_barometre,
       valeurInitiale: row.valeur_initiale,
       valeurActuelle: row.valeur_actuelle,
@@ -20,7 +22,7 @@ export default class IndicateurSQLRepository {
     }));
   }
 
-  async getByChantierId(chantierId: string) {
+  async getByChantierId(chantierId: string): Promise<Indicateur[]> {
     const indicateurs: indicateur[] = await this.prisma.indicateur.findMany({
       where: { chantier_id: chantierId },
     });

--- a/src/server/infrastructure/test/indicateur/IndicateurRowBuilder.ts
+++ b/src/server/infrastructure/test/indicateur/IndicateurRowBuilder.ts
@@ -1,0 +1,61 @@
+import { indicateur } from '@prisma/client';
+
+export default class IndicateurRowBuilder {
+  private _id: string = 'IND-001';
+
+  private _chantierId: string = 'CH-001';
+
+  private _nom: string = 'Indicateur 1';
+
+  private _codeInsee: string = '78';
+
+  private _maille: string = 'NAT';
+
+  withId(id: string) {
+    this._id = id;
+    return this;
+  }
+
+  withNom(nom: string) {
+    this._nom = nom;
+    return this;
+  }
+
+  withChantierId(chantierId: string) {
+    this._chantierId = chantierId;
+    return this;
+  }
+
+  withMaille(maille: string) {
+    this._maille = maille;
+    return this;
+  }
+
+  withCodeInsee(codeInsee: string) {
+    this._codeInsee = codeInsee;
+    return this;
+  }
+
+  build(): indicateur {
+    return {
+      id: this._id,
+      nom: this._id,
+      chantier_id: this._chantierId,
+      maille: this._maille,
+      code_insee: this._codeInsee,
+
+      objectif_valeur_cible: null,
+      objectif_taux_avancement: null,
+      objectif_date_valeur_cible: null,
+      type_id: null,
+      type_nom: null,
+      est_barometre: null,
+      est_phare: null,
+      valeur_initiale: null,
+      date_valeur_initiale: null,
+      valeur_actuelle: null,
+      date_valeur_actuelle: null,
+      territoire_nom: null,
+    };
+  }
+}


### PR DESCRIPTION
### Observations

- L'objet Indicateur va probablement suivre le même modèle que l'objet Chantier pour gérer les différentes mailles, ce sera à faire au moment où on doit afficher la carte par département du chantier

- Les types d'indicateurs sont peu renseignés dans les données que nous avons, on a mis 'CONTEXTE' comme type par défaut si le type n'est pas renseigné

- On a expérimenté une classe builder pour les lignes de la table indicateurs