### PR TITLE
feat: affichage des données de météo nationale (138)

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test:server": "npm run test:server:unit && npm run test:server:integration",
     "test:server:unit": "jest --passWithNoTests src/server/.*.unit.test.*",
     "test:server:integration": "jest --config=jest.integration.config.js src/server/.*.integration.test.*",
-    "test:database:init": "dotenv -e .env.test -- npm run database:init",
+    "test:database:init": "dotenv -e .env.test -- npm run database:init -- --force",
     "database:init": "prisma migrate reset"
   },
   "browserslist": {

--- a/src/client/components/PageChantier/AvancementChantier/AvancementChantier.tsx
+++ b/src/client/components/PageChantier/AvancementChantier/AvancementChantier.tsx
@@ -16,7 +16,7 @@ const colonnes = [
     cell: 'National',
     enableSorting: false,
   }),
-  reactTableColonnesHelper.accessor('météo', {
+  reactTableColonnesHelper.accessor('mailles.nationale.FR.météo', {
     header: 'Météo',
     cell: météo => <PictoMétéo valeur={météo.getValue()} />,
     enableSorting: false,

--- a/src/client/components/PageChantiers/ListeChantiers/ListeChantiers.tsx
+++ b/src/client/components/PageChantiers/ListeChantiers/ListeChantiers.tsx
@@ -55,7 +55,7 @@ const colonnes = [
     },
     enableSorting: false,
   }),
-  reactTableColonnesHelper.accessor('météo', {
+  reactTableColonnesHelper.accessor('mailles.nationale.FR.météo', {
     header: 'Météo',
     cell: météo => <PictoMétéo valeur={météo.getValue()} />,
     enableGlobalFilter: false,

--- a/src/client/utils/cartographie/préparerDonnéesCartographie.ts
+++ b/src/client/utils/cartographie/préparerDonnéesCartographie.ts
@@ -2,7 +2,7 @@ import { Territoire } from '@/server/domain/chantier/Chantier.interface';
 import { Agrégation } from '@/client/utils/types';
 import {
   agrégerDonnéesTerritoires, DonnéesTerritoires, réduireDonnéesTerritoires,
-  TerritoireSansCodeInsee,
+  TerritoireSansCodeInseeNiMétéo,
 } from '@/client/utils/chantier/donnéesTerritoires/donnéesTerritoires';
 import {
   CartographieValeur,
@@ -11,7 +11,7 @@ import { CartographieDonnées } from '@/components/_commons/Cartographie/Cartogr
 
 export default function préparerDonnéesCartographie(
   listeDonnéesTerritoires: DonnéesTerritoires<Territoire>[],
-  fonctionDeRéduction: (territoiresAgrégés: Agrégation<TerritoireSansCodeInsee>) => CartographieValeur,
+  fonctionDeRéduction: (territoiresAgrégés: Agrégation<TerritoireSansCodeInseeNiMétéo>) => CartographieValeur,
 ): CartographieDonnées {
   const donnéesTerritoiresAgrégés = agrégerDonnéesTerritoires(listeDonnéesTerritoires);
 

--- a/src/client/utils/chantier/donnéesTerritoires/donnéesTerritoires.ts
+++ b/src/client/utils/chantier/donnéesTerritoires/donnéesTerritoires.ts
@@ -23,7 +23,7 @@ const codes = {
 
 type CodeInsee = string;
 export type DonnéesTerritoires<T> = Record<Maille, Record<CodeInsee, T>>;
-export type TerritoireSansCodeInsee = Omit<Territoire, 'codeInsee'>;
+export type TerritoireSansCodeInseeNiMétéo = Omit<Territoire, 'codeInsee' | 'météo'>;
 
 function initialiserDonnéesTerritoires<T>(donnéesInitiales: T) {
   return Object.fromEntries(
@@ -40,15 +40,15 @@ function initialiserDonnéesTerritoires<T>(donnéesInitiales: T) {
 }
 
 function initialiserDonnéesTerritoiresAgrégésVide() {
-  return initialiserDonnéesTerritoires<Agrégation<TerritoireSansCodeInsee>>({
+  return initialiserDonnéesTerritoires<Agrégation<TerritoireSansCodeInseeNiMétéo>>({
     avancement: [],
   });
 }
 
 function agrégerDonnéesTerritoiresÀUnAgrégat(
-  donnéesTerritoiresAgrégées: DonnéesTerritoires<Agrégation<TerritoireSansCodeInsee>>,
-  donnéesTerritoires: DonnéesTerritoires<TerritoireSansCodeInsee>,
-): DonnéesTerritoires<Agrégation<TerritoireSansCodeInsee>> {
+  donnéesTerritoiresAgrégées: DonnéesTerritoires<Agrégation<TerritoireSansCodeInseeNiMétéo>>,
+  donnéesTerritoires: DonnéesTerritoires<TerritoireSansCodeInseeNiMétéo>,
+): DonnéesTerritoires<Agrégation<TerritoireSansCodeInseeNiMétéo>> {
   const agrégat = { ...donnéesTerritoiresAgrégées };
 
   for (const maille of mailles) {
@@ -78,8 +78,8 @@ export function agrégerDonnéesTerritoires(listeDonnéesTerritoires: DonnéesTe
 }
 
 export function réduireDonnéesTerritoires<T>(
-  donnéesTerritoiresAgrégées: DonnéesTerritoires<Agrégation<TerritoireSansCodeInsee>>,
-  fonctionDeRéduction: (territoiresAgrégés: Agrégation<TerritoireSansCodeInsee>) => T,
+  donnéesTerritoiresAgrégées: DonnéesTerritoires<Agrégation<TerritoireSansCodeInseeNiMétéo>>,
+  fonctionDeRéduction: (territoiresAgrégés: Agrégation<TerritoireSansCodeInseeNiMétéo>) => T,
   donnéesInitiales: T,
 ): DonnéesTerritoires<T> {
   const donnéesRéduites = initialiserDonnéesTerritoires<T>(donnéesInitiales);

--- a/src/fixtures/ChantierFixture.ts
+++ b/src/fixtures/ChantierFixture.ts
@@ -28,7 +28,6 @@ class ChantierFixture implements FixtureInterface<Chantier> {
       axe: { id: générerUnIdentifiantUnique('AXE'), nom: faker.lorem.words(3) },
       nomPPG: faker.lorem.words(3),
       périmètreIds: [générerUnIdentifiantUnique('PER')],
-      météo: MétéoFixture.générer(),
       mailles: {
         nationale: this.générérFakeTerritoires(['FR']),
         régionale: this.générérFakeTerritoires(this.code_insee_régions),
@@ -49,6 +48,7 @@ class ChantierFixture implements FixtureInterface<Chantier> {
           annuel: faker.datatype.number({ min: 0, max: 100, precision: 0.01 }),
           global: faker.datatype.number({ min: 0, max: 100, precision: 0.01 }),
         },
+        météo: MétéoFixture.générer(),
       };
     });
     return result;

--- a/src/server/domain/chantier/Chantier.interface.ts
+++ b/src/server/domain/chantier/Chantier.interface.ts
@@ -14,6 +14,7 @@ export type Maille = typeof mailles[number];
 export type Territoire = {
   codeInsee: string,
   avancement: Avancement,
+  météo: Météo,
 };
 
 export type Territoires = Record<string, Territoire>;
@@ -27,5 +28,4 @@ export default interface Chantier {
   mailles: Record<Maille, Territoires>;
   directeurAdministrationCentrale: string[],
   ministères: string[],
-  météo: Météo;
 }

--- a/src/server/domain/chantier/Météo.interface.ts
+++ b/src/server/domain/chantier/Météo.interface.ts
@@ -1,2 +1,22 @@
 type Météo = 1 | 2 | 3 | 4 | null;
+
 export default Météo;
+
+const VALEURS_MÉTÉO: Record<string, Météo> = {
+  SOLEIL: 1,
+  COUVERT: 2,
+  NUAGE: 3,
+  ORAGE: 4,
+  NON_RENSEIGNEE: null,
+  NON_NECESSAIRE: null, // TODO: différent de NON_RENSEIGNEE
+};
+
+export function météoFromString(label: string | null): Météo {
+  if (!label) {
+    return VALEURS_MÉTÉO.NON_RENSEIGNEE;
+  }
+  if (!Object.keys(VALEURS_MÉTÉO).includes(label)) {
+    throw new Error(`Erreur: météo inconnue pour le label '${label}'`);
+  }
+  return VALEURS_MÉTÉO[label];
+}

--- a/src/server/domain/chantier/Météo.interface.unit.test.ts
+++ b/src/server/domain/chantier/Météo.interface.unit.test.ts
@@ -1,0 +1,13 @@
+import { météoFromString } from '@/server/domain/chantier/Météo.interface';
+
+describe('météoFromString', () => {
+  it('Renvoie null pour une météo non renseignée', () => {
+    const result = météoFromString('NON_RENSEIGNE');
+    expect(result).toBeNull();
+  });
+
+  it("Échoue si la valeur n'est pas connue", () => {
+    expect(() => météoFromString('VALEUR_INEXISTANTE'))
+      .toThrow(/VALEUR_INEXISTANTE/);
+  });
+});

--- a/src/server/domain/chantier/Météo.interface.unit.test.ts
+++ b/src/server/domain/chantier/Météo.interface.unit.test.ts
@@ -2,7 +2,12 @@ import { météoFromString } from '@/server/domain/chantier/Météo.interface';
 
 describe('météoFromString', () => {
   it('Renvoie null pour une météo non renseignée', () => {
-    const result = météoFromString('NON_RENSEIGNE');
+    const result = météoFromString('NON_RENSEIGNEE');
+    expect(result).toBeNull();
+  });
+
+  it('Renvoie null pour une valeur manquante', () => {
+    const result = météoFromString(null);
     expect(result).toBeNull();
   });
 

--- a/src/server/infrastructure/chantier/ChantierRandomRepository.unit.test.ts
+++ b/src/server/infrastructure/chantier/ChantierRandomRepository.unit.test.ts
@@ -1,5 +1,6 @@
 import ChantierRandomRepository from '@/server/infrastructure/chantier/ChantierRandomRepository';
 import ChantierRepository from '@/server/domain/chantier/ChantierRepository.interface';
+import { météoFromString } from '@/server/domain/chantier/Météo.interface';
 
 describe('ChantierRandomRepository', () => {
   test('génère une valeur', async () => {
@@ -21,6 +22,7 @@ describe('ChantierRandomRepository', () => {
           FR: {
             codeInsee: 'FR',
             avancement: { annuel: 14, global: 18 },
+            météo: météoFromString('SOLEIL'),
           },
         },
         régionale: {},
@@ -41,6 +43,7 @@ describe('ChantierRandomRepository', () => {
             annuel: 14,
             global: 18,
           },
+          météo: météoFromString('SOLEIL'),
         },
       },
       régionale: {},

--- a/src/server/infrastructure/chantier/ChantierSQLRepository.integration.test.ts
+++ b/src/server/infrastructure/chantier/ChantierSQLRepository.integration.test.ts
@@ -1,16 +1,17 @@
 import ChantierRepository from '@/server/domain/chantier/ChantierRepository.interface';
 import { prisma } from '@/server/infrastructure/test/integrationTestSetup';
 import ChantierRowBuilder from '@/server/infrastructure/test/rowBuilder/ChantierRowBuilder';
+import { météoFromString } from '@/server/domain/chantier/Météo.interface';
 import ChantierSQLRepository from './ChantierSQLRepository';
 
 describe('ChantierSQLRepository', () => {
-  test('Accède à un chantier par son id', async () => {
+  test('Accède à un chantier par son id, vérification de quelques champs', async () => {
     // GIVEN
     const repository: ChantierRepository = new ChantierSQLRepository(prisma);
     await prisma.chantier.createMany({
       data: [
         new ChantierRowBuilder()
-          .withId('CH-001').withNom('Chantier 1').build(),
+          .withId('CH-001').withNom('Chantier 1').withMétéo('COUVERT').build(),
         new ChantierRowBuilder()
           .withId('CH-002').withNom('Chantier 2').build(),
       ],
@@ -22,6 +23,7 @@ describe('ChantierSQLRepository', () => {
 
     // THEN
     expect(result1.nom).toEqual('Chantier 1');
+    expect(result1.mailles.nationale.FR.météo).toEqual(météoFromString('COUVERT'));
     expect(result2.nom).toEqual('Chantier 2');
   });
 
@@ -44,10 +46,8 @@ describe('ChantierSQLRepository', () => {
       nationale: {
         FR: {
           codeInsee: 'FR',
-          avancement: {
-            annuel: null,
-            global: 18,
-          },
+          avancement: { annuel: null, global: 18 },
+          météo: météoFromString('SOLEIL'),
         },
       },
       régionale: {},
@@ -76,16 +76,15 @@ describe('ChantierSQLRepository', () => {
       nationale: {
         FR: {
           codeInsee: 'FR',
-          avancement: {
-            annuel: null,
-            global: 18,
-          },
+          avancement: { annuel: null, global: 18 },
+          météo: météoFromString('SOLEIL'),
         },
       },
       départementale: {
         '13': {
           codeInsee: '13',
           avancement: { annuel: null, global: 45 },
+          météo: météoFromString('SOLEIL'),
         },
       },
       régionale: {},

--- a/src/server/infrastructure/test/rowBuilder/ChantierRowBuilder.ts
+++ b/src/server/infrastructure/test/rowBuilder/ChantierRowBuilder.ts
@@ -11,6 +11,8 @@ export default class ChantierRowBuilder {
 
   private _tauxAvancement: number = 42;
 
+  private _météo: string = 'SOLEIL';
+
   withId(id: string) {
     this._id = id;
     return this;
@@ -42,6 +44,11 @@ export default class ChantierRowBuilder {
     return this;
   }
 
+  withMétéo(météo: string) {
+    this._météo = météo;
+    return this;
+  }
+
   build(): chantier {
     return {
       id: this._id,
@@ -55,7 +62,7 @@ export default class ChantierRowBuilder {
       directeurs_administration_centrale: [],
       ministeres: [],
       directions_administration_centrale: [],
-      meteo: 'NON_NECESSAIRE',
+      meteo: this._météo,
     };
   }
 }


### PR DESCRIPTION
Cette PR permet d'afficher les données de météo nationales présentes dans le champs `chantier.meteo`.

### Observation

L'affichage des compteurs de météo "agrégée" de la sélection de périmètres de la page d'accueil n'est pas incluse dans cette PR.

Il manque aussi la différence entre "non renseignée" et "non nécessaire", qui reste à mieux définir.