### PR TITLE
fix: corrige la taille du tableau de la liste des chantiers (144)

### DIFF
--- a/src/client/components/PageChantiers/ListeChantiers/ListeChantiers.styled.ts
+++ b/src/client/components/PageChantiers/ListeChantiers/ListeChantiers.styled.ts
@@ -1,0 +1,20 @@
+import styled from '@emotion/styled';
+
+const ListeChantiersStyled = styled.div`
+
+  display: grid;
+  
+  thead th {
+    &:nth-child(1){
+      min-width: 23.75rem;
+    },
+    &:nth-child(2){
+      min-width: 15rem;
+    },
+    &:nth-child(3){
+      min-width: 20rem;
+    },
+  }
+`;
+
+export default ListeChantiersStyled;

--- a/src/client/components/PageChantiers/ListeChantiers/ListeChantiers.tsx
+++ b/src/client/components/PageChantiers/ListeChantiers/ListeChantiers.tsx
@@ -14,6 +14,7 @@ import {
   périmètreGéographique as périmètreGéographiqueStore,
 } from '@/stores/useSélecteursPageChantiersStore/useSélecteursPageChantiersStore';
 import { récupérerAvancement, récupérerMétéo } from '@/client/utils/chantier/donnéesTerritoires/donnéesTerritoires';
+import ListeChantiersStyled from '@/components/PageChantiers/ListeChantiers/ListeChantiers.styled';
 import ListeChantiersProps from './ListeChantiers.interface';
 
 function afficherLesBarresDeProgression(avancement: Avancement) {
@@ -77,11 +78,13 @@ function colonnesChantiers(périmètreGéographique: PérimètreGéographiqueIde
 export default function ListeChantiers({ chantiers }: ListeChantiersProps) {
   const périmètreGéographique = périmètreGéographiqueStore();
   return (
-    <Tableau<typeof chantiers[number]>
-      colonnes={colonnesChantiers(périmètreGéographique)}
-      données={chantiers}
-      entité="chantiers"
-      titre="Liste des chantiers"
-    />
+    <ListeChantiersStyled>
+      <Tableau<typeof chantiers[number]>
+        colonnes={colonnesChantiers(périmètreGéographique)}
+        données={chantiers}
+        entité="chantiers"
+        titre="Liste des chantiers"
+      />
+    </ListeChantiersStyled>
   );
 }


### PR DESCRIPTION
Rend le tableau des chantiers scrollable sur la page d'accueil, pour garder une lisibilité meilleure 