### PR TITLE
chore: ajoute un chrono pour mesurer les perfs (000)

### DIFF
--- a/src/server/infrastructure/test/tools/Stopwatch.ts
+++ b/src/server/infrastructure/test/tools/Stopwatch.ts
@@ -1,0 +1,86 @@
+// Usage:
+//
+//     import stopwatch from '@/server/infrastructure/test/tools/Stopwatch';
+//
+//     stopwatch.start('init');
+//     for (...) {
+//       stopwatch.start('in loop');
+//       stopwatch.time('in loop');
+//     }
+//     stopwatch.time('init');
+//
+//     stopwatch.logAll();
+//
+// Voir aussi : les tests unitaires de la classe pour les comportements spécifiques.
+
+export interface Logger {
+  log(param: any): void
+}
+
+export interface Clock {
+  now(): number
+}
+
+export class Stopwatch {
+  private startTimes = new Map();
+
+  private times = new Map();
+
+  private labels: string[] = [];
+
+  constructor(private readonly logger: Logger, private readonly clock: Clock) {}
+
+  start(label: string) {
+    this.startTimes.set(label, this.clock.now());
+    if (!this.times.has(label)) {
+      this.times.set(label, 0);
+      this.labels.push(label);
+    }
+  }
+
+  time(label: string) {
+    if (!this.times.has(label)) {
+      throw new Error(`Error: attempt to time ${label} (not started).`);
+    }
+    const measure = this.clock.now() - this.startTimes.get(label);
+    const sum = this.times.get(label);
+    this.times.set(label, sum + measure);
+  }
+
+  log(label: string) {
+    const measure = this.times.has(label) ? this.times.get(label) : null;
+    this.logger.log(`⌚ Time for label "${label}": ${measure} ⌚`);
+  }
+
+  logAll() {
+    for (const label of this.labels) {
+      this.log(label);
+    }
+  }
+}
+
+let stopwatch: Stopwatch | null = null;
+
+function getInstance(): Stopwatch {
+  if (!stopwatch) {
+    stopwatch = new Stopwatch(console, Date);
+  }
+  return stopwatch;
+}
+
+const moduleInterface = {
+  start(label: string) {
+    getInstance().start(label);
+  },
+  time(label: string) {
+    getInstance().time(label);
+  },
+  log(label: string) {
+    getInstance().log(label);
+  },
+  logAll() {
+    getInstance().logAll();
+  },
+};
+
+export default moduleInterface;

--- a/src/server/infrastructure/test/tools/Stopwatch.unit.test.ts
+++ b/src/server/infrastructure/test/tools/Stopwatch.unit.test.ts
@@ -1,0 +1,101 @@
+/* eslint-disable sonarjs/no-duplicate-string */
+import { Stopwatch } from './Stopwatch';
+
+function fakeLogger(logs: string[]) {
+  return ({
+    log: (s: string) => {logs.push(s);},
+  });
+}
+
+function fakeClock(delta: number) {
+  let n = 0;
+  return ({
+    now: () => {
+      const result = delta * n;
+      n += 1;
+      return result;
+    },
+  });
+}
+
+describe('Stopwatch', () => {
+  it('tracks one label', () => {
+    // GIVEN
+    const logs: string[] = [];
+    const stopwatch = new Stopwatch(fakeLogger(logs), fakeClock(10));
+
+    // WHEN
+    stopwatch.start('one');
+    stopwatch.time('one');
+
+    stopwatch.log('one');
+
+    // THEN
+    expect(logs).toStrictEqual(['⌚ Time for label "one": 10 ⌚']);
+  });
+
+  it('tracks two nested labels', () => {
+    // GIVEN
+    const logs: string[] = [];
+    const stopwatch = new Stopwatch(fakeLogger(logs), fakeClock(10));
+
+    // WHEN
+    stopwatch.start('one');
+    stopwatch.start('two');
+    stopwatch.time('two');
+    stopwatch.time('one');
+
+    stopwatch.log('one');
+    stopwatch.log('two');
+
+    // THEN
+    expect(logs).toStrictEqual([
+      '⌚ Time for label "one": 30 ⌚',
+      '⌚ Time for label "two": 10 ⌚',
+    ]);
+  });
+
+  it('logs all labels', () => {
+    // GIVEN
+    const logs: string[] = [];
+    const stopwatch = new Stopwatch(fakeLogger(logs), fakeClock(10));
+
+    // WHEN
+    stopwatch.start('one');
+    stopwatch.start('two');
+    stopwatch.time('two');
+    stopwatch.time('one');
+
+    stopwatch.logAll();
+
+    // THEN
+    expect(logs).toStrictEqual([
+      '⌚ Time for label "one": 30 ⌚',
+      '⌚ Time for label "two": 10 ⌚',
+    ]);
+  });
+
+  it('tracking labels can be intertwined', () => {
+    // GIVEN
+    const logs: string[] = [];
+    const stopwatch = new Stopwatch(fakeLogger(logs), fakeClock(10));
+
+    // WHEN
+    stopwatch.start('one');
+    stopwatch.time('one');
+
+    stopwatch.start('two');
+    stopwatch.time('two');
+
+    stopwatch.start('one');
+    stopwatch.time('one');
+
+    stopwatch.logAll();
+
+    // THEN
+    expect(logs).toStrictEqual([
+      '⌚ Time for label "one": 20 ⌚',
+      '⌚ Time for label "two": 10 ⌚',
+    ]);
+  });
+});


### PR DESCRIPTION
### Problème

Aujourd'hui on a eu besoin de mesurer un peu finement des temps passés dans des fonctions. Le rapport du plugin React ne nous donnait pas assez d'infos.

### Solution

Ajouter une classe d'une quarantaine de lignes qui permet de tracker des mesures de temps associées à des labels, et de les logger.

Usage :

```javascript
import stopwatch from '@/server/infrastructure/test/tools/Stopwatch';

// Fonction à mesurer
function init() {
  stopwatch.start('init');
  // ...
  for (...) {
    stopwatch.start('in loop');
    // Calculs qu'on veut mesurer à part ...
    stopwatch.time('in loop');
  }
  // ...
  stopwatch.time('init');
}

  // Plus tard, quand on veut le compte-rendu (après appel des fonctions à investiguer) :
  stopwatch.logAll();

```
Voir aussi : les tests unitaires de la classe pour les comportements spécifiques.

### Observations

Une autre option est d'utiliser des outils de profiling TypeScript, j'explore ça en parallèle, à mon avis c'est une compétence nécessaire.