### PR TITLE
feat: exposition du champ est_barometre (178)

### DIFF
--- a/src/fixtures/ChantierFixture.ts
+++ b/src/fixtures/ChantierFixture.ts
@@ -39,6 +39,7 @@ class ChantierFixture implements FixtureInterface<Chantier> {
         directeursAdminCentrale: [{ nom: 'DAC1', direction: 'DAC1' }, { nom: 'DAC2', direction: 'DAC2' }],
         directeursProjet: [],
       },
+      estBaromètre: faker.datatype.boolean(),
       ...valeursFixes,
     };
   }

--- a/src/server/domain/chantier/Chantier.interface.ts
+++ b/src/server/domain/chantier/Chantier.interface.ts
@@ -35,4 +35,5 @@ export default interface Chantier {
     directeursAdminCentrale: DirecteurAdministrationCentrale[],
     directeursProjet: Contact[]
   }
+  estBaromètre: boolean;
 }

--- a/src/server/infrastructure/chantier/ChantierSQLParser.ts
+++ b/src/server/infrastructure/chantier/ChantierSQLParser.ts
@@ -50,6 +50,7 @@ export function parseChantier(chantierRows: chantier[]): Chantier {
       directeursAdminCentrale: [],
       directeursProjet: [],
     },
+    estBaromètre: Boolean(chantierMailleNationale.est_barometre),
   };
 
   if (chantierMailleNationale.directeurs_administration_centrale) {

--- a/src/server/infrastructure/chantier/ChantierSQLRepository.integration.test.ts
+++ b/src/server/infrastructure/chantier/ChantierSQLRepository.integration.test.ts
@@ -207,6 +207,24 @@ describe('ChantierSQLRepository', () => {
     expect(result.responsables.directeursProjet[0]).toStrictEqual({ nom: 'Jean Bon', email: null });
   });
 
+  test('Un chantier est du baromètre', async () => {
+    // GIVEN
+    const repository: ChantierRepository = new ChantierSQLRepository(prisma);
+
+    const chantierId = 'CH-001';
+
+    await prisma.chantier.create({
+      data: new ChantierRowBuilder()
+        .withId(chantierId).withEstBaromètre(true).build(),
+    });
+
+    // WHEN
+    const result = await repository.getById(chantierId);
+
+    // THEN
+    expect(result.estBaromètre).toBe(true);
+  });
+
   describe("Gestion d'erreur", () => {
     test('Erreur en cas de chantier non trouvé', async () => {
       // GIVEN

--- a/src/server/infrastructure/test/tools/rowBuilder/ChantierRowBuilder.ts
+++ b/src/server/infrastructure/test/tools/rowBuilder/ChantierRowBuilder.ts
@@ -25,6 +25,8 @@ export default class ChantierRowBuilder {
 
   private _ministeres: string[] = ['Ministère 1'];
 
+  private _estBaromètre: boolean = false;
+
   withId(id: string): ChantierRowBuilder {
     this._id = id;
     return this;
@@ -91,6 +93,11 @@ export default class ChantierRowBuilder {
     return this;
   }
 
+  withEstBaromètre(estBaromètre: boolean): ChantierRowBuilder {
+    this._estBaromètre = estBaromètre;
+    return this;
+  }
+
   build(): chantier {
     return {
       id: this._id,
@@ -110,7 +117,7 @@ export default class ChantierRowBuilder {
       ppg: 'TBD',
       objectifs: 'TBD',
       date_objectifs: null,
-      est_barometre: null,
+      est_barometre: this._estBaromètre,
     };
   }
 }


### PR DESCRIPTION
Ajout de l'info côté back.

### Observation

Dépend de la branche #144 (162) pour l'import des données :heavy_check_mark:

Point de vue base, le champs peut être nul, point de vue code on a décidé que nul => false donc le champs est soit vrai soit faux.