### PR TITLE
feat: ajoute les dates pour les valeurs initiale et actuelle dans les indicateurs (173)

### DIFF
--- a/src/client/components/PageChantier/Indicateurs/CarteIndicateur/CarteIndicateur.styled.ts
+++ b/src/client/components/PageChantier/Indicateurs/CarteIndicateur/CarteIndicateur.styled.ts
@@ -5,6 +5,22 @@ const CarteIndicateurStyled = styled.div`
     font-size: 0.625rem;
     line-height: 1rem;
   }
+
+  td {
+    min-height: 2rem;
+    vertical-align: top;
+  }
+
+  .indicateur-valeur,
+  .indicateur-date-valeur {
+    font-size: inherit;
+  }
+
+  .indicateur-date-valeur {
+    height: 1rem;
+    font-size: 0.625rem;
+    line-height: 1rem;
+  }
 `;
 
 export default CarteIndicateurStyled;

--- a/src/client/components/PageChantier/Indicateurs/CarteIndicateur/CarteIndicateur.tsx
+++ b/src/client/components/PageChantier/Indicateurs/CarteIndicateur/CarteIndicateur.tsx
@@ -9,7 +9,7 @@ import PictoBaromètre from '@/components/_commons/PictoBaromètre/PictoBaromèt
 import { formaterDate } from '@/client/utils/date/date';
 import CarteIndicateurStyled from './CarteIndicateur.styled';
 
-function afficherValeurEtDate(valeur: number | null, date?: string) {
+function afficherValeurEtDate(valeur: number | null, date?: string | null) {
   const dateFormatée = formaterDate(date, 'mm/yyyy');
   return (
     <>
@@ -27,11 +27,7 @@ function afficherValeurEtDate(valeur: number | null, date?: string) {
   );
 }
 
-const reactTableColonnesHelper = createColumnHelper<Indicateur & {
-  dateValeurInitiale?: string; //TODO en attendant les données du back -> à mettre dans le type Indicateur côté back + enlever le '?'
-  dateValeurActuelle?: string; //TODO en attendant les données du back -> à mettre dans le type Indicateur côté back + enlever le '?'
-  territoire: string //TODO idem qu'au dessus ?
-}>();
+const reactTableColonnesHelper = createColumnHelper<Indicateur & { territoire: string }>();
 
 const colonnes = [
   reactTableColonnesHelper.accessor('territoire', {

--- a/src/client/components/PageChantier/Indicateurs/CarteIndicateur/CarteIndicateur.tsx
+++ b/src/client/components/PageChantier/Indicateurs/CarteIndicateur/CarteIndicateur.tsx
@@ -27,7 +27,11 @@ function afficherValeurEtDate(valeur: number | null, date?: string) {
   );
 }
 
-const reactTableColonnesHelper = createColumnHelper<Indicateur & { territoire: string }>();
+const reactTableColonnesHelper = createColumnHelper<Indicateur & {
+  dateValeurInitiale?: string; //TODO en attendant les données du back -> à mettre dans le type Indicateur côté back + enlever le '?'
+  dateValeurActuelle?: string; //TODO en attendant les données du back -> à mettre dans le type Indicateur côté back + enlever le '?'
+  territoire: string //TODO idem qu'au dessus ?
+}>();
 
 const colonnes = [
   reactTableColonnesHelper.accessor('territoire', {
@@ -37,12 +41,12 @@ const colonnes = [
   }),
   reactTableColonnesHelper.accessor('valeurInitiale', {
     header: 'Valeur initiale',
-    cell: valeurInitiale => afficherValeurEtDate(valeurInitiale.getValue(), valeurInitiale.row.dateValeurInitiale), //TODO
+    cell: valeurInitiale => afficherValeurEtDate(valeurInitiale.getValue(), valeurInitiale.row.original.dateValeurInitiale),
     enableSorting: false,
   }),
   reactTableColonnesHelper.accessor('valeurActuelle', {
     header: 'Valeur actuelle',
-    cell: valeurActuelle => afficherValeurEtDate(valeurActuelle.getValue(), valeurActuelle.row.dateValeurActuelle), //TODO
+    cell: valeurActuelle => afficherValeurEtDate(valeurActuelle.getValue(), valeurActuelle.row.original.dateValeurActuelle),
     enableSorting: false,
   }),
   reactTableColonnesHelper.accessor('valeurCible', {

--- a/src/client/components/PageChantier/Indicateurs/CarteIndicateur/CarteIndicateur.tsx
+++ b/src/client/components/PageChantier/Indicateurs/CarteIndicateur/CarteIndicateur.tsx
@@ -6,7 +6,26 @@ import Tableau from '@/components/_commons/Tableau/Tableau';
 import CarteIndicateurProps from '@/components/PageChantier/Indicateurs/CarteIndicateur/CarteIndicateur.interface';
 import BarreDeProgression from '@/components/_commons/BarreDeProgression/BarreDeProgression';
 import PictoBaromètre from '@/components/_commons/PictoBaromètre/PictoBaromètre';
+import { formaterDate } from '@/client/utils/date/date';
 import CarteIndicateurStyled from './CarteIndicateur.styled';
+
+function afficherValeurEtDate(valeur: number | null, date?: string) {
+  const dateFormatée = formaterDate(date, 'mm/yyyy');
+  return (
+    <>
+      <p className='indicateur-valeur'>
+        {valeur?.toLocaleString()}
+      </p>
+      {
+        !!dateFormatée && (
+          <p className='indicateur-date-valeur texte-gris'>
+            { `(${dateFormatée})` }
+          </p>
+        )
+      }
+    </>
+  );
+}
 
 const reactTableColonnesHelper = createColumnHelper<Indicateur & { territoire: string }>();
 
@@ -18,17 +37,17 @@ const colonnes = [
   }),
   reactTableColonnesHelper.accessor('valeurInitiale', {
     header: 'Valeur initiale',
-    cell: valeurInitiale => valeurInitiale.getValue()?.toLocaleString(),
+    cell: valeurInitiale => afficherValeurEtDate(valeurInitiale.getValue(), valeurInitiale.row.dateValeurInitiale), //TODO
     enableSorting: false,
   }),
   reactTableColonnesHelper.accessor('valeurActuelle', {
     header: 'Valeur actuelle',
-    cell: valeurActuelle => valeurActuelle.getValue()?.toLocaleString(),
+    cell: valeurActuelle => afficherValeurEtDate(valeurActuelle.getValue(), valeurActuelle.row.dateValeurActuelle), //TODO
     enableSorting: false,
   }),
   reactTableColonnesHelper.accessor('valeurCible', {
     header: 'Valeur cible',
-    cell: valeurCible => valeurCible.getValue()?.toLocaleString(),
+    cell: valeurCible => afficherValeurEtDate(valeurCible.getValue()),
     enableSorting: false,
   }),
   reactTableColonnesHelper.accessor('tauxAvancementGlobal', {

--- a/src/client/utils/date/date.ts
+++ b/src/client/utils/date/date.ts
@@ -1,0 +1,16 @@
+type FormatDeDate = 'mm/yyyy';
+
+const toLocaleDateStringOptions: Record<FormatDeDate, Intl.DateTimeFormatOptions> = {
+  'mm/yyyy': { year: 'numeric', month: 'numeric' },
+};
+
+export function formaterDate(sqlDate: string | null | undefined, format: FormatDeDate) {
+  if (!sqlDate)
+    return null;
+
+  if (Number.isNaN(Date.parse(sqlDate)))
+    return null;
+
+  const date = new Date(sqlDate);
+  return date.toLocaleDateString('fr-FR', toLocaleDateStringOptions[format]);
+}

--- a/src/client/utils/date/date.unit.test.ts
+++ b/src/client/utils/date/date.unit.test.ts
@@ -1,0 +1,31 @@
+import { formaterDate } from '@/client/utils/date/date';
+
+describe('formaterDate', () => {
+
+  describe('formate selon le modèle: mm/yyyy', () => {
+    it("documente l'attendu pour une date et un horaire", () => {
+      const sqldate = '2023-02-13 16:03:56';
+      const résultat = formaterDate(sqldate, 'mm/yyyy');
+      expect(résultat).toEqual('02/2023');
+    });
+
+    it("documente l'attendu pour une date seulement", () => {
+      const sqldate = '2023-04-21';
+      const résultat = formaterDate(sqldate, 'mm/yyyy');
+      expect(résultat).toEqual('04/2023');
+    });
+
+    it('renvoie null si la date est invalide car inexistante', () => {
+      const sqldate = '2023-99-01';
+      const résultat = formaterDate(sqldate, 'mm/yyyy');
+      expect(résultat).toEqual(null);
+    });
+
+    it('renvoie null si la date est invalide car ne respectant pas le format', () => {
+      const sqldate = '2023-0112';
+      const résultat = formaterDate(sqldate, 'mm/yyyy');
+      expect(résultat).toEqual(null);
+    });
+  });
+  
+});

--- a/src/fixtures/IndicateurFixture.ts
+++ b/src/fixtures/IndicateurFixture.ts
@@ -16,8 +16,10 @@ class IndicateurFixture implements FixtureInterface<Indicateur> {
       tauxAvancementGlobal: faker.helpers.arrayElement([null, faker.datatype.number({ min: 0, max: 100, precision: 0.01 })]),
       evolutionValeurActuelle: [1, 2, 3, 4],
       evolutionDateValeurActuelle: ['2021-06-30', '2022-06-30', '2023-06-30', '2024-06-30'],
+      dateValeurInitiale: '2020-01-01',
+      dateValeurActuelle: '2023-02-01',
       ...valeursFixes,
-    }; 
+    };
   }
 
   générerPlusieurs(quantité: number, valeursFixes: Partial<Indicateur>[] = []) {

--- a/src/server/domain/indicateur/Indicateur.interface.ts
+++ b/src/server/domain/indicateur/Indicateur.interface.ts
@@ -12,6 +12,8 @@ export default interface Indicateur {
   valeurInitiale: Valeur;
   valeurActuelle: Valeur;
   valeurCible: Valeur;
+  dateValeurInitiale: string | null;
+  dateValeurActuelle: string | null;
   tauxAvancementGlobal: Taux;
   evolutionValeurActuelle: number[];
   evolutionDateValeurActuelle: string[];

--- a/src/server/infrastructure/indicateur/IndicateurSQLRepository.integration.test.ts
+++ b/src/server/infrastructure/indicateur/IndicateurSQLRepository.integration.test.ts
@@ -23,7 +23,11 @@ describe('IndicateurSQLRepository', () => {
     const date1 = '2021-06-30';
     const date2 = '2022-06-30';
     const date3 = '2023-06-30';
-    
+    const dateA = '2018-07-24';
+    const dateB = '2022-12-17';
+    const dateC = '2019-09-02';
+    const dateD = '2023-01-14';
+
     const indicateurs: indicateur[] = [
       new IndicateurRowBuilder()
         .withId('IND-001')
@@ -31,6 +35,8 @@ describe('IndicateurSQLRepository', () => {
         .withChantierId(chantierId)
         .withEvolutionValeurActuelle([1, 2])
         .withEvolutionDateValeurActuelle([date1, date2])
+        .withDateValeurInitiale(dateA)
+        .withDateValeurActuelle(dateB)
         .build(),
 
       new IndicateurRowBuilder()
@@ -41,6 +47,8 @@ describe('IndicateurSQLRepository', () => {
         .withMaille('REG')
         .withEvolutionValeurActuelle([0.4, 43, 18])
         .withEvolutionDateValeurActuelle([date1, date2, date3])
+        .withDateValeurInitiale('2017-01-01')
+        .withDateValeurActuelle('2018-01-01')
         .build(),
 
       new IndicateurRowBuilder()
@@ -49,6 +57,8 @@ describe('IndicateurSQLRepository', () => {
         .withChantierId(chantierId)
         .withEvolutionValeurActuelle([0.4, 0, 0.654])
         .withEvolutionDateValeurActuelle([date1, date2, date3])
+        .withDateValeurInitiale(dateC)
+        .withDateValeurActuelle(dateD)
         .build(),
     ];
 
@@ -67,5 +77,9 @@ describe('IndicateurSQLRepository', () => {
     expect(result[1].evolutionDateValeurActuelle).toEqual([date1, date2, date3]);
     expect(result[0].evolutionValeurActuelle.length).toEqual(result[0].evolutionDateValeurActuelle.length);
     expect(result[1].evolutionValeurActuelle.length).toEqual(result[1].evolutionDateValeurActuelle.length);
+    expect(result[0].dateValeurInitiale).toEqual(dateA);
+    expect(result[1].dateValeurInitiale).toEqual(dateC);
+    expect(result[0].dateValeurActuelle).toEqual(dateB);
+    expect(result[1].dateValeurActuelle).toEqual(dateD);
   });
 });

--- a/src/server/infrastructure/indicateur/IndicateurSQLRepository.ts
+++ b/src/server/infrastructure/indicateur/IndicateurSQLRepository.ts
@@ -15,7 +15,6 @@ export default class IndicateurSQLRepository implements IndicateurRepository {
 
   mapToDomain(indicateurs: indicateur[]): Indicateur[] {
     return indicateurs.map(row => {
-      const evolutionDateValeurActuelle = row.evolution_date_valeur_actuelle.map(d => toDateStringWithoutTime(d));
       return ({
         id: row.id,
         nom: row.nom,
@@ -26,7 +25,9 @@ export default class IndicateurSQLRepository implements IndicateurRepository {
         valeurCible: row.objectif_valeur_cible,
         tauxAvancementGlobal: row.objectif_taux_avancement,
         evolutionValeurActuelle: row.evolution_valeur_actuelle,
-        evolutionDateValeurActuelle,
+        evolutionDateValeurActuelle: row.evolution_date_valeur_actuelle.map(d => toDateStringWithoutTime(d)),
+        dateValeurInitiale: row.date_valeur_initiale !== null ? toDateStringWithoutTime(row.date_valeur_initiale) : null,
+        dateValeurActuelle: row.date_valeur_actuelle !== null ? toDateStringWithoutTime(row.date_valeur_actuelle) : null,
       });
     });
   }

--- a/src/server/infrastructure/test/tools/rowBuilder/IndicateurRowBuilder.ts
+++ b/src/server/infrastructure/test/tools/rowBuilder/IndicateurRowBuilder.ts
@@ -15,6 +15,10 @@ export default class IndicateurRowBuilder {
 
   private _evolutionDateValeurActuelle: string[] = ['2021-06-30', '2022-06-30'];
 
+  private _dateValeurInitiale: string | null = '2020-01-01';
+
+  private _dateValeurActuelle: string | null = '2023-02-01';
+
   withId(id: string): IndicateurRowBuilder {
     this._id = id;
     return this;
@@ -50,6 +54,16 @@ export default class IndicateurRowBuilder {
     return this;
   }
 
+  withDateValeurInitiale(dateValeurInitiale: string | null): IndicateurRowBuilder {
+    this._dateValeurInitiale = dateValeurInitiale;
+    return this;
+  }
+
+  withDateValeurActuelle(dateValeurActuelle: string | null): IndicateurRowBuilder {
+    this._dateValeurActuelle = dateValeurActuelle;
+    return this;
+  }
+
   build(): indicateur {
     return {
       id: this._id,
@@ -66,9 +80,9 @@ export default class IndicateurRowBuilder {
       est_barometre: null,
       est_phare: null,
       valeur_initiale: null,
-      date_valeur_initiale: null,
+      date_valeur_initiale: this._dateValeurInitiale !== null ? new Date(this._dateValeurInitiale) : null,
       valeur_actuelle: null,
-      date_valeur_actuelle: null,
+      date_valeur_actuelle: this._dateValeurActuelle !== null ? new Date(this._dateValeurActuelle) : null,
       territoire_nom: null,
       evolution_valeur_actuelle: this._evolutionValeurActuelle,
       evolution_date_valeur_actuelle: this._evolutionDateValeurActuelle.map(s => new Date(s)),


### PR DESCRIPTION
A suivre : la connexion avec les données du back et l'ajout de deux champs `dateValeurInitiale` et `dateValeurActuelle` dans le type `Indicateur`

A l'issue de cette connexion avec le backend, retirer les TODO dans src/client/.../CarteIndicateur.tsx