### PR TITLE
feat: exposition source mode de calcule et description indicateur (257)

### DIFF
--- a/data/pilote_data_jobs/transformations/ditp_ppg_dbt/models/marts/indicateur.sql
+++ b/data/pilote_data_jobs/transformations/ditp_ppg_dbt/models/marts/indicateur.sql
@@ -74,7 +74,8 @@ dfakto_indicateur AS (
     d_indicateurs.evolution_valeur_actuelle,
     d_indicateurs.evolution_date_valeur_actuelle,
     m_indicateurs.description,
-    m_indicateurs.source
+    m_indicateurs.source,
+    m_indicateurs.mode_de_calcul
 FROM {{ ref('stg_ppg_metadata__indicateurs') }} m_indicateurs
     JOIN dfakto_indicateur d_indicateurs ON m_indicateurs.nom = d_indicateurs.effect_id AND d_indicateurs.nom_structure IN ('Département', 'Région', 'Réforme')
     LEFT JOIN {{ ref('stg_ppg_metadata__indicateur_types') }} indicateur_types ON indicateur_types.id = m_indicateurs.indicateur_type_id

--- a/data/pilote_data_jobs/transformations/ditp_ppg_dbt/models/marts/indicateur.sql
+++ b/data/pilote_data_jobs/transformations/ditp_ppg_dbt/models/marts/indicateur.sql
@@ -72,7 +72,9 @@ dfakto_indicateur AS (
     END maille,
     m_zones.nom AS territoire_nom,
     d_indicateurs.evolution_valeur_actuelle,
-    d_indicateurs.evolution_date_valeur_actuelle
+    d_indicateurs.evolution_date_valeur_actuelle,
+    m_indicateurs.description,
+    m_indicateurs.source
 FROM {{ ref('stg_ppg_metadata__indicateurs') }} m_indicateurs
     JOIN dfakto_indicateur d_indicateurs ON m_indicateurs.nom = d_indicateurs.effect_id AND d_indicateurs.nom_structure IN ('Département', 'Région', 'Réforme')
     LEFT JOIN {{ ref('stg_ppg_metadata__indicateur_types') }} indicateur_types ON indicateur_types.id = m_indicateurs.indicateur_type_id

--- a/data/pilote_data_jobs/transformations/ditp_ppg_dbt/models/staging/ppg_metadata/stg_ppg_metadata__indicateurs.sql
+++ b/data/pilote_data_jobs/transformations/ditp_ppg_dbt/models/staging/ppg_metadata/stg_ppg_metadata__indicateurs.sql
@@ -19,7 +19,8 @@ renamed as (
         indic_is_baro as est_barometre,
         indic_type as indicateur_type_id,
         indic_source as source,
-        indic_source_url as source_url
+        indic_source_url as source_url,
+        indic_mode_calcul as mode_de_calcul
 
     from source
 

--- a/prisma/migrations/20230307150331_ajout_source_et_description_table_indicateur/migration.sql
+++ b/prisma/migrations/20230307150331_ajout_source_et_description_table_indicateur/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "indicateur" ADD COLUMN     "description" TEXT,
+ADD COLUMN     "source" TEXT;

--- a/prisma/migrations/20230308094704_ajout_mode_de_calcul_table_indicateur/migration.sql
+++ b/prisma/migrations/20230308094704_ajout_mode_de_calcul_table_indicateur/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "indicateur" ADD COLUMN     "mode_de_calcul" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -59,6 +59,7 @@ model indicateur {
   evolution_date_valeur_actuelle DateTime[] @db.Date
   description String?
   source String?
+  mode_de_calcul String?
 
   @@id([id, code_insee, maille])
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -57,6 +57,8 @@ model indicateur {
   maille String
   evolution_valeur_actuelle Float[]
   evolution_date_valeur_actuelle DateTime[] @db.Date
+  description String?
+  source String?
 
   @@id([id, code_insee, maille])
 }

--- a/src/fixtures/IndicateurFixture.ts
+++ b/src/fixtures/IndicateurFixture.ts
@@ -13,6 +13,8 @@ class IndicateurFixture implements FixtureInterface<Indicateur> {
       nom: faker.lorem.words(5),
       type: faker.helpers.arrayElement(typesIndicateur),
       estIndicateurDuBaromètre: faker.datatype.boolean(),
+      source: 'ma source',
+      description: 'ma description',
       ...valeursFixes,
     };
   }

--- a/src/fixtures/IndicateurFixture.ts
+++ b/src/fixtures/IndicateurFixture.ts
@@ -15,6 +15,7 @@ class IndicateurFixture implements FixtureInterface<Indicateur> {
       estIndicateurDuBaromètre: faker.datatype.boolean(),
       source: 'ma source',
       description: 'ma description',
+      modeDeCalcul: 'mon mode de calcul',
       ...valeursFixes,
     };
   }

--- a/src/fixtures/IndicateurFixture.ts
+++ b/src/fixtures/IndicateurFixture.ts
@@ -1,9 +1,7 @@
 import { faker } from '@faker-js/faker';
 import Indicateur, {
-  IndicateurDonnéesTerritoires,
   typesIndicateur,
 } from '@/server/domain/indicateur/Indicateur.interface';
-import { codeInseeDépartements, codeInseeRégions } from '@/fixtures/codesInsee';
 import FixtureInterface from './Fixture.interface';
 import { générerUnIdentifiantUnique } from './utils';
 
@@ -15,31 +13,8 @@ class IndicateurFixture implements FixtureInterface<Indicateur> {
       nom: faker.lorem.words(5),
       type: faker.helpers.arrayElement(typesIndicateur),
       estIndicateurDuBaromètre: faker.datatype.boolean(),
-      mailles: {
-        nationale: this.générerFakeIndicateurTerritorialisé(['FR']),
-        régionale: this.générerFakeIndicateurTerritorialisé(codeInseeRégions),
-        départementale: this.générerFakeIndicateurTerritorialisé(codeInseeDépartements),
-      },
       ...valeursFixes,
     };
-  }
-
-  private générerFakeIndicateurTerritorialisé(code_insee_territoire: string[]): IndicateurDonnéesTerritoires {
-    const result: IndicateurDonnéesTerritoires = {};
-    code_insee_territoire.forEach((code_insee) => {
-      result[code_insee] = {
-        codeInsee: code_insee,
-        valeurInitiale: faker.helpers.arrayElement([null, faker.datatype.number({ max: 99 })]),
-        valeurActuelle: faker.helpers.arrayElement([null, faker.datatype.number({ min: 99, max: 199 })]),
-        valeurCible: faker.helpers.arrayElement([null, faker.datatype.number({ min: 199, max: 250 })]),
-        tauxAvancementGlobal: faker.helpers.arrayElement([null, faker.datatype.number({ min: 0, max: 100, precision: 0.01 })]),
-        evolutionValeurActuelle: [25, 65, 150, 199],
-        evolutionDateValeurActuelle: ['2021-06-30', '2022-06-30', '2023-06-30', '2024-06-30'],
-        dateValeurInitiale: '2020-01-01',
-        dateValeurActuelle: '2023-02-01',
-      };
-    });
-    return result;
   }
 
   générerPlusieurs(quantité: number, valeursFixes: Partial<Indicateur>[] = []) {

--- a/src/server/domain/indicateur/Indicateur.interface.ts
+++ b/src/server/domain/indicateur/Indicateur.interface.ts
@@ -1,4 +1,3 @@
-import { Maille } from '@/server/domain/maille/Maille.interface';
 import { CodeInsee } from '@/server/domain/territoire/Territoire.interface';
 
 export const typesIndicateur = ['IMPACT', 'DEPL', 'Q_SERV', 'REBOND', 'CONTEXTE', null] as const;
@@ -6,20 +5,6 @@ export const typesIndicateur = ['IMPACT', 'DEPL', 'Q_SERV', 'REBOND', 'CONTEXTE'
 export type TypeIndicateur = typeof typesIndicateur[number];
 export type Valeur = number | null;
 export type Taux = number | null;
-
-export type IndicateurTerritorialisé = {
-  codeInsee: CodeInsee,
-  valeurInitiale: Valeur;
-  valeurActuelle: Valeur;
-  valeurCible: Valeur;
-  dateValeurInitiale: string | null;
-  dateValeurActuelle: string | null;
-  tauxAvancementGlobal: Taux;
-  evolutionValeurActuelle: number[];
-  evolutionDateValeurActuelle: string[];
-};
-
-export type IndicateurDonnéesTerritoires = Record<string, IndicateurTerritorialisé>;
 
 export type CartographieIndicateurTerritorialisée = {
   avancementAnnuel: number | null,
@@ -33,5 +18,4 @@ export default interface Indicateur {
   nom: string;
   type: TypeIndicateur;
   estIndicateurDuBaromètre: boolean | null;
-  mailles: Record<Maille, IndicateurDonnéesTerritoires>;
 }

--- a/src/server/domain/indicateur/Indicateur.interface.ts
+++ b/src/server/domain/indicateur/Indicateur.interface.ts
@@ -18,4 +18,6 @@ export default interface Indicateur {
   nom: string;
   type: TypeIndicateur;
   estIndicateurDuBaromètre: boolean | null;
+  description: string | null;
+  source: string | null;
 }

--- a/src/server/domain/indicateur/Indicateur.interface.ts
+++ b/src/server/domain/indicateur/Indicateur.interface.ts
@@ -20,4 +20,5 @@ export default interface Indicateur {
   estIndicateurDuBaromètre: boolean | null;
   description: string | null;
   source: string | null;
+  modeDeCalcul: string | null;
 }

--- a/src/server/infrastructure/indicateur/IndicateurSQLRepository.integration.test.ts
+++ b/src/server/infrastructure/indicateur/IndicateurSQLRepository.integration.test.ts
@@ -44,6 +44,7 @@ describe('IndicateurSQLRepository', () => {
           .withDateValeurActuelle(dateB)
           .withSource('ma source')
           .withDescription('ma description')
+          .withModeDeCalcul('mon mode de calcul')
           .build(),
 
         new IndicateurRowBuilder()
@@ -58,6 +59,7 @@ describe('IndicateurSQLRepository', () => {
           .withDateValeurActuelle('2018-01-01')
           .withSource('ma source')
           .withDescription('ma description')
+          .withModeDeCalcul('mon mode de calcul')
           .build(),
 
         new IndicateurRowBuilder()
@@ -70,6 +72,7 @@ describe('IndicateurSQLRepository', () => {
           .withDateValeurActuelle(dateD)
           .withSource('ma source')
           .withDescription('ma description')
+          .withModeDeCalcul('mon mode de calcul')
           .build(),
       ];
 
@@ -82,6 +85,7 @@ describe('IndicateurSQLRepository', () => {
       expect(result.length).toEqual(2);
       expect(result[0].id).toEqual('IND-001');
       expect(result[0].source).toStrictEqual('ma source');
+      expect(result[0].modeDeCalcul).toStrictEqual('mon mode de calcul');
       expect(result[1].id).toEqual('IND-002');
       expect(result[1].description).toEqual('ma description');
     });

--- a/src/server/infrastructure/indicateur/IndicateurSQLRepository.integration.test.ts
+++ b/src/server/infrastructure/indicateur/IndicateurSQLRepository.integration.test.ts
@@ -76,16 +76,6 @@ describe('IndicateurSQLRepository', () => {
       expect(result.length).toEqual(2);
       expect(result[0].id).toEqual('IND-001');
       expect(result[1].id).toEqual('IND-002');
-      expect(result[0].mailles.nationale.FR.evolutionValeurActuelle).toEqual([1, 2]);
-      expect(result[1].mailles.nationale.FR.evolutionValeurActuelle).toEqual([0.4, 0, 0.654]);
-      expect(result[0].mailles.nationale.FR.evolutionDateValeurActuelle).toEqual([new Date(date1).toISOString(), new Date(date2).toISOString()]);
-      expect(result[1].mailles.nationale.FR.evolutionDateValeurActuelle).toEqual([new Date(date1).toISOString(), new Date(date2).toISOString(), new Date(date3).toISOString()]);
-      expect(result[0].mailles.nationale.FR.evolutionValeurActuelle.length).toEqual(result[0].mailles.nationale.FR.evolutionDateValeurActuelle.length);
-      expect(result[1].mailles.nationale.FR.evolutionValeurActuelle.length).toEqual(result[1].mailles.nationale.FR.evolutionDateValeurActuelle.length);
-      expect(result[0].mailles.nationale.FR.dateValeurInitiale).toEqual(new Date(dateA).toISOString());
-      expect(result[1].mailles.nationale.FR.dateValeurInitiale).toEqual(new Date(dateC).toISOString());
-      expect(result[0].mailles.nationale.FR.dateValeurActuelle).toEqual(new Date(dateB).toISOString());
-      expect(result[1].mailles.nationale.FR.dateValeurActuelle).toEqual(new Date(dateD).toISOString());
     });
   });
 

--- a/src/server/infrastructure/indicateur/IndicateurSQLRepository.integration.test.ts
+++ b/src/server/infrastructure/indicateur/IndicateurSQLRepository.integration.test.ts
@@ -42,6 +42,8 @@ describe('IndicateurSQLRepository', () => {
           .withEvolutionDateValeurActuelle([date1, date2])
           .withDateValeurInitiale(dateA)
           .withDateValeurActuelle(dateB)
+          .withSource('ma source')
+          .withDescription('ma description')
           .build(),
 
         new IndicateurRowBuilder()
@@ -54,6 +56,8 @@ describe('IndicateurSQLRepository', () => {
           .withEvolutionDateValeurActuelle([date1, date2, date3])
           .withDateValeurInitiale('2017-01-01')
           .withDateValeurActuelle('2018-01-01')
+          .withSource('ma source')
+          .withDescription('ma description')
           .build(),
 
         new IndicateurRowBuilder()
@@ -64,6 +68,8 @@ describe('IndicateurSQLRepository', () => {
           .withEvolutionDateValeurActuelle([date1, date2, date3])
           .withDateValeurInitiale(dateC)
           .withDateValeurActuelle(dateD)
+          .withSource('ma source')
+          .withDescription('ma description')
           .build(),
       ];
 
@@ -75,7 +81,9 @@ describe('IndicateurSQLRepository', () => {
       // THEN
       expect(result.length).toEqual(2);
       expect(result[0].id).toEqual('IND-001');
+      expect(result[0].source).toStrictEqual('ma source');
       expect(result[1].id).toEqual('IND-002');
+      expect(result[1].description).toEqual('ma description');
     });
   });
 

--- a/src/server/infrastructure/indicateur/IndicateurSQLRepository.ts
+++ b/src/server/infrastructure/indicateur/IndicateurSQLRepository.ts
@@ -37,6 +37,8 @@ export default class IndicateurSQLRepository implements IndicateurRepository {
           régionale: {},
           départementale: {},
         },
+        source: row.source,
+        description: row.description,
       });
     });
   }

--- a/src/server/infrastructure/indicateur/IndicateurSQLRepository.ts
+++ b/src/server/infrastructure/indicateur/IndicateurSQLRepository.ts
@@ -39,6 +39,7 @@ export default class IndicateurSQLRepository implements IndicateurRepository {
         },
         source: row.source,
         description: row.description,
+        modeDeCalcul: row.mode_de_calcul,
       });
     });
   }
@@ -47,7 +48,6 @@ export default class IndicateurSQLRepository implements IndicateurRepository {
     const indicateurs: indicateur[] = await this.prisma.indicateur.findMany({
       where: { chantier_id: chantierId, maille: 'NAT' },
     });
-
     return this.mapToDomain(indicateurs);
   }
 

--- a/src/server/infrastructure/test/tools/rowBuilder/IndicateurRowBuilder.ts
+++ b/src/server/infrastructure/test/tools/rowBuilder/IndicateurRowBuilder.ts
@@ -27,6 +27,10 @@ export default class IndicateurRowBuilder {
 
   private _objectifTauxAvancement: number | null = 0;
 
+  private _source: string | null = 'ma source';
+
+  private _description: string | null = 'ma description';
+
   withId(id: string): IndicateurRowBuilder {
     this._id = id;
     return this;
@@ -92,6 +96,17 @@ export default class IndicateurRowBuilder {
     return this;
   }
 
+  withSource(source: string | null): IndicateurRowBuilder {
+    this._source = source;
+    return this;
+  }
+
+  withDescription(description: string | null): IndicateurRowBuilder {
+    this._description = description;
+    return this;
+  }
+
+
   build(): indicateur {
     return {
       id: this._id,
@@ -114,6 +129,8 @@ export default class IndicateurRowBuilder {
       territoire_nom: null,
       evolution_valeur_actuelle: this._evolutionValeurActuelle,
       evolution_date_valeur_actuelle: this._evolutionDateValeurActuelle.map(s => new Date(s)),
+      source: this._source,
+      description: this._description,
     };
   }
 }

--- a/src/server/infrastructure/test/tools/rowBuilder/IndicateurRowBuilder.ts
+++ b/src/server/infrastructure/test/tools/rowBuilder/IndicateurRowBuilder.ts
@@ -31,6 +31,8 @@ export default class IndicateurRowBuilder {
 
   private _description: string | null = 'ma description';
 
+  private _modeDeCalcul: string | null = 'mon mode de calcul';
+
   withId(id: string): IndicateurRowBuilder {
     this._id = id;
     return this;
@@ -106,6 +108,11 @@ export default class IndicateurRowBuilder {
     return this;
   }
 
+  withModeDeCalcul(modeDeCalcul: string | null): IndicateurRowBuilder {
+    this._modeDeCalcul = modeDeCalcul;
+    return this;
+  }
+
 
   build(): indicateur {
     return {
@@ -131,6 +138,7 @@ export default class IndicateurRowBuilder {
       evolution_date_valeur_actuelle: this._evolutionDateValeurActuelle.map(s => new Date(s)),
       source: this._source,
       description: this._description,
+      mode_de_calcul: this._modeDeCalcul,
     };
   }
 }


### PR DESCRIPTION
retire l'indicateur territorialisé qui n'est plus utilisé dans le front
ajoute les champs source, mode de calcul et description dans la table public.indicateur et les expose au front