### PR TITLE
feat: ajoute la barre de progression pour l'avancement de l'année (179)

### DIFF
--- a/src/client/components/PageChantier/Indicateurs/Bloc/useIndicateurBloc.tsx
+++ b/src/client/components/PageChantier/Indicateurs/Bloc/useIndicateurBloc.tsx
@@ -84,16 +84,14 @@ export default function useIndicateurs(détailsIndicateur: Record<CodeInsee, Dé
     reactTableColonnesHelper.accessor('données.avancement.global', {
       header: 'Taux avancement global',
       cell: avancementGlobal => (
-        <>
-          {avancementGlobal.getValue() === null ? '- %' : `${avancementGlobal.getValue()!.toFixed(0)}%`}
-          <BarreDeProgression
-            afficherTexte={false}
-            fond='bleu'
-            taille='moyenne'
-            valeur={avancementGlobal.getValue()}
-            variante='primaire'
-          />
-        </>
+        <BarreDeProgression
+          afficherTexte
+          fond='bleu'
+          positionTexte='dessus'
+          taille='moyenne'
+          valeur={avancementGlobal.getValue()}
+          variante='primaire'
+        />
       ),
       enableSorting: false, 
     }),

--- a/src/client/components/PageChantier/usePageChantier.ts
+++ b/src/client/components/PageChantier/usePageChantier.ts
@@ -49,7 +49,7 @@ export default function usePageChantier(chantier: Chantier) {
   }, [territoiresComparés]);
 
   const donnéesTerritoiresAgrégées = useMemo(() => new AgrégateurChantiersParTerritoire([chantier]).agréger(), [chantier]);
-    
+
   const avancementRégional = () => {
     if (mailleAssociéeAuTerritoireSélectionné === 'régionale')
       return donnéesTerritoiresAgrégées.régionale.territoires[territoireSélectionné.codeInsee].répartition.avancements.global.moyenne;
@@ -65,11 +65,15 @@ export default function usePageChantier(chantier: Chantier) {
 
   const avancements = {
     nationale: {
-      moyenne: donnéesTerritoiresAgrégées.nationale.répartition.avancements.global.moyenne,
-      moyenneAnnuelle: donnéesTerritoiresAgrégées.nationale.répartition.avancements.global.moyenne,
-      médiane: donnéesTerritoiresAgrégées[mailleSélectionnée].répartition.avancements.global.médiane,
-      minimum: donnéesTerritoiresAgrégées[mailleSélectionnée].répartition.avancements.global.minimum,
-      maximum: donnéesTerritoiresAgrégées[mailleSélectionnée].répartition.avancements.global.maximum,
+      global: {
+        moyenne: donnéesTerritoiresAgrégées.nationale.répartition.avancements.global.moyenne,
+        médiane: donnéesTerritoiresAgrégées[mailleSélectionnée].répartition.avancements.global.médiane,
+        minimum: donnéesTerritoiresAgrégées[mailleSélectionnée].répartition.avancements.global.minimum,
+        maximum: donnéesTerritoiresAgrégées[mailleSélectionnée].répartition.avancements.global.maximum,
+      },
+      annuel: {
+        moyenne: donnéesTerritoiresAgrégées.nationale.répartition.avancements.annuel.moyenne,
+      },
     },
     départementale: {
       moyenne: avancementDépartemental(),

--- a/src/client/components/PageChantier/usePageChantier.ts
+++ b/src/client/components/PageChantier/usePageChantier.ts
@@ -52,23 +52,24 @@ export default function usePageChantier(chantier: Chantier) {
     
   const avancementRégional = () => {
     if (mailleAssociéeAuTerritoireSélectionné === 'régionale')
-      return donnéesTerritoiresAgrégées.régionale.territoires[territoireSélectionné.codeInsee].répartition.avancements.moyenne;
+      return donnéesTerritoiresAgrégées.régionale.territoires[territoireSélectionné.codeInsee].répartition.avancements.global.moyenne;
 
     if (mailleAssociéeAuTerritoireSélectionné === 'départementale' && territoireSélectionné.codeInseeParent)
-      return donnéesTerritoiresAgrégées.régionale.territoires[territoireSélectionné.codeInseeParent].répartition.avancements.moyenne;
+      return donnéesTerritoiresAgrégées.régionale.territoires[territoireSélectionné.codeInseeParent].répartition.avancements.global.moyenne;
   };
 
   const avancementDépartemental = () => {
     if (mailleAssociéeAuTerritoireSélectionné === 'départementale')
-      return donnéesTerritoiresAgrégées[mailleSélectionnée].territoires[territoireSélectionné.codeInsee].répartition.avancements.moyenne;
+      return donnéesTerritoiresAgrégées[mailleSélectionnée].territoires[territoireSélectionné.codeInsee].répartition.avancements.global.moyenne;
   };
 
   const avancements = {
     nationale: {
-      moyenne: donnéesTerritoiresAgrégées.nationale.répartition.avancements.moyenne,
-      médiane: donnéesTerritoiresAgrégées[mailleSélectionnée].répartition.avancements.médiane,
-      minimum: donnéesTerritoiresAgrégées[mailleSélectionnée].répartition.avancements.minimum,
-      maximum: donnéesTerritoiresAgrégées[mailleSélectionnée].répartition.avancements.maximum,
+      moyenne: donnéesTerritoiresAgrégées.nationale.répartition.avancements.global.moyenne,
+      moyenneAnnuelle: donnéesTerritoiresAgrégées.nationale.répartition.avancements.global.moyenne,
+      médiane: donnéesTerritoiresAgrégées[mailleSélectionnée].répartition.avancements.global.médiane,
+      minimum: donnéesTerritoiresAgrégées[mailleSélectionnée].répartition.avancements.global.minimum,
+      maximum: donnéesTerritoiresAgrégées[mailleSélectionnée].répartition.avancements.global.maximum,
     },
     départementale: {
       moyenne: avancementDépartemental(),

--- a/src/client/components/PageChantiers/TableauChantiers/Avancement/TableauChantiersAvancement.tsx
+++ b/src/client/components/PageChantiers/TableauChantiers/Avancement/TableauChantiersAvancement.tsx
@@ -10,7 +10,7 @@ export default function TableauChantiersAvancement({ avancement }: TableauChanti
         </span>
       ) : (
         <BarreDeProgression
-          fond="gris"
+          fond="blanc"
           taille="petite"
           valeur={avancement}
           variante='primaire'

--- a/src/client/components/PageChantiers/usePageChantiers.tsx
+++ b/src/client/components/PageChantiers/usePageChantiers.tsx
@@ -48,11 +48,15 @@ export default function usePageChantiers(chantiers: Chantier[]) {
   }, [chantiersFiltrés]);
 
   const avancements = {
-    moyenne: donnéesTerritoiresAgrégées[mailleAssociéeAuTerritoireSélectionné].territoires[territoireSélectionné.codeInsee].répartition.avancements.global.moyenne,
-    moyenneAnnuelle: donnéesTerritoiresAgrégées[mailleAssociéeAuTerritoireSélectionné].territoires[territoireSélectionné.codeInsee].répartition.avancements.annuel.moyenne,
-    médiane: donnéesTerritoiresAgrégées[mailleSélectionnée].répartition.avancements.global.médiane,
-    minimum: donnéesTerritoiresAgrégées[mailleSélectionnée].répartition.avancements.global.minimum,
-    maximum: donnéesTerritoiresAgrégées[mailleSélectionnée].répartition.avancements.global.maximum,
+    global: {
+      moyenne: donnéesTerritoiresAgrégées[mailleAssociéeAuTerritoireSélectionné].territoires[territoireSélectionné.codeInsee].répartition.avancements.global.moyenne,
+      médiane: donnéesTerritoiresAgrégées[mailleSélectionnée].répartition.avancements.global.médiane,
+      minimum: donnéesTerritoiresAgrégées[mailleSélectionnée].répartition.avancements.global.minimum,
+      maximum: donnéesTerritoiresAgrégées[mailleSélectionnée].répartition.avancements.global.maximum,
+    },
+    annuel: {
+      moyenne: donnéesTerritoiresAgrégées[mailleAssociéeAuTerritoireSélectionné].territoires[territoireSélectionné.codeInsee].répartition.avancements.annuel.moyenne,
+    },
   };
 
   const météos = donnéesTerritoiresAgrégées[mailleAssociéeAuTerritoireSélectionné].territoires[territoireSélectionné.codeInsee].répartition.météos;

--- a/src/client/components/PageChantiers/usePageChantiers.tsx
+++ b/src/client/components/PageChantiers/usePageChantiers.tsx
@@ -48,17 +48,18 @@ export default function usePageChantiers(chantiers: Chantier[]) {
   }, [chantiersFiltrés]);
 
   const avancements = {
-    moyenne: donnéesTerritoiresAgrégées[mailleAssociéeAuTerritoireSélectionné].territoires[territoireSélectionné.codeInsee].répartition.avancements.moyenne,
-    médiane: donnéesTerritoiresAgrégées[mailleSélectionnée].répartition.avancements.médiane,
-    minimum: donnéesTerritoiresAgrégées[mailleSélectionnée].répartition.avancements.minimum,
-    maximum: donnéesTerritoiresAgrégées[mailleSélectionnée].répartition.avancements.maximum,
+    moyenne: donnéesTerritoiresAgrégées[mailleAssociéeAuTerritoireSélectionné].territoires[territoireSélectionné.codeInsee].répartition.avancements.global.moyenne,
+    moyenneAnnuelle: donnéesTerritoiresAgrégées[mailleAssociéeAuTerritoireSélectionné].territoires[territoireSélectionné.codeInsee].répartition.avancements.annuel.moyenne,
+    médiane: donnéesTerritoiresAgrégées[mailleSélectionnée].répartition.avancements.global.médiane,
+    minimum: donnéesTerritoiresAgrégées[mailleSélectionnée].répartition.avancements.global.minimum,
+    maximum: donnéesTerritoiresAgrégées[mailleSélectionnée].répartition.avancements.global.maximum,
   };
 
   const météos = donnéesTerritoiresAgrégées[mailleAssociéeAuTerritoireSélectionné].territoires[territoireSélectionné.codeInsee].répartition.météos;
 
   const donnéesCartographie = useMemo(() => {
     return objectEntries(donnéesTerritoiresAgrégées[mailleSélectionnée].territoires).map(([codeInsee, territoire]) => ({
-      valeur: territoire.répartition.avancements.moyenne,
+      valeur: territoire.répartition.avancements.global.moyenne,
       codeInsee: codeInsee,
     }));
   }, [donnéesTerritoiresAgrégées, mailleSélectionnée]);

--- a/src/client/components/_commons/Avancements/Avancements.interface.ts
+++ b/src/client/components/_commons/Avancements/Avancements.interface.ts
@@ -1,9 +1,13 @@
 export default interface AvancementsProps {
   avancements: {
-    moyenne: number | null,
-    moyenneAnnuelle: number | null,
-    médiane: number | null,
-    minimum: number | null,
-    maximum: number | null
+    global: {
+      moyenne: number | null,
+      médiane: number | null,
+      minimum: number | null,
+      maximum: number | null
+    },
+    annuel: {
+      moyenne: number | null,
+    }
   }
 }

--- a/src/client/components/_commons/Avancements/Avancements.interface.ts
+++ b/src/client/components/_commons/Avancements/Avancements.interface.ts
@@ -1,6 +1,7 @@
 export default interface AvancementsProps {
   avancements: {
     moyenne: number | null,
+    moyenneAnnuelle: number | null,
     médiane: number | null,
     minimum: number | null,
     maximum: number | null

--- a/src/client/components/_commons/Avancements/Avancements.tsx
+++ b/src/client/components/_commons/Avancements/Avancements.tsx
@@ -1,11 +1,12 @@
 import JaugeDeProgression from '@/components/_commons/JaugeDeProgression/JaugeDeProgression';
+import BarreDeProgression from '@/components/_commons/BarreDeProgression/BarreDeProgression';
 import AvancementsProps from './Avancements.interface';
 
 export default function Avancements({ avancements }: AvancementsProps) {
   return (
     <div className='fr-container'>
-      <div className="fr-grid-row fr-grid-row--gutters">
-        <div className="fr-col-12 fr-col-lg-6 fr-mx-auto">
+      <div className="fr-grid-row fr-grid-row--gutters fr-mb-n4w">
+        <div className="fr-col-12 fr-col-lg-6 fr-mx-auto fr-pb-0">
           <JaugeDeProgression
             couleur='bleu'
             libellé="Taux d'avancement global"
@@ -13,7 +14,7 @@ export default function Avancements({ avancements }: AvancementsProps) {
             taille='grande'
           />
         </div>
-        <div className="fr-col-12 fr-col-lg-6">
+        <div className="fr-col-12 fr-col-lg-6 fr-pb-0">
           <div className="fr-grid-row fr-grid-row--gutters">
             <div className="fr-col-4">
               <JaugeDeProgression
@@ -39,6 +40,19 @@ export default function Avancements({ avancements }: AvancementsProps) {
                 taille='petite'
               />
             </div>
+          </div>
+          <div className='fr-mt-3w'>
+            <BarreDeProgression
+              bordure={null}
+              fond='grisClair'
+              positionTexte='dessus'
+              taille='fine'
+              valeur={30}
+              variante="secondaire"
+            />
+            <p className='fr-text--xs'>
+              Année en cours
+            </p>
           </div>
         </div>
       </div>

--- a/src/client/components/_commons/Avancements/Avancements.tsx
+++ b/src/client/components/_commons/Avancements/Avancements.tsx
@@ -47,7 +47,7 @@ export default function Avancements({ avancements }: AvancementsProps) {
               fond='grisClair'
               positionTexte='dessus'
               taille='fine'
-              valeur={30}
+              valeur={avancements.moyenneAnnuelle}
               variante="secondaire"
             />
             <p className='fr-text--xs'>

--- a/src/client/components/_commons/Avancements/Avancements.tsx
+++ b/src/client/components/_commons/Avancements/Avancements.tsx
@@ -10,7 +10,7 @@ export default function Avancements({ avancements }: AvancementsProps) {
           <JaugeDeProgression
             couleur='bleu'
             libellé="Taux d'avancement global"
-            pourcentage={avancements.moyenne}
+            pourcentage={avancements.global.moyenne}
             taille='grande'
           />
         </div>
@@ -20,7 +20,7 @@ export default function Avancements({ avancements }: AvancementsProps) {
               <JaugeDeProgression
                 couleur='orange'
                 libellé="Minimum"
-                pourcentage={avancements.minimum}
+                pourcentage={avancements.global.minimum}
                 taille='petite'
               />
             </div>
@@ -28,7 +28,7 @@ export default function Avancements({ avancements }: AvancementsProps) {
               <JaugeDeProgression
                 couleur='violet'
                 libellé="Médiane"
-                pourcentage={avancements.médiane}
+                pourcentage={avancements.global.médiane}
                 taille='petite'
               />
             </div>
@@ -36,7 +36,7 @@ export default function Avancements({ avancements }: AvancementsProps) {
               <JaugeDeProgression
                 couleur='vert'
                 libellé="Maximum"
-                pourcentage={avancements.maximum}
+                pourcentage={avancements.global.maximum}
                 taille='petite'
               />
             </div>
@@ -47,7 +47,7 @@ export default function Avancements({ avancements }: AvancementsProps) {
               fond='grisClair'
               positionTexte='dessus'
               taille='fine'
-              valeur={avancements.moyenneAnnuelle}
+              valeur={avancements.annuel.moyenne}
               variante="secondaire"
             />
             <p className='fr-text--xs'>

--- a/src/client/components/_commons/BarreDeProgression/BarreDeProgression.integration.test.tsx
+++ b/src/client/components/_commons/BarreDeProgression/BarreDeProgression.integration.test.tsx
@@ -40,7 +40,7 @@ describe('Barre de progression', () => {
       />,
     );
     const barreDeProgression = document.querySelectorAll('.barre-de-progression')[0];
-    expect(barreDeProgression).toHaveClass('dessus');
+    expect(barreDeProgression).toHaveClass('texte-dessus');
     expect(barreDeProgression).toHaveStyle('flex-direction: column-reverse');
   });
 
@@ -54,7 +54,7 @@ describe('Barre de progression', () => {
       />,
     );
     const barreDeProgression = document.querySelectorAll('.barre-de-progression')[0];
-    expect(barreDeProgression).toHaveClass('côté');
+    expect(barreDeProgression).toHaveClass('texte-côté');
     expect(barreDeProgression).toHaveStyle('flex-direction: row');
   });
 });

--- a/src/client/components/_commons/BarreDeProgression/BarreDeProgression.integration.test.tsx
+++ b/src/client/components/_commons/BarreDeProgression/BarreDeProgression.integration.test.tsx
@@ -1,0 +1,60 @@
+import '@testing-library/jest-dom';
+import { render, within } from '@testing-library/react';
+import BarreDeProgression from '@/components/_commons/BarreDeProgression/BarreDeProgression';
+
+describe('Barre de progression', () => {
+  test('la barre de progression est complété de son pourcentage', () => {
+    render(
+      <BarreDeProgression
+        afficherTexte
+        taille='petite'
+        valeur={20}
+        variante='primaire'
+      />,
+    );
+    const pourcentage = document.querySelectorAll('.pourcentage')[0] as HTMLElement;
+    const valeur = within(pourcentage).getByText('20 %');
+    expect(valeur).toBeInTheDocument();
+  });
+
+  test("la barre de progression n'est pas complété de son pourcentage", () => {
+    render(
+      <BarreDeProgression
+        afficherTexte={false}
+        taille='petite'
+        valeur={20}
+        variante='primaire'
+      />,
+    );
+    const pourcentage = document.querySelectorAll('.pourcentage').length;
+    expect(pourcentage).toBe(0);
+  });
+
+  test('le pourcentage est placé au dessus de la barre de progression', () => {
+    render(
+      <BarreDeProgression
+        positionTexte="dessus"
+        taille='petite'
+        valeur={20}
+        variante='primaire'
+      />,
+    );
+    const barreDeProgression = document.querySelectorAll('.barre-de-progression')[0];
+    expect(barreDeProgression).toHaveClass('dessus');
+    expect(barreDeProgression).toHaveStyle('flex-direction: column-reverse');
+  });
+
+  test('le pourcentage est placé à côté de la barre de progression', () => {
+    render(
+      <BarreDeProgression
+        positionTexte="côté"
+        taille='petite'
+        valeur={20}
+        variante='primaire'
+      />,
+    );
+    const barreDeProgression = document.querySelectorAll('.barre-de-progression')[0];
+    expect(barreDeProgression).toHaveClass('côté');
+    expect(barreDeProgression).toHaveStyle('flex-direction: row');
+  });
+});

--- a/src/client/components/_commons/BarreDeProgression/BarreDeProgression.interface.ts
+++ b/src/client/components/_commons/BarreDeProgression/BarreDeProgression.interface.ts
@@ -1,7 +1,8 @@
 export type BarreDeProgressionTaille = 'fine' | 'petite' | 'moyenne' | 'grande';
 export type BarreDeProgressionVariante = 'primaire' | 'secondaire';
-export type BarreDeProgressionFond = 'bleu' | 'blanc' | 'gris' | 'grisClair';
-export type BarreDeProgressionBordure = 'bleu' | 'gris' | null;
+export type BarreDeProgressionFond = 'bleu' | 'blanc' | 'grisMoyen' | 'grisClair';
+export type BarreDeProgressionBordure = 'bleu' | 'grisMoyen' | null;
+export type BarreDeProgressionPositionTexte = 'côté' | 'dessus';
 
 
 export default interface BarreDeProgressionProps {
@@ -10,7 +11,7 @@ export default interface BarreDeProgressionProps {
   fond?: BarreDeProgressionFond,
   bordure?: BarreDeProgressionBordure,
   valeur: number | null,
-  positionTexte? : 'côté' | 'dessus',
+  positionTexte? : BarreDeProgressionPositionTexte,
   afficherTexte?: boolean,
 }
 
@@ -18,6 +19,6 @@ export type BarreDeProgressionStyledProps = {
   variante: BarreDeProgressionVariante
   fond: BarreDeProgressionFond,
   bordure: BarreDeProgressionBordure,
-  positionTexte : 'côté' | 'dessus',
+  positionTexte : BarreDeProgressionPositionTexte,
   taille: BarreDeProgressionTaille,
 };

--- a/src/client/components/_commons/BarreDeProgression/BarreDeProgression.interface.ts
+++ b/src/client/components/_commons/BarreDeProgression/BarreDeProgression.interface.ts
@@ -1,17 +1,23 @@
-export type BarreDeProgressionTaille = 'petite' | 'moyenne' | 'grande';
+export type BarreDeProgressionTaille = 'fine' | 'petite' | 'moyenne' | 'grande';
 export type BarreDeProgressionVariante = 'primaire' | 'secondaire';
-export type BarreDeProgressionFond = 'bleu' | 'gris';
+export type BarreDeProgressionFond = 'bleu' | 'blanc' | 'gris' | 'grisClair';
+export type BarreDeProgressionBordure = 'bleu' | 'gris' | null;
+
 
 export default interface BarreDeProgressionProps {
   taille: BarreDeProgressionTaille,
   variante: BarreDeProgressionVariante,
   fond?: BarreDeProgressionFond,
+  bordure?: BarreDeProgressionBordure,
   valeur: number | null,
+  positionTexte? : 'côté' | 'dessus',
   afficherTexte?: boolean,
 }
 
 export type BarreDeProgressionStyledProps = {
   variante: BarreDeProgressionVariante
   fond: BarreDeProgressionFond,
+  bordure: BarreDeProgressionBordure,
+  positionTexte : 'côté' | 'dessus',
   taille: BarreDeProgressionTaille,
 };

--- a/src/client/components/_commons/BarreDeProgression/BarreDeProgression.styled.ts
+++ b/src/client/components/_commons/BarreDeProgression/BarreDeProgression.styled.ts
@@ -4,58 +4,43 @@ import { BarreDeProgressionStyledProps } from './BarreDeProgression.interface';
 const borderRadius = '0.375rem';
 
 const couleurDeFond = {
-  'bleu': {
-    remplissage: 'var(--blue-ecume-850-200)',
-    contour: 'var(--blue-ecume-850-200)',
-  },
-  'gris': {
-    remplissage: 'var(--background-disabled-grey)',
-    contour: '#bababa',
-  },
+  'bleu': 'var(--blue-ecume-850-200)',
+  'blanc': '#ffffff',
+  'gris': '#bababa',
+  'grisClair' : '#E5E5E5',
 };
 
-const couleurDeBarre = {
+const couleurBordure = {
+  'bleu' : 'var(--blue-ecume-850-200)',
+  'gris' : '#bababa',
+};
+
+const couleurDeBarreEtTexte = {
   'primaire': 'var(--background-action-high-blue-france)',
-  'secondaire': '#5f5ff1',
+  'secondaire': 'var(--grey-625-425)',
 };
 
 export const dimensions = {
+  fine: { hauteur: '0.5rem', largeurTexte: '2.75rem', classNameDsfr: 'fr-text--xxs' },
   petite: { hauteur: '0.75rem', largeurTexte: '2.75rem', classNameDsfr: 'fr-text--xs' },
   moyenne: { hauteur: '0.75rem', largeurTexte: '4rem', classNameDsfr: 'fr-h4' },
   grande: { hauteur: '2rem', largeurTexte: '6.5rem', classNameDsfr: 'fr-h1' },
 };
 
-const grandientBarreSecondaire = `
-  linear-gradient(
-    -45deg,
-    #000 5%,
-    ${couleurDeBarre.secondaire} 5%,
-    ${couleurDeBarre.secondaire} 45%,
-    #000 45%,
-    #000 55%,
-    ${couleurDeBarre.secondaire} 55%,
-    ${couleurDeBarre.secondaire} 95%,
-    #000 95%
-  )
-`;
-
 const BarreDeProgressionStyled = styled.div<BarreDeProgressionStyledProps>`
   max-width: 100%;
-
+  
   .barre {
-    flex-grow: 1;
-    max-width: 12.5rem;
-
     progress {
       display: block;
       width: 100%;
       height: ${props => dimensions[props.taille].hauteur};
-      background-color: ${props => couleurDeFond[props.fond].remplissage};
-      border: 1px solid ${props => couleurDeFond[props.fond].contour};
+      background-color: ${props => couleurDeFond[props.fond]};
+      border: ${props => props.bordure ? `1px solid ${couleurBordure[props.bordure]}` : 'none'};
       border-radius: ${borderRadius};
 
       &::-webkit-progress-bar {
-        background-color: ${props => couleurDeFond[props.fond].remplissage};
+        background-color: ${props => couleurDeFond[props.fond]};
         border-radius: ${borderRadius};
       }
 
@@ -68,19 +53,15 @@ const BarreDeProgressionStyled = styled.div<BarreDeProgressionStyledProps>`
       }
 
       &[value]::-moz-progress-bar {
-        background-color: ${props => props.variante === 'secondaire' ? null : couleurDeBarre[props.variante]};
-        background-image: ${props => props.variante === 'secondaire' ? grandientBarreSecondaire : null};
-        background-size: ${props => props.variante === 'secondaire' ? '8px 8px' : null};
+        background-color: ${props => couleurDeBarreEtTexte[props.variante]};
       }
 
       &[value]::-webkit-progress-value {
-        background-color: ${props => props.variante === 'secondaire' ? null : couleurDeBarre[props.variante]};
-        background-image: ${props => props.variante === 'secondaire' ? grandientBarreSecondaire : null};
-        background-size: ${props => props.variante === 'secondaire' ? '8px 8px' : null};
+        background-color: ${props => couleurDeBarreEtTexte[props.variante]};
       }
 
       &:not([value])::-moz-progress-bar {
-        background-color: ${props => couleurDeFond[props.fond].remplissage};
+        background-color: ${props => couleurDeFond[props.fond]};
       }
     }
 
@@ -88,20 +69,35 @@ const BarreDeProgressionStyled = styled.div<BarreDeProgressionStyledProps>`
       height: 0;
     }
   }
-
-  .pourcentage {
-    flex-grow: 0;
-    flex-shrink: 0;
-
-    p {
-      width: ${props => dimensions[props.taille].largeurTexte};
-      padding-left: 0.5em;
-      color: ${props => couleurDeBarre[props.variante]};
-      text-align: right;
-      white-space: nowrap;
-      vertical-align: middle;
+  
+  .pourcentage{
+    p{
+      color: ${props => couleurDeBarreEtTexte[props.variante]};
     }
   }
+  
+  &.côté{
+    align-items: center;
+
+    .barre{
+      flex-grow: 1;
+      max-width: 12.5rem;
+    }
+
+    .pourcentage {
+      p {
+        padding-left: 0.5em;
+        text-align: right;
+        white-space: nowrap;
+        vertical-align: middle;
+      }
+    }
+  }
+  
+  &.dessus{
+    flex-direction: column-reverse;
+  }
+  
 `;
 
 export default BarreDeProgressionStyled;

--- a/src/client/components/_commons/BarreDeProgression/BarreDeProgression.styled.ts
+++ b/src/client/components/_commons/BarreDeProgression/BarreDeProgression.styled.ts
@@ -6,13 +6,13 @@ const borderRadius = '0.375rem';
 const couleurDeFond = {
   'bleu': 'var(--blue-ecume-850-200)',
   'blanc': '#ffffff',
-  'gris': '#bababa',
+  'grisMoyen': '#bababa',
   'grisClair' : '#E5E5E5',
 };
 
 const couleurBordure = {
   'bleu' : 'var(--blue-ecume-850-200)',
-  'gris' : '#bababa',
+  'grisMoyen' : '#bababa',
 };
 
 const couleurDeBarreEtTexte = {
@@ -21,7 +21,7 @@ const couleurDeBarreEtTexte = {
 };
 
 export const dimensions = {
-  fine: { hauteur: '0.5rem', largeurTexte: '2.75rem', classNameDsfr: 'fr-text--xxs' },
+  fine: { hauteur: '0.5rem', largeurTexte: '2.75rem', classNameDsfr: 'fr-text--xs' },
   petite: { hauteur: '0.75rem', largeurTexte: '2.75rem', classNameDsfr: 'fr-text--xs' },
   moyenne: { hauteur: '0.75rem', largeurTexte: '4rem', classNameDsfr: 'fr-h4' },
   grande: { hauteur: '2rem', largeurTexte: '6.5rem', classNameDsfr: 'fr-h1' },
@@ -61,7 +61,7 @@ const BarreDeProgressionStyled = styled.div<BarreDeProgressionStyledProps>`
       }
 
       &:not([value])::-moz-progress-bar {
-        background-color: ${props => couleurDeFond[props.fond]}0;
+        background-color: ${props => couleurDeFond[props.fond]};
       }
     }
 
@@ -72,11 +72,11 @@ const BarreDeProgressionStyled = styled.div<BarreDeProgressionStyledProps>`
   
   .pourcentage{
     p{
-      color: ${props => couleurDeFond[props.fond]}1;
+      color: ${props => couleurDeFond[props.fond]};
     }
   }
   
-  &.côté{
+  &.texte-côté{
     flex-direction: row;
     align-items: center;
 
@@ -95,7 +95,7 @@ const BarreDeProgressionStyled = styled.div<BarreDeProgressionStyledProps>`
     }
   }
   
-  &.dessus{
+  &.texte-dessus{
     flex-direction: column-reverse;
   }
   

--- a/src/client/components/_commons/BarreDeProgression/BarreDeProgression.styled.ts
+++ b/src/client/components/_commons/BarreDeProgression/BarreDeProgression.styled.ts
@@ -61,7 +61,7 @@ const BarreDeProgressionStyled = styled.div<BarreDeProgressionStyledProps>`
       }
 
       &:not([value])::-moz-progress-bar {
-        background-color: ${props => couleurDeFond[props.fond]};
+        background-color: ${props => couleurDeFond[props.fond]}0;
       }
     }
 
@@ -72,11 +72,12 @@ const BarreDeProgressionStyled = styled.div<BarreDeProgressionStyledProps>`
   
   .pourcentage{
     p{
-      color: ${props => couleurDeBarreEtTexte[props.variante]};
+      color: ${props => couleurDeFond[props.fond]}1;
     }
   }
   
   &.côté{
+    flex-direction: row;
     align-items: center;
 
     .barre{

--- a/src/client/components/_commons/BarreDeProgression/BarreDeProgression.tsx
+++ b/src/client/components/_commons/BarreDeProgression/BarreDeProgression.tsx
@@ -15,7 +15,7 @@ export default function BarreDeProgression({
   return (
     <BarreDeProgressionStyled
       bordure={bordure}
-      className={`flex fr-pb-1v ${positionTexte}`}
+      className={`barre-de-progression flex fr-pb-1v ${positionTexte}`}
       fond={fond}
       positionTexte={positionTexte}
       taille={taille}
@@ -31,8 +31,10 @@ export default function BarreDeProgression({
       </div>
       {
         !!afficherTexte && (
-          <div className='pourcentage'>
-            <p className={`${dimensions[taille].classNameDsfr}  fr-mb-0 bold`}>
+          <div className={`pourcentage ${positionTexte}`}>
+            <p
+              className={`${dimensions[taille].classNameDsfr}  fr-mb-0 bold`}
+            >
               {pourcentageAffiché}
             </p>
           </div>

--- a/src/client/components/_commons/BarreDeProgression/BarreDeProgression.tsx
+++ b/src/client/components/_commons/BarreDeProgression/BarreDeProgression.tsx
@@ -4,8 +4,8 @@ import BarreDeProgressionStyled, { dimensions } from './BarreDeProgression.style
 export default function BarreDeProgression({
   taille,
   variante,
-  fond = 'gris',
-  bordure = 'gris',
+  fond = 'grisMoyen',
+  bordure = 'grisMoyen',
   positionTexte = 'côté',
   valeur,
   afficherTexte = true,
@@ -15,7 +15,7 @@ export default function BarreDeProgression({
   return (
     <BarreDeProgressionStyled
       bordure={bordure}
-      className={`barre-de-progression flex fr-pb-1v ${positionTexte}`}
+      className={`barre-de-progression flex fr-pb-1v texte-${positionTexte}`}
       fond={fond}
       positionTexte={positionTexte}
       taille={taille}
@@ -31,9 +31,9 @@ export default function BarreDeProgression({
       </div>
       {
         !!afficherTexte && (
-          <div className={`pourcentage ${positionTexte}`}>
+          <div className={`pourcentage texte-${positionTexte}`}>
             <p
-              className={`${dimensions[taille].classNameDsfr}  fr-mb-0 bold`}
+              className={`${dimensions[taille].classNameDsfr} fr-mb-0 bold`}
             >
               {pourcentageAffiché}
             </p>

--- a/src/client/components/_commons/BarreDeProgression/BarreDeProgression.tsx
+++ b/src/client/components/_commons/BarreDeProgression/BarreDeProgression.tsx
@@ -5,6 +5,8 @@ export default function BarreDeProgression({
   taille,
   variante,
   fond = 'gris',
+  bordure = 'gris',
+  positionTexte = 'côté',
   valeur,
   afficherTexte = true,
 }: BarreDeProgressionProps) {
@@ -12,8 +14,10 @@ export default function BarreDeProgression({
 
   return (
     <BarreDeProgressionStyled
-      className="flex fr-grid-row--middle fr-pb-1v"
+      bordure={bordure}
+      className={`flex fr-pb-1v ${positionTexte}`}
       fond={fond}
+      positionTexte={positionTexte}
       taille={taille}
       variante={variante}
     >

--- a/src/client/utils/chantier/agrégateur/agrégateur.interface.ts
+++ b/src/client/utils/chantier/agrégateur/agrégateur.interface.ts
@@ -4,10 +4,15 @@ import { Météo } from '@/server/domain/météo/Météo.interface';
 import { CodeInsee } from '@/server/domain/territoire/Territoire.interface';
 
 type RépartitionAvancements = {
-  moyenne: number | null,
-  médiane: number | null,
-  minimum: number | null,
-  maximum: number | null,
+  global: {
+    moyenne: number | null,
+    médiane: number | null,
+    minimum: number | null,
+    maximum: number | null,
+  },
+  annuel: {
+    moyenne: number | null,
+  }
 };
 
 type RépartitionMétéos = Record<Météo, number>;

--- a/src/client/utils/chantier/agrégateur/agrégateur.ts
+++ b/src/client/utils/chantier/agrégateur/agrégateur.ts
@@ -8,6 +8,11 @@ import { Maille } from '@/server/domain/maille/Maille.interface';
 import { Météo } from '@/server/domain/météo/Météo.interface';
 import { AgrégatParTerritoire } from './agrégateur.interface';
 
+type AvancementRegroupementDonnéesBrutes = {
+  global: (number | null) [],
+  annuel: (number | null) [],
+};
+
 export class AgrégateurChantiersParTerritoire {
   private agrégat: AgrégatParTerritoire = this._créerAgrégatInitial();
 
@@ -34,14 +39,21 @@ export class AgrégateurChantiersParTerritoire {
 
   private _calculerLesRépartitions() {
     objectEntries(this.agrégat).forEach(([maille, codesInsee]) => {
-      let avancementsPourCetteMaille: (number | null)[] = [];
-     
+      let avancementsPourCetteMaille: AvancementRegroupementDonnéesBrutes = {
+        global: [],
+        annuel: [],
+      };
+
+
       objectEntries(codesInsee.territoires).forEach(([codeInsee, donnéesTerritoire]) => {
-        const avancements = donnéesTerritoire.donnéesBrutes.avancements.map(avancement => avancement.global);
-        avancementsPourCetteMaille = [...avancementsPourCetteMaille, ...avancements];
-  
+        const avancementsGlobaux = donnéesTerritoire.donnéesBrutes.avancements.map(avancement => avancement.global);
+        const avancementsAnnuels = donnéesTerritoire.donnéesBrutes.avancements.map(avancement => avancement.annuel);
+        avancementsPourCetteMaille.global = [...avancementsPourCetteMaille.global, ...avancementsGlobaux];
+        avancementsPourCetteMaille.annuel = [...avancementsPourCetteMaille.annuel, ...avancementsAnnuels];
+
+
         this._calculerLaRépartitionDesMétéosParTerritoire(maille, codeInsee, donnéesTerritoire.donnéesBrutes.météos);
-        this._calculerLaRépartitionDesAvancementsParTerritoire(maille, avancements, codeInsee);
+        this._calculerLaRépartitionDesAvancementsParTerritoire(maille, avancementsPourCetteMaille, codeInsee);
       });
   
       this._calculerLaRépartitionDesAvancementsParMaille(maille, avancementsPourCetteMaille);
@@ -54,28 +66,40 @@ export class AgrégateurChantiersParTerritoire {
     });
   }
 
-  private _calculerLaRépartitionDesAvancementsParTerritoire(maille: Maille, avancements: (number | null)[], codeInsee: string | number) {
-    this.agrégat[maille].territoires[codeInsee].répartition.avancements.minimum = valeurMinimum(avancements);
-    this.agrégat[maille].territoires[codeInsee].répartition.avancements.maximum = valeurMaximum(avancements);
-    this.agrégat[maille].territoires[codeInsee].répartition.avancements.moyenne = calculerMoyenne(avancements);
-    this.agrégat[maille].territoires[codeInsee].répartition.avancements.médiane = calculerMédiane(avancements);
+  private _calculerLaRépartitionDesAvancementsParTerritoire(maille: Maille, avancements: AvancementRegroupementDonnéesBrutes, codeInsee: string | number) {
+
+    this.agrégat[maille].territoires[codeInsee].répartition.avancements.global.minimum = valeurMinimum(avancements.global);
+    this.agrégat[maille].territoires[codeInsee].répartition.avancements.global.maximum = valeurMaximum(avancements.global);
+    this.agrégat[maille].territoires[codeInsee].répartition.avancements.global.moyenne = calculerMoyenne(avancements.global);
+    this.agrégat[maille].territoires[codeInsee].répartition.avancements.global.médiane = calculerMédiane(avancements.global);
+
+    this.agrégat[maille].territoires[codeInsee].répartition.avancements.annuel.moyenne = calculerMédiane(avancements.annuel);
+
   }
 
-  private _calculerLaRépartitionDesAvancementsParMaille(maille: Maille, avancements: (number | null)[]) {
-    this.agrégat[maille].répartition.avancements.minimum = valeurMinimum(avancements);
-    this.agrégat[maille].répartition.avancements.maximum = valeurMaximum(avancements);
-    this.agrégat[maille].répartition.avancements.moyenne = calculerMoyenne(avancements);
-    this.agrégat[maille].répartition.avancements.médiane = calculerMédiane(avancements);
+  private _calculerLaRépartitionDesAvancementsParMaille(maille: Maille, avancements: AvancementRegroupementDonnéesBrutes) {
+    this.agrégat[maille].répartition.avancements.global.minimum = valeurMinimum(avancements.global);
+    this.agrégat[maille].répartition.avancements.global.maximum = valeurMaximum(avancements.global);
+    this.agrégat[maille].répartition.avancements.global.moyenne = calculerMoyenne(avancements.global);
+    this.agrégat[maille].répartition.avancements.global.médiane = calculerMédiane(avancements.global);
+
+    this.agrégat[maille].répartition.avancements.annuel.moyenne = calculerMoyenne(avancements.annuel);
+
   }
 
   private _créerDonnéesInitialesPourUnTerritoire() {
     return {
       répartition: {
         avancements: {
-          moyenne: null,
-          médiane: null,
-          minimum: null,
-          maximum: null,
+          global: {
+            moyenne: null,
+            médiane: null,
+            minimum: null,
+            maximum: null,
+          },
+          annuel: {
+            moyenne: null,
+          },
         },
         météos: {
           'NON_RENSEIGNEE': 0,
@@ -97,10 +121,15 @@ export class AgrégateurChantiersParTerritoire {
     return {
       répartition: {
         avancements: {
-          moyenne: null,
-          médiane: null,
-          minimum: null,
-          maximum: null,
+          global: {
+            moyenne: null,
+            médiane: null,
+            minimum: null,
+            maximum: null,
+          },
+          annuel: {
+            moyenne: null,
+          },
         },
       },
       territoires: Object.fromEntries(

--- a/src/client/utils/chantier/agrégateur/agrégateur.ts
+++ b/src/client/utils/chantier/agrégateur/agrégateur.ts
@@ -73,7 +73,7 @@ export class AgrégateurChantiersParTerritoire {
     this.agrégat[maille].territoires[codeInsee].répartition.avancements.global.moyenne = calculerMoyenne(avancements.global);
     this.agrégat[maille].territoires[codeInsee].répartition.avancements.global.médiane = calculerMédiane(avancements.global);
 
-    this.agrégat[maille].territoires[codeInsee].répartition.avancements.annuel.moyenne = calculerMédiane(avancements.annuel);
+    this.agrégat[maille].territoires[codeInsee].répartition.avancements.annuel.moyenne = calculerMoyenne(avancements.annuel);
 
   }
 


### PR DESCRIPTION
Cette PR ne contient que l'évolution du composant, la fonctionnalité n'est pas présente.
J'ai fait le choix ici de réutiliser la variante "secondaire" plus utilisée dans son état actuel (barre de progression striée).

La complexité vient surtout de la position du pourcentage qui varie (à côté ou bien au dessus), flex direction m'a aidé pour cela. 

C'est un premier jet, il y a de la refacto à faire 