### PR TITLE
feat: implémente la gestion d'habilitations (000)

### DIFF
--- a/doc/adr/002. Politique d'accès.md
+++ b/doc/adr/002. Politique d'accès.md
@@ -1,0 +1,32 @@
+# 002. Politique d'accès
+
+Date : 2023-03-24
+
+## Contexte
+
+Pour la mise en place du système d'autorisation / habilitation, nous avons besoin de :
+
+- Définir la politique de controle d'access
+
+#### Propositions
+
+##### 2 Options:
+###### Tout est bloqué par défaut (white list)
+####### Avantages:
+
+####### Inconvénients:
+
+###### Tout est autorisé par default (black list)
+####### Avantages:
+
+####### Inconvénients:
+- politique de log pour identifier ce qui se passe
+
+
+## Décision
+
+## État
+
+
+## Conséquences
+

--- a/src/database/prisma/schema.prisma
+++ b/src/database/prisma/schema.prisma
@@ -96,3 +96,42 @@ model commentaire {
     maille String
     code_insee String
 }
+
+model utilisateur {
+  id String @id
+  email String
+  profil_id String
+  ministere_id String?
+}
+
+model utilisateur_chantier {
+  utilisateur_id String
+  chantier_id String
+
+  @@id([utilisateur_id, chantier_id])
+}
+
+model utilisateur_territoire {
+  utilisateur_id String
+  chantier_id String
+
+  @@id([utilisateur_id, chantier_id])
+}
+
+model profil {
+  id String @id
+  nom String
+}
+
+model profil_habilitation {
+  profil_id String
+  habilitation_scope_id String
+
+  @@id([profil_id, habilitation_scope_id])
+}
+
+model habilitation_scope {
+  id String @id
+  nom String
+  description String
+}

--- a/src/database/prisma/schema.prisma
+++ b/src/database/prisma/schema.prisma
@@ -97,11 +97,21 @@ model commentaire {
     code_insee String
 }
 
+model territoire {
+  id String @id
+  nom String
+  maille String
+  code_insee String
+  path String
+  utilisateur utilisateur_territoire[]
+}
+
 model utilisateur {
   id String @id
   email String
   profil_id String
   ministere_id String?
+  territoire utilisateur_territoire[]
 }
 
 model utilisateur_chantier {
@@ -112,10 +122,12 @@ model utilisateur_chantier {
 }
 
 model utilisateur_territoire {
+  utilisateur utilisateur @relation(fields: [utilisateur_id], references: [id])
   utilisateur_id String
-  chantier_id String
+  territoire territoire @relation(fields: [territoire_id], references: [id])
+  territoire_id String
 
-  @@id([utilisateur_id, chantier_id])
+  @@id([utilisateur_id, territoire_id])
 }
 
 model profil {


### PR DESCRIPTION
Note : on a remarqué que pour itérer rapidement sur la création de base de données, on pouvait travailler sur le schéma Prisma, le modifier à volonté et faire des `npx prisma db push` pour appliquer les modifications sans créer la migration. Ensuite, quand tout nous paraît bon, on peut générer le ficher SQL de migration avec `npx prisma migrate dev`.

Note : remplace #218

Note : on a aussi découvert `npx prisma studio`, qui lance un serveur Web local d'édition des données, avec `npx prisma db push` ça peut remplacer l'usage de dbeaver pour construire des modèles de données avec des feedback rapides.