### PR TITLE
fix: correction d'un bug si plusieurs responsables (000)

### DIFF
--- a/src/client/components/PageChantier/Responsables/ResponsablesLigne/ResponsablesLigne.tsx
+++ b/src/client/components/PageChantier/Responsables/ResponsablesLigne/ResponsablesLigne.tsx
@@ -13,11 +13,8 @@ export default function ResponsablesLigne({ libellé, contenu }: ResponsablesLig
             ? contenu.map((élément, i) => {
               return (
                 <Fragment key={`responsable-${élément}`}>
-                  {
-                    i === contenu.length - 1
-                      ? élément
-                      : élément + ', '
-                  }
+                  {élément}
+                  {contenu.length - 1 !== i ? ', ' : null}
                 </Fragment>
               );
             })


### PR DESCRIPTION
Corrige des éléments au niveau de la zone "Responsables". Notamment [Object object], qui apparaissait quand il y avait plusieurs responsables (problème de concaténation)