### PR TITLE
fix: corrige des météos incohérentes entre "cartographies" et "météo et synthèse" (289)

### DIFF
--- a/src/client/components/PageChantier/Cartes/Cartes.interface.ts
+++ b/src/client/components/PageChantier/Cartes/Cartes.interface.ts
@@ -1,5 +1,0 @@
-import Chantier from '@/server/domain/chantier/Chantier.interface';
-
-export default interface CartesProps {
-  chantier: Chantier
-}

--- a/src/client/components/PageChantier/PageChantier.tsx
+++ b/src/client/components/PageChantier/PageChantier.tsx
@@ -32,11 +32,13 @@ const listeRubriques: Rubrique[] = [
 
 export default function PageChantier({ chantier, indicateurs, habilitation }: PageChantierProps) {
   const [estOuverteBarreLatérale, setEstOuverteBarreLatérale] = useState(false);
-  const { avancements, détailsIndicateurs, commentaires, synthèseDesRésultats, objectifs } = usePageChantier(chantier);
+  const { avancements, synthèseDesRésultats, cartes, objectifs, détailsIndicateurs, commentaires } = usePageChantier(chantier);
   const mailleAssociéeAuTerritoireSélectionné = mailleAssociéeAuTerritoireSélectionnéTerritoiresStore();
   const territoireSélectionné = territoireSélectionnéTerritoiresStore();
   
   const modeÉcriture = checkAuthorizationChantierScope(habilitation, chantier.id, SCOPE_SAISIE_INDICATEURS);
+
+  console.log(chantier.mailles, cartes);
 
   return (
     <PageChantierStyled className="flex">

--- a/src/client/components/PageChantier/PageChantier.tsx
+++ b/src/client/components/PageChantier/PageChantier.tsx
@@ -8,13 +8,13 @@ import { mailleAssociéeAuTerritoireSélectionnéTerritoiresStore, territoireSé
 import BarreLatéraleEncart from '@/components/_commons/BarreLatérale/BarreLatéraleEncart/BarreLatéraleEncart';
 import Commentaires from '@/components/PageChantier/Commentaires/Commentaires';
 import { SCOPE_SAISIE_INDICATEURS, checkAuthorizationChantierScope } from '@/server/domain/identité/Habilitation';
+import RépartitionGéographique from '@/components/PageChantier/RépartitionGéographique/RépartitionGéographique';
 import AvancementChantier from './AvancementChantier/AvancementChantier';
 import Indicateurs, { listeRubriquesIndicateurs } from './Indicateurs/Indicateurs';
 import PageChantierProps from './PageChantier.interface';
 import Responsables from './Responsables/Responsables';
 import SynthèseDesRésultats from './SynthèseDesRésultats/SynthèseDesRésultats';
 import PageChantierEnTête from './PageChantierEnTête/PageChantierEnTête';
-import Cartes from './Cartes/Cartes';
 import Sommaire from './Sommaire/Sommaire';
 import PageChantierStyled from './PageChantier.styled';
 import usePageChantier from './usePageChantier';
@@ -37,8 +37,6 @@ export default function PageChantier({ chantier, indicateurs, habilitation }: Pa
   const territoireSélectionné = territoireSélectionnéTerritoiresStore();
   
   const modeÉcriture = checkAuthorizationChantierScope(habilitation, chantier.id, SCOPE_SAISIE_INDICATEURS);
-
-  console.log(chantier.mailles, cartes);
 
   return (
     <PageChantierStyled className="flex">
@@ -76,11 +74,14 @@ export default function PageChantier({ chantier, indicateurs, habilitation }: Pa
               />
             </div>
           </div>
-          <div className="fr-grid-row fr-grid-row--gutters fr-my-0 fr-pb-1w">
-            <div className="fr-col-12">
-              <Cartes chantier={chantier} />
+          {
+            cartes !== null &&
+            <div className="fr-grid-row fr-grid-row--gutters fr-my-0 fr-pb-1w">
+              <div className="fr-col-12">
+                <RépartitionGéographique données={cartes} />
+              </div>
             </div>
-          </div>
+          }
           {
             objectifs !== null && 
             <div className="fr-grid-row fr-grid-row--gutters fr-my-0 fr-pb-1w">

--- a/src/client/components/PageChantier/PageChantier.tsx
+++ b/src/client/components/PageChantier/PageChantier.tsx
@@ -32,7 +32,7 @@ const listeRubriques: Rubrique[] = [
 
 export default function PageChantier({ chantier, indicateurs, habilitation }: PageChantierProps) {
   const [estOuverteBarreLatérale, setEstOuverteBarreLatérale] = useState(false);
-  const { avancements, synthèseDesRésultats, cartes, objectifs, détailsIndicateurs, commentaires } = usePageChantier(chantier);
+  const { avancements, synthèseDesRésultats, répartitionGéographique, objectifs, détailsIndicateurs, commentaires } = usePageChantier(chantier);
   const mailleAssociéeAuTerritoireSélectionné = mailleAssociéeAuTerritoireSélectionnéTerritoiresStore();
   const territoireSélectionné = territoireSélectionnéTerritoiresStore();
   
@@ -75,10 +75,13 @@ export default function PageChantier({ chantier, indicateurs, habilitation }: Pa
             </div>
           </div>
           {
-            cartes !== null &&
+            répartitionGéographique !== null &&
             <div className="fr-grid-row fr-grid-row--gutters fr-my-0 fr-pb-1w">
               <div className="fr-col-12">
-                <RépartitionGéographique données={cartes} />
+                <RépartitionGéographique
+                  avancementsGlobauxTerritoriaux={répartitionGéographique.avancementsGlobauxTerritoriaux}
+                  météosTerritoriales={répartitionGéographique.météosTerritoriales}
+                />
               </div>
             </div>
           }

--- a/src/client/components/PageChantier/PageChantier.tsx
+++ b/src/client/components/PageChantier/PageChantier.tsx
@@ -32,7 +32,15 @@ const listeRubriques: Rubrique[] = [
 
 export default function PageChantier({ chantier, indicateurs, habilitation }: PageChantierProps) {
   const [estOuverteBarreLatérale, setEstOuverteBarreLatérale] = useState(false);
-  const { avancements, synthèseDesRésultats, répartitionGéographique, objectifs, détailsIndicateurs, commentaires } = usePageChantier(chantier);
+  const {
+    avancements,
+    synthèseDesRésultats,
+    répartitionGéographique,
+    objectifs,
+    détailsIndicateurs,
+    commentaires,
+    refetchRépartitionGéographique,
+  } = usePageChantier(chantier);
   const mailleAssociéeAuTerritoireSélectionné = mailleAssociéeAuTerritoireSélectionnéTerritoiresStore();
   const territoireSélectionné = territoireSélectionnéTerritoiresStore();
   
@@ -70,6 +78,7 @@ export default function PageChantier({ chantier, indicateurs, habilitation }: Pa
             <div className={`${mailleAssociéeAuTerritoireSélectionné === 'nationale' ? 'fr-col-xl-12' : 'fr-col-xl-6'} fr-col-12`}>
               <SynthèseDesRésultats
                 modeÉcriture={modeÉcriture}
+                refetchRépartitionGéographique={refetchRépartitionGéographique}
                 synthèseDesRésultatsInitiale={synthèseDesRésultats}
               />
             </div>

--- a/src/client/components/PageChantier/RépartitionGéographique/RépartitionGéographique.interface.ts
+++ b/src/client/components/PageChantier/RépartitionGéographique/RépartitionGéographique.interface.ts
@@ -4,12 +4,6 @@ import { Météo } from '@/server/domain/météo/Météo.interface';
 import Avancement from '@/server/domain/avancement/Avancement.interface';
 
 export default interface CartesProps {
-  avancementsGlobauxTerritoriaux: Record<Maille, Record<CodeInsee, {
-    codeInsee: CodeInsee,
-    avancementGlobal: Avancement['global'],
-  }>>,
-  météosTerritoriales: Record<Maille, Record<CodeInsee, {
-    codeInsee: CodeInsee,
-    météo: Météo,
-  }>>
+  avancementsGlobauxTerritoriaux: Record<Maille, Record<CodeInsee, Avancement['global']>>,
+  météosTerritoriales: Record<Maille, Record<CodeInsee, Météo>>
 }

--- a/src/client/components/PageChantier/RépartitionGéographique/RépartitionGéographique.interface.ts
+++ b/src/client/components/PageChantier/RépartitionGéographique/RépartitionGéographique.interface.ts
@@ -1,0 +1,9 @@
+import { Maille } from '@/server/domain/maille/Maille.interface';
+import { CodeInsee } from '@/server/domain/territoire/Territoire.interface';
+import {
+  DonnéesTerritoriales,
+} from '@/server/domain/chantierDonnéesTerritoriales/chantierDonnéesTerritoriales.interface';
+
+export default interface CartesProps {
+  données: Record<Maille, Record<CodeInsee, DonnéesTerritoriales>>,
+}

--- a/src/client/components/PageChantier/RépartitionGéographique/RépartitionGéographique.interface.ts
+++ b/src/client/components/PageChantier/RépartitionGéographique/RépartitionGéographique.interface.ts
@@ -1,9 +1,15 @@
 import { Maille } from '@/server/domain/maille/Maille.interface';
 import { CodeInsee } from '@/server/domain/territoire/Territoire.interface';
-import {
-  DonnéesTerritoriales,
-} from '@/server/domain/chantierDonnéesTerritoriales/chantierDonnéesTerritoriales.interface';
+import { Météo } from '@/server/domain/météo/Météo.interface';
+import Avancement from '@/server/domain/avancement/Avancement.interface';
 
 export default interface CartesProps {
-  données: Record<Maille, Record<CodeInsee, DonnéesTerritoriales>>,
+  avancementsGlobauxTerritoriaux: Record<Maille, Record<CodeInsee, {
+    codeInsee: CodeInsee,
+    avancementGlobal: Avancement['global'],
+  }>>,
+  météosTerritoriales: Record<Maille, Record<CodeInsee, {
+    codeInsee: CodeInsee,
+    météo: Météo,
+  }>>
 }

--- a/src/client/components/PageChantier/RépartitionGéographique/RépartitionGéographique.tsx
+++ b/src/client/components/PageChantier/RépartitionGéographique/RépartitionGéographique.tsx
@@ -5,18 +5,18 @@ import CartographieAvancement from '@/components/_commons/Cartographie/Cartograp
 import CartographieMétéo from '@/components/_commons/Cartographie/CartographieMétéo/CartographieMétéo';
 import Titre from '@/components/_commons/Titre/Titre';
 import useCartographie from '@/components/_commons/Cartographie/useCartographie';
-import CartesProps from './Cartes.interface';
+import RépartitionGéographiqueProps from './RépartitionGéographique.interface';
 
-export default function Cartes({ chantier }: CartesProps) {
+export default function RépartitionGéographique({ données }: RépartitionGéographiqueProps) {
   const mailleSélectionnée = mailleSélectionnéeTerritoiresStore();
   const { auClicTerritoireCallback } = useCartographie();
 
-  const donnéesCartographieAvancement = objectEntries(chantier.mailles[mailleSélectionnée]).map(([codeInsee, territoire]) => ({
+  const donnéesCartographieAvancement = objectEntries(données[mailleSélectionnée]).map(([codeInsee, territoire]) => ({
     valeur: territoire.avancement.global,
     codeInsee: codeInsee,
   }));
 
-  const donnéesCartographieMétéo = objectEntries(chantier.mailles[mailleSélectionnée]).map(([codeInsee, territoire]) => ({
+  const donnéesCartographieMétéo = objectEntries(données[mailleSélectionnée]).map(([codeInsee, territoire]) => ({
     valeur: territoire.météo,
     codeInsee: codeInsee,
   }));

--- a/src/client/components/PageChantier/RépartitionGéographique/RépartitionGéographique.tsx
+++ b/src/client/components/PageChantier/RépartitionGéographique/RépartitionGéographique.tsx
@@ -7,17 +7,17 @@ import Titre from '@/components/_commons/Titre/Titre';
 import useCartographie from '@/components/_commons/Cartographie/useCartographie';
 import RépartitionGéographiqueProps from './RépartitionGéographique.interface';
 
-export default function RépartitionGéographique({ données }: RépartitionGéographiqueProps) {
+export default function RépartitionGéographique({ avancementsGlobauxTerritoriaux, météosTerritoriales }: RépartitionGéographiqueProps) {
   const mailleSélectionnée = mailleSélectionnéeTerritoiresStore();
   const { auClicTerritoireCallback } = useCartographie();
 
-  const donnéesCartographieAvancement = objectEntries(données[mailleSélectionnée]).map(([codeInsee, territoire]) => ({
-    valeur: territoire.avancement.global,
+  const donnéesCartographieAvancement = objectEntries(avancementsGlobauxTerritoriaux[mailleSélectionnée]).map(([codeInsee, donnéesTerritoriales]) => ({
+    valeur: donnéesTerritoriales.avancementGlobal,
     codeInsee: codeInsee,
   }));
 
-  const donnéesCartographieMétéo = objectEntries(données[mailleSélectionnée]).map(([codeInsee, territoire]) => ({
-    valeur: territoire.météo,
+  const donnéesCartographieMétéo = objectEntries(météosTerritoriales[mailleSélectionnée]).map(([codeInsee, donnéesTerritoriales]) => ({
+    valeur: donnéesTerritoriales.météo,
     codeInsee: codeInsee,
   }));
 

--- a/src/client/components/PageChantier/RépartitionGéographique/RépartitionGéographique.tsx
+++ b/src/client/components/PageChantier/RépartitionGéographique/RépartitionGéographique.tsx
@@ -11,13 +11,13 @@ export default function RépartitionGéographique({ avancementsGlobauxTerritoria
   const mailleSélectionnée = mailleSélectionnéeTerritoiresStore();
   const { auClicTerritoireCallback } = useCartographie();
 
-  const donnéesCartographieAvancement = objectEntries(avancementsGlobauxTerritoriaux[mailleSélectionnée]).map(([codeInsee, donnéesTerritoriales]) => ({
-    valeur: donnéesTerritoriales.avancementGlobal,
+  const donnéesCartographieAvancement = objectEntries(avancementsGlobauxTerritoriaux[mailleSélectionnée]).map(([codeInsee, avancementGlobal]) => ({
+    valeur: avancementGlobal,
     codeInsee: codeInsee,
   }));
 
-  const donnéesCartographieMétéo = objectEntries(météosTerritoriales[mailleSélectionnée]).map(([codeInsee, donnéesTerritoriales]) => ({
-    valeur: donnéesTerritoriales.météo,
+  const donnéesCartographieMétéo = objectEntries(météosTerritoriales[mailleSélectionnée]).map(([codeInsee, météo]) => ({
+    valeur: météo,
     codeInsee: codeInsee,
   }));
 

--- a/src/client/components/PageChantier/SynthèseDesRésultats/SynthèseDesRésultats.interface.ts
+++ b/src/client/components/PageChantier/SynthèseDesRésultats/SynthèseDesRésultats.interface.ts
@@ -3,4 +3,5 @@ import SynthèseDesRésultats from '@/server/domain/synthèseDesRésultats/Synth
 export interface SynthèseDesRésultatsProps {
   synthèseDesRésultatsInitiale: SynthèseDesRésultats
   modeÉcriture: boolean
+  refetchRépartitionGéographique: () => void
 }

--- a/src/client/components/PageChantier/SynthèseDesRésultats/SynthèseDesRésultats.tsx
+++ b/src/client/components/PageChantier/SynthèseDesRésultats/SynthèseDesRésultats.tsx
@@ -11,7 +11,7 @@ import useSynthèseDesRésultats from '@/components/PageChantier/SynthèseDesRé
 import Alerte from '@/components/_commons/Alerte/Alerte';
 import SynthèseDesRésultatsFormulaire from './SynthèseDesRésultatsFormulaire/SynthèseDesRésultatsFormulaire';
 
-export default function SynthèseDesRésultats({ synthèseDesRésultatsInitiale, modeÉcriture }: SynthèseDesRésultatsProps) {
+export default function SynthèseDesRésultats({ synthèseDesRésultatsInitiale, modeÉcriture, refetchRépartitionGéographique }: SynthèseDesRésultatsProps) {
   const {
     synthèseDesRésultats,
     nomTerritoireSélectionné,
@@ -20,7 +20,7 @@ export default function SynthèseDesRésultats({ synthèseDesRésultatsInitiale,
     synthèseDesRésultatsCréée,
     activerLeModeÉdition,
     désactiverLeModeÉdition,
-  } = useSynthèseDesRésultats(synthèseDesRésultatsInitiale);
+  } = useSynthèseDesRésultats(synthèseDesRésultatsInitiale, refetchRépartitionGéographique);
 
   return (
     <SynthèseDesRésultatsStyled id="synthèse">

--- a/src/client/components/PageChantier/SynthèseDesRésultats/useSynthèseDesRésultats.ts
+++ b/src/client/components/PageChantier/SynthèseDesRésultats/useSynthèseDesRésultats.ts
@@ -3,7 +3,7 @@ import AlerteProps from '@/components/_commons/Alerte/Alerte.interface';
 import SynthèseDesRésultats from '@/server/domain/synthèseDesRésultats/SynthèseDesRésultats.interface';
 import { territoireSélectionnéTerritoiresStore } from '@/stores/useTerritoiresStore/useTerritoiresStore';
 
-export default function useSynthèseDesRésultats(synthèseDesRésultatsInitiale: SynthèseDesRésultats) {
+export default function useSynthèseDesRésultats(synthèseDesRésultatsInitiale: SynthèseDesRésultats, refetchRépartitionGéographique: () => void) {
   const territoireSélectionné = territoireSélectionnéTerritoiresStore();
 
   const [modeÉdition, setModeÉdition] = useState(false);
@@ -25,6 +25,7 @@ export default function useSynthèseDesRésultats(synthèseDesRésultatsInitiale
       message: 'Météo et synthèse des résultats publiées',
     });
     désactiverLeModeÉdition();
+    refetchRépartitionGéographique();
   };
 
   useEffect(() => {

--- a/src/client/components/PageChantier/usePageChantier.ts
+++ b/src/client/components/PageChantier/usePageChantier.ts
@@ -43,11 +43,13 @@ export default function usePageChantier(chantier: Chantier) {
     { refetchOnWindowFocus: false },
   );
 
-  const { data: répartitionGéographique } = api.chantierDonnéesTerritoriales.récupérerRépartitionGéographique.useQuery(
+  const { data: répartitionGéographique, refetch: refetchRépartitionGéographique } = api.chantierDonnéesTerritoriales.récupérerRépartitionGéographique.useQuery(
     {
       chantierId: chantier.id,
     },
-    { refetchOnWindowFocus: false },
+    {
+      refetchOnWindowFocus: false,
+    },
   );
 
   useEffect(() => {
@@ -107,5 +109,6 @@ export default function usePageChantier(chantier: Chantier) {
     objectifs: objectifs ?? null,
     détailsIndicateurs,
     commentaires: commentaires ?? null,
+    refetchRépartitionGéographique,
   };
 }

--- a/src/client/components/PageChantier/usePageChantier.ts
+++ b/src/client/components/PageChantier/usePageChantier.ts
@@ -43,7 +43,7 @@ export default function usePageChantier(chantier: Chantier) {
     { refetchOnWindowFocus: false },
   );
 
-  const { data: cartes } = api.chantierDonnéesTerritoriales.récupérerRépartitionGéographique.useQuery(
+  const { data: répartitionGéographique } = api.chantierDonnéesTerritoriales.récupérerRépartitionGéographique.useQuery(
     {
       chantierId: chantier.id,
     },
@@ -103,7 +103,7 @@ export default function usePageChantier(chantier: Chantier) {
   return { 
     avancements, 
     synthèseDesRésultats: synthèseDesRésultats ?? null,
-    cartes: cartes ?? null,
+    répartitionGéographique: répartitionGéographique ?? null,
     objectifs: objectifs ?? null,
     détailsIndicateurs,
     commentaires: commentaires ?? null,

--- a/src/client/components/PageChantier/usePageChantier.ts
+++ b/src/client/components/PageChantier/usePageChantier.ts
@@ -43,6 +43,13 @@ export default function usePageChantier(chantier: Chantier) {
     { refetchOnWindowFocus: false },
   );
 
+  const { data: cartes } = api.chantierDonnéesTerritoriales.récupérerRépartitionGéographique.useQuery(
+    {
+      chantierId: chantier.id,
+    },
+    { refetchOnWindowFocus: false },
+  );
+
   useEffect(() => {
     if (territoiresComparés.length > 0) return;    
     fetch(`/api/chantier/${chantier.id}/indicateurs?codesInsee=${territoireSélectionné.codeInsee}&maille=${mailleAssociéeAuTerritoireSélectionné}`)
@@ -95,9 +102,10 @@ export default function usePageChantier(chantier: Chantier) {
 
   return { 
     avancements, 
-    détailsIndicateurs, 
-    commentaires: commentaires ?? null,
-    objectifs: objectifs ?? null,
     synthèseDesRésultats: synthèseDesRésultats ?? null,
+    cartes,
+    objectifs: objectifs ?? null,
+    détailsIndicateurs,
+    commentaires: commentaires ?? null,
   };
 }

--- a/src/client/components/PageChantier/usePageChantier.ts
+++ b/src/client/components/PageChantier/usePageChantier.ts
@@ -103,7 +103,7 @@ export default function usePageChantier(chantier: Chantier) {
   return { 
     avancements, 
     synthèseDesRésultats: synthèseDesRésultats ?? null,
-    cartes,
+    cartes: cartes ?? null,
     objectifs: objectifs ?? null,
     détailsIndicateurs,
     commentaires: commentaires ?? null,

--- a/src/server/domain/chantierDonnéesTerritoriales/chantierDonnéesTerritoriales.interface.ts
+++ b/src/server/domain/chantierDonnéesTerritoriales/chantierDonnéesTerritoriales.interface.ts
@@ -1,0 +1,9 @@
+import { CodeInsee } from '@/server/domain/territoire/Territoire.interface';
+import Avancement from '@/server/domain/avancement/Avancement.interface';
+import { Météo } from '@/server/domain/météo/Météo.interface';
+
+export type DonnéesTerritoriales = {
+  codeInsee: CodeInsee,
+  avancement: Avancement,
+  météo: Météo,
+};

--- a/src/server/domain/chantierDonnéesTerritoriales/chantierDonnéesTerritoriales.interface.ts
+++ b/src/server/domain/chantierDonnéesTerritoriales/chantierDonnéesTerritoriales.interface.ts
@@ -1,9 +1,5 @@
-import { CodeInsee } from '@/server/domain/territoire/Territoire.interface';
 import Avancement from '@/server/domain/avancement/Avancement.interface';
-import { Météo } from '@/server/domain/météo/Météo.interface';
 
-export type DonnéesTerritoriales = {
-  codeInsee: CodeInsee,
+export type ChantierDonnéesTerritoriales = {
   avancement: Avancement,
-  météo: Météo,
 };

--- a/src/server/domain/synthèseDesRésultats/SynthèseDesRésultatsRepository.interface.ts
+++ b/src/server/domain/synthèseDesRésultats/SynthèseDesRésultatsRepository.interface.ts
@@ -5,10 +5,7 @@ import SynthèseDesRésultats from './SynthèseDesRésultats.interface';
 
 export default interface SynthèseDesRésultatsRepository {
   récupérerLaPlusRécenteParChantierIdEtTerritoire(chantierId: string, maille: Maille, codeInsee: CodeInsee): Promise<SynthèseDesRésultats>
-  récupérerLesPlusRécentesPourTousLesTerritoires(chantierId: string): Promise<Record<Maille, Record<CodeInsee, {
-    codeInsee: CodeInsee,
-    synthèseDesRésultats: SynthèseDesRésultats,
-  }>>>
+  récupérerLesPlusRécentesPourTousLesTerritoires(chantierId: string): Promise<Record<Maille, Record<CodeInsee, SynthèseDesRésultats>>>
   récupérerHistorique(chantierId: string, maille: Maille, codeInsee: CodeInsee): Promise<SynthèseDesRésultats[]>;
   créer(chantierId: string, maille: Maille, codeInsee: CodeInsee, id: string, contenu: string, auteur: string, météo: Météo, date: Date): Promise<SynthèseDesRésultats>;
 }

--- a/src/server/domain/synthèseDesRésultats/SynthèseDesRésultatsRepository.interface.ts
+++ b/src/server/domain/synthèseDesRésultats/SynthèseDesRésultatsRepository.interface.ts
@@ -5,6 +5,10 @@ import SynthèseDesRésultats from './SynthèseDesRésultats.interface';
 
 export default interface SynthèseDesRésultatsRepository {
   récupérerLaPlusRécenteParChantierIdEtTerritoire(chantierId: string, maille: Maille, codeInsee: CodeInsee): Promise<SynthèseDesRésultats>
+  récupérerLesPlusRécentesPourTousLesTerritoires(chantierId: string): Promise<Record<Maille, Record<CodeInsee, {
+    codeInsee: CodeInsee,
+    synthèseDesRésultats: SynthèseDesRésultats,
+  }>>>
   récupérerHistorique(chantierId: string, maille: Maille, codeInsee: CodeInsee): Promise<SynthèseDesRésultats[]>;
   créer(chantierId: string, maille: Maille, codeInsee: CodeInsee, id: string, contenu: string, auteur: string, météo: Météo, date: Date): Promise<SynthèseDesRésultats>;
 }

--- a/src/server/infrastructure/Dependencies.ts
+++ b/src/server/infrastructure/Dependencies.ts
@@ -37,10 +37,14 @@ import { UtilisateurSQLRepository } from '@/server/infrastructure/accès_donnée
 import { UtilisateurIAMRepository } from '@/server/domain/identité/UtilisateurIAMRepository';
 import UtilisateurIAMKeycloakRepository
   from '@/server/infrastructure/accès_données/identité/UtilisateurIAMKeycloakRepository';
+import ChantierDonnéesTerritorialesSQLRepository from './accès_données/chantierDonnéesTerritoriales/ChantierDonnéesTerritorialesSQLRepository';
+import ChantierDonnéesTerritorialesRepository from './accès_données/chantierDonnéesTerritoriales/ChantierDonnéesTerritorialesRepository.interface';
 import ObjectifSQLRepository from './accès_données/objectif/ObjectifSQLRepository';
 
 class Dependencies {
   private readonly _chantierRepository: ChantierRepository;
+
+  private readonly _chantierDonnéesTerritorialesRepository: ChantierDonnéesTerritorialesRepository;
 
   private readonly _axeRepository: AxeRepository;
 
@@ -68,6 +72,7 @@ class Dependencies {
     logger.debug('Using database.');
     const prisma = new PrismaClient();
     this._chantierRepository = new ChantierSQLRepository(prisma);
+    this._chantierDonnéesTerritorialesRepository = new ChantierDonnéesTerritorialesSQLRepository(prisma);
     this._axeRepository = new AxeSQLRepository(prisma);
     this._ppgRepository = new PpgSQLRepository(prisma);
     this._ministèreRepository = new MinistèreSQLRepository(prisma);
@@ -89,6 +94,10 @@ class Dependencies {
 
   getChantierRepository(): ChantierRepository {
     return this._chantierRepository;
+  }
+
+  getChantierDonnéesTerritorialesRepository(): ChantierDonnéesTerritorialesRepository {
+    return this._chantierDonnéesTerritorialesRepository;
   }
 
   getAxeRepository(): AxeRepository {

--- a/src/server/infrastructure/accès_données/chantierDonnéesTerritoriales/ChantierDonnéesTerritorialesRepository.interface.ts
+++ b/src/server/infrastructure/accès_données/chantierDonnéesTerritoriales/ChantierDonnéesTerritorialesRepository.interface.ts
@@ -1,0 +1,9 @@
+import { Maille } from '@/server/domain/maille/Maille.interface';
+import { CodeInsee } from '@/server/domain/territoire/Territoire.interface';
+import {
+  DonnéesTerritoriales,
+} from '@/server/domain/chantierDonnéesTerritoriales/chantierDonnéesTerritoriales.interface';
+
+export default interface ChantierDonnéesTerritorialesRepository {
+  récupérerTousLesAvancementsDUnChantier(chantierId: string): Promise<Record<Maille, Record<CodeInsee, DonnéesTerritoriales>>>
+}

--- a/src/server/infrastructure/accès_données/chantierDonnéesTerritoriales/ChantierDonnéesTerritorialesRepository.interface.ts
+++ b/src/server/infrastructure/accès_données/chantierDonnéesTerritoriales/ChantierDonnéesTerritorialesRepository.interface.ts
@@ -1,9 +1,12 @@
 import { Maille } from '@/server/domain/maille/Maille.interface';
 import { CodeInsee } from '@/server/domain/territoire/Territoire.interface';
 import {
-  DonnéesTerritoriales,
+  ChantierDonnéesTerritoriales,
 } from '@/server/domain/chantierDonnéesTerritoriales/chantierDonnéesTerritoriales.interface';
 
 export default interface ChantierDonnéesTerritorialesRepository {
-  récupérerTousLesAvancementsDUnChantier(chantierId: string): Promise<Record<Maille, Record<CodeInsee, DonnéesTerritoriales>>>
+  récupérerTousLesAvancementsDUnChantier(chantierId: string): Promise<Record<Maille, Record<CodeInsee, {
+    codeInsee: CodeInsee,
+    chantierDonnéesTerritoriales: ChantierDonnéesTerritoriales,
+  }>>>
 }

--- a/src/server/infrastructure/accès_données/chantierDonnéesTerritoriales/ChantierDonnéesTerritorialesRepository.interface.ts
+++ b/src/server/infrastructure/accès_données/chantierDonnéesTerritoriales/ChantierDonnéesTerritorialesRepository.interface.ts
@@ -5,8 +5,5 @@ import {
 } from '@/server/domain/chantierDonnéesTerritoriales/chantierDonnéesTerritoriales.interface';
 
 export default interface ChantierDonnéesTerritorialesRepository {
-  récupérerTousLesAvancementsDUnChantier(chantierId: string): Promise<Record<Maille, Record<CodeInsee, {
-    codeInsee: CodeInsee,
-    chantierDonnéesTerritoriales: ChantierDonnéesTerritoriales,
-  }>>>
+  récupérerTousLesAvancementsDUnChantier(chantierId: string): Promise<Record<Maille, Record<CodeInsee, ChantierDonnéesTerritoriales>>>
 }

--- a/src/server/infrastructure/accès_données/chantierDonnéesTerritoriales/ChantierDonnéesTerritorialesSQLRepository.ts
+++ b/src/server/infrastructure/accès_données/chantierDonnéesTerritoriales/ChantierDonnéesTerritorialesSQLRepository.ts
@@ -1,10 +1,35 @@
-import { PrismaClient } from '@prisma/client';
+import { PrismaClient, synthese_des_resultats } from '@prisma/client';
 import { Maille } from '@/server/domain/maille/Maille.interface';
-import { CodeInsee } from '@/server/domain/territoire/Territoire.interface';
+import { CodeInsee, Territoires } from '@/server/domain/territoire/Territoire.interface';
 import {
   DonnéesTerritoriales,
 } from '@/server/domain/chantierDonnéesTerritoriales/chantierDonnéesTerritoriales.interface';
+import départements from '@/client/constants/départements.json';
+import régions from '@/client/constants/régions.json';
+import { TerritoireGéographique } from '@/stores/useTerritoiresStore/useTerritoiresStore.interface';
+import { Météo } from '@/server/domain/météo/Météo.interface';
 import ChantierDonnéesTerritorialesRepository from './ChantierDonnéesTerritorialesRepository.interface';
+
+function créerDonnéesTerritoires(
+  territoires: TerritoireGéographique[],
+  avancementsTerritorials: Array<{ code_insee: string, taux_avancement: number | null }>,
+  météosTerritoriales: Array<{ code_insee: string, meteo: string | null }>,
+) {
+  let donnéesTerritoires: Territoires = {};
+
+  territoires.forEach(territoire => {
+    const avancementTerritorial = avancementsTerritorials.find(c => c.code_insee === territoire.codeInsee);
+    const météoTerritoriale = météosTerritoriales.find(s => s.code_insee === territoire.codeInsee);
+
+    donnéesTerritoires[territoire.codeInsee] = {
+      codeInsee: territoire.codeInsee,
+      avancement: { annuel: null, global: avancementTerritorial?.taux_avancement ?? null },
+      météo: météoTerritoriale?.meteo as Météo ?? 'NON_RENSEIGNEE',
+    };
+  });
+
+  return donnéesTerritoires;
+}
 
 export default class ChantierDonnéesTerritorialesSQLRepository implements ChantierDonnéesTerritorialesRepository {
   private prisma: PrismaClient;
@@ -13,11 +38,55 @@ export default class ChantierDonnéesTerritorialesSQLRepository implements Chant
     this.prisma = prisma;
   }
 
-  async récupérerTousLesAvancementsDUnChantier(): Promise<Record<Maille, Record<CodeInsee, DonnéesTerritoriales>>> {
+  async récupérerTousLesAvancementsDUnChantier(chantierId: string): Promise<Record<Maille, Record<CodeInsee, DonnéesTerritoriales>>> {
+    const chantierRows = await this.prisma.chantier.findMany({
+      where: {
+        id: chantierId,
+      },
+    });
+
+    type Row = Pick<synthese_des_resultats, 'maille' | 'code_insee' | 'meteo'>;
+
+    const synthèseDesRésultatsRows = await this.prisma.$queryRaw<Row[]>`
+      with meteos_les_plus_recentes as (
+        select maille, code_insee, max(date_commentaire) as max_date
+        from synthese_des_resultats
+        where chantier_id = ${chantierId}
+        group by maille, code_insee
+      )
+      select maille, code_insee, meteo
+      from synthese_des_resultats as m
+        inner join meteos_les_plus_recentes as m_recentes
+          on m.maille = m_recentes.maille
+            and m.code_insee = m_recentes.code_insee
+            and m.date_commentaire = m_recentes.max_date
+      where chantier_id = ${chantierId}
+    `;
+
+    const chantierMailleNationale = chantierRows.find(c => c.maille === 'NAT');
+    const synthèseDesRésultatsMailleNationale = synthèseDesRésultatsRows.find(s => s.maille === 'NAT');
+
     return {
-      nationale: {},
-      régionale: {},
-      départementale: {},
+      nationale: {
+        FR: {
+          codeInsee: 'FR',
+          avancement: {
+            annuel: null,
+            global: chantierMailleNationale?.taux_avancement ?? null,
+          },
+          météo: synthèseDesRésultatsMailleNationale?.meteo as Météo ?? 'NON_RENSEIGNEE',
+        },
+      },
+      régionale: créerDonnéesTerritoires(
+        régions,
+        chantierRows.filter(c => c.maille === 'REG'),
+        synthèseDesRésultatsRows.filter(s => s.maille === 'REG'),
+      ),
+      départementale: créerDonnéesTerritoires(
+        départements,
+        chantierRows.filter(c => c.maille === 'DEPT'),
+        synthèseDesRésultatsRows.filter(s => s.maille === 'DEPT'),
+      ),
     };
   }
 }

--- a/src/server/infrastructure/accès_données/chantierDonnéesTerritoriales/ChantierDonnéesTerritorialesSQLRepository.ts
+++ b/src/server/infrastructure/accès_données/chantierDonnéesTerritoriales/ChantierDonnéesTerritorialesSQLRepository.ts
@@ -1,0 +1,23 @@
+import { PrismaClient } from '@prisma/client';
+import { Maille } from '@/server/domain/maille/Maille.interface';
+import { CodeInsee } from '@/server/domain/territoire/Territoire.interface';
+import {
+  DonnéesTerritoriales,
+} from '@/server/domain/chantierDonnéesTerritoriales/chantierDonnéesTerritoriales.interface';
+import ChantierDonnéesTerritorialesRepository from './ChantierDonnéesTerritorialesRepository.interface';
+
+export default class ChantierDonnéesTerritorialesSQLRepository implements ChantierDonnéesTerritorialesRepository {
+  private prisma: PrismaClient;
+
+  constructor(prisma: PrismaClient) {
+    this.prisma = prisma;
+  }
+
+  async récupérerTousLesAvancementsDUnChantier(): Promise<Record<Maille, Record<CodeInsee, DonnéesTerritoriales>>> {
+    return {
+      nationale: {},
+      régionale: {},
+      départementale: {},
+    };
+  }
+}

--- a/src/server/infrastructure/accès_données/chantierDonnéesTerritoriales/ChantierDonnéesTerritorialesSQLRepository.ts
+++ b/src/server/infrastructure/accès_données/chantierDonnéesTerritoriales/ChantierDonnéesTerritorialesSQLRepository.ts
@@ -1,5 +1,4 @@
 import { PrismaClient } from '@prisma/client';
-import { Maille } from '@/server/domain/maille/Maille.interface';
 import { CodeInsee } from '@/server/domain/territoire/Territoire.interface';
 import départements from '@/client/constants/départements.json';
 import régions from '@/client/constants/régions.json';
@@ -30,10 +29,7 @@ export default class ChantierDonnéesTerritorialesSQLRepository implements Chant
     };
   }
 
-  async récupérerTousLesAvancementsDUnChantier(chantierId: string): Promise<Record<Maille, Record<CodeInsee, {
-    codeInsee: CodeInsee,
-    chantierDonnéesTerritoriales: ChantierDonnéesTerritoriales,
-  }>>> {
+  async récupérerTousLesAvancementsDUnChantier(chantierId: string) {
     const chantierRows = await this.prisma.chantier.findMany({
       where: {
         id: chantierId,
@@ -44,13 +40,10 @@ export default class ChantierDonnéesTerritorialesSQLRepository implements Chant
 
     return {
       nationale: {
-        FR: {
-          codeInsee: 'FR',
-          chantierDonnéesTerritoriales: chantierMailleNationale ? this.mapperVersDomaine(chantierMailleNationale) : {
-            avancement: {
-              annuel: null,
-              global: null,
-            },
+        FR: chantierMailleNationale ? this.mapperVersDomaine(chantierMailleNationale) : {
+          avancement: {
+            annuel: null,
+            global: null,
           },
         },
       },
@@ -69,18 +62,15 @@ export default class ChantierDonnéesTerritorialesSQLRepository implements Chant
     territoires: TerritoireGéographique[],
     chantierDonnéesTerritoriales: chantier_donnees_territoriales[],
   ) {
-    let donnéesTerritoires: Record<CodeInsee, { codeInsee: CodeInsee, chantierDonnéesTerritoriales: ChantierDonnéesTerritoriales }> = {};
+    let donnéesTerritoires: Record<CodeInsee, ChantierDonnéesTerritoriales> = {};
 
     territoires.forEach(territoire => {
       const avancementTerritorial = chantierDonnéesTerritoriales.find(c => c.code_insee === territoire.codeInsee) ?? null;
 
-      donnéesTerritoires[territoire.codeInsee] = {
-        codeInsee: territoire.codeInsee,
-        chantierDonnéesTerritoriales: avancementTerritorial ? this.mapperVersDomaine(avancementTerritorial) : {
-          avancement: {
-            annuel: null,
-            global: null,
-          },
+      donnéesTerritoires[territoire.codeInsee] = avancementTerritorial ? this.mapperVersDomaine(avancementTerritorial) : {
+        avancement: {
+          annuel: null,
+          global: null,
         },
       };
     });

--- a/src/server/infrastructure/accès_données/synthèseDesRésultats/SynthèseDesRésultatsSQLRepository.ts
+++ b/src/server/infrastructure/accès_données/synthèseDesRésultats/SynthèseDesRésultatsSQLRepository.ts
@@ -66,10 +66,7 @@ export class SynthèseDesRésultatsSQLRepository implements SynthèseDesRésulta
     return this.mapperVersDomaine(synthèseDesRésultats);
   }
 
-  async récupérerLesPlusRécentesPourTousLesTerritoires(chantierId: string): Promise<Record<Maille, Record<CodeInsee, {
-    codeInsee: CodeInsee,
-    synthèseDesRésultats: SynthèseDesRésultats,
-  }>>> {
+  async récupérerLesPlusRécentesPourTousLesTerritoires(chantierId: string) {
     const synthèsesDesRésultats = await this.prisma.$queryRaw<synthese_des_resultats[]>`
       with meteos_les_plus_recentes as (
         select maille, code_insee, max(date_commentaire) as max_date
@@ -90,10 +87,7 @@ export class SynthèseDesRésultatsSQLRepository implements SynthèseDesRésulta
 
     return {
       nationale: {
-        FR: {
-          codeInsee: 'FR',
-          synthèseDesRésultats: this.mapperVersDomaine(synthèsesDesRésultatsMailleNationale),
-        },
+        FR: this.mapperVersDomaine(synthèsesDesRésultatsMailleNationale),
       },
       régionale: this._territorialiser(
         régions,
@@ -125,15 +119,12 @@ export class SynthèseDesRésultatsSQLRepository implements SynthèseDesRésulta
     territoires: TerritoireGéographique[],
     synthèsesDesRésultatsTerritoriales: synthese_des_resultats[],
   ) {
-    let donnéesTerritoires: Record<CodeInsee, { codeInsee: string, synthèseDesRésultats: SynthèseDesRésultats }> = {};
+    let donnéesTerritoires: Record<CodeInsee, SynthèseDesRésultats> = {};
 
     territoires.forEach(territoire => {
       const synthèseTerritoriale = synthèsesDesRésultatsTerritoriales.find(c => c.code_insee === territoire.codeInsee) ?? null;
 
-      donnéesTerritoires[territoire.codeInsee] = {
-        codeInsee: territoire.codeInsee,
-        synthèseDesRésultats: this.mapperVersDomaine(synthèseTerritoriale),
-      };
+      donnéesTerritoires[territoire.codeInsee] = this.mapperVersDomaine(synthèseTerritoriale);
     });
 
     return donnéesTerritoires;

--- a/src/server/infrastructure/api/trpc/routes/chantierDonnéesTerritoriales.ts
+++ b/src/server/infrastructure/api/trpc/routes/chantierDonnéesTerritoriales.ts
@@ -1,0 +1,17 @@
+import {
+  créerRouteurTRPC,
+  procédureProtégée,
+} from '@/server/infrastructure/api/trpc/trpc';
+import { dependencies } from '@/server/infrastructure/Dependencies';
+import { validationChantierDonnéesTerritorialesRépartitionGéographique } from '@/validation/chantierDonnéesTerritoriales';
+import RécupérerChantierRépartitionGéographiqueUseCase
+  from '@/server/usecase/chantierDonnéesTerritoriales/RécupérerChantierRépartitionGéographiqueUseCase';
+
+export const chantierDonnéesTerritorialesRouter = créerRouteurTRPC({
+  récupérerRépartitionGéographique: procédureProtégée
+    .input(validationChantierDonnéesTerritorialesRépartitionGéographique)
+    .query(({ input }) => {
+      const récupérerRépartitionGéographiqueUseCase = new RécupérerChantierRépartitionGéographiqueUseCase(dependencies.getChantierDonnéesTerritorialesRepository());
+      return récupérerRépartitionGéographiqueUseCase.run(input.chantierId);
+    }),
+});

--- a/src/server/infrastructure/api/trpc/routes/routes.ts
+++ b/src/server/infrastructure/api/trpc/routes/routes.ts
@@ -1,9 +1,11 @@
 import { créerRouteurTRPC } from '@/server/infrastructure/api/trpc/trpc';
+import { chantierDonnéesTerritorialesRouter } from './chantierDonnéesTerritoriales';
 import { synthèseDesRésultatsRouter } from './synthèseDesRésultats';
 import { commentaireRouter } from './commentaire';
 import { publicationRouter } from './publication';
 
 export const appRouter = créerRouteurTRPC({
+  chantierDonnéesTerritoriales: chantierDonnéesTerritorialesRouter,
   synthèseDesRésultats: synthèseDesRésultatsRouter,
   commentaire: commentaireRouter,
   publication: publicationRouter,

--- a/src/server/usecase/chantierDonnéesTerritoriales/RécupérerChantierRépartitionGéographiqueUseCase.ts
+++ b/src/server/usecase/chantierDonnéesTerritoriales/RécupérerChantierRépartitionGéographiqueUseCase.ts
@@ -21,30 +21,24 @@ export default class RécupérerChantierRépartitionGéographiqueUseCase {
       this.synthèseDesRésultatsRepository.récupérerLesPlusRécentesPourTousLesTerritoires(chantierId),
     ]);
 
-    let avancementsGlobauxTerritoriaux: Record<Maille, Record<CodeInsee, { codeInsee: string, avancementGlobal: Avancement['global'] }>> = {
+    let avancementsGlobauxTerritoriaux: Record<Maille, Record<CodeInsee, Avancement['global']>> = {
       nationale: {},
       régionale: {},
       départementale: {},
     };
 
-    let météosTerritoriales: Record<Maille, Record<CodeInsee, { codeInsee: string, météo: Météo }>> = {
+    let météosTerritoriales: Record<Maille, Record<CodeInsee, Météo>> = {
       nationale: {},
       régionale: {},
       départementale: {},
     };
 
     for (const maille of mailles) {
-      for (const [codeInsee, données] of objectEntries(chantierDonnéesTerritoriales[maille])) {
-        avancementsGlobauxTerritoriaux[maille][codeInsee] = {
-          codeInsee,
-          avancementGlobal: données.chantierDonnéesTerritoriales.avancement.global,
-        };
+      for (const [codeInsee, donnéesTerritoriales] of objectEntries(chantierDonnéesTerritoriales[maille])) {
+        avancementsGlobauxTerritoriaux[maille][codeInsee] = donnéesTerritoriales.avancement.global;
       }
-      for (const [codeInsee, données] of objectEntries(synthèsesDesRésultatsTerritoriales[maille])) {
-        météosTerritoriales[maille][codeInsee] = {
-          codeInsee,
-          météo: données.synthèseDesRésultats?.météo ?? 'NON_RENSEIGNEE',
-        };
+      for (const [codeInsee, synthèseDesRésultats] of objectEntries(synthèsesDesRésultatsTerritoriales[maille])) {
+        météosTerritoriales[maille][codeInsee] = synthèseDesRésultats?.météo ?? 'NON_RENSEIGNEE';
       }
     }
 

--- a/src/server/usecase/chantierDonnéesTerritoriales/RécupérerChantierRépartitionGéographiqueUseCase.ts
+++ b/src/server/usecase/chantierDonnéesTerritoriales/RécupérerChantierRépartitionGéographiqueUseCase.ts
@@ -1,0 +1,18 @@
+import { dependencies } from '@/server/infrastructure/Dependencies';
+import ChantierDonnéesTerritorialesRepository
+  from '@/server/infrastructure/accès_données/chantierDonnéesTerritoriales/ChantierDonnéesTerritorialesRepository.interface';
+import { Maille } from '@/server/domain/maille/Maille.interface';
+import { CodeInsee } from '@/server/domain/territoire/Territoire.interface';
+import {
+  DonnéesTerritoriales,
+} from '@/server/domain/chantierDonnéesTerritoriales/chantierDonnéesTerritoriales.interface';
+
+export default class RécupérerChantierRépartitionGéographiqueUseCase {
+  constructor(
+    private readonly chantierDonnéesTerritorialesRepository: ChantierDonnéesTerritorialesRepository = dependencies.getChantierDonnéesTerritorialesRepository(),
+  ) {}
+
+  async run(chantierId: string): Promise<Record<Maille, Record<CodeInsee, DonnéesTerritoriales>>> {
+    return this.chantierDonnéesTerritorialesRepository.récupérerTousLesAvancementsDUnChantier(chantierId);
+  }
+}

--- a/src/server/usecase/chantierDonnéesTerritoriales/RécupérerChantierRépartitionGéographiqueUseCase.unit.test.ts
+++ b/src/server/usecase/chantierDonnéesTerritoriales/RécupérerChantierRépartitionGéographiqueUseCase.unit.test.ts
@@ -1,0 +1,80 @@
+import ChantierDonnéesTerritorialesRepository
+  from '@/server/infrastructure/accès_données/chantierDonnéesTerritoriales/ChantierDonnéesTerritorialesRepository.interface';
+import SynthèseDesRésultatsRepository
+  from '@/server/domain/synthèseDesRésultats/SynthèseDesRésultatsRepository.interface';
+import RécupérerChantierRépartitionGéographiqueUseCase from './RécupérerChantierRépartitionGéographiqueUseCase';
+
+const RANDOM_UUID = '123';
+
+jest.mock('node:crypto', () => ({
+  randomUUID: () => RANDOM_UUID,
+}));
+
+describe('RécupérerChantierRépartitionGéographiqueUseCase', () => {
+  test('renvoie la donnée au bon format pour tous les territoires de toutes les mailles', async () => {
+    //GIVEN
+    const chantierId = 'CH-011';
+
+    const stubChantierDonnéesTerritorialesRepository = { récupérerTousLesAvancementsDUnChantier: jest.fn().mockReturnValue({
+      nationale: {
+        FR: { avancement: { global: 0.9, annuel: null } },
+      },
+      régionale: {
+        '01': { avancement: { global: 0.1, annuel: null } },
+      },
+      départementale: {
+        '12': { avancement: { global: 0.2, annuel: null } },
+        '13': { avancement: { global: 0.3, annuel: null } },
+      },
+    }) } as unknown as ChantierDonnéesTerritorialesRepository;
+
+    const stubSynthèseDesRésultatsRepository = { récupérerLesPlusRécentesPourTousLesTerritoires: jest.fn().mockReturnValue({
+      nationale: {
+        FR: { météo: 'SOLEIL' },
+      },
+      régionale: {
+        '01': { météo: 'NUAGE' },
+      },
+      départementale: {
+        '12': { météo: 'NON_RENSEIGNEE' },
+        '13': { météo: 'COUVERT' },
+      },
+    }) } as unknown as SynthèseDesRésultatsRepository;
+
+    const récupérerChantierRépartitionGéographiqueUseCase = new RécupérerChantierRépartitionGéographiqueUseCase(
+      stubChantierDonnéesTerritorialesRepository,
+      stubSynthèseDesRésultatsRepository,
+    );
+
+    //WHEN
+    const répartitionGéographique = await récupérerChantierRépartitionGéographiqueUseCase.run(chantierId);
+
+    //THEN
+    expect(répartitionGéographique).toStrictEqual({
+      avancementsGlobauxTerritoriaux: {
+        nationale: {
+          FR: 0.9,
+        },
+        régionale: {
+          '01': 0.1,
+        },
+        départementale: {
+          '12': 0.2,
+          '13': 0.3,
+        },
+      },
+      météosTerritoriales: {
+        nationale: {
+          FR: 'SOLEIL',
+        },
+        régionale: {
+          '01': 'NUAGE',
+        },
+        départementale: {
+          '12': 'NON_RENSEIGNEE',
+          '13': 'COUVERT',
+        },
+      },
+    });
+  });
+});

--- a/src/validation/chantierDonnéesTerritoriales.ts
+++ b/src/validation/chantierDonnéesTerritoriales.ts
@@ -1,0 +1,5 @@
+import { z } from 'zod';
+
+export const validationChantierDonnéesTerritorialesRépartitionGéographique = z.object({
+  chantierId: z.string(),
+});


### PR DESCRIPTION
Cette PR fait office de `hotfix` pour la mise en service, il faut noter que les modifications apportées ici ne sont pas pérennes. Les parties du code modifiées seront refactorées après refonte du modèle de données (schéma prisma) et des SQLRepositories correspondant

Points d'attention techniques :
- `usePageChantier`: ajout d'un appel api pour récupérer les données de la RépartitionGéographique
  - le hook expose une nouvelle variable : une fonction `refetchRépartitionGéographique` pour déclencher la màj de l'UI (rubrique Répartition Géographique) lorsque la météo est modifiée par l'utilisateur (dans la rubrique Météo et synthèse des résultats)

- `ChantierDonnéesTerritoriales`: correspond à la jointure entre les potentielles futures tables `Chantier` et `Territoire`. Elle sera amené à contenir les avancements d'un chantier pour chaque territoire. Pour l'instant, cette table d'association n'existe pas en base de données mais le repository associé a déjà été créé pour anticiper cette future migration du schéma de base de données.

- les tests pour `ChantierDonnéesTerritorialesSQLRepository` n'ont pas été rédigés pour les raisons évoquées au-dessus
- les tests pour `RécupérerChantierRépartitionGéographiqueUseCase` n'utilisent pas les builders pour éviter d'y être couplés en vue de la future refacto
