### PR TITLE
fix: corrige les météos incohérentes entre chantier et synthèse (289)

### DIFF
--- a/src/client/components/PageChantier/PageChantier.interface.ts
+++ b/src/client/components/PageChantier/PageChantier.interface.ts
@@ -1,9 +1,7 @@
-import Chantier from '@/server/domain/chantier/Chantier.interface';
 import { Habilitation } from '@/server/domain/identité/Habilitation';
 import Indicateur from '@/server/domain/indicateur/Indicateur.interface';
 
 export default interface PageChantierProps {
-  chantier: Chantier
   indicateurs: Indicateur[]
   habilitation: Habilitation
 }

--- a/src/client/components/PageChantier/PageChantier.tsx
+++ b/src/client/components/PageChantier/PageChantier.tsx
@@ -7,7 +7,7 @@ import SélecteursMaillesEtTerritoires from '@/components/_commons/SélecteursMa
 import { mailleAssociéeAuTerritoireSélectionnéTerritoiresStore, territoireSélectionnéTerritoiresStore } from '@/stores/useTerritoiresStore/useTerritoiresStore';
 import BarreLatéraleEncart from '@/components/_commons/BarreLatérale/BarreLatéraleEncart/BarreLatéraleEncart';
 import Commentaires from '@/components/PageChantier/Commentaires/Commentaires';
-import { SCOPE_SAISIE_INDICATEURS, checkAuthorizationChantierScope } from '@/server/domain/identité/Habilitation';
+import Loader from '@/components/_commons/Loader/Loader';
 import AvancementChantier from './AvancementChantier/AvancementChantier';
 import Indicateurs, { listeRubriquesIndicateurs } from './Indicateurs/Indicateurs';
 import PageChantierProps from './PageChantier.interface';
@@ -21,13 +21,21 @@ import usePageChantier from './usePageChantier';
 import Objectifs from './Objectifs/Objectifs';
 import DécisionsStratégiques from './DécisionsStratégiques/DécisionsStratégiques';
 
-export default function PageChantier({ chantier, indicateurs, habilitation }: PageChantierProps) {
+export default function PageChantier({ indicateurs, habilitation }: PageChantierProps) {
   const [estOuverteBarreLatérale, setEstOuverteBarreLatérale] = useState(false);
-  const { avancements, détailsIndicateurs, commentaires, synthèseDesRésultats, objectifs, décisionStratégique } = usePageChantier(chantier);
+  const {
+    chantier,
+    rechargerChantier,
+    avancements,
+    détailsIndicateurs,
+    commentaires,
+    synthèseDesRésultats,
+    objectifs,
+    décisionStratégique,
+    modeÉcriture,
+  } = usePageChantier(habilitation);
   const mailleAssociéeAuTerritoireSélectionné = mailleAssociéeAuTerritoireSélectionnéTerritoiresStore();
   const territoireSélectionné = territoireSélectionnéTerritoiresStore();
-  
-  const modeÉcriture = checkAuthorizationChantierScope(habilitation, chantier.id, SCOPE_SAISIE_INDICATEURS);
 
   const listeRubriques: Rubrique[] = useMemo(() => (
     mailleAssociéeAuTerritoireSélectionné === 'nationale' ? (
@@ -74,82 +82,97 @@ export default function PageChantier({ chantier, indicateurs, habilitation }: Pa
         >
           Menu latéral
         </button>
-        <PageChantierEnTête chantier={chantier} />
-        <div className='fr-p-4w'>
-          <div className="fr-grid-row fr-grid-row--gutters fr-my-0 fr-pb-1w">
-            <div className={`${mailleAssociéeAuTerritoireSélectionné === 'nationale' ? 'fr-col-xl-6' : 'fr-col-xl-12'} fr-col-12`}>
-              <AvancementChantier avancements={avancements} />
-            </div>
-            <div className='fr-col-xl-6 fr-col-12'>
-              <Responsables chantier={chantier} />
-            </div>
-            <div className={`${mailleAssociéeAuTerritoireSélectionné === 'nationale' ? 'fr-col-xl-12' : 'fr-col-xl-6'} fr-col-12`}>
-              <SynthèseDesRésultats
-                modeÉcriture={modeÉcriture}
-                synthèseDesRésultatsInitiale={synthèseDesRésultats}
-              />
-            </div>
-          </div>
-          <div className="fr-grid-row fr-grid-row--gutters fr-my-0 fr-pb-1w">
-            <div className="fr-col-12">
-              <Cartes chantier={chantier} />
-            </div>
-          </div>
-          {
-            objectifs !== null && 
-            <div className="fr-grid-row fr-grid-row--gutters fr-my-0 fr-pb-1w">
-              <div className="fr-col-12">
-                <Objectifs
-                  chantierId={chantier.id} 
-                  codeInsee='FR'
-                  maille='nationale'
-                  modeÉcriture={modeÉcriture}
-                  objectifs={objectifs}
-                />
-              </div>
-            </div>
-          }
-          {
-            détailsIndicateurs !== null && (
-              <div className="fr-grid-row fr-grid-row--gutters fr-my-0 fr-pb-1w">
-                <div className="fr-col-12">
-                  <Indicateurs
-                    détailsIndicateurs={détailsIndicateurs}
-                    indicateurs={indicateurs}
-                  />
+        {
+          chantier !== null ? (
+            <>
+              <PageChantierEnTête chantier={chantier} />
+              <div className='fr-p-4w'>
+                <div className="fr-grid-row fr-grid-row--gutters fr-my-0 fr-pb-1w">
+                  {
+                    avancements !== null &&
+                    <>
+                      <div className={`${mailleAssociéeAuTerritoireSélectionné === 'nationale' ? 'fr-col-xl-6' : 'fr-col-xl-12'} fr-col-12`}>
+                        <AvancementChantier avancements={avancements} />
+                      </div>
+                      <div className='fr-col-xl-6 fr-col-12'>
+                        <Responsables chantier={chantier} />
+                      </div>
+                    </>
+                  }
+                  <div className={`${mailleAssociéeAuTerritoireSélectionné === 'nationale' ? 'fr-col-xl-12' : 'fr-col-xl-6'} fr-col-12`}>
+                    <SynthèseDesRésultats
+                      modeÉcriture={modeÉcriture}
+                      rechargerChantier={rechargerChantier}
+                      synthèseDesRésultatsInitiale={synthèseDesRésultats}
+                    />
+                  </div>
                 </div>
-              </div>
-            )
-          }
-          {
-            décisionStratégique !== null
-            && mailleAssociéeAuTerritoireSélectionné === 'nationale' &&
-            <div className="fr-grid-row fr-grid-row--gutters fr-my-0 fr-pb-1w">
-              <div className="fr-col-12">
-                <DécisionsStratégiques
-                  chantierId={chantier.id}
-                  décisionStratégique={décisionStratégique}
-                  modeÉcriture={modeÉcriture}
-                />
-              </div>
-            </div>
-          }
-          {
-            commentaires !== null && (
-              <div className="fr-grid-row fr-grid-row--gutters fr-my-0 fr-pb-1w">
-                <div className="fr-col-12">
-                  <Commentaires
-                    chantierId={chantier.id} 
-                    codeInsee={territoireSélectionné.codeInsee}
-                    commentaires={commentaires}
-                    maille={mailleAssociéeAuTerritoireSélectionné}
-                    modeÉcriture={modeÉcriture}
-                  />
+                <div className="fr-grid-row fr-grid-row--gutters fr-my-0 fr-pb-1w">
+                  <div className="fr-col-12">
+                    <Cartes chantier={chantier} />
+                  </div>
                 </div>
+                {
+                  objectifs !== null &&
+                  <div className="fr-grid-row fr-grid-row--gutters fr-my-0 fr-pb-1w">
+                    <div className="fr-col-12">
+                      <Objectifs
+                        chantierId={chantier.id}
+                        codeInsee='FR'
+                        maille='nationale'
+                        modeÉcriture={modeÉcriture}
+                        objectifs={objectifs}
+                      />
+                    </div>
+                  </div>
+                }
+                {
+                  détailsIndicateurs !== null && (
+                    <div className="fr-grid-row fr-grid-row--gutters fr-my-0 fr-pb-1w">
+                      <div className="fr-col-12">
+                        <Indicateurs
+                          détailsIndicateurs={détailsIndicateurs}
+                          indicateurs={indicateurs}
+                        />
+                      </div>
+                    </div>
+                  )
+                }
+                {
+                  décisionStratégique !== null
+                  && mailleAssociéeAuTerritoireSélectionné === 'nationale'
+                  && process.env.NEXT_PUBLIC_FT_DECISIONS_STRATEGIQUES_DISABLED !== 'true' &&
+                  <div className="fr-grid-row fr-grid-row--gutters fr-my-0 fr-pb-1w">
+                    <div className="fr-col-12">
+                      <DécisionsStratégiques
+                        chantierId={chantier.id}
+                        décisionStratégique={décisionStratégique}
+                        modeÉcriture={modeÉcriture}
+                      />
+                    </div>
+                  </div>
+                }
+                {
+                  commentaires !== null && (
+                    <div className="fr-grid-row fr-grid-row--gutters fr-my-0 fr-pb-1w">
+                      <div className="fr-col-12">
+                        <Commentaires
+                          chantierId={chantier.id}
+                          codeInsee={territoireSélectionné.codeInsee}
+                          commentaires={commentaires}
+                          maille={mailleAssociéeAuTerritoireSélectionné}
+                          modeÉcriture={modeÉcriture}
+                        />
+                      </div>
+                    </div>
+                  )
+                }
               </div>
-            )
-          }
-        </div>
+            </>
+          ) : (
+            <Loader />
+          )
+        }
       </div>
     </PageChantierStyled>
   );

--- a/src/client/components/PageChantier/SynthèseDesRésultats/SynthèseDesRésultats.interface.ts
+++ b/src/client/components/PageChantier/SynthèseDesRésultats/SynthèseDesRésultats.interface.ts
@@ -3,4 +3,5 @@ import { RouterOutputs } from '@/server/infrastructure/api/trpc/trpc.interface';
 export interface SynthèseDesRésultatsProps {
   synthèseDesRésultatsInitiale: RouterOutputs['synthèseDesRésultats']['récupérerLaPlusRécente']
   modeÉcriture: boolean
+  rechargerChantier: () => void
 }

--- a/src/client/components/PageChantier/SynthèseDesRésultats/SynthèseDesRésultats.tsx
+++ b/src/client/components/PageChantier/SynthèseDesRésultats/SynthèseDesRésultats.tsx
@@ -10,7 +10,7 @@ import Alerte from '@/components/_commons/Alerte/Alerte';
 import SynthèseDesRésultatsAffichage from '@/components/PageChantier/SynthèseDesRésultats/SynthèseDesRésultatsAffichage/SynthèseDesRésultatsAffichage';
 import SynthèseDesRésultatsFormulaire from './SynthèseDesRésultatsFormulaire/SynthèseDesRésultatsFormulaire';
 
-export default function SynthèseDesRésultats({ synthèseDesRésultatsInitiale, modeÉcriture }: SynthèseDesRésultatsProps) {
+export default function SynthèseDesRésultats({ synthèseDesRésultatsInitiale, modeÉcriture, rechargerChantier }: SynthèseDesRésultatsProps) {
   const {
     synthèseDesRésultats,
     nomTerritoireSélectionné,
@@ -19,7 +19,7 @@ export default function SynthèseDesRésultats({ synthèseDesRésultatsInitiale,
     synthèseDesRésultatsCréée,
     activerLeModeÉdition,
     désactiverLeModeÉdition,
-  } = useSynthèseDesRésultats(synthèseDesRésultatsInitiale);
+  } = useSynthèseDesRésultats(synthèseDesRésultatsInitiale, rechargerChantier);
 
   return (
     <SynthèseDesRésultatsStyled id="synthèse">

--- a/src/client/components/PageChantier/SynthèseDesRésultats/useSynthèseDesRésultats.ts
+++ b/src/client/components/PageChantier/SynthèseDesRésultats/useSynthèseDesRésultats.ts
@@ -3,7 +3,7 @@ import AlerteProps from '@/components/_commons/Alerte/Alerte.interface';
 import SynthèseDesRésultats from '@/server/domain/synthèseDesRésultats/SynthèseDesRésultats.interface';
 import { territoireSélectionnéTerritoiresStore } from '@/stores/useTerritoiresStore/useTerritoiresStore';
 
-export default function useSynthèseDesRésultats(synthèseDesRésultatsInitiale: SynthèseDesRésultats) {
+export default function useSynthèseDesRésultats(synthèseDesRésultatsInitiale: SynthèseDesRésultats, rechargerChantier: () => void) {
   const territoireSélectionné = territoireSélectionnéTerritoiresStore();
 
   const [modeÉdition, setModeÉdition] = useState(false);
@@ -19,6 +19,7 @@ export default function useSynthèseDesRésultats(synthèseDesRésultatsInitiale
   };
 
   const synthèseDesRésultatsCréée = (synthèse: SynthèseDesRésultats) => {
+    rechargerChantier();
     setSynthèseDesRésultats(synthèse);
     setAlerte({
       type: 'succès',

--- a/src/database/seed.ts
+++ b/src/database/seed.ts
@@ -159,7 +159,16 @@ class DatabaseSeeder {
   }
 
   private async _créerSynthèsesDesRésultats() {
-    this._synthèsesDesRésultats = this._chantiers.map(c => new SynthèseDesRésultatsSQLRowBuilder().avecChantierId(c.id).build());
+    this._synthèsesDesRésultats = this._chantiers.map(c => {
+      const possèdeCommentaireEtMétéo = c.meteo !== 'NON_RENSEIGNEE';
+      return (
+        new SynthèseDesRésultatsSQLRowBuilder(possèdeCommentaireEtMétéo)
+          .avecChantierId(c.id)
+          .avecMaille(c.maille).avecCodeInsee(c.code_insee)
+          .avecMétéo(c.meteo)
+          .build()
+      );
+    });
 
     await prisma.synthese_des_resultats.createMany({ data: this._synthèsesDesRésultats });
   }

--- a/src/pages/chantier/[id].tsx
+++ b/src/pages/chantier/[id].tsx
@@ -2,8 +2,7 @@ import { getServerSession } from 'next-auth/next';
 import { GetServerSidePropsContext } from 'next';
 import PageChantier from '@/components/PageChantier/PageChantier';
 
-import Chantier from '@/server/domain/chantier/Chantier.interface';
-import { ChantierId, Habilitation, SCOPE_LECTURE } from '@/server/domain/identité/Habilitation';
+import { ChantierId, Habilitation } from '@/server/domain/identité/Habilitation';
 import Indicateur from '@/server/domain/indicateur/Indicateur.interface';
 
 import { dependencies } from '@/server/infrastructure/Dependencies';
@@ -11,15 +10,13 @@ import logger from '@/server/infrastructure/logger';
 import { authOptions } from '@/server/infrastructure/api/auth/[...nextauth]';
 
 interface NextPageChantierProps {
-  chantier: Chantier,
   habilitation: Habilitation,
   indicateurs: Indicateur[],
 }
 
-export default function NextPageChantier({ chantier, indicateurs, habilitation }: NextPageChantierProps) {
+export default function NextPageChantier({ indicateurs, habilitation }: NextPageChantierProps) {
   return (
     <PageChantier
-      chantier={chantier}
       habilitation={habilitation}
       indicateurs={indicateurs}
     />
@@ -41,15 +38,12 @@ export async function getServerSideProps(context: GetServerSidePropsContext<Para
   }
 
   const habilitation = session.habilitation;
-  const chantierRepository = dependencies.getChantierRepository();
-  const chantier: Chantier = await chantierRepository.getById(params.id, session.habilitation, SCOPE_LECTURE);
 
   const indicateurRepository = dependencies.getIndicateurRepository();
   const indicateurs: Indicateur[] = await indicateurRepository.récupérerParChantierId(params.id);
 
   return {
     props: {
-      chantier,
       indicateurs,
       habilitation,
     },

--- a/src/server/domain/chantier/ChantierRepository.interface.ts
+++ b/src/server/domain/chantier/ChantierRepository.interface.ts
@@ -1,7 +1,5 @@
-import SynthèseDesRésultats from '@/server/domain/synthèseDesRésultats/SynthèseDesRésultats.interface';
 import Chantier from '@/server/domain/chantier/Chantier.interface';
 import { Météo } from '@/server/domain/météo/Météo.interface';
-import { Commentaires } from '@/server/domain/commentaire/Commentaire.interface';
 import { CodeInsee } from '@/server/domain/territoire/Territoire.interface';
 import { Maille } from '@/server/domain/maille/Maille.interface';
 import { Habilitation, Scope } from '@/server/domain/identité/Habilitation';
@@ -10,10 +8,5 @@ export default interface ChantierRepository {
   getById(id: string, habilitation: Habilitation, scope: string): Promise<Chantier>;
   getListe(habilitation: Habilitation, scope: Scope): Promise<Chantier[]>;
   récupérerMétéoParChantierIdEtTerritoire(chantierId: string, maille: Maille, codeInsee: CodeInsee): Promise<Météo | null>
+  modifierMétéo(chantierId: string, maille: Maille, codeInsee: CodeInsee, météo: Météo): Promise<void>;
 }
-
-export type InfosChantier = {
-  synthèseDesRésultats: SynthèseDesRésultats
-  météo: Météo | null
-  commentaires: Commentaires
-};

--- a/src/server/infrastructure/accès_données/chantier/ChantierSQLRepository.ts
+++ b/src/server/infrastructure/accès_données/chantier/ChantierSQLRepository.ts
@@ -79,4 +79,19 @@ export default class ChantierSQLRepository implements ChantierRepository {
     // TODO: avoir une réflexion sur avoir un mapper et retourné un objet du domainz Chantier
     return chantierRow.meteo as Météo | null;
   }
+
+  async modifierMétéo(chantierId: string, maille: Maille, codeInsee: CodeInsee, météo: Météo) {
+    await this.prisma.chantier.update({
+      data: {
+        meteo: météo,
+      },
+      where: {
+        id_code_insee_maille: {
+          id: chantierId,
+          maille: CODES_MAILLES[maille],
+          code_insee: codeInsee,
+        },
+      },
+    });
+  }
 }

--- a/src/server/infrastructure/api/trpc/routes/chantier.ts
+++ b/src/server/infrastructure/api/trpc/routes/chantier.ts
@@ -1,0 +1,17 @@
+import {
+  créerRouteurTRPC,
+  procédureProtégée,
+} from '@/server/infrastructure/api/trpc/trpc';
+import { dependencies } from '@/server/infrastructure/Dependencies';
+import { validationChantierContexte } from '@/validation/chantier';
+import RécupérerChantierUseCase from '@/server/usecase/chantier/RécupérerChantierUseCase';
+import { SCOPE_LECTURE } from '@/server/domain/identité/Habilitation';
+
+export const chantierRouter = créerRouteurTRPC({
+  récupérer: procédureProtégée
+    .input(validationChantierContexte)
+    .query(({ input, ctx }) => {
+      const récupérerChantierUseCase = new RécupérerChantierUseCase(dependencies.getChantierRepository());
+      return récupérerChantierUseCase.run(input.chantierId, ctx.session.habilitation, SCOPE_LECTURE);
+    }),
+});

--- a/src/server/infrastructure/api/trpc/routes/routes.ts
+++ b/src/server/infrastructure/api/trpc/routes/routes.ts
@@ -1,8 +1,10 @@
 import { créerRouteurTRPC } from '@/server/infrastructure/api/trpc/trpc';
+import { chantierRouter } from './chantier';
 import { synthèseDesRésultatsRouter } from './synthèseDesRésultats';
 import { publicationRouter } from './publication';
 
 export const appRouter = créerRouteurTRPC({
+  chantier: chantierRouter,
   synthèseDesRésultats: synthèseDesRésultatsRouter,
   publication: publicationRouter,
 });

--- a/src/server/infrastructure/test/builders/sqlRow/SynthèseDesRésultatsSQLRow.builder.ts
+++ b/src/server/infrastructure/test/builders/sqlRow/SynthèseDesRésultatsSQLRow.builder.ts
@@ -18,9 +18,11 @@ export default class SyntheseDesResultatsRowBuilder {
 
   private _météo: synthese_des_resultats['meteo'];
 
+  private _dateMétéo: synthese_des_resultats['date_meteo'];
+
   private _auteur: synthese_des_resultats['auteur'];
 
-  constructor() {
+  constructor(possèdeCommentaireEtMétéo = Math.random() < 0.95) {
     const maille = générerUneMailleAléatoire();
     const codesInsee = retourneUneListeDeCodeInseeCohérentePourUneMaille(maille);
 
@@ -28,10 +30,11 @@ export default class SyntheseDesResultatsRowBuilder {
     this._chantierId = générerUnIdentifiantUnique('CH');
     this._maille = maille;
     this._codeInsee = faker.helpers.arrayElement(codesInsee);
-    this._commentaire = faker.helpers.arrayElement([null, faker.lorem.paragraphs()]);
-    this._dateCommentaire = faker.helpers.arrayElement([null, faker.date.recent(10, '2023-02-01T00:00:00.000Z')]);
-    this._météo = new MétéoBuilder().build();
-    this._auteur = faker.helpers.arrayElement([null, faker.name.fullName()]);
+    this._commentaire = possèdeCommentaireEtMétéo ? faker.lorem.paragraphs() : null;
+    this._dateCommentaire = possèdeCommentaireEtMétéo ? faker.date.recent(10, '2023-02-01T00:00:00.000Z') : null;
+    this._météo = possèdeCommentaireEtMétéo ? new MétéoBuilder().build() : null;
+    this._dateMétéo = possèdeCommentaireEtMétéo ? faker.date.recent(10, '2023-02-01T00:00:00.000Z') : null;
+    this._auteur = possèdeCommentaireEtMétéo ? faker.name.fullName() : null;
   }
 
   avecId(id: synthese_des_resultats['id']): SyntheseDesResultatsRowBuilder {
@@ -46,7 +49,7 @@ export default class SyntheseDesResultatsRowBuilder {
 
   avecMaille(maille: synthese_des_resultats['maille']): SyntheseDesResultatsRowBuilder {
     const codesInsee = retourneUneListeDeCodeInseeCohérentePourUneMaille(maille);
-    
+
     this._maille = maille;
     this._codeInsee = faker.helpers.arrayElement(codesInsee);
     return this;
@@ -72,6 +75,11 @@ export default class SyntheseDesResultatsRowBuilder {
     return this;
   }
 
+  avecDateMétéo(dateMétéo: synthese_des_resultats['date_meteo']): SyntheseDesResultatsRowBuilder {
+    this._dateMétéo = dateMétéo;
+    return this;
+  }
+
   avecAuteur(auteur: synthese_des_resultats['auteur']): SyntheseDesResultatsRowBuilder {
     this._auteur = auteur;
     return this;
@@ -84,7 +92,7 @@ export default class SyntheseDesResultatsRowBuilder {
       maille: this._maille,
       code_insee: this._codeInsee,
       meteo: this._météo,
-      date_meteo: null,
+      date_meteo: this._dateMétéo,
       commentaire: this._commentaire,
       date_commentaire: this._dateCommentaire,
       auteur: this._auteur,

--- a/src/server/usecase/chantier/RécupérerChantierUseCase.ts
+++ b/src/server/usecase/chantier/RécupérerChantierUseCase.ts
@@ -1,0 +1,14 @@
+import ChantierRepository from '@/server/domain/chantier/ChantierRepository.interface';
+import { dependencies } from '@/server/infrastructure/Dependencies';
+import { Habilitation } from '@/server/domain/identité/Habilitation';
+import Chantier from '@/server/domain/chantier/Chantier.interface';
+
+export default class RécupérerChantierUseCase {
+  constructor(
+    private readonly chantierRepository: ChantierRepository = dependencies.getChantierRepository(),
+  ) {}
+
+  async run(chantierId: string, habilitation: Habilitation, scope: string): Promise<Chantier> {
+    return this.chantierRepository.getById(chantierId, habilitation, scope);
+  }
+}

--- a/src/server/usecase/synthèse/CréerUneSynthèseDesRésultatsUseCase.ts
+++ b/src/server/usecase/synthèse/CréerUneSynthèseDesRésultatsUseCase.ts
@@ -5,15 +5,21 @@ import { Maille } from '@/server/domain/maille/Maille.interface';
 import { CodeInsee } from '@/server/domain/territoire/Territoire.interface';
 import { Météo } from '@/server/domain/météo/Météo.interface';
 import SynthèseDesRésultats from '@/server/domain/synthèseDesRésultats/SynthèseDesRésultats.interface';
+import ChantierRepository from '@/server/domain/chantier/ChantierRepository.interface';
 
 export default class CréerUneSynthèseDesRésultatsUseCase {
   constructor(
     private readonly synthèsesDesRésultatsRepository: SynthèseDesRésultatsRepository = dependencies.getSynthèseDesRésultatsRepository(),
+    private readonly chantierRepository: ChantierRepository = dependencies.getChantierRepository(),
   ) {}
 
   async run(chantierId: string, maille: Maille, codeInsee: CodeInsee, contenu: string, auteur: string, météo: Météo): Promise<SynthèseDesRésultats> {
     const date = new Date();
     const id = randomUUID();
-    return this.synthèsesDesRésultatsRepository.créer(chantierId, maille, codeInsee, id, contenu, auteur, météo, date);
+    const [, synthèseDesRésultatsCréée] = await Promise.all([
+      this.chantierRepository.modifierMétéo(chantierId, maille, codeInsee, météo),
+      this.synthèsesDesRésultatsRepository.créer(chantierId, maille, codeInsee, id, contenu, auteur, météo, date),
+    ]);
+    return synthèseDesRésultatsCréée;
   }
 }

--- a/src/server/usecase/synthèse/CréerUneSynthèseDesRésultatsUseCase.unit.test.ts
+++ b/src/server/usecase/synthèse/CréerUneSynthèseDesRésultatsUseCase.unit.test.ts
@@ -1,6 +1,7 @@
 import SynthèseDesRésultatsRepository
   from '@/server/domain/synthèseDesRésultats/SynthèseDesRésultatsRepository.interface';
 import CréerUneSynthèseDesRésultatsUseCase from '@/server/usecase/synthèse/CréerUneSynthèseDesRésultatsUseCase';
+import ChantierRepository from '@/server/domain/chantier/ChantierRepository.interface';
 
 const RANDOM_UUID = '123';
 
@@ -21,7 +22,8 @@ describe('CréerUneSynthèseDesRésultatsUseCase', () => {
 
     jest.useFakeTimers().setSystemTime(date);
     const stubSynthèseDesRésultatsRepository = { créer: jest.fn() } as unknown as SynthèseDesRésultatsRepository;
-    const créerUneSynthèseDesRésultats = new CréerUneSynthèseDesRésultatsUseCase(stubSynthèseDesRésultatsRepository);
+    const stubChantierRepository = { modifierMétéo: jest.fn() } as unknown as ChantierRepository;
+    const créerUneSynthèseDesRésultats = new CréerUneSynthèseDesRésultatsUseCase(stubSynthèseDesRésultatsRepository, stubChantierRepository);
 
     //WHEN
     await créerUneSynthèseDesRésultats.run(chantierId, maille, codeInsee, contenu, auteur, météo);
@@ -47,7 +49,8 @@ describe('CréerUneSynthèseDesRésultatsUseCase', () => {
       date,
       météo,
     }) } as unknown as SynthèseDesRésultatsRepository;
-    const créerUneSynthèseDesRésultats = new CréerUneSynthèseDesRésultatsUseCase(stubSynthèseDesRésultatsRepository);
+    const stubChantierRepository = { modifierMétéo: jest.fn() } as unknown as ChantierRepository;
+    const créerUneSynthèseDesRésultats = new CréerUneSynthèseDesRésultatsUseCase(stubSynthèseDesRésultatsRepository, stubChantierRepository);
 
     //WHEN
     const synthèseDesRésultatsCréée = await créerUneSynthèseDesRésultats.run(chantierId, maille, codeInsee, contenu, auteur, météo);

--- a/src/validation/chantier.ts
+++ b/src/validation/chantier.ts
@@ -1,0 +1,5 @@
+import { z } from 'zod';
+
+export const validationChantierContexte = z.object({
+  chantierId: z.string(),
+});


### PR DESCRIPTION
Le correctif n'est pas idéal : il se contente de mettre en cohérence le champ `meteo` de la table `chantier` et  de la table `synthese_des_resultats` à chaque publication d'une synthèse. Dans l'idéal, il faut supprimer le doublon météo et n'avoir qu'une seule source de vérité -> à refacto après le remaniement du modèle de données

Les données de la PageChantier sont désormais récupérées depuis un endpoint API