### PR TITLE
feat: retrait des rubriques si pas d'indicateur (355)

### DIFF
--- a/src/client/components/PageChantier/Indicateurs/Indicateurs.interface.ts
+++ b/src/client/components/PageChantier/Indicateurs/Indicateurs.interface.ts
@@ -2,7 +2,7 @@ import { Rubrique } from '@/components/_commons/Sommaire/Sommaire.interface';
 import { DétailsIndicateurs } from '@/server/domain/indicateur/DétailsIndicateur.interface';
 import Indicateur, { TypeIndicateur } from '@/server/domain/indicateur/Indicateur.interface';
 
-export type ÉlémentPageIndicateursType = Rubrique & { typeIndicateur: NonNullable<TypeIndicateur> };
+export type ÉlémentPageIndicateursType = Rubrique & { typeIndicateur: TypeIndicateur };
 
 export default interface RubriquesIndicateursProps {
   indicateurs: Indicateur[];

--- a/src/client/components/PageChantier/Indicateurs/Indicateurs.tsx
+++ b/src/client/components/PageChantier/Indicateurs/Indicateurs.tsx
@@ -1,8 +1,6 @@
 import Titre from '@/components/_commons/Titre/Titre';
 import IndicateursProps, { ÉlémentPageIndicateursType } from '@/components/PageChantier/Indicateurs/Indicateurs.interface';
 import IndicateurBloc from '@/components/PageChantier/Indicateurs/Bloc/IndicateurBloc';
-import Indicateur, { TypeIndicateur, typesIndicateur } from '@/server/domain/indicateur/Indicateur.interface';
-import Bloc from '@/components/_commons/Bloc/Bloc';
 
 export const listeRubriquesIndicateurs: ÉlémentPageIndicateursType[] = [
   { nom: 'Indicateurs d\'impact', ancre: 'impact', typeIndicateur: 'IMPACT' },
@@ -13,9 +11,10 @@ export const listeRubriquesIndicateurs: ÉlémentPageIndicateursType[] = [
 ];
 
 export default function Indicateurs({ indicateurs, détailsIndicateurs, estDisponibleALImport = false, estInteractif = true }: IndicateursProps) {
-  const indicateursGroupésParType: Record<NonNullable<TypeIndicateur>, Indicateur[]> = Object.fromEntries(
-    typesIndicateur.map(type => [type, indicateurs.filter(indicateur => indicateur.type === type)]),
-  );
+
+  if (indicateurs.length === 0) {
+    return null;
+  }
 
   return (
     <section id="indicateurs">
@@ -26,41 +25,30 @@ export default function Indicateurs({ indicateurs, détailsIndicateurs, estDispo
         Indicateurs
       </Titre>
       { 
-        listeRubriquesIndicateurs.map(rubrique => (
-          <section
-            className='fr-mb-3w'
-            id={rubrique.ancre}
-            key={rubrique.ancre}
-          >
-            <Titre
-              baliseHtml='h3'
-              className='fr-text--lg fr-mb-1w'
+        indicateurs.map(indicateur => {
+          const rubriqueIndicateur = listeRubriquesIndicateurs.find(ind => ind.typeIndicateur === indicateur.type);
+          return (
+            <section
+              className='fr-mb-3w'
+              id={rubriqueIndicateur?.ancre}
+              key={rubriqueIndicateur?.ancre}
             >
-              {rubrique.nom}
-            </Titre>
-            {
-              (indicateursGroupésParType[rubrique.typeIndicateur].length === 0
-                ? (
-                  <Bloc>
-                    <p className="fr-m-0">
-                      Aucun indicateur
-                    </p>
-                  </Bloc>
-                )
-                : (
-                  indicateursGroupésParType[rubrique.typeIndicateur].map(indicateur => (
-                    <IndicateurBloc
-                      détailsIndicateur={détailsIndicateurs[indicateur.id]}
-                      estDisponibleALImport={estDisponibleALImport}
-                      estInteractif={estInteractif}
-                      indicateur={indicateur}
-                      key={indicateur.id}
-                    />
-                  ))
-                ))
-            }
-          </section>
-        ))
+              <Titre
+                baliseHtml='h3'
+                className='fr-text--lg fr-mb-1w'
+              >
+                {rubriqueIndicateur?.nom}
+              </Titre>
+              <IndicateurBloc
+                détailsIndicateur={détailsIndicateurs[indicateur.id]}
+                estDisponibleALImport={estDisponibleALImport}
+                estInteractif={estInteractif}
+                indicateur={indicateur}
+                key={indicateur.id}
+              />
+            </section>
+          );
+        })
       }
     </section>
   );

--- a/src/client/components/PageChantier/Indicateurs/Indicateurs.tsx
+++ b/src/client/components/PageChantier/Indicateurs/Indicateurs.tsx
@@ -24,30 +24,37 @@ export default function Indicateurs({ indicateurs, détailsIndicateurs, estDispo
       >
         Indicateurs
       </Titre>
-      { 
-        indicateurs.map(indicateur => {
-          const rubriqueIndicateur = listeRubriquesIndicateurs.find(ind => ind.typeIndicateur === indicateur.type);
-          return (
-            <section
-              className='fr-mb-3w'
-              id={rubriqueIndicateur?.ancre}
-              key={rubriqueIndicateur?.ancre}
-            >
-              <Titre
-                baliseHtml='h3'
-                className='fr-text--lg fr-mb-1w'
+      {
+        listeRubriquesIndicateurs.map(rubriqueIndicateur => {
+          const indicateursDeCetteRubrique = indicateurs.filter(ind => ind.type === rubriqueIndicateur.typeIndicateur);
+
+          if (indicateursDeCetteRubrique.length > 0) {
+            return (
+              <section
+                className='fr-mb-3w'
+                id={rubriqueIndicateur.ancre}
+                key={rubriqueIndicateur.ancre}
               >
-                {rubriqueIndicateur?.nom}
-              </Titre>
-              <IndicateurBloc
-                détailsIndicateur={détailsIndicateurs[indicateur.id]}
-                estDisponibleALImport={estDisponibleALImport}
-                estInteractif={estInteractif}
-                indicateur={indicateur}
-                key={indicateur.id}
-              />
-            </section>
-          );
+                <Titre
+                  baliseHtml='h3'
+                  className='fr-text--lg fr-mb-1w'
+                >
+                  {rubriqueIndicateur.nom}
+                </Titre>
+                {
+                  indicateursDeCetteRubrique.map(indicateur => (
+                    <IndicateurBloc
+                      détailsIndicateur={détailsIndicateurs[indicateur.id]}
+                      estDisponibleALImport={estDisponibleALImport}
+                      estInteractif={estInteractif}
+                      indicateur={indicateur}
+                      key={indicateur.id}
+                    />
+                  ))
+                }
+              </section>
+            );
+          }
         })
       }
     </section>

--- a/src/client/components/PageChantier/PageChantier.tsx
+++ b/src/client/components/PageChantier/PageChantier.tsx
@@ -45,30 +45,31 @@ export default function PageChantier({ indicateurs, chantierId }: PageChantierPr
         indicateurs.some(indicateur => indicateur.type === rubriqueIndicateur.typeIndicateur)
       ),
     );
-    return (
-      territoireSélectionné!.maille === 'nationale' ? (
-        [
-          { nom: 'Avancement du chantier', ancre: 'avancement' },
-          { nom: 'Responsables', ancre: 'responsables' },
-          { nom: 'Météo et synthèse des résultats', ancre: 'synthèse' },
-          { nom: 'Répartition géographique', ancre: 'cartes' },
-          { nom: 'Objectifs', ancre: 'objectifs' },
-          { nom: 'Décisions stratégiques', ancre: 'décisions-stratégiques' },
-          { nom: 'Indicateurs', ancre: 'indicateurs', sousRubriques: rubriquesIndicateursNonVides },
-          { nom: 'Commentaires', ancre: 'commentaires' },
-        ]
-      ) : (
-        [
-          { nom: 'Avancement du chantier', ancre: 'avancement' },
-          { nom: 'Responsables', ancre: 'responsables' },
-          { nom: 'Météo et synthèse des résultats', ancre: 'synthèse' },
-          { nom: 'Répartition géographique', ancre: 'cartes' },
-          { nom: 'Objectifs', ancre: 'objectifs' },
-          { nom: 'Indicateurs', ancre: 'indicateurs', sousRubriques: rubriquesIndicateursNonVides },
-          { nom: 'Commentaires', ancre: 'commentaires' },
-        ]
-      )
-    );
+    let rubriques = [];
+
+    rubriques = territoireSélectionné!.maille === 'nationale' ? [
+      { nom: 'Avancement du chantier', ancre: 'avancement' },
+      { nom: 'Responsables', ancre: 'responsables' },
+      { nom: 'Météo et synthèse des résultats', ancre: 'synthèse' },
+      { nom: 'Répartition géographique', ancre: 'cartes' },
+      { nom: 'Objectifs', ancre: 'objectifs' },
+      { nom: 'Décisions stratégiques', ancre: 'décisions-stratégiques' },
+      { nom: 'Indicateurs', ancre: 'indicateurs', sousRubriques: rubriquesIndicateursNonVides },
+      { nom: 'Commentaires', ancre: 'commentaires' },
+    ] : [
+      { nom: 'Avancement du chantier', ancre: 'avancement' },
+      { nom: 'Responsables', ancre: 'responsables' },
+      { nom: 'Météo et synthèse des résultats', ancre: 'synthèse' },
+      { nom: 'Répartition géographique', ancre: 'cartes' },
+      { nom: 'Objectifs', ancre: 'objectifs' },
+      { nom: 'Indicateurs', ancre: 'indicateurs', sousRubriques: rubriquesIndicateursNonVides },
+      { nom: 'Commentaires', ancre: 'commentaires' },
+    ];
+
+    if (rubriquesIndicateursNonVides.length === 0)
+      rubriques = rubriques.filter(rubrique => rubrique.nom != 'Indicateurs');
+
+    return rubriques;
   }, [indicateurs, territoireSélectionné]);
 
   return (

--- a/src/server/domain/indicateur/Indicateur.interface.ts
+++ b/src/server/domain/indicateur/Indicateur.interface.ts
@@ -1,4 +1,4 @@
-export const typesIndicateur = ['IMPACT', 'DEPL', 'Q_SERV', 'REBOND', 'CONTEXTE', null] as const;
+export const typesIndicateur = ['IMPACT', 'DEPL', 'Q_SERV', 'REBOND', 'CONTEXTE'] as const;
 export type TypeIndicateur = typeof typesIndicateur[number];
 
 export default interface Indicateur {

--- a/src/server/infrastructure/accès_données/indicateur/IndicateurSQLRepository.ts
+++ b/src/server/infrastructure/accès_données/indicateur/IndicateurSQLRepository.ts
@@ -136,7 +136,10 @@ export default class IndicateurSQLRepository implements IndicateurRepository {
 
   async récupérerParChantierId(chantierId: string): Promise<Indicateur[]> {
     const indicateurs: IndicateurPrisma[] = await this.prisma.indicateur.findMany({
-      where: { chantier_id: chantierId, maille: 'NAT' },
+      where: { chantier_id: chantierId, maille: 'NAT',
+        NOT: {
+          type_id : null,
+        } },
     });
     
     return indicateurs.map((indicateur) => this._mapToDomain(indicateur));


### PR DESCRIPTION
Je propose dans cette PR de retirer la valeur null pour le type d'un indicateur, de cette façon on parcourt simplement les indicateurs sur la page et non plus les rubriques (liés aux types). La reqûete de récupération assume de ne reçevoir de la BDD uniquements des indicateurs avavec un type différent de null, car nous n'en faisons rien dans l'app 