### PR TITLE
Modification du schéma pour ajouter les départements de la Corse et permettre une valeur vide dans la value

### DIFF
--- a/public/schema/sans-contraintes.json
+++ b/public/schema/sans-contraintes.json
@@ -72,7 +72,7 @@
       "type":"string",
       "constraints":{
         "required":true,
-        "pattern":"^((D[0-9]{2,3})|(R[0-9]{2,3})|(A[0-9]{2,3})|FRANCE)$"
+        "pattern":"^((D[0-9]{2,3})|(D2A)|(D2B)|(R[0-9]{2,3})|(A[0-9]{2,3})|FRANCE)$"
       }
     },
     {

--- a/public/schema/sans-contraintes.json
+++ b/public/schema/sans-contraintes.json
@@ -105,7 +105,7 @@
       "example":"12.23",
       "type":"number",
       "constraints":{
-        "required":true
+        "required":false
       }
     }
   ],


### PR DESCRIPTION
### Modification schema Validata

Schema `sans-contraintes.json`

Modifs **mineures** :

- ajout des 2 dept de Corse dans le regex des zones
- on peut entrer des valeurs vides

cf [ticket #38](https://trello.com/c/VAuFzfdP/38-a-definir-modif-schema-1) du Trello datafactory.