### PR TITLE
fix: envoit les chantiers par batch de taille configurable pour l'export CSV (247)

### DIFF
--- a/src/client/components/PageAccueil/PageChantiers/ExportDesDonnées/ExportDesDonnées.tsx
+++ b/src/client/components/PageAccueil/PageChantiers/ExportDesDonnées/ExportDesDonnées.tsx
@@ -22,14 +22,21 @@ export const ID_HTML_MODALE_EXPORT = 'modale-exporter-les-données';
 
 export default function ExportDesDonnées() {
   const [ressourceÀExporter, setRessourceÀExporter] = useState<keyof typeof ressources | undefined>();
+  const [estDésactivé, setEstDésactivé] = useState(false);
 
   return (
     <Modale
       idHtml={ID_HTML_MODALE_EXPORT}
+      ouvertureCallback={() => {
+        setEstDésactivé(false);
+      }}
       titre="Exporter les données"
     >
       <form
         className="fr-mt-2w"
+        onChange={() => {
+          setEstDésactivé(false);
+        }}
         onSubmit={(événement) => {
           événement.preventDefault();
           if (!ressourceÀExporter)
@@ -37,6 +44,7 @@ export default function ExportDesDonnées() {
 
           const { url, baseDuNomDeFichier } = ressources[ressourceÀExporter];
           if (url) {
+            setEstDésactivé(true);
             const a = window.document.createElement('a');
             a.href = url;
             a.target = '_self';
@@ -93,7 +101,7 @@ export default function ExportDesDonnées() {
           <li>
             <button
               className="fr-btn fr-btn--icon-left fr-icon-download-line btn-radius"
-              disabled={ressourceÀExporter === undefined}
+              disabled={(ressourceÀExporter === undefined) || estDésactivé}
               type="submit"
             >
               Exporter les données

--- a/src/server/domain/chantier/ChantierRepository.interface.ts
+++ b/src/server/domain/chantier/ChantierRepository.interface.ts
@@ -16,6 +16,7 @@ export default interface ChantierRepository {
   getChantierStatistiques(habilitations: Habilitations, listeChantier: Chantier['id'][], maille: Maille): Promise<AvancementsStatistiques>;
   récupérerMétéoParChantierIdEtTerritoire(chantierId: string, maille: Maille, codeInsee: CodeInsee): Promise<Météo | null>
   modifierMétéo(chantierId: string, territoireCode: string, météo: Météo): Promise<void>;
-  récupérerPourExports(habilitations: Habilitations): Promise<ChantierPourExport[]>;
+
+  récupérerPourExports(chantierIdsLecture: string[], territoireCodesLecture: string[]): Promise<ChantierPourExport[]>;
   récupérerChantierIdsAssociésAuxPérimètresMinistèriels(périmètreIds: PérimètreMinistériel['id'][]): Promise<Chantier['id'][]> 
 }

--- a/src/server/infrastructure/Configuration.ts
+++ b/src/server/infrastructure/Configuration.ts
@@ -61,7 +61,7 @@ export class Configuration {
     // En test, le NODE_ENV est à test
     this.securedEnv = process.env.NODE_ENV === 'production';
 
-    this.exportCsvChantierIdChunkSize = Number.parseInt(process.env.EXPORT_CSV_CHANTIER_ID_CHUNK_SIZE || '10');
+    this.exportCsvChantierIdChunkSize = Number.parseInt(process.env.EXPORT_CSV_CHANTIER_ID_CHUNK_SIZE || '5');
   }
 }
 

--- a/src/server/infrastructure/Configuration.ts
+++ b/src/server/infrastructure/Configuration.ts
@@ -1,3 +1,5 @@
+import process from 'node:process';
+
 export class Configuration {
   public readonly env: string;
 
@@ -29,6 +31,8 @@ export class Configuration {
 
   public readonly devSessionMaxAge: number = 30 * 24 * 60 * 60; // 30 days
 
+  public readonly exportCsvChantierIdChunkSize: number;
+
   constructor() {
     this.logLevel = process.env.LOG_LEVEL || 'info';
 
@@ -56,6 +60,8 @@ export class Configuration {
     // En local, en faisant npm run dev, le NODE_ENV est à development
     // En test, le NODE_ENV est à test
     this.securedEnv = process.env.NODE_ENV === 'production';
+
+    this.exportCsvChantierIdChunkSize = Number.parseInt(process.env.EXPORT_CSV_CHANTIER_ID_CHUNK_SIZE || '10');
   }
 }
 

--- a/src/server/infrastructure/Dependencies.ts
+++ b/src/server/infrastructure/Dependencies.ts
@@ -12,7 +12,6 @@ import SynthèseDesRésultatsRepository
 import {
   SynthèseDesRésultatsSQLRepository,
 } from '@/server/infrastructure/accès_données/chantier/synthèseDesRésultats/SynthèseDesRésultatsSQLRepository';
-import logger from '@/server/infrastructure/logger';
 import AxeRepository from '@/server/domain/axe/AxeRepository.interface';
 import AxeSQLRepository from '@/server/infrastructure/accès_données/axe/AxeSQLRepository';
 import PpgRepository from '@/server/domain/ppg/PpgRepository.interface';
@@ -126,7 +125,6 @@ class Dependencies {
   private _utilisateurIAMRepository: UtilisateurIAMRepository | undefined;
 
   constructor() {
-    logger.debug('Using database.');
     const prisma = new PrismaClient();
     this._chantierRepository = new ChantierSQLRepository(prisma);
     this._axeRepository = new AxeSQLRepository(prisma);

--- a/src/server/infrastructure/accès_données/chantier/ChantierSQLRepository.integration.test.ts
+++ b/src/server/infrastructure/accès_données/chantier/ChantierSQLRepository.integration.test.ts
@@ -20,7 +20,7 @@ describe('ChantierSQLRepository', () => {
       await prisma.chantier.create({
         data: new ChantierSQLRowBuilder().avecId(chantierId).avecMaille('NAT').build(),
       });
-      
+
       const habilitation = { lecture: {
 
         chantiers: ['CH-001', 'CH-002'],
@@ -69,10 +69,8 @@ describe('ChantierSQLRepository', () => {
       // Given
       const repository = new ChantierSQLRepository(prisma);
 
-      const habilitation = { lecture: {
-        chantiers: ['CH-001', 'CH-002', 'CH-003', 'CH-004', 'CH-005'],
-        territoires: ['NAT-FR', 'DEPT-01', 'REG-84'],
-      } } as unknown as Utilisateur['habilitations'];
+      const chantierIdsLecture = ['CH-001', 'CH-002', 'CH-003', 'CH-004', 'CH-005'];
+      const territoireCodesLecture = ['NAT-FR', 'DEPT-01', 'REG-84'];
 
       const chantier001Builder = new ChantierSQLRowBuilder()
         .avecId('CH-001')
@@ -234,7 +232,7 @@ describe('ChantierSQLRepository', () => {
       ] });
 
       // When
-      const result = await repository.récupérerPourExports(habilitation);
+      const result = await repository.récupérerPourExports(chantierIdsLecture, territoireCodesLecture);
 
       // Then
       expect(result).toEqual([
@@ -294,10 +292,8 @@ describe('ChantierSQLRepository', () => {
 
       const repository = new ChantierSQLRepository(prisma);
 
-      const habilitation = { lecture: {
-        chantiers: ['CH-001'],
-        territoires: [territoireHabilité.code],
-      } } as unknown as Utilisateur['habilitations'];
+      const chantierIdsLecture = ['CH-001'];
+      const territoireCodesLecture = [territoireHabilité.code];
 
       const chantiersHabilités = [
         new ChantierSQLRowBuilder()
@@ -329,7 +325,7 @@ describe('ChantierSQLRepository', () => {
       ] });
 
       // When
-      const result = await repository.récupérerPourExports(habilitation);
+      const result = await repository.récupérerPourExports(chantierIdsLecture, territoireCodesLecture);
 
       // Then
       expect(result).toEqual([

--- a/src/server/infrastructure/accès_données/chantier/ChantierSQLRepository.ts
+++ b/src/server/infrastructure/accès_données/chantier/ChantierSQLRepository.ts
@@ -126,15 +126,11 @@ export default class ChantierSQLRepository implements ChantierRepository {
     });
   }
 
-  async récupérerPourExports(habilitations: Habilitations): Promise<ChantierPourExport[]> {
-    const h = new Habilitation(habilitations);
-    const chantiersLecture = h.récupérerListeChantiersIdsAccessiblesEnLecture();
-    const territoiresLecture = h.récupérerListeTerritoireCodesAccessiblesEnLecture();
-
+  async récupérerPourExports(chantierIdsLecture: string[], territoireCodesLecture: string[]): Promise<ChantierPourExport[]> {
     const rows = await this.prisma.$queryRaw<any[]>`
         with chantier_ids as (select distinct c.id
                               from chantier c
-                              where c.id in (${Prisma.join(chantiersLecture)})
+                              where c.id in (${Prisma.join(chantierIdsLecture)})
                                 and ministeres <> '{}'),
              derniers_commentaires as (select *
                                        from (select c.*,
@@ -181,7 +177,7 @@ export default class ChantierSQLRepository implements ChantierRepository {
                s.meteo             meteo
 
         from chantier_ids cids
-                 inner join territoire t on t.code in (${Prisma.join(territoiresLecture)})
+                 inner join territoire t on t.code in (${Prisma.join(territoireCodesLecture)})
                  left outer join chantier c on c.id = cids.id and c.territoire_code = t.code
                  left outer join chantier c_n on c_n.id = cids.id and c_n.maille = 'NAT'
                  left outer join chantier c_r on (c_r.id = cids.id and c_r.maille = 'REG')

--- a/src/server/infrastructure/api/export/chantiers-sans-filtre.ts
+++ b/src/server/infrastructure/api/export/chantiers-sans-filtre.ts
@@ -4,6 +4,7 @@ import { stringify } from 'csv-stringify';
 import assert from 'node:assert/strict';
 import { ExportCsvDesChantiersSansFiltreUseCase } from '@/server/usecase/chantier/ExportCsvDesChantiersSansFiltreUseCase';
 import { authOptions } from '@/server/infrastructure/api/auth/[...nextauth]';
+import Habilitation from '@/server/domain/utilisateur/habilitation/Habilitation';
 
 
 export default async function handleExportDesChantiersSansFiltre(request: NextApiRequest, response: NextApiResponse): Promise<void> {
@@ -21,7 +22,8 @@ export default async function handleExportDesChantiersSansFiltre(request: NextAp
   stringifier.pipe(response);
 
   const exportCsvDesChantiersSansFiltreUseCase = new ExportCsvDesChantiersSansFiltreUseCase();
-  for await (const partialResult of exportCsvDesChantiersSansFiltreUseCase.run(session.habilitations, session.profil)) {
+  const habilitation = new Habilitation(session.habilitations);
+  for await (const partialResult of exportCsvDesChantiersSansFiltreUseCase.run(habilitation, session.profil)) {
     for (const chantierPourExport of partialResult) {
       stringifier.write(chantierPourExport);
     }

--- a/src/server/infrastructure/logger.ts
+++ b/src/server/infrastructure/logger.ts
@@ -9,6 +9,7 @@ logger.info({
   logLevel: config.logLevel,
   env: config.env,
   securedEnv: config.securedEnv,
+  isUsingDevCredentials: config.isUsingDevCredentials,
 });
 
 export default logger;

--- a/src/server/usecase/chantier/ExportCsvDesChantiersSansFiltreUseCase.ts
+++ b/src/server/usecase/chantier/ExportCsvDesChantiersSansFiltreUseCase.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/dot-notation */
 import { dependencies } from '@/server/infrastructure/Dependencies';
-import { Habilitations } from '@/server/domain/utilisateur/habilitation/Habilitation.interface';
 import { formaterMétéo, NON, NON_APPLICABLE, OUI } from '@/server/infrastructure/export_csv/valeurs';
 import { ChantierPourExport } from '@/server/usecase/chantier/ExportCsvDesChantiersSansFiltreUseCase.interface';
 import { libellésTypesCommentaire } from '@/client/constants/libellésCommentaire';
@@ -40,10 +39,9 @@ export class ExportCsvDesChantiersSansFiltreUseCase {
     private readonly chantierRepository = dependencies.getChantierRepository(),
   ) {}
 
-  public async* run(habilitations: Habilitations, profil: Profil): AsyncGenerator<string[][]> {
-    const h = new Habilitation(habilitations);
-    const chantierIdsLecture = h.récupérerListeChantiersIdsAccessiblesEnLecture();
-    const territoireCodesLecture = h.récupérerListeTerritoireCodesAccessiblesEnLecture();
+  public async* run(habilitation: Habilitation, profil: Profil): AsyncGenerator<string[][]> {
+    const chantierIdsLecture = habilitation.récupérerListeChantiersIdsAccessiblesEnLecture();
+    const territoireCodesLecture = habilitation.récupérerListeTerritoireCodesAccessiblesEnLecture();
 
     const chunkSize = configuration.exportCsvChantierIdChunkSize;
     for (let i = 0; i < chantierIdsLecture.length; i += chunkSize) {


### PR DESCRIPTION
### Problème

Actuellement, l'export CSV est fait en une seule requête SQL et l'opération occupe beaucoup de mémoire sur le serveur. L'envoi au navigateur des lignes CSV est aussi fait en une seule fois. 

### Solution

Découper la requête et l'envoi des lignes CSV vers le navigateurs en lots de 5 chantiers (taille des lots configurable par variable d'env).

### Observations

Il y a des améliorations possibles, comme désactiver le bouton d'export pendant le téléchargement (pour éviter que l'utilisateur clique plusieurs fois sur une opération coûteuse).

Pas certain non plus que le generator soit nécessaire, un iterator aurait pu suffire (?)
- on dirait que iterator est moins pratique à implémenter en fait : <https://javascript.info/async-iterators-generators>

À appliquer à l'export des indicateurs ?

À l'occasion, j'ai détecté une amélioration possible, sortir le code de transformation CSV du UseCase. J'ai ajouté un commentaire ici qui explique un peu l'idée :
- https://github.com/DITP-pilotage/pilote-2/pull/347/files#r1227023805