### PR TITLE
redmine::561 ignore month in date test

### DIFF
--- a/data_management/data_factory/macros/df3_validation/df3_date_early.sql
+++ b/data_management/data_factory/macros/df3_validation/df3_date_early.sql
@@ -1,4 +1,4 @@
-{% macro df3_date_early(colname_date)%}
+{% macro df3_date_early(colname_date, ignore_day)%}
 
 {{ config(
     tags=["df3","df3_validation"],
@@ -11,7 +11,14 @@ with jjoin as (select
     coalesce(a.id, b.id) as id, 
     coalesce(a.territoire_code, b.territoire_code) as territoire_code,
     a.{{colname_date}} as computed_value,
-    b.{{colname_date}} as target_value
+    b.{{colname_date}} as target_value,
+    -- On calcule si on doit ignorer cette ligne dans les résultats des tests en fonction du param "ignore_day"
+    case
+        -- si ignore_day=TRUE, si le mois est identique => TRUE
+        when {{ignore_day}}::bool then date_trunc('month', a.{{colname_date}}) = date_trunc('month', b.{{colname_date}})
+        -- si ignore_day=FALSE => FALSE
+        else false
+    end as ignore_row
     from {{ ref('df3_indicateur') }} a
     full join  {{ ref('indicateur') }} b
     on a.territoire_code=b.territoire_code and a.id=b.id
@@ -20,5 +27,6 @@ with jjoin as (select
 select * from jjoin
 where 
     (computed_value is not null and target_value is not null and computed_value::date < target_value::date)
+    and not ignore_row
 
 {% endmacro %}

--- a/data_management/data_factory/macros/df3_validation/df3_date_late.sql
+++ b/data_management/data_factory/macros/df3_validation/df3_date_late.sql
@@ -1,4 +1,4 @@
-{% macro df3_date_late(colname_date)%}
+{% macro df3_date_late(colname_date, ignore_day)%}
 
 {{ config(
     tags=["df3","df3_validation"],
@@ -11,7 +11,14 @@ with jjoin as (select
     coalesce(a.id, b.id) as id, 
     coalesce(a.territoire_code, b.territoire_code) as territoire_code,
     a.{{colname_date}} as computed_value,
-    b.{{colname_date}} as target_value
+    b.{{colname_date}} as target_value,
+    -- On calcule si on doit ignorer cette ligne dans les résultats des tests en fonction du param "ignore_day"
+    case
+        -- si ignore_day=TRUE, si le mois est identique => TRUE
+        when {{ignore_day}}::bool then date_trunc('month', a.{{colname_date}}) = date_trunc('month', b.{{colname_date}})
+        -- si ignore_day=FALSE => FALSE
+        else false
+    end as ignore_row
     from {{ ref('df3_indicateur') }} a
     full join  {{ ref('indicateur') }} b
     on a.territoire_code=b.territoire_code and a.id=b.id
@@ -20,5 +27,6 @@ with jjoin as (select
 select * from jjoin
 where 
     (computed_value is not null and target_value is not null and computed_value::date > target_value::date)
+    and not ignore_row
 
 {% endmacro %}

--- a/data_management/data_factory/macros/df3_validation/schema.yml
+++ b/data_management/data_factory/macros/df3_validation/schema.yml
@@ -10,6 +10,9 @@ macros:
       - name: colname_date
         type: string
         description: Nom de la colonne de `df2.df3_indicateur` et `public.indicateur` contenant une date à vérifier.
+      - name: ignore_day
+        type: boolean
+        description: Indique si on doit ignorer le jour du mois. Ie, si le mois est identique, on considère les dates identiques.
   - name: df3_date_late
     description: |
       Macro de test de la `df2.df3_indicateur` par rapport à `public.indicateur`. 
@@ -19,6 +22,9 @@ macros:
       - name: colname_date
         type: string
         description: Nom de la colonne de `df2.df3_indicateur` et `public.indicateur` contenant une date à vérifier.
+      - name: ignore_day
+        type: boolean
+        description: Indique si on doit ignorer le jour du mois. Ie, si le mois est identique, on considère les dates identiques.
   - name: df3_not_equal_bool
     description: |
       Macro de test de la `df2.df3_indicateur` par rapport à `public.indicateur`. 

--- a/data_management/data_factory/tests/df3/va/df3_va_date_late.sql
+++ b/data_management/data_factory/tests/df3/va/df3_va_date_late.sql
@@ -1,3 +1,3 @@
 {{ config(enabled=true, tags=["scope_indicateur", "metric_va"]) }}
 
-{{ df3_date_late('date_valeur_actuelle') }}
+{{ df3_date_late('date_valeur_actuelle', 'TRUE') }}

--- a/data_management/data_factory/tests/df3/va/df3_va_date_soon.sql
+++ b/data_management/data_factory/tests/df3/va/df3_va_date_soon.sql
@@ -1,3 +1,3 @@
 {{ config(enabled=true, tags=["scope_indicateur", "metric_va"]) }}
 
-{{ df3_date_early('date_valeur_actuelle') }}
+{{ df3_date_early('date_valeur_actuelle', 'TRUE') }}

--- a/data_management/data_factory/tests/df3/vca/df3_vca_date_late.sql
+++ b/data_management/data_factory/tests/df3/vca/df3_vca_date_late.sql
@@ -1,3 +1,3 @@
 {{ config(enabled=true, tags=["scope_indicateur", "metric_vca"]) }}
 
-{{ df3_date_late('objectif_date_valeur_cible_intermediaire') }}
+{{ df3_date_late('objectif_date_valeur_cible_intermediaire', 'TRUE') }}

--- a/data_management/data_factory/tests/df3/vca/df3_vca_date_soon.sql
+++ b/data_management/data_factory/tests/df3/vca/df3_vca_date_soon.sql
@@ -1,3 +1,3 @@
 {{ config(enabled=true, tags=["scope_indicateur", "metric_vca"]) }}
 
-{{ df3_date_early('objectif_date_valeur_cible_intermediaire') }}
+{{ df3_date_early('objectif_date_valeur_cible_intermediaire', 'TRUE') }}

--- a/data_management/data_factory/tests/df3/vcg/df3_vcg_date_late.sql
+++ b/data_management/data_factory/tests/df3/vcg/df3_vcg_date_late.sql
@@ -1,3 +1,3 @@
 {{ config(enabled=true, tags=["scope_indicateur", "metric_vcg"]) }}
 
-{{ df3_date_late('objectif_date_valeur_cible') }}
+{{ df3_date_late('objectif_date_valeur_cible', 'TRUE') }}

--- a/data_management/data_factory/tests/df3/vcg/df3_vcg_date_soon.sql
+++ b/data_management/data_factory/tests/df3/vcg/df3_vcg_date_soon.sql
@@ -1,3 +1,3 @@
 {{ config(enabled=true, tags=["scope_indicateur", "metric_vcg"]) }}
 
-{{ df3_date_early('objectif_date_valeur_cible') }}
+{{ df3_date_early('objectif_date_valeur_cible', 'TRUE') }}

--- a/data_management/data_factory/tests/df3/vi/df3_vi_date_late.sql
+++ b/data_management/data_factory/tests/df3/vi/df3_vi_date_late.sql
@@ -1,3 +1,3 @@
 {{ config(enabled=true, tags=["scope_indicateur", "metric_vi"]) }}
 
-{{ df3_date_late('date_valeur_initiale') }}
+{{ df3_date_late('date_valeur_initiale', 'TRUE') }}

--- a/data_management/data_factory/tests/df3/vi/df3_vi_date_soon.sql
+++ b/data_management/data_factory/tests/df3/vi/df3_vi_date_soon.sql
@@ -1,3 +1,3 @@
 {{ config(enabled=true, tags=["scope_indicateur", "metric_vi"]) }}
 
-{{ df3_date_early('date_valeur_initiale') }}
+{{ df3_date_early('date_valeur_initiale', 'TRUE') }}


### PR DESCRIPTION
dbt.macro: ajout param ignore_day

pour ignorer le jour exact dans la comparaison des dates mais comparer seulement le mois.

Modif de tous les tests qui utilisaient cette macro