### PR TITLE
fix: revert simplification PIL-90 (PIL-129)

### DIFF
--- a/data_management/data_factory/models/df3/5_exposition/df3_indicateur.sql
+++ b/data_management/data_factory/models/df3/5_exposition/df3_indicateur.sql
@@ -45,16 +45,16 @@ sort_mesures_vaca_last as (
 	mi.indic_id as id,
 	mi.indic_nom as nom,
 	mi.indic_parent_ch as chantier_id,
-	a.vcg as objectif_valeur_cible,
+	gvcg.vcg as objectif_valeur_cible,
 	tag as objectif_taux_avancement,
 	mi.indic_type as type_id,
 	mit.indic_type_name as type_nom,
 	mi.indic_is_baro as est_barometre,
 	mi.indic_is_phare as est_phare,
 	a.metric_date::date as date_valeur_actuelle,
-	a.vig_date::date as date_valeur_initiale,
+	gvig.vig_date::date as date_valeur_initiale,
 	a.vaca as valeur_actuelle,
-	a.vig as valeur_initiale,
+	gvig.vig as valeur_initiale,
 	terr.code_insee,
 	mz.zone_type as maille,
 	terr.nom as territoire_nom,
@@ -67,11 +67,11 @@ sort_mesures_vaca_last as (
 	mpi.poids_pourcent_dept as ponderation_dept,
 	mpi.poids_pourcent_nat as ponderation_nat,
 	mpi.poids_pourcent_reg as ponderation_reg,
-	a.vcg_date::date as objectif_date_valeur_cible,
-	a.vca_courant as objectif_valeur_cible_intermediaire,
+	gvcg.vcg_date::date as objectif_date_valeur_cible,
+	gvca.vca as objectif_valeur_cible_intermediaire,
 	taa_courant as objectif_taux_avancement_intermediaire,
 	-- Ajouter taa_adate ? ou pas besoin
-	a.vca_courant_date::date as objectif_date_valeur_cible_intermediaire,
+	gvca.vca_date::date as objectif_date_valeur_cible_intermediaire,
     COALESCE(z_appl.est_applicable, true) AS est_applicable,
 	last_update_indic_zone.dernier_import_date,
     last_update_indic_zone.dernier_import_rapport_id,
@@ -89,9 +89,9 @@ sort_mesures_vaca_last as (
 	--left join raw_data.metadata_indicateurs mi on mi1.indic_id = mi.indic_id 
 	-- -- -- left join {{ ref('merge_computed_values') }} mcv on mi.indic_id=mcv.indic_id and t.zone_id=mcv.zone_id
 	-- Récupération VIG, VCG, et VCA (redmine::621)
-	--left join {{ ref('get_vig') }} gvig on mi.indic_id=gvig.indic_id and t.zone_id=gvig.zone_id
-	--left join {{ ref('get_vcg') }} gvcg on mi.indic_id=gvcg.indic_id and t.zone_id=gvcg.zone_id
-	--left join (select * from {{ ref('get_vca') }} where yyear=(date_part('year', now()))) gvca on mi.indic_id=gvca.indic_id and t.zone_id=gvca.zone_id
+	left join {{ ref('get_vig') }} gvig on mi.indic_id=gvig.indic_id and t.zone_id=gvig.zone_id
+	left join {{ ref('get_vcg') }} gvcg on mi.indic_id=gvcg.indic_id and t.zone_id=gvcg.zone_id
+	left join (select * from {{ ref('get_vca') }} where yyear=(date_part('year', now()))) gvca on mi.indic_id=gvca.indic_id and t.zone_id=gvca.zone_id
 	left join {{ ref('metadata_indicateur_types') }} mit on mit.indic_type_id = mi.indic_type 
 	left join {{ ref('metadata_parametrage_indicateurs') }} mpi on mi.indic_id = mpi.indic_id 
 	left join public.territoire terr on t.zone_id = terr.zone_id 


### PR DESCRIPTION
en effet, on se basait alors sur la table "sort_mesures_vaca" pour avoir les vc/vi . Or, cette table ignore les lignes avec VA NULL (cf L38). Donc lorsqu'une ligne était sans VA, aucune VI/VC ne remontait ! C'est corrigé en utilisant de nouveau les tables get_vig, get_vcg et get_vca qui ont été créée pour cet usage précis.