### PR TITLE
Pil 551 modifier adresse contact

### DIFF
--- a/auth/themes/ditp/login/login.ftl
+++ b/auth/themes/ditp/login/login.ftl
@@ -23,7 +23,7 @@
                                     <strong>Votre identifiant ou votre mot de passe est erroné</strong>
                                   </li>
                                   <li>
-                                    <strong>Vous compte n’existe pas</strong> : faites-en la demande en envoyant un courrier électronique à l’adresse <a href="mailto:support.ditp@modernisation.gouv.fr">support.ditp@modernisation.gouv.fr</a>
+                                    <strong>Vous compte n’existe pas</strong> : faites-en la demande en envoyant un courrier électronique à l’adresse <a href="mailto:pilote.ditp@modernisation.gouv.fr">pilote.ditp@modernisation.gouv.fr</a>
                                   </li>
                                   <li>
                                     <strong>Votre demande de compte est encore en attente de validation</strong> : attendez qu’elle soit validée par votre référent, et vous recevrez un courriel intitulé “création de compte Pilote” de confirmation vous invitant à créer votre mot de passe

--- a/doc/api/pilote-api.yml
+++ b/doc/api/pilote-api.yml
@@ -15,7 +15,7 @@ info:
     # Détails techniques
     ## Authentification
 
-    Pour utiliser l'API, vous devrez **récupérer un token d'API**. Celui-ci sera à demander par email à l'adresse [support.ditp@modernisation.gouv.fr](mailto:support.ditp@modernisation.gouv.fr?subject=[api.token]%20&cc=colin.dugeai@modernisation.gouv.fr&body=%0D%0A%0D%0A%0D%0A%0D%0A%0D%0A%20tag:api.token) avec en début d'objet *[api.token]*.
+    Pour utiliser l'API, vous devrez **récupérer un token d'API**. Celui-ci sera à demander par email à l'adresse [pilote.ditp@modernisation.gouv.fr](mailto:pilote.ditp@modernisation.gouv.fr?subject=[api.token]%20&cc=johan.boucaut@modernisation.gouv.fr&body=%0D%0A%0D%0A%0D%0A%0D%0A%0D%0A%20tag:api.token) avec en début d'objet *[api.token]*.
 
     Ce token devra être inséré en *header* pour chaque requête envoyée vers l'API. `Authorization: Bearer <token>`.
 
@@ -66,7 +66,7 @@ info:
     *   Toutes les zones du template d'import ne sont pas nécessaires. Certaines lignes du fichier d'import peuvent être supprimées. Il n’est ainsi pas nécessaire d’importer la totalité des départements pour chaque mise à jour.
     *   Il n'est pas possible d'importer plusieurs valeurs pour la même zone, date, identifiant d'indicateur et type de valeur. Cela générerait une erreur.
 
-    **Si vous rencontrez des difficultés, merci de nous contacter à l’adresse suivante** (en mentionnant *[api]* dans l'objet de votre mail): [support.ditp@modernisation.gouv.fr](mailto:support.ditp@modernisation.gouv.fr?subject=[api]%20&cc=colin.dugeai@modernisation.gouv.fr&body=%0D%0A%0D%0A%0D%0A%0D%0A%0D%0A%20tag:api)
+    **Si vous rencontrez des difficultés, merci de nous contacter à l’adresse suivante** (en mentionnant *[api]* dans l'objet de votre mail): [pilote.ditp@modernisation.gouv.fr](mailto:pilote.ditp@modernisation.gouv.fr?subject=[api]%20&cc=colin.dugeai@modernisation.gouv.fr&body=%0D%0A%0D%0A%0D%0A%0D%0A%0D%0A%20tag:api)
   contact: {}
 servers:
   - url: 'http://localhost:3000/api/open-api'

--- a/src/client/components/DonnéesPersonnellesCookies/DonneesPersonnellesCookies.tsx
+++ b/src/client/components/DonnéesPersonnellesCookies/DonneesPersonnellesCookies.tsx
@@ -26,10 +26,10 @@ const DonneesPersonnellesCookies: FunctionComponent<{}> = () => {
                 Pour toute question au sujet de la gestion des cookies, vous pouvez utiliser l’adresse suivante : 
                 {' '}
                 <Link
-                  href='mailto:support.ditp@modernisation.gouv.fr'
-                  title='Envoyer un courriel à support.ditp@modernisation.gouv.fr'
+                  href='mailto:pilote.ditp@modernisation.gouv.fr'
+                  title='Envoyer un courriel à pilote.ditp@modernisation.gouv.fr'
                 >
-                  support.ditp@modernisation.gouv.fr
+                  pilote.ditp@modernisation.gouv.fr
                 </Link>
               </p>  
             </div>
@@ -167,10 +167,10 @@ const DonneesPersonnellesCookies: FunctionComponent<{}> = () => {
               ou par courriel à :
               {' '}
               <Link
-                href='mailto:support.ditp@modernisation.gouv.fr'
-                title='Envoyer un courriel à support.ditp@modernisation.gouv.fr'
+                href='mailto:pilote.ditp@modernisation.gouv.fr'
+                title='Envoyer un courriel à pilote.ditp@modernisation.gouv.fr'
               >
-                support.ditp@modernisation.gouv.fr
+                pilote.ditp@modernisation.gouv.fr
               </Link>
             </p>
             <p className='fr-text fr-col-12'>

--- a/src/client/components/PageAdminGestionContenus/useMessageInformation.ts
+++ b/src/client/components/PageAdminGestionContenus/useMessageInformation.ts
@@ -20,7 +20,7 @@ export const useMessageInformation = ({ messageInformation, modificationReussie 
   const reactHookForm = useForm<ContenuForm>({
     resolver: zodResolver(validationContenu),
     defaultValues: {
-      bandeauTexte: messageInformation.bandeauTexte || 'Des opérations de maintenance sont en cours et peuvent perturber le fonctionnement normal de PILOTE. En cas de difficultés : support.ditp@modernisation.gouv.fr',
+      bandeauTexte: messageInformation.bandeauTexte || 'Des opérations de maintenance sont en cours et peuvent perturber le fonctionnement normal de PILOTE. En cas de difficultés : pilote.ditp@modernisation.gouv.fr',
       bandeauType: messageInformation.bandeauType || 'WARNING',
       isBandeauActif: messageInformation.isBandeauActif || false,
     },

--- a/src/client/components/_commons/MiseEnPage/EnTête/EnTête.tsx
+++ b/src/client/components/_commons/MiseEnPage/EnTête/EnTête.tsx
@@ -21,7 +21,7 @@ const EnTête: FunctionComponent<{}> = () => {
   const { messageInformation } = useEntete();
 
   const isBandeauActif = messageInformation?.isBandeauActif || false;
-  const bandeauTexte = messageInformation?.bandeauTexte || 'Des opérations de maintenance sont en cours et peuvent perturber le fonctionnement normal de PILOTE. En cas de difficultés : support.ditp@modernisation.gouv.fr';
+  const bandeauTexte = messageInformation?.bandeauTexte || 'Des opérations de maintenance sont en cours et peuvent perturber le fonctionnement normal de PILOTE. En cas de difficultés : pilote.ditp@modernisation.gouv.fr';
   const bandeauType = messageInformation?.bandeauType || 'WARNING';
 
   return (

--- a/src/client/components/_commons/PageVide/PageVide.tsx
+++ b/src/client/components/_commons/PageVide/PageVide.tsx
@@ -40,7 +40,7 @@ const PageVide: FunctionComponent<PageVideProps> = ({ titre }) => {
                 </p>
                 <a
                   className='fr-btn fr-btn--secondary'
-                  href='mailto:support.ditp@modernisation.gouv.fr'
+                  href='mailto:pilote.ditp@modernisation.gouv.fr'
                 >
                   Contactez-nous
                 </a>

--- a/src/client/utils/i18n/wordingFr.ts
+++ b/src/client/utils/i18n/wordingFr.ts
@@ -42,7 +42,7 @@ export const wordingFr = {
         TITRE_ALERT_ERREUR: 'Le fichier ne peut pas être importé',
         MESSAGE_ALERT_ERREUR: 'Il contient des erreurs expliquées dans le rapport d’erreurs ci-dessous. Nous vous recommandons de consulter les ressources et/ou de remplir le modèle de fichier à remplir.',
         TITRE_ALERT_ERREUR_SUPPORT: 'Le fichier ne peut pas être importé',
-        MESSAGE_ALERT_ERREUR_SUPPORT: 'Il contient des erreurs non identifiées. Nous vous recommandons de consulter les ressources, de remplir le modèle de fichier à remplir ou de contacter le support de la DITP: support.ditp@modernisation.gouv.fr.',
+        MESSAGE_ALERT_ERREUR_SUPPORT: 'Il contient des erreurs non identifiées. Nous vous recommandons de consulter les ressources, de remplir le modèle de fichier à remplir ou de contacter le support de la DITP: pilote.ditp@modernisation.gouv.fr.',
         TABLEAU_ERREUR: {
           ENTETE: {
             NOM: "Type d'erreur",
@@ -159,7 +159,7 @@ export const wordingFr = {
       }, 
       SECTION_CONTACT: {
         MESSAGE_CONTACT: 'Si vous rencontrez des difficultés lors de l’import de votre fichier, merci de nous contacter à l’adresse : ',
-        ADRESSE_MAIL: 'support.ditp@modernisation.gouv.fr',
+        ADRESSE_MAIL: 'pilote.ditp@modernisation.gouv.fr',
       },
     },
   },

--- a/src/server/app/contrats/MessageInformationContrat.ts
+++ b/src/server/app/contrats/MessageInformationContrat.ts
@@ -7,7 +7,7 @@ export interface MessageInformationContrat {
   bandeauType: string
 }
 export const presenterEnMessageInformationContrat = (messageInformation: MessageInformation): MessageInformationContrat => ({
-  bandeauTexte: messageInformation.bandeauTexte || 'Des opérations de maintenance sont en cours et peuvent perturber le fonctionnement normal de PILOTE. En cas de difficultés : support.ditp@modernisation.gouv.fr',
+  bandeauTexte: messageInformation.bandeauTexte || 'Des opérations de maintenance sont en cours et peuvent perturber le fonctionnement normal de PILOTE. En cas de difficultés : pilote.ditp@modernisation.gouv.fr',
   bandeauType: messageInformation.bandeauType || 'WARNING',
   isBandeauActif: messageInformation.isBandeauActif || false,
 });

--- a/src/validation/utilisateur.ts
+++ b/src/validation/utilisateur.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 import { ProfilCode, profilsCodes } from '@/server/domain/utilisateur/Utilisateur.interface';
 import { ProfilEnum } from '@/server/app/enum/profil.enum';
 
-const customErrorMail = 'Vous essayez de créer un compte pour une adresse dont le domaine n’est pas en .gouv.fr. Veuillez contacter support.ditp@modernisation.gouv.fr pour plus d’informations.';
+const customErrorMail = 'Vous essayez de créer un compte pour une adresse dont le domaine n’est pas en .gouv.fr. Veuillez contacter pilote.ditp@modernisation.gouv.fr pour plus d’informations.';
 
 const customErrorMap: z.ZodErrorMap = (issue, ctx) => {
   if (issue.code === z.ZodIssueCode.invalid_string && issue.validation === 'email') {


### PR DESCRIPTION
Modification de tous les fichiers contenant l'adresse support.ditp@modernisation.gouv.fr pour la remplacer par pilote.ditp@modernisation.gouv.fr