### PR TITLE
refactor: fetch du user connecté et nettoyage de la session

### DIFF
--- a/src/client/components/_commons/IndicateursChantier/Bloc/ModalePropositionValeurAvancementV2/ModalePropositionValeurAvancementV2.tsx
+++ b/src/client/components/_commons/IndicateursChantier/Bloc/ModalePropositionValeurAvancementV2/ModalePropositionValeurAvancementV2.tsx
@@ -15,16 +15,20 @@ import { LIMITE_CARACTERES_DOCUMENTATION_PROPOSITION } from "@/validation/propos
 import { useRefreshRouter } from "@/client/hooks/useRefreshRouter";
 import { useBlocIndicateurContext } from "@/components/PageChantier/useBlocIndicateurContext";
 import { SelecteurNew } from "@/components/_commons/SelecteurNew/SelecteurNew";
+import api from "@/server/infrastructure/api/trpc/api";
 
 export const ModalePropositionValeurAvancementV2: FunctionComponent<
   PropsWithChildren
 > = ({ children }) => {
+  const [utilisateur] =
+    api.profilUtilisateur.getUtilisateurConnecte.useSuspenseQuery();
+  const auteurModification = `${utilisateur.prenom} ${utilisateur.nom}`;
+
   const {
     reactHookForm,
     creerPropositonValeurAvancement,
     etapePropositionValeurAvancement,
     setEtapePropositionValeurAvancement,
-    auteurModification,
     EtapeSuivanteEstDesactive,
     estUneModificationDeProposition,
     optionsMois,

--- a/src/client/components/_commons/IndicateursChantier/Bloc/ModalePropositionValeurAvancementV2/useModalePropositionValeurAvancementV2.ts
+++ b/src/client/components/_commons/IndicateursChantier/Bloc/ModalePropositionValeurAvancementV2/useModalePropositionValeurAvancementV2.ts
@@ -1,7 +1,6 @@
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useMemo, useState } from "react";
-import { useSession } from "next-auth/react";
 import { z } from "zod";
 import { LIMITE_CARACTERES_DOCUMENTATION_PROPOSITION } from "@/validation/proposition-valeur-avancement";
 import api from "@/server/infrastructure/api/trpc/api";

--- a/src/client/components/_commons/IndicateursChantier/Bloc/ModalePropositionValeurAvancementV2/useModalePropositionValeurAvancementV2.ts
+++ b/src/client/components/_commons/IndicateursChantier/Bloc/ModalePropositionValeurAvancementV2/useModalePropositionValeurAvancementV2.ts
@@ -134,10 +134,6 @@ const genererOptionsMois = (
 };
 
 const useModalePropositionValeurAvancementV2 = () => {
-  const { data: session } = useSession();
-
-  const auteurModification = session?.user.name;
-
   const { indicateur, detailIndicateurDuTerritoire, territoireCode } =
     useBlocIndicateurContext();
 
@@ -265,7 +261,6 @@ const useModalePropositionValeurAvancementV2 = () => {
     creerPropositonValeurAvancement,
     etapePropositionValeurAvancement,
     setEtapePropositionValeurAvancement,
-    auteurModification,
     EtapeSuivanteEstDesactive,
     estUneModificationDeProposition,
     optionsMois,

--- a/src/client/components/_commons/IndicateursChantier/Bloc/ModaleSuppressionValeurAvancementV2/ModaleSuppressionValeurAvancementV2.tsx
+++ b/src/client/components/_commons/IndicateursChantier/Bloc/ModaleSuppressionValeurAvancementV2/ModaleSuppressionValeurAvancementV2.tsx
@@ -7,6 +7,7 @@ import { formaterDate } from "@/client/utils/date/date";
 import TextAreaAvecLabel from "@/components/_commons/TextAreaAvecLabel/TextAreaAvecLabel";
 import { LIMITE_CARACTERES_DOCUMENTATION_PROPOSITION } from "@/validation/proposition-valeur-avancement";
 import { useRefreshRouter } from "@/client/hooks/useRefreshRouter";
+import api from "@/server/infrastructure/api/trpc/api";
 import useModaleSuppressionValeurAvancementV2, {
   EtapeSuppressionPropositionValeurAvancement,
   Stepper,
@@ -33,14 +34,15 @@ export const ModaleSuppressionValeurAvancementV2: FunctionComponent<
     supprimerPropositionValeurAvancement,
     etapePropositionValeurAvancement,
     setEtapePropositionValeurAvancement,
-    auteurModification,
     etapeSuivanteEstDesactive,
   } = useModaleSuppressionValeurAvancementV2({
     indicateur,
     detailIndicateur,
     territoireCode,
   });
-
+  const [utilisateur] =
+    api.profilUtilisateur.getUtilisateurConnecte.useSuspenseQuery();
+  const auteurModification = `${utilisateur.prenom} ${utilisateur.nom}`;
   const refreshRouter = useRefreshRouter();
 
   return (

--- a/src/client/components/_commons/IndicateursChantier/Bloc/ModaleSuppressionValeurAvancementV2/useModaleSuppressionValeurAvancementV2.ts
+++ b/src/client/components/_commons/IndicateursChantier/Bloc/ModaleSuppressionValeurAvancementV2/useModaleSuppressionValeurAvancementV2.ts
@@ -1,6 +1,5 @@
 import { useForm } from "react-hook-form";
 import { useState } from "react";
-import { useSession } from "next-auth/react";
 import { z } from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
 import Indicateur from "@/server/domain/indicateur/Indicateur.interface";
@@ -50,10 +49,6 @@ const useModaleSuppressionValeurAvancementV2 = ({
   detailIndicateur: DétailsIndicateur;
   territoireCode: string;
 }) => {
-  const { data: session } = useSession();
-
-  const auteurModification = session?.user.name!;
-
   const [
     etapePropositionValeurAvancement,
     setEtapePropositionValeurAvancement,
@@ -74,7 +69,6 @@ const useModaleSuppressionValeurAvancementV2 = ({
     const inputs = {
       csrf: récupérerUnCookie("csrf") ?? "",
       indicId: indicateur.id,
-      auteurModification,
       territoireCode,
       dateValeurAvancement: detailIndicateur.proposition!.dateValeurAvancement,
       motif: data.motifSuppression,
@@ -95,7 +89,6 @@ const useModaleSuppressionValeurAvancementV2 = ({
     supprimerPropositionValeurAvancement,
     etapePropositionValeurAvancement,
     setEtapePropositionValeurAvancement,
-    auteurModification,
     etapeSuivanteEstDesactive: !reactHookForm.formState.isValid,
   };
 };

--- a/src/client/components/_commons/MiseEnPage/EnTete/EnTete.tsx
+++ b/src/client/components/_commons/MiseEnPage/EnTete/EnTete.tsx
@@ -9,6 +9,7 @@ import api from "@/server/infrastructure/api/trpc/api";
 import { BoutonContacterEquipePilote } from "@/components/PageAccueil/BoutonContacterEquipePilote";
 import { BoutonSeConnecter } from "@/components/_commons/BoutonSeConnecter";
 import { BoutonApplicationsPilote } from "@/components/_commons/MiseEnPage/EnTete/BoutonApplicationsPilote";
+import { ClientOnly } from "@/components/shared/ClientOnly";
 
 const useEntete = () => {
   const { data: messageInformation } =
@@ -69,19 +70,21 @@ export const EnTete = () => {
             </div>
             <div className="fr-header__tools">
               <div className="fr-header__tools-links">
-                <div className="flex align-center gap-4">
-                  <BoutonContacterEquipePilote />
-                  {session?.user?.email ? (
-                    <>
-                      {peutVoirLeBoutonApplicationsPilote ? (
-                        <BoutonApplicationsPilote />
-                      ) : null}
-                      <Utilisateur email={session.user.email} />
-                    </>
-                  ) : (
-                    <BoutonSeConnecter />
-                  )}
-                </div>
+                <ClientOnly>
+                  <div className="flex align-center gap-4">
+                    <BoutonContacterEquipePilote />
+                    {session?.user?.email ? (
+                      <>
+                        {peutVoirLeBoutonApplicationsPilote ? (
+                          <BoutonApplicationsPilote />
+                        ) : null}
+                        <Utilisateur email={session.user.email} />
+                      </>
+                    ) : (
+                      <BoutonSeConnecter />
+                    )}
+                  </div>
+                </ClientOnly>
               </div>
             </div>
           </div>

--- a/src/client/components/_commons/MiseEnPage/EnTete/EnTete.tsx
+++ b/src/client/components/_commons/MiseEnPage/EnTete/EnTete.tsx
@@ -11,6 +11,27 @@ import { BoutonSeConnecter } from "@/components/_commons/BoutonSeConnecter";
 import { BoutonApplicationsPilote } from "@/components/_commons/MiseEnPage/EnTete/BoutonApplicationsPilote";
 import { ClientOnly } from "@/components/shared/ClientOnly";
 
+const InformationsEspaceConnecte = () => {
+  const { data: session } = useSession();
+
+  const peutVoirLeBoutonApplicationsPilote =
+    process.env.NEXT_PUBLIC_FF_PILOTE_EVAL === "true" &&
+    (process.env.NEXT_PUBLIC_FF_ACCES_PILOTE === "true" ||
+      session?.profil === "DITP_ADMIN");
+
+  if (session?.user != null)
+    return (
+      <>
+        {peutVoirLeBoutonApplicationsPilote ? (
+          <BoutonApplicationsPilote />
+        ) : null}
+        <Utilisateur />
+      </>
+    );
+
+  return <BoutonSeConnecter />;
+};
+
 const useEntete = () => {
   const { data: messageInformation } =
     api.gestionContenu.récupérerMessageInformation.useQuery();
@@ -28,10 +49,6 @@ export const EnTete = () => {
     messageInformation?.bandeauTexte ||
     "Des opérations de maintenance sont en cours et peuvent perturber le fonctionnement normal de PILOTE. En cas de difficultés : pilote.ditp@modernisation.gouv.fr";
   const bandeauType = messageInformation?.bandeauType || "WARNING";
-  const peutVoirLeBoutonApplicationsPilote =
-    process.env.NEXT_PUBLIC_FF_PILOTE_EVAL === "true" &&
-    (process.env.NEXT_PUBLIC_FF_ACCES_PILOTE === "true" ||
-      session?.profil === "DITP_ADMIN");
 
   return (
     <header className="fr-header" role="banner">
@@ -70,27 +87,22 @@ export const EnTete = () => {
             </div>
             <div className="fr-header__tools">
               <div className="fr-header__tools-links">
-                <ClientOnly>
-                  <div className="flex align-center gap-4">
-                    <BoutonContacterEquipePilote />
-                    {session?.user?.email ? (
-                      <>
-                        {peutVoirLeBoutonApplicationsPilote ? (
-                          <BoutonApplicationsPilote />
-                        ) : null}
-                        <Utilisateur email={session.user.email} />
-                      </>
-                    ) : (
-                      <BoutonSeConnecter />
-                    )}
-                  </div>
-                </ClientOnly>
+                <div className="flex align-center gap-4">
+                  <BoutonContacterEquipePilote />
+                  <ClientOnly>
+                    <InformationsEspaceConnecte />
+                  </ClientOnly>
+                </div>
               </div>
             </div>
           </div>
         </div>
       </div>
-      {session?.user ? <Navigation /> : null}
+      {session?.user ? (
+        <ClientOnly>
+          <Navigation />
+        </ClientOnly>
+      ) : null}
       {isBandeauActif ? (
         <BandeauInformation bandeauType={bandeauType}>
           {bandeauTexte}

--- a/src/client/components/_commons/MiseEnPage/EnTete/Utilisateur/Utilisateur.tsx
+++ b/src/client/components/_commons/MiseEnPage/EnTete/Utilisateur/Utilisateur.tsx
@@ -8,14 +8,10 @@ import { clsxm } from "@/utils/clsxm";
 import { Dropdown } from "@/components/shared/Dropdown";
 import api from "@/server/infrastructure/api/trpc/api";
 
-export const Utilisateur = ({ email }: { email: string }) => {
+export const Utilisateur = () => {
   const [estDeplie, setEstDeplie] = useState<boolean>(false);
-  // const { data: user } = api.profilUtilisateur.getUtilisateurConnecte.useQuery(
-  //   undefined,
-  //   {
-  //     staleTime: 5 * 60 * 1000,
-  //   },
-  // );
+  const [{ email }] =
+    api.profilUtilisateur.getUtilisateurConnecte.useSuspenseQuery();
 
   const { data: panelAdminEstDisponible } =
     api.gestionContenu.récupérerVariableContenu.useQuery({

--- a/src/client/components/_commons/MiseEnPage/EnTete/Utilisateur/Utilisateur.tsx
+++ b/src/client/components/_commons/MiseEnPage/EnTete/Utilisateur/Utilisateur.tsx
@@ -10,6 +10,12 @@ import api from "@/server/infrastructure/api/trpc/api";
 
 export const Utilisateur = ({ email }: { email: string }) => {
   const [estDeplie, setEstDeplie] = useState<boolean>(false);
+  // const { data: user } = api.profilUtilisateur.getUtilisateurConnecte.useQuery(
+  //   undefined,
+  //   {
+  //     staleTime: 5 * 60 * 1000,
+  //   },
+  // );
 
   const { data: panelAdminEstDisponible } =
     api.gestionContenu.récupérerVariableContenu.useQuery({

--- a/src/client/components/_commons/MiseEnPage/MiseEnPage.tsx
+++ b/src/client/components/_commons/MiseEnPage/MiseEnPage.tsx
@@ -3,7 +3,6 @@ import {
   FunctionComponent,
   Suspense,
   useCallback,
-  useEffect,
   useMemo,
   useState,
 } from "react";
@@ -13,23 +12,13 @@ import MiseEnPageStyled from "@/components/_commons/MiseEnPage/MiseEnPage.styled
 import api from "@/server/infrastructure/api/trpc/api";
 import { actionsTerritoiresStore } from "@/stores/useTerritoiresStore/useTerritoiresStore";
 import { ClientOnly } from "@/components/shared/ClientOnly";
+import { usePrefetchUtilisateurConnecte } from "@/client/hooks/usePrefetchUtilisateurConnecte";
 import { EnTete } from "./EnTete/EnTete";
 import PiedDePage from "./PiedDePage/PiedDePage";
 
 interface MiseEnPageProps {
   afficherLeLoader: boolean;
   children: React.ReactNode;
-}
-
-function usePrefetchUtilisateurConnecte() {
-  const session = useSession();
-  const [enabled, setEnabled] = useState(false);
-  api.profilUtilisateur.getUtilisateurConnecte.useQuery(undefined, { enabled });
-
-  useEffect(() => {
-    if (session.status !== "authenticated") return;
-    setEnabled(true);
-  }, [session.status]);
 }
 
 const MiseEnPage: FunctionComponent<MiseEnPageProps> = ({

--- a/src/client/components/_commons/MiseEnPage/MiseEnPage.tsx
+++ b/src/client/components/_commons/MiseEnPage/MiseEnPage.tsx
@@ -1,16 +1,35 @@
 import { useSession } from "next-auth/react";
-import { FunctionComponent, useCallback, useMemo, useState } from "react";
+import {
+  FunctionComponent,
+  Suspense,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 import PageLanding from "@/components/PageLanding/PageLanding";
 import Loader from "@/client/components/_commons/Loader/Loader";
 import MiseEnPageStyled from "@/components/_commons/MiseEnPage/MiseEnPage.styled";
 import api from "@/server/infrastructure/api/trpc/api";
 import { actionsTerritoiresStore } from "@/stores/useTerritoiresStore/useTerritoiresStore";
+import { ClientOnly } from "@/components/shared/ClientOnly";
 import { EnTete } from "./EnTete/EnTete";
 import PiedDePage from "./PiedDePage/PiedDePage";
 
 interface MiseEnPageProps {
   afficherLeLoader: boolean;
   children: React.ReactNode;
+}
+
+function usePrefetchUtilisateurConnecte() {
+  const session = useSession();
+  const [enabled, setEnabled] = useState(false);
+  api.profilUtilisateur.getUtilisateurConnecte.useQuery(undefined, { enabled });
+
+  useEffect(() => {
+    if (session.status !== "authenticated") return;
+    setEnabled(true);
+  }, [session.status]);
 }
 
 const MiseEnPage: FunctionComponent<MiseEnPageProps> = ({
@@ -30,6 +49,7 @@ const MiseEnPage: FunctionComponent<MiseEnPageProps> = ({
       refetchOnWindowFocus: false,
       enabled: false,
     });
+  usePrefetchUtilisateurConnecte();
 
   const récupérerLesTerritoires = useCallback(async () => {
     const { data: territoires } = await fetchRécupérerLesTerritoires();
@@ -68,7 +88,13 @@ const MiseEnPage: FunctionComponent<MiseEnPageProps> = ({
               </p>
             </div>
           ) : null}
-          {status === "unauthenticated" ? <PageLanding /> : children}
+          {status === "unauthenticated" ? (
+            <PageLanding />
+          ) : (
+            <ClientOnly>
+              <Suspense>{children}</Suspense>
+            </ClientOnly>
+          )}
           <PiedDePage />
         </div>
       )}

--- a/src/client/components/_commons/MiseEnPage/MiseEnPage.tsx
+++ b/src/client/components/_commons/MiseEnPage/MiseEnPage.tsx
@@ -1,11 +1,5 @@
 import { useSession } from "next-auth/react";
-import {
-  FunctionComponent,
-  Suspense,
-  useCallback,
-  useMemo,
-  useState,
-} from "react";
+import { FunctionComponent, useCallback, useMemo, useState } from "react";
 import PageLanding from "@/components/PageLanding/PageLanding";
 import Loader from "@/client/components/_commons/Loader/Loader";
 import MiseEnPageStyled from "@/components/_commons/MiseEnPage/MiseEnPage.styled";
@@ -80,9 +74,7 @@ const MiseEnPage: FunctionComponent<MiseEnPageProps> = ({
           {status === "unauthenticated" ? (
             <PageLanding />
           ) : (
-            <ClientOnly>
-              <Suspense>{children}</Suspense>
-            </ClientOnly>
+            <ClientOnly>{children}</ClientOnly>
           )}
           <PiedDePage />
         </div>

--- a/src/client/components/_commons/MiseEnPage/Navigation/BaseNavigation.tsx
+++ b/src/client/components/_commons/MiseEnPage/Navigation/BaseNavigation.tsx
@@ -101,7 +101,7 @@ export const BaseNavigation = ({ pages }: { pages: LienNavigation[] }) => {
             <BoutonContacterEquipePilote />
           </div>
           <div className="flex">
-            <Utilisateur email={session!.user!.email!} />
+            <Utilisateur />
           </div>
         </div>
         <nav

--- a/src/client/components/shared/ClientOnly.tsx
+++ b/src/client/components/shared/ClientOnly.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { Suspense } from "react";
 
 type ClientOnlyProps = {
   /** Rendered on the server, and on the client until hydration completes (optional). */
@@ -23,6 +24,6 @@ export function ClientOnly({ fallback = null, children }: ClientOnlyProps) {
   }, []);
 
   if (!mounted) return fallback;
-  if (typeof children === "function") return children();
-  return children;
+  if (typeof children === "function") return <Suspense>{children()}</Suspense>;
+  return <Suspense>children</Suspense>;
 }

--- a/src/client/components/shared/ClientOnly.tsx
+++ b/src/client/components/shared/ClientOnly.tsx
@@ -25,5 +25,5 @@ export function ClientOnly({ fallback = null, children }: ClientOnlyProps) {
 
   if (!mounted) return fallback;
   if (typeof children === "function") return <Suspense>{children()}</Suspense>;
-  return <Suspense>children</Suspense>;
+  return <Suspense>{children}</Suspense>;
 }

--- a/src/client/components/shared/ClientOnly.tsx
+++ b/src/client/components/shared/ClientOnly.tsx
@@ -1,0 +1,28 @@
+import * as React from "react";
+
+type ClientOnlyProps = {
+  /** Rendered on the server, and on the client until hydration completes (optional). */
+  fallback?: React.ReactNode;
+  /**
+   * Either regular children, or a render function that only runs on the client.
+   * Prefer the render function when children need access to `window`, etc.
+   */
+  children: React.ReactNode | (() => React.ReactNode);
+};
+
+/**
+ * ClientOnly
+ * - SSR: renders `fallback` (or nothing).
+ * - Client: renders children only after mount, preventing SSR/hydration issues.
+ */
+export function ClientOnly({ fallback = null, children }: ClientOnlyProps) {
+  const [mounted, setMounted] = React.useState(false);
+
+  React.useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted) return fallback;
+  if (typeof children === "function") return children();
+  return children;
+}

--- a/src/client/hooks/usePrefetchUtilisateurConnecte.ts
+++ b/src/client/hooks/usePrefetchUtilisateurConnecte.ts
@@ -1,0 +1,14 @@
+import { useSession } from "next-auth/react";
+import { useEffect, useState } from "react";
+import api from "@/server/infrastructure/api/trpc/api";
+
+export function usePrefetchUtilisateurConnecte() {
+  const session = useSession();
+  const [enabled, setEnabled] = useState(false);
+  api.profilUtilisateur.getUtilisateurConnecte.useQuery(undefined, { enabled });
+
+  useEffect(() => {
+    if (session.status !== "authenticated") return;
+    setEnabled(true);
+  }, [session.status]);
+}

--- a/src/server/infrastructure/api/auth/[...nextauth].tsx
+++ b/src/server/infrastructure/api/auth/[...nextauth].tsx
@@ -260,8 +260,10 @@ export const authOptions: AuthOptions = {
 
       // Send properties to the client
       session.user = {
+        // TODO(CHAN 20/01/2026) : supprimer les anciennes infos de la session après déploiement
         ...piloteToken.user,
         id: utilisateur!.id,
+        email: utilisateur!.email,
       };
       session.accessToken = piloteToken.accessToken;
       session.profil = utilisateur?.profil;

--- a/src/server/infrastructure/api/trpc/routes/profilUtilisateur.ts
+++ b/src/server/infrastructure/api/trpc/routes/profilUtilisateur.ts
@@ -1,0 +1,29 @@
+import {
+  créerRouteurTRPC,
+  procédureProtégée,
+} from "@/server/infrastructure/api/trpc/trpc";
+import { UnauthorizedError } from "@/server/app/error-boundary/unauthorized-error";
+import { dependencies } from "@/server/infrastructure/Dependencies";
+
+export const profilUtilisateurRouter = créerRouteurTRPC({
+  getUtilisateurConnecte: procédureProtégée.query(async ({ ctx }) => {
+    const session = ctx.session;
+    if (session == null) {
+      throw new UnauthorizedError("Utilisateur non authentifié");
+    }
+
+    const utilisateur = await dependencies
+      .getUtilisateurRepository()
+      .récupérer(session.user.email);
+
+    if (utilisateur == null) {
+      throw new UnauthorizedError("Utilisateur non authentifié");
+    }
+
+    return {
+      id: utilisateur.id,
+      prenom: utilisateur.prénom,
+      nom: utilisateur.nom,
+    };
+  }),
+});

--- a/src/server/infrastructure/api/trpc/routes/profilUtilisateur.ts
+++ b/src/server/infrastructure/api/trpc/routes/profilUtilisateur.ts
@@ -24,6 +24,7 @@ export const profilUtilisateurRouter = créerRouteurTRPC({
       id: utilisateur.id,
       prenom: utilisateur.prénom,
       nom: utilisateur.nom,
+      email: utilisateur.email,
     };
   }),
 });

--- a/src/server/infrastructure/api/trpc/routes/routes.ts
+++ b/src/server/infrastructure/api/trpc/routes/routes.ts
@@ -4,6 +4,7 @@ import { metadataIndicateurRouter } from "@/server/infrastructure/api/trpc/route
 import { gestionContenuRouter } from "@/server/infrastructure/api/trpc/routes/gestionContenu";
 import { gestionTokenAPIRouter } from "@/server/infrastructure/api/trpc/routes/gestionTokenAPI";
 import { evaluationRouter } from "@/server/infrastructure/api/trpc/routes/evaluation";
+import { profilUtilisateurRouter } from "@/server/infrastructure/api/trpc/routes/profilUtilisateur";
 import { chantierRouter } from "./chantier";
 import { synthèseDesRésultatsRouter } from "./synthèseDesRésultats";
 import { publicationRouter } from "./publication";
@@ -29,4 +30,5 @@ export const appRouter = créerRouteurTRPC({
   profil: profilRouter,
   parametrageNouveautes: parametrageNouveautesRouter,
   evaluation: evaluationRouter,
+  profilUtilisateur: profilUtilisateurRouter,
 });

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -1,4 +1,3 @@
-import { DefaultSession } from "next-auth";
 import { $Enums } from "@prisma/client";
 import { Habilitations } from "@/server/gestion-utilisateur/domain/habilitation/Habilitation.interface";
 import { ProfilCode } from "@/server/gestion-utilisateur/domain/utilisateur/utilisateur.interface";
@@ -7,7 +6,8 @@ declare module "next-auth" {
   interface Session {
     user: {
       id: string;
-    } & DefaultSession["user"];
+      email: string;
+    };
     accessToken: string;
     habilitations: Habilitations;
     applicationsAccessibles: $Enums.application_accessible[];

--- a/src/validation/proposition-valeur-avancement.ts
+++ b/src/validation/proposition-valeur-avancement.ts
@@ -30,7 +30,6 @@ export const validationPropositionValeurAvancement = z.object({
 });
 
 export const validationSuppressionValeurAvancementV2 = z.object({
-  auteurModification: z.string(),
   indicId: z.string(),
   territoireCode: z.string(),
   dateValeurAvancement: z.string(),


### PR DESCRIPTION
Pas mal de nettoyage / nouvelles choses dans cette PR :

- suppression de code inutilisé : côté PVA, on envoyait l'auteur de modification sans jamais rien en fait côté serveur ;
- nettoyage de la session : suppression de certains champs (dont le nom), type de l'email non nullable
- nouvelle query TRPC pour charger l'utilisateur connecté -> la nouvelle source pour obtenir les informations hors-session comme le prénom / nom
- configuration de l'app pour passage en ClientOnly pour la partie connectée. Dans les faits c'était déjà le cas avant, maintenant c'est "officialisé" par le composant ClientOnly que l'on peut utiliser autre part si besoin.

(Je réfléchis pour cleaner le chargement des chantiers)