### PR TITLE
feat: logo sur l'export image

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -144,6 +144,7 @@
         "nock": "^13.3.0",
         "node-mocks-http": "^1.12.2",
         "pino-pretty": "^10.0.0",
+        "playwright-core": "1.42.1",
         "postcss-styled-components": "^0.2.1",
         "prettier": "^3.6.2",
         "prisma": "6.2.1",

--- a/src/client/components/_commons/IndicateursChantier/Bloc/Détails/Évolution/BaseIndicateurEvolution.tsx
+++ b/src/client/components/_commons/IndicateursChantier/Bloc/Détails/Évolution/BaseIndicateurEvolution.tsx
@@ -55,17 +55,19 @@ export const BaseIndicateurEvolution = forwardRef<
           <p className="fr-badge fr-badge--no-icon">NON RENSEIGNÉ</p>
         )}
 
-        <div className="border-t border-gray-300 flex items-center gap-10 p-4 mt-4">
-          <p className="fr-logo">Gouvernement</p>
-          <div>
-            <Link href="/" title="Retour à l'accueil du site">
-              <p className="fr-header__service-title mb-0">PILOTE</p>
-            </Link>
-            <p className="fr-header__service-tagline fr-text--sm mb-0">
-              Piloter l'action publique par les résultats
-            </p>
+        {modeImpression ? (
+          <div className="border-t border-gray-300 flex items-center gap-10 p-4 mt-4">
+            <p className="fr-logo">Gouvernement</p>
+            <div>
+              <Link href="/" title="Retour à l'accueil du site">
+                <p className="fr-header__service-title mb-0">PILOTE</p>
+              </Link>
+              <p className="fr-header__service-tagline fr-text--sm mb-0">
+                Piloter l'action publique par les résultats
+              </p>
+            </div>
           </div>
-        </div>
+        ) : null}
       </IndicateurÉvolutionStyled>
     );
   },

--- a/src/client/components/_commons/IndicateursChantier/Bloc/Détails/Évolution/BaseIndicateurEvolution.tsx
+++ b/src/client/components/_commons/IndicateursChantier/Bloc/Détails/Évolution/BaseIndicateurEvolution.tsx
@@ -55,7 +55,7 @@ export const BaseIndicateurEvolution = forwardRef<
           <p className="fr-badge fr-badge--no-icon">NON RENSEIGNÉ</p>
         )}
 
-        {modeImpression ? (
+        {modeImpression || true ? (
           <LogoPilote className="border-t border-gray-300 p-4 mt-4" />
         ) : null}
       </IndicateurÉvolutionStyled>

--- a/src/client/components/_commons/IndicateursChantier/Bloc/Détails/Évolution/BaseIndicateurEvolution.tsx
+++ b/src/client/components/_commons/IndicateursChantier/Bloc/Détails/Évolution/BaseIndicateurEvolution.tsx
@@ -1,5 +1,6 @@
 import { forwardRef } from "react";
 import { Line } from "react-chartjs-2";
+import Link from "next/link";
 import Titre from "@/client/components/_commons/Titre/Titre";
 import LineChart from "./LineChart/LineChart";
 import IndicateurÉvolutionStyled from "./IndicateurÉvolution.styled";
@@ -53,6 +54,18 @@ export const BaseIndicateurEvolution = forwardRef<
         ) : (
           <p className="fr-badge fr-badge--no-icon">NON RENSEIGNÉ</p>
         )}
+
+        <div className="border-t border-gray-300 flex items-center gap-10 p-4 mt-4">
+          <p className="fr-logo">Gouvernement</p>
+          <div>
+            <Link href="/" title="Retour à l'accueil du site">
+              <p className="fr-header__service-title mb-0">PILOTE</p>
+            </Link>
+            <p className="fr-header__service-tagline fr-text--sm mb-0">
+              Piloter l'action publique par les résultats
+            </p>
+          </div>
+        </div>
       </IndicateurÉvolutionStyled>
     );
   },

--- a/src/client/components/_commons/IndicateursChantier/Bloc/Détails/Évolution/BaseIndicateurEvolution.tsx
+++ b/src/client/components/_commons/IndicateursChantier/Bloc/Détails/Évolution/BaseIndicateurEvolution.tsx
@@ -55,7 +55,7 @@ export const BaseIndicateurEvolution = forwardRef<
           <p className="fr-badge fr-badge--no-icon">NON RENSEIGNÉ</p>
         )}
 
-        {modeImpression || true ? (
+        {modeImpression ? (
           <LogoPilote className="border-t border-gray-300 p-4 mt-4" />
         ) : null}
       </IndicateurÉvolutionStyled>

--- a/src/client/components/_commons/IndicateursChantier/Bloc/Détails/Évolution/BaseIndicateurEvolution.tsx
+++ b/src/client/components/_commons/IndicateursChantier/Bloc/Détails/Évolution/BaseIndicateurEvolution.tsx
@@ -1,7 +1,7 @@
 import { forwardRef } from "react";
 import { Line } from "react-chartjs-2";
-import Link from "next/link";
 import Titre from "@/client/components/_commons/Titre/Titre";
+import { LogoPilote } from "@/components/_commons/LogoPilote";
 import LineChart from "./LineChart/LineChart";
 import IndicateurÉvolutionStyled from "./IndicateurÉvolution.styled";
 import type { BaseEvolutionProps } from "./types";
@@ -56,17 +56,7 @@ export const BaseIndicateurEvolution = forwardRef<
         )}
 
         {modeImpression ? (
-          <div className="border-t border-gray-300 flex items-center gap-10 p-4 mt-4">
-            <p className="fr-logo">Gouvernement</p>
-            <div>
-              <Link href="/" title="Retour à l'accueil du site">
-                <p className="fr-header__service-title mb-0">PILOTE</p>
-              </Link>
-              <p className="fr-header__service-tagline fr-text--sm mb-0">
-                Piloter l'action publique par les résultats
-              </p>
-            </div>
-          </div>
+          <LogoPilote className="border-t border-gray-300 p-4 mt-4" />
         ) : null}
       </IndicateurÉvolutionStyled>
     );

--- a/src/client/components/_commons/LogoPilote.tsx
+++ b/src/client/components/_commons/LogoPilote.tsx
@@ -2,8 +2,13 @@ import Link from "next/link";
 import { clsxm } from "@/utils/clsxm";
 
 export const LogoPilote = ({ className }: { className?: string }) => (
-  <div className={clsxm("fr-header__logo flex items-center gap-8", className)}>
-    <p className="fr-logo">Gouvernement</p>
+  <div
+    className={clsxm(
+      "fr-header__logo flex items-center fr-col-10 fr-col-md-11 fr-col-lg-12",
+      className,
+    )}
+  >
+    <p className="fr-logo fr-mr-5v">Gouvernement</p>
     <div>
       <Link href="/" title="Retour à l'accueil du site">
         <p className="fr-header__service-title mb-0">PILOTE</p>

--- a/src/client/components/_commons/LogoPilote.tsx
+++ b/src/client/components/_commons/LogoPilote.tsx
@@ -1,0 +1,16 @@
+import Link from "next/link";
+import { clsxm } from "@/utils/clsxm";
+
+export const LogoPilote = ({ className }: { className?: string }) => (
+  <div className={clsxm("fr-header__logo flex items-center gap-8", className)}>
+    <p className="fr-logo">Gouvernement</p>
+    <div>
+      <Link href="/" title="Retour à l'accueil du site">
+        <p className="fr-header__service-title mb-0">PILOTE</p>
+      </Link>
+      <p className="fr-header__service-tagline fr-text--sm mb-0">
+        Piloter l'action publique par les résultats
+      </p>
+    </div>
+  </div>
+);

--- a/src/client/components/_commons/MiseEnPage/EnTete/EnTete.tsx
+++ b/src/client/components/_commons/MiseEnPage/EnTete/EnTete.tsx
@@ -10,6 +10,7 @@ import { BoutonContacterEquipePilote } from "@/components/PageAccueil/BoutonCont
 import { BoutonSeConnecter } from "@/components/_commons/BoutonSeConnecter";
 import { BoutonApplicationsPilote } from "@/components/_commons/MiseEnPage/EnTete/BoutonApplicationsPilote";
 import { ClientOnly } from "@/components/shared/ClientOnly";
+import { LogoPilote } from "@/components/_commons/LogoPilote";
 
 const InformationsEspaceConnecte = () => {
   const { data: session } = useSession();
@@ -57,17 +58,7 @@ export const EnTete = () => {
           <div className="fr-header__body-row">
             <div className="fr-header__brand fr-enlarge-link">
               <div className="fr-header__brand-top fr-grid-row">
-                <div className="fr-header__logo flex align-center fr-col-10 fr-col-md-11 fr-col-lg-12">
-                  <p className="fr-logo fr-mr-5v">Gouvernement</p>
-                  <div>
-                    <Link href="/" title="Retour à l'accueil du site">
-                      <p className="fr-header__service-title">PILOTE</p>
-                    </Link>
-                    <p className="fr-header__service-tagline fr-text--sm">
-                      Piloter l'action publique par les résultats
-                    </p>
-                  </div>
-                </div>
+                <LogoPilote />
                 {!!session ? (
                   <div className="fr-header__navbar fr-col-2 fr-col-md-1 fr-lg-col-0">
                     <button

--- a/src/client/components/_commons/MiseEnPage/EnTete/EnTete.tsx
+++ b/src/client/components/_commons/MiseEnPage/EnTete/EnTete.tsx
@@ -1,6 +1,5 @@
 import "@gouvfr/dsfr/dist/component/header/header.min.css";
 import "@gouvfr/dsfr/dist/component/logo/logo.min.css";
-import Link from "next/link";
 import { useSession } from "next-auth/react";
 import { Navigation } from "@/components/_commons/MiseEnPage/Navigation/Navigation";
 import { Utilisateur } from "@/components/_commons/MiseEnPage/EnTete/Utilisateur/Utilisateur";


### PR DESCRIPTION
- Ajoute du logo sur l'export image
- Création d'un composant générique <LogoPilote />
- (Refacto du header pour utiliser le composant générique)

<img width="2400" height="1482" alt="image" src="https://github.com/user-attachments/assets/66516fd9-07f3-4a3d-bb65-19655be4d0fb" />
