### PR TITLE
fix: typage système de modules — VerifyCradle + imports corrigés

### DIFF
--- a/src/server/albert/module.ts
+++ b/src/server/albert/module.ts
@@ -13,8 +13,11 @@ import {
 } from "@/server/module-system";
 import type { PrismaPilote } from "@/server/db/PrismaPilote";
 
-type AlbertCradle = {
+type AlbertImports = {
   prisma: PrismaPilote;
+};
+
+type AlbertOwnCradle = {
   createGetTauxAvancementTerritoireTool: ReturnType<
     typeof createGetTauxAvancementTerritoireTool
   >;
@@ -32,6 +35,8 @@ type AlbertCradle = {
   >;
   evaluerChatUseCase: EvaluerChatUseCase;
 };
+
+type AlbertCradle = AlbertOwnCradle & AlbertImports;
 
 export const albertModule = defineModule<NoExports, AlbertCradle>()({
   name: "albert",
@@ -57,7 +62,7 @@ export const albertModule = defineModule<NoExports, AlbertCradle>()({
         createGetValeursIndicateurTool,
       ),
       evaluerChatUseCase: asModuleClass(EvaluerChatUseCase),
-    });
+    } satisfies Record<keyof AlbertOwnCradle, unknown>);
   },
 });
 

--- a/src/server/albert/module.ts
+++ b/src/server/albert/module.ts
@@ -10,12 +10,11 @@ import {
   defineModule,
   type ExtractScope,
   type NoExports,
+  type VerifyCradle,
 } from "@/server/module-system";
-import type { PrismaPilote } from "@/server/db/PrismaPilote";
+import type { SharedDependencies } from "@/server/shared/module";
 
-type AlbertImports = {
-  prisma: PrismaPilote;
-};
+type AlbertImports = SharedDependencies;
 
 type AlbertOwnCradle = {
   createGetTauxAvancementTerritoireTool: ReturnType<
@@ -62,7 +61,7 @@ export const albertModule = defineModule<NoExports, AlbertCradle>()({
         createGetValeursIndicateurTool,
       ),
       evaluerChatUseCase: asModuleClass(EvaluerChatUseCase),
-    } satisfies Record<keyof AlbertOwnCradle, unknown>);
+    } satisfies VerifyCradle<AlbertOwnCradle>);
   },
 });
 

--- a/src/server/authentification/module.ts
+++ b/src/server/authentification/module.ts
@@ -4,6 +4,7 @@ import {
   defineModule,
   type ExtractScope,
   type NoExports,
+  type VerifyCradle,
 } from "@/server/module-system";
 
 type AuthentificationCradle = {
@@ -20,7 +21,7 @@ export const authentificationModule = defineModule<
   register: (container, { asModuleClass }) => {
     container.register({
       utilisateurRepository: asModuleClass(UtilisateurSQLRepository),
-    } satisfies Record<keyof AuthentificationCradle, unknown>);
+    } satisfies VerifyCradle<AuthentificationCradle>);
   },
 });
 

--- a/src/server/authentification/module.ts
+++ b/src/server/authentification/module.ts
@@ -20,7 +20,7 @@ export const authentificationModule = defineModule<
   register: (container, { asModuleClass }) => {
     container.register({
       utilisateurRepository: asModuleClass(UtilisateurSQLRepository),
-    });
+    } satisfies Record<keyof AuthentificationCradle, unknown>);
   },
 });
 

--- a/src/server/chantiers/module.ts
+++ b/src/server/chantiers/module.ts
@@ -9,7 +9,11 @@ import { PropositionValeurAvancementRepository } from "@/server/chantiers/domain
 import { PrismaPropositionValeurAvancementRepository } from "@/server/chantiers/infrastructure/adapters/PrismaPropositionValeurAvancementRepository";
 import type { IndicateurTerritoireValeurEvenementExports } from "@/server/indicateur-territoire-valeur-evenement/module";
 import type { DatajobsExecutionExports } from "@/server/datajobs-execution/module";
-import { defineModule, type ExtractScope } from "@/server/module-system";
+import {
+  defineModule,
+  type ExtractScope,
+  type VerifyCradle,
+} from "@/server/module-system";
 import type { LegacyExport } from "@/server/legacy/module";
 import { TerritoireRepository } from "./domain/ports/TerritoireRepository";
 import { PrismaTerritoireRepository } from "./infrastructure/adapters/PrismaTerritoireRepository";
@@ -134,7 +138,7 @@ export const chantiersModule = defineModule<ChantierExports, ChantierCradle>()({
       recupererAvancementsTerritoiresQuery: asModuleClass(
         RecupererAvancementsTerritoiresQuery,
       ),
-    } satisfies Record<keyof ChantierOwnCradle, unknown>);
+    } satisfies VerifyCradle<ChantierOwnCradle>);
   },
 });
 

--- a/src/server/chantiers/module.ts
+++ b/src/server/chantiers/module.ts
@@ -39,32 +39,35 @@ type ChantierExports = {
   mesuresIndicateurQuery: RecupererMesuresIndicateurParPeriodeQuery;
 };
 
-type ChantierCradle = ChantierExports &
-  IndicateurTerritoireValeurEvenementExports &
+type ChantierImports = IndicateurTerritoireValeurEvenementExports &
   LegacyExport &
-  DatajobsExecutionExports & {
-    chantierRepository: ChantierRepository;
-    indicateurRepository: IndicateurRepository;
-    territoireRepository: TerritoireRepository;
-    ministereRepository: MinistereRepository;
-    propositionValeurAvancementRepository: PropositionValeurAvancementRepository;
-    utilisateurRepository: UtilisateurRepository;
-    envoieEmailService: EnvoieEmailService;
-    recupererDonneesChantierQuery: RecupererDonneesChantierQuery;
-    exportCsvDesChantiersUseCase: ExportCsvDesChantiersUseCase;
-    exportCsvDesIndicateursUseCase: ExportCsvDesIndicateursUseCase;
-    exportCsvDesHistoriquesIndicateursUseCase: ExportCsvDesHistoriquesIndicateursUseCase;
-    recupererDetailsIndicateursV2UseCase: RecupererDetailsIndicateursV2UseCase;
-    recupererChantiersAccessiblesEnLectureUseCaseV2: RecupererChantiersAccessiblesEnLectureUseCaseV2;
-    recupererChantiersAccessiblesEnLectureUseCaseRapportDetailleV2: RecupererChantiersAccessiblesEnLectureUseCaseRapportDetailleV2;
-    recupererChantierUseCaseV2: RecupererChantierUseCaseV2;
-    listerDetailsIndicateurTerritoireUseCaseV2: ListerDetailsIndicateurTerritoireUseCaseV2;
-    rapportPropositionsAvancementRepository: RapportPropositionsAvancementRepository;
-    creerLesRapportsPropositionsUseCase: CreerLesRapportsPropositionsUseCase;
-    envoyerLesRapportsPropositionsUseCase: EnvoyerLesRapportsPropositionsUseCase;
-    getChantierMeteosTerritoiresQuery: GetChantierMeteosTerritoiresQuery;
-    recupererAvancementsTerritoiresQuery: RecupererAvancementsTerritoiresQuery;
-  };
+  DatajobsExecutionExports;
+
+type ChantierOwnCradle = ChantierExports & {
+  chantierRepository: ChantierRepository;
+  indicateurRepository: IndicateurRepository;
+  territoireRepository: TerritoireRepository;
+  ministereRepository: MinistereRepository;
+  propositionValeurAvancementRepository: PropositionValeurAvancementRepository;
+  utilisateurRepository: UtilisateurRepository;
+  envoieEmailService: EnvoieEmailService;
+  recupererDonneesChantierQuery: RecupererDonneesChantierQuery;
+  exportCsvDesChantiersUseCase: ExportCsvDesChantiersUseCase;
+  exportCsvDesIndicateursUseCase: ExportCsvDesIndicateursUseCase;
+  exportCsvDesHistoriquesIndicateursUseCase: ExportCsvDesHistoriquesIndicateursUseCase;
+  recupererDetailsIndicateursV2UseCase: RecupererDetailsIndicateursV2UseCase;
+  recupererChantiersAccessiblesEnLectureUseCaseV2: RecupererChantiersAccessiblesEnLectureUseCaseV2;
+  recupererChantiersAccessiblesEnLectureUseCaseRapportDetailleV2: RecupererChantiersAccessiblesEnLectureUseCaseRapportDetailleV2;
+  recupererChantierUseCaseV2: RecupererChantierUseCaseV2;
+  listerDetailsIndicateurTerritoireUseCaseV2: ListerDetailsIndicateurTerritoireUseCaseV2;
+  rapportPropositionsAvancementRepository: RapportPropositionsAvancementRepository;
+  creerLesRapportsPropositionsUseCase: CreerLesRapportsPropositionsUseCase;
+  envoyerLesRapportsPropositionsUseCase: EnvoyerLesRapportsPropositionsUseCase;
+  getChantierMeteosTerritoiresQuery: GetChantierMeteosTerritoiresQuery;
+  recupererAvancementsTerritoiresQuery: RecupererAvancementsTerritoiresQuery;
+};
+
+type ChantierCradle = ChantierOwnCradle & ChantierImports;
 
 export const chantiersModule = defineModule<ChantierExports, ChantierCradle>()({
   name: "chantiers",
@@ -131,7 +134,7 @@ export const chantiersModule = defineModule<ChantierExports, ChantierCradle>()({
       recupererAvancementsTerritoiresQuery: asModuleClass(
         RecupererAvancementsTerritoiresQuery,
       ),
-    });
+    } satisfies Record<keyof ChantierOwnCradle, unknown>);
   },
 });
 

--- a/src/server/commentaires/module.ts
+++ b/src/server/commentaires/module.ts
@@ -61,7 +61,7 @@ export const commentaireModule = defineModule<NoExports, CommentaireCradle>()({
       recupererHistoriqueCommentaireQuery: asModuleClass(
         RecupererHistoriqueCommentaireQuery,
       ),
-    });
+    } satisfies Record<keyof CommentaireCradle, unknown>);
   },
 });
 

--- a/src/server/commentaires/module.ts
+++ b/src/server/commentaires/module.ts
@@ -14,6 +14,7 @@ import {
   defineModule,
   type ExtractScope,
   type NoExports,
+  type VerifyCradle,
 } from "@/server/module-system";
 
 type CommentaireCradle = {
@@ -61,7 +62,7 @@ export const commentaireModule = defineModule<NoExports, CommentaireCradle>()({
       recupererHistoriqueCommentaireQuery: asModuleClass(
         RecupererHistoriqueCommentaireQuery,
       ),
-    } satisfies Record<keyof CommentaireCradle, unknown>);
+    } satisfies VerifyCradle<CommentaireCradle>);
   },
 });
 

--- a/src/server/datajobs-execution/module.ts
+++ b/src/server/datajobs-execution/module.ts
@@ -17,7 +17,7 @@ export const datajobsExecutionModule = defineModule<
   register: (container, { asModuleClass }) => {
     container.register({
       datajobsExecutionQueries: asModuleClass(DatajobsExecutionQueries),
-    });
+    } satisfies Record<keyof DatajobsExecutionCradle, unknown>);
   },
 });
 

--- a/src/server/datajobs-execution/module.ts
+++ b/src/server/datajobs-execution/module.ts
@@ -1,4 +1,8 @@
-import { defineModule, type ExtractScope } from "@/server/module-system";
+import {
+  defineModule,
+  type ExtractScope,
+  type VerifyCradle,
+} from "@/server/module-system";
 import { DatajobsExecutionQueries } from "./DatajobsExecution";
 
 export type DatajobsExecutionExports = {
@@ -17,7 +21,7 @@ export const datajobsExecutionModule = defineModule<
   register: (container, { asModuleClass }) => {
     container.register({
       datajobsExecutionQueries: asModuleClass(DatajobsExecutionQueries),
-    } satisfies Record<keyof DatajobsExecutionCradle, unknown>);
+    } satisfies VerifyCradle<DatajobsExecutionCradle>);
   },
 });
 

--- a/src/server/decisions-strategiques/module.ts
+++ b/src/server/decisions-strategiques/module.ts
@@ -14,6 +14,7 @@ import {
   defineModule,
   type ExtractScope,
   type NoExports,
+  type VerifyCradle,
 } from "@/server/module-system";
 
 type ImportDecisionStrategiqueCradle = {
@@ -72,7 +73,7 @@ export const importDecisionStrategiqueModule = defineModule<
       recupererHistoriqueDecisionStrategiqueQuery: asModuleClass(
         RecupererHistoriqueDecisionStrategiqueQuery,
       ),
-    } satisfies Record<keyof ImportDecisionStrategiqueCradle, unknown>);
+    } satisfies VerifyCradle<ImportDecisionStrategiqueCradle>);
   },
 });
 

--- a/src/server/decisions-strategiques/module.ts
+++ b/src/server/decisions-strategiques/module.ts
@@ -72,7 +72,7 @@ export const importDecisionStrategiqueModule = defineModule<
       recupererHistoriqueDecisionStrategiqueQuery: asModuleClass(
         RecupererHistoriqueDecisionStrategiqueQuery,
       ),
-    });
+    } satisfies Record<keyof ImportDecisionStrategiqueCradle, unknown>);
   },
 });
 

--- a/src/server/evaluation/module.ts
+++ b/src/server/evaluation/module.ts
@@ -23,6 +23,7 @@ import {
   defineModule,
   type ExtractScope,
   type NoExports,
+  type VerifyCradle,
 } from "@/server/module-system";
 import { EnregistrerBrouillonAutoEvaluationObjectifsHandler } from "./handlers/EnregistrerBrouillonAutoEvaluationObjectifsHandler";
 import { EnregistrerBrouillonAutoEvaluationCriteresHandler } from "./handlers/EnregistrerBrouillonAutoEvaluationCriteresHandler";
@@ -152,7 +153,7 @@ export const piloteEvalModule = defineModule<NoExports, PiloteEvalCradle>()({
       transmettreAppreciationHandler: asModuleClass(
         TransmettreAppreciationHandler,
       ),
-    } satisfies Record<keyof PiloteEvalCradle, unknown>);
+    } satisfies VerifyCradle<PiloteEvalCradle>);
   },
 });
 

--- a/src/server/evaluation/module.ts
+++ b/src/server/evaluation/module.ts
@@ -152,7 +152,7 @@ export const piloteEvalModule = defineModule<NoExports, PiloteEvalCradle>()({
       transmettreAppreciationHandler: asModuleClass(
         TransmettreAppreciationHandler,
       ),
-    });
+    } satisfies Record<keyof PiloteEvalCradle, unknown>);
   },
 });
 

--- a/src/server/fiche-conducteur/module.ts
+++ b/src/server/fiche-conducteur/module.ts
@@ -20,6 +20,7 @@ import {
   defineModule,
   type ExtractScope,
   type NoExports,
+  type VerifyCradle,
 } from "@/server/module-system";
 
 type FicheConducteurCradle = {
@@ -68,7 +69,7 @@ export const ficheConducteurModule = defineModule<
       decisionStrategiqueRepository: asModuleClass(
         PrismaDecisionStrategiqueRepository,
       ),
-    } satisfies Record<keyof FicheConducteurCradle, unknown>);
+    } satisfies VerifyCradle<FicheConducteurCradle>);
   },
 });
 

--- a/src/server/fiche-conducteur/module.ts
+++ b/src/server/fiche-conducteur/module.ts
@@ -68,7 +68,7 @@ export const ficheConducteurModule = defineModule<
       decisionStrategiqueRepository: asModuleClass(
         PrismaDecisionStrategiqueRepository,
       ),
-    });
+    } satisfies Record<keyof FicheConducteurCradle, unknown>);
   },
 });
 

--- a/src/server/gestion-utilisateur/module.ts
+++ b/src/server/gestion-utilisateur/module.ts
@@ -15,7 +15,11 @@ import { RecupererTousLesTerritoiresUseCase } from "@/server/usecase/territoire/
 import { RecupererListeUtilisateursUseCase } from "@/server/gestion-utilisateur/usecases/RecupererListeUtilisateursUseCase";
 import { PrismaHistorisationModificationRepository } from "@/server/infrastructure/accès_données/historisationModification/PrismaHistorisationModificationRepository";
 import { HistorisationModificationRepository } from "@/server/domain/historisationModification/HistorisationModificationRepository";
-import { defineModule, type ExtractScope } from "@/server/module-system";
+import {
+  defineModule,
+  type ExtractScope,
+  type VerifyCradle,
+} from "@/server/module-system";
 import { UtilisateurRepository } from "./domain/ports/UtilisateurRepository";
 import { UtilisateurIAMRepository } from "./domain/ports/UtilisateurIAMRepository";
 import { TokenAPIInformationRepository } from "./domain/ports/TokenAPIInformationRepository";
@@ -209,7 +213,7 @@ export const gestionUtilisateurModule = defineModule<
       importerDesUtilisateursUseCase: asModuleClass(
         ImporterDesUtilisateursUseCase,
       ),
-    } satisfies Record<keyof GestionUtilisateurCradle, unknown>);
+    } satisfies VerifyCradle<GestionUtilisateurCradle>);
   },
 });
 

--- a/src/server/gestion-utilisateur/module.ts
+++ b/src/server/gestion-utilisateur/module.ts
@@ -209,7 +209,7 @@ export const gestionUtilisateurModule = defineModule<
       importerDesUtilisateursUseCase: asModuleClass(
         ImporterDesUtilisateursUseCase,
       ),
-    });
+    } satisfies Record<keyof GestionUtilisateurCradle, unknown>);
   },
 });
 

--- a/src/server/habilitations-coordinateur/module.ts
+++ b/src/server/habilitations-coordinateur/module.ts
@@ -4,6 +4,7 @@ import {
   defineModule,
   type ExtractScope,
   type NoExports,
+  type VerifyCradle,
 } from "@/server/module-system";
 
 type HabilitationsCoordinateurCradle = {
@@ -26,7 +27,7 @@ export const habilitationsCoordinateurModule = defineModule<
       ajouterLesChantierAuxHabilitationsHandler: asModuleClass(
         AjouterLesChantierAuxHabilitationsHandler,
       ),
-    } satisfies Record<keyof HabilitationsCoordinateurCradle, unknown>);
+    } satisfies VerifyCradle<HabilitationsCoordinateurCradle>);
   },
 });
 

--- a/src/server/habilitations-coordinateur/module.ts
+++ b/src/server/habilitations-coordinateur/module.ts
@@ -26,7 +26,7 @@ export const habilitationsCoordinateurModule = defineModule<
       ajouterLesChantierAuxHabilitationsHandler: asModuleClass(
         AjouterLesChantierAuxHabilitationsHandler,
       ),
-    });
+    } satisfies Record<keyof HabilitationsCoordinateurCradle, unknown>);
   },
 });
 

--- a/src/server/import-indicateur/module.ts
+++ b/src/server/import-indicateur/module.ts
@@ -22,6 +22,7 @@ import {
   defineModule,
   type ExtractScope,
   type NoExports,
+  type VerifyCradle,
 } from "@/server/module-system";
 import { PropositionValeurAvancementRepository } from "./domain/ports/PropositionValeurAvancementRepository";
 import { PrismaPropositionValeurAvancementRepository } from "./infrastructure/adapters/PrismaPropositionValeurAvancementRepository";
@@ -89,7 +90,7 @@ export const importIndicateurModule = defineModule<
       propositionValeurAvancementRepository: asModuleClass(
         PrismaPropositionValeurAvancementRepository,
       ),
-    } satisfies Record<keyof ImportIndicateurOwnCradle, unknown>);
+    } satisfies VerifyCradle<ImportIndicateurOwnCradle>);
   },
 });
 

--- a/src/server/import-indicateur/module.ts
+++ b/src/server/import-indicateur/module.ts
@@ -26,7 +26,9 @@ import {
 import { PropositionValeurAvancementRepository } from "./domain/ports/PropositionValeurAvancementRepository";
 import { PrismaPropositionValeurAvancementRepository } from "./infrastructure/adapters/PrismaPropositionValeurAvancementRepository";
 
-type ImportIndicateurCradle = IndicateurTerritoireValeurEvenementExports & {
+type ImportIndicateurImports = IndicateurTerritoireValeurEvenementExports;
+
+type ImportIndicateurOwnCradle = {
   httpClient: HttpClient;
   publierFichierImportIndicateurHandler: PublierFichierImportIndicateurHandler;
   publierFichierIndicateurImporteUseCase: PublierFichierIndicateurImporteUseCase;
@@ -41,6 +43,9 @@ type ImportIndicateurCradle = IndicateurTerritoireValeurEvenementExports & {
   importDonneeIndicateurAPIHandler: ImportDonneeIndicateurAPIHandler;
   propositionValeurAvancementRepository: PropositionValeurAvancementRepository;
 };
+
+type ImportIndicateurCradle = ImportIndicateurOwnCradle &
+  ImportIndicateurImports;
 
 export const importIndicateurModule = defineModule<
   NoExports,
@@ -84,7 +89,7 @@ export const importIndicateurModule = defineModule<
       propositionValeurAvancementRepository: asModuleClass(
         PrismaPropositionValeurAvancementRepository,
       ),
-    });
+    } satisfies Record<keyof ImportIndicateurOwnCradle, unknown>);
   },
 });
 

--- a/src/server/indicateur-territoire-valeur-evenement/module.ts
+++ b/src/server/indicateur-territoire-valeur-evenement/module.ts
@@ -1,7 +1,11 @@
 import { PrismaIndicateurTerritoireValeurEvenementRepository } from "@/server/indicateur-territoire-valeur-evenement/infrastructure/PrismaIndicateurTerritoireValeurEvenementRepository";
 import { PrismaMesureIndicateurRepository } from "@/server/indicateur-territoire-valeur-evenement/infrastructure/PrismaMesureIndicateurRepository";
 import { MesureIndicateurRepository } from "@/server/indicateur-territoire-valeur-evenement/domain/ports/MesureIndicateurRepository";
-import { defineModule, type ExtractScope } from "@/server/module-system";
+import {
+  defineModule,
+  type ExtractScope,
+  type VerifyCradle,
+} from "@/server/module-system";
 import { IndicateurTerritoireValeurEvenementRepository } from "./domain/ports/IndicateurTerritoireValeurEvenementRepository";
 import { CreerPropositionValeurAvancementUseCase } from "./usecases/CreerPropositionValeurAvancementUseCase";
 import { AccepterPropositionValeurAvancementUseCase } from "./usecases/AccepterPropositionValeurAvancementUseCase";
@@ -88,10 +92,7 @@ export const indicateurTerritoireValeurEvenementModule = defineModule<
           RecupererHistoriqueIndicateurTerritoireValeurEvenementUseCase,
         ),
       evenementsVAQuery: asModuleClass(RecupererEvenementsVAParPeriodeQuery),
-    } satisfies Record<
-      keyof IndicateurTerritoireValeurEvenementCradle,
-      unknown
-    >);
+    } satisfies VerifyCradle<IndicateurTerritoireValeurEvenementCradle>);
   },
 });
 

--- a/src/server/indicateur-territoire-valeur-evenement/module.ts
+++ b/src/server/indicateur-territoire-valeur-evenement/module.ts
@@ -88,7 +88,10 @@ export const indicateurTerritoireValeurEvenementModule = defineModule<
           RecupererHistoriqueIndicateurTerritoireValeurEvenementUseCase,
         ),
       evenementsVAQuery: asModuleClass(RecupererEvenementsVAParPeriodeQuery),
-    });
+    } satisfies Record<
+      keyof IndicateurTerritoireValeurEvenementCradle,
+      unknown
+    >);
   },
 });
 

--- a/src/server/legacy/module.ts
+++ b/src/server/legacy/module.ts
@@ -67,7 +67,11 @@ import { RécupérerTerritoireParCodeUseCase } from "@/server/fiche-territoriale
 import { RécupérerTauxAvancementTerritoireUseCase } from "@/server/fiche-territoriale/usecases/RécupérerTauxAvancementTerritoireUseCase";
 import { RécupérerRépartitionMétéoUseCase } from "@/server/fiche-territoriale/usecases/RécupérerRépartitionMétéoUseCase";
 import { RécupérerListeChantierFicheTerritorialeUseCase } from "@/server/fiche-territoriale/usecases/RécupérerListeChantierFicheTerritorialeUseCase";
-import { defineModule, type ExtractScope } from "@/server/module-system";
+import {
+  defineModule,
+  type ExtractScope,
+  type VerifyCradle,
+} from "@/server/module-system";
 
 export type LegacyExport = {
   agregerAvancementsChantiersUseCase: AgregerAvancementsChantiersUseCase;
@@ -292,7 +296,7 @@ export const legacyModule = defineModule<LegacyExport, LegacyCradle>()({
             ministereRepository: ficheTerritorialeMinistereRepository,
           }),
       ).scoped(),
-    } satisfies Record<keyof LegacyCradle, unknown>);
+    } satisfies VerifyCradle<LegacyCradle>);
   },
 });
 

--- a/src/server/legacy/module.ts
+++ b/src/server/legacy/module.ts
@@ -292,7 +292,7 @@ export const legacyModule = defineModule<LegacyExport, LegacyCradle>()({
             ministereRepository: ficheTerritorialeMinistereRepository,
           }),
       ).scoped(),
-    });
+    } satisfies Record<keyof LegacyCradle, unknown>);
   },
 });
 

--- a/src/server/module-system/ModuleDef.ts
+++ b/src/server/module-system/ModuleDef.ts
@@ -56,6 +56,9 @@ export const defineModule =
   ): ModuleDef<TName, TExports, TCradle> =>
     def;
 
+// Vérifie que toutes les clés du cradle sont enregistrées
+export type VerifyCradle<T> = Record<keyof T, unknown>;
+
 // Type utilitaire pour les modules qui n'exportent rien
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export type NoExports = {};

--- a/src/server/module-system/index.ts
+++ b/src/server/module-system/index.ts
@@ -7,6 +7,7 @@ export type {
   NoExports,
   TypedAsClass,
   TypedAsFunction,
+  VerifyCradle,
 } from "./ModuleDef";
 export { bootModules } from "./bootModules";
 export type { AnyModuleDef, ExtractCradle } from "./bootModules";

--- a/src/server/objectifs/module.ts
+++ b/src/server/objectifs/module.ts
@@ -61,7 +61,7 @@ export const objectifModule = defineModule<NoExports, ObjectifCradle>()({
       recupererHistoriqueObjectifQuery: asModuleClass(
         RecupererHistoriqueObjectifQuery,
       ),
-    });
+    } satisfies Record<keyof ObjectifCradle, unknown>);
   },
 });
 

--- a/src/server/objectifs/module.ts
+++ b/src/server/objectifs/module.ts
@@ -14,6 +14,7 @@ import {
   defineModule,
   type ExtractScope,
   type NoExports,
+  type VerifyCradle,
 } from "@/server/module-system";
 
 type ObjectifCradle = {
@@ -61,7 +62,7 @@ export const objectifModule = defineModule<NoExports, ObjectifCradle>()({
       recupererHistoriqueObjectifQuery: asModuleClass(
         RecupererHistoriqueObjectifQuery,
       ),
-    } satisfies Record<keyof ObjectifCradle, unknown>);
+    } satisfies VerifyCradle<ObjectifCradle>);
   },
 });
 

--- a/src/server/parametrage-centre-aide/module.ts
+++ b/src/server/parametrage-centre-aide/module.ts
@@ -2,6 +2,7 @@ import {
   defineModule,
   type ExtractScope,
   type NoExports,
+  type VerifyCradle,
 } from "@/server/module-system";
 import { CreerArticleCentreAideUseCase } from "./usecases/CreerArticleCentreAideUseCase";
 import { PrismaArticleCentreAideRepository } from "./infrastructure/adapters/PrismaArticleCentreAideRepository";
@@ -42,7 +43,7 @@ export const parametrageCentreAideModule = defineModule<
       supprimerArticleCentreAideUseCase: asModuleClass(
         SupprimerArticleCentreAideUseCase,
       ),
-    } satisfies Record<keyof ParametrageCentreAideCradle, unknown>);
+    } satisfies VerifyCradle<ParametrageCentreAideCradle>);
   },
 });
 

--- a/src/server/parametrage-centre-aide/module.ts
+++ b/src/server/parametrage-centre-aide/module.ts
@@ -42,7 +42,7 @@ export const parametrageCentreAideModule = defineModule<
       supprimerArticleCentreAideUseCase: asModuleClass(
         SupprimerArticleCentreAideUseCase,
       ),
-    });
+    } satisfies Record<keyof ParametrageCentreAideCradle, unknown>);
   },
 });
 

--- a/src/server/parametrage-indicateur/module.ts
+++ b/src/server/parametrage-indicateur/module.ts
@@ -86,7 +86,7 @@ export const parametrageIndicateurModule = defineModule<
       enregistrerMetadataIndicateurHandler: asModuleClass(
         EnregistrerMetadataIndicateurHandler,
       ),
-    });
+    } satisfies Record<keyof ParametrageIndicateurCradle, unknown>);
   },
 });
 

--- a/src/server/parametrage-indicateur/module.ts
+++ b/src/server/parametrage-indicateur/module.ts
@@ -18,6 +18,7 @@ import {
   defineModule,
   type ExtractScope,
   type NoExports,
+  type VerifyCradle,
 } from "@/server/module-system";
 
 type ParametrageIndicateurCradle = {
@@ -86,7 +87,7 @@ export const parametrageIndicateurModule = defineModule<
       enregistrerMetadataIndicateurHandler: asModuleClass(
         EnregistrerMetadataIndicateurHandler,
       ),
-    } satisfies Record<keyof ParametrageIndicateurCradle, unknown>);
+    } satisfies VerifyCradle<ParametrageIndicateurCradle>);
   },
 });
 

--- a/src/server/parametrage-nouveautes/module.ts
+++ b/src/server/parametrage-nouveautes/module.ts
@@ -29,7 +29,7 @@ export const parametrageNouveautesModule = defineModule<
       nouveauteRepository: asModuleClass(PrismaNouveauteRepository),
       listerNouveautesUseCase: asModuleClass(ListerNouveautesUseCase),
       modifierNouveauteUseCase: asModuleClass(ModifierNouveauteUseCase),
-    });
+    } satisfies Record<keyof ParametrageNouveautesCradle, unknown>);
   },
 });
 

--- a/src/server/parametrage-nouveautes/module.ts
+++ b/src/server/parametrage-nouveautes/module.ts
@@ -2,6 +2,7 @@ import {
   defineModule,
   type ExtractScope,
   type NoExports,
+  type VerifyCradle,
 } from "@/server/module-system";
 import { CreerNouveauteUseCase } from "./usecases/CreerNouveauteUseCase";
 import { PrismaNouveauteRepository } from "./infrastructure/adapters/PrismaNouveauteRepository";
@@ -29,7 +30,7 @@ export const parametrageNouveautesModule = defineModule<
       nouveauteRepository: asModuleClass(PrismaNouveauteRepository),
       listerNouveautesUseCase: asModuleClass(ListerNouveautesUseCase),
       modifierNouveauteUseCase: asModuleClass(ModifierNouveauteUseCase),
-    } satisfies Record<keyof ParametrageNouveautesCradle, unknown>);
+    } satisfies VerifyCradle<ParametrageNouveautesCradle>);
   },
 });
 

--- a/src/server/profil-utilisateur/module.ts
+++ b/src/server/profil-utilisateur/module.ts
@@ -12,13 +12,19 @@ import {
   type NoExports,
 } from "@/server/module-system";
 
-type ProfilUtilisateurCradle = {
+type ProfilUtilisateurImports = {
+  emailManager: EmailManager;
+};
+
+type ProfilUtilisateurOwnCradle = {
   profilUtilisateurRepository: ProfilUtilisateurRepository;
   profilModifieSideEffects: ProfilModifieSideEffects;
   modifierMonProfilUseCase: ModifierMonProfilUseCase;
   getProfilUtilisateurQuery: GetProfilUtilisateurQuery;
-  emailManager: EmailManager;
 };
+
+type ProfilUtilisateurCradle = ProfilUtilisateurOwnCradle &
+  ProfilUtilisateurImports;
 
 export const profilUtilisateurModule = defineModule<
   NoExports,
@@ -43,7 +49,7 @@ export const profilUtilisateurModule = defineModule<
       }),
       modifierMonProfilUseCase: asModuleClass(ModifierMonProfilUseCase),
       getProfilUtilisateurQuery: asModuleClass(GetProfilUtilisateurQuery),
-    });
+    } satisfies Record<keyof ProfilUtilisateurOwnCradle, unknown>);
   },
 });
 

--- a/src/server/profil-utilisateur/module.ts
+++ b/src/server/profil-utilisateur/module.ts
@@ -4,17 +4,16 @@ import { ModifierMonProfilUseCase } from "@/server/profil-utilisateur/usecases/M
 import { GetProfilUtilisateurQuery } from "@/server/profil-utilisateur/queries/GetProfilUtilisateurQuery";
 import { ProfilModifieSideEffects } from "@/server/profil-utilisateur/domain/ports/ProfilModifieSideEffects";
 import { KeycloakBrevoProfilModifieSideEffects } from "@/server/profil-utilisateur/infrastructure/adapters/KeycloakBrevoProfilModifieSideEffects";
-import type { EmailManager } from "@/server/infrastructure/email-manager/EmailManager";
 import { configuration } from "@/config";
 import {
   defineModule,
   type ExtractScope,
   type NoExports,
+  type VerifyCradle,
 } from "@/server/module-system";
+import type { SharedDependencies } from "@/server/shared/module";
 
-type ProfilUtilisateurImports = {
-  emailManager: EmailManager;
-};
+type ProfilUtilisateurImports = SharedDependencies;
 
 type ProfilUtilisateurOwnCradle = {
   profilUtilisateurRepository: ProfilUtilisateurRepository;
@@ -49,7 +48,7 @@ export const profilUtilisateurModule = defineModule<
       }),
       modifierMonProfilUseCase: asModuleClass(ModifierMonProfilUseCase),
       getProfilUtilisateurQuery: asModuleClass(GetProfilUtilisateurQuery),
-    } satisfies Record<keyof ProfilUtilisateurOwnCradle, unknown>);
+    } satisfies VerifyCradle<ProfilUtilisateurOwnCradle>);
   },
 });
 

--- a/src/server/rapports-hebdomadaires/module.ts
+++ b/src/server/rapports-hebdomadaires/module.ts
@@ -5,6 +5,7 @@ import {
   defineModule,
   type ExtractScope,
   type NoExports,
+  type VerifyCradle,
 } from "@/server/module-system";
 import { ActiviteComptesGateway } from "./domain/ports/ActiviteComptesGateway";
 import { CoordinateurGateway } from "./domain/ports/CoordinateurGateway";
@@ -77,7 +78,7 @@ export const rapportsHebdomadairesModule = defineModule<
       recupererRapportHebdomadaireQuery: asModuleClass(
         RecupererRapportHebdomadaireQuery,
       ),
-    } satisfies Record<keyof RapportsHebdomadairesOwnCradle, unknown>);
+    } satisfies VerifyCradle<RapportsHebdomadairesOwnCradle>);
   },
 });
 

--- a/src/server/rapports-hebdomadaires/module.ts
+++ b/src/server/rapports-hebdomadaires/module.ts
@@ -23,20 +23,25 @@ import { EnvoyerRapportsHebdomadairesUseCase } from "./usecases/EnvoyerRapportsH
 import { ListerRapportsHebdomadairesQuery } from "./queries/ListerRapportsHebdomadairesQuery";
 import { RecupererRapportHebdomadaireQuery } from "./queries/RecupererRapportHebdomadaireQuery";
 
-type RapportsHebdomadairesCradle = GestionUtilisateurExports &
+type RapportsHebdomadairesImports = GestionUtilisateurExports &
   ChantierExports &
-  IndicateurTerritoireValeurEvenementExports & {
-    activiteComptesGateway: ActiviteComptesGateway;
-    coordinateurGateway: CoordinateurGateway;
-    rapportRepository: RapportRepository;
-    envoieEmailService: EnvoieEmailService;
-    chantierGateway: ChantierGateway;
-    activiteIndicateurGateway: ActiviteIndicateurGateway;
-    produireRapportsHebdomadairesUseCase: ProduireRapportsHebdomadairesUseCase;
-    envoyerRapportsHebdomadairesUseCase: EnvoyerRapportsHebdomadairesUseCase;
-    listerRapportsHebdomadairesQuery: ListerRapportsHebdomadairesQuery;
-    recupererRapportHebdomadaireQuery: RecupererRapportHebdomadaireQuery;
-  };
+  IndicateurTerritoireValeurEvenementExports;
+
+type RapportsHebdomadairesOwnCradle = {
+  activiteComptesGateway: ActiviteComptesGateway;
+  coordinateurGateway: CoordinateurGateway;
+  rapportRepository: RapportRepository;
+  envoieEmailService: EnvoieEmailService;
+  chantierGateway: ChantierGateway;
+  activiteIndicateurGateway: ActiviteIndicateurGateway;
+  produireRapportsHebdomadairesUseCase: ProduireRapportsHebdomadairesUseCase;
+  envoyerRapportsHebdomadairesUseCase: EnvoyerRapportsHebdomadairesUseCase;
+  listerRapportsHebdomadairesQuery: ListerRapportsHebdomadairesQuery;
+  recupererRapportHebdomadaireQuery: RecupererRapportHebdomadaireQuery;
+};
+
+type RapportsHebdomadairesCradle = RapportsHebdomadairesOwnCradle &
+  RapportsHebdomadairesImports;
 
 export const rapportsHebdomadairesModule = defineModule<
   NoExports,
@@ -72,7 +77,7 @@ export const rapportsHebdomadairesModule = defineModule<
       recupererRapportHebdomadaireQuery: asModuleClass(
         RecupererRapportHebdomadaireQuery,
       ),
-    });
+    } satisfies Record<keyof RapportsHebdomadairesOwnCradle, unknown>);
   },
 });
 

--- a/src/server/shared/module.ts
+++ b/src/server/shared/module.ts
@@ -7,7 +7,11 @@ import { configuration } from "@/config";
 import { PrismaPilote } from "@/server/db/PrismaPilote";
 import { type Transaction } from "@/server/db/Transaction";
 import { PrismaTransaction } from "@/server/db/PrismaTransaction";
-import { defineModule, type NoExports } from "@/server/module-system";
+import {
+  defineModule,
+  type NoExports,
+  type VerifyCradle,
+} from "@/server/module-system";
 
 type SharedCradle = {
   prisma: PrismaPilote;
@@ -30,6 +34,6 @@ export const sharedModule = defineModule<NoExports, SharedCradle>()({
           ? new StubEmailManager()
           : new BrevoEmailManager(),
       ).singleton(),
-    } satisfies Record<keyof SharedCradle, unknown>);
+    } satisfies VerifyCradle<SharedCradle>);
   },
 });

--- a/src/server/shared/module.ts
+++ b/src/server/shared/module.ts
@@ -30,6 +30,6 @@ export const sharedModule = defineModule<NoExports, SharedCradle>()({
           ? new StubEmailManager()
           : new BrevoEmailManager(),
       ).singleton(),
-    });
+    } satisfies Record<keyof SharedCradle, unknown>);
   },
 });

--- a/src/server/syntheses-des-resultats/module.ts
+++ b/src/server/syntheses-des-resultats/module.ts
@@ -13,6 +13,7 @@ import {
   defineModule,
   type ExtractScope,
   type NoExports,
+  type VerifyCradle,
 } from "@/server/module-system";
 import { EnregistrerSyntheseDesResultatsService } from "@/server/syntheses-des-resultats/services/EnregistrerSyntheseDesResultatsService";
 import { PublierSyntheseDesResultatsUseCase } from "@/server/syntheses-des-resultats/usecases/PublierSyntheseDesResultatsUseCase";
@@ -85,7 +86,7 @@ export const importSyntheseDesResultatsModule = defineModule<
       importSyntheseDesResultatsAPIHandler: asModuleClass(
         ImportSyntheseDesResultatsAPIHandler,
       ),
-    } satisfies Record<keyof ImportSyntheseDesResultatsCradle, unknown>);
+    } satisfies VerifyCradle<ImportSyntheseDesResultatsCradle>);
   },
 });
 

--- a/src/server/syntheses-des-resultats/module.ts
+++ b/src/server/syntheses-des-resultats/module.ts
@@ -85,7 +85,7 @@ export const importSyntheseDesResultatsModule = defineModule<
       importSyntheseDesResultatsAPIHandler: asModuleClass(
         ImportSyntheseDesResultatsAPIHandler,
       ),
-    });
+    } satisfies Record<keyof ImportSyntheseDesResultatsCradle, unknown>);
   },
 });
 


### PR DESCRIPTION
## Summary

- Ajout d'un type utilitaire `VerifyCradle<T>` (`Record<keyof T, unknown>`) dans `module-system`, utilisé par tous les modules à la place du pattern `satisfies Record<keyof X, unknown>` répété partout
- Correction des imports inline dans `albert/module.ts` et `profil-utilisateur/module.ts` pour réutiliser `SharedDependencies`

## Problème

Le refactoring `ModuleRegistration` → `satisfies` avait laissé des trous dans la raquette au niveau de l'enregistrement des modules :

1. **Imports définis en dur** — `albert/module.ts` redéclarait `{ prisma: PrismaPilote }` et `profil-utilisateur/module.ts` redéclarait `{ emailManager: EmailManager }` au lieu de réutiliser `SharedDependencies` exporté par le module `shared`. Si le cradle partagé évolue (ajout d'un service, renommage), ces types inline ne suivent pas et le compilateur ne détecte rien — on risque un crash runtime sur une dépendance manquante.

2. **`satisfies` manquant** — ces deux mêmes modules n'avaient pas le `satisfies Record<keyof OwnCradle, unknown>` sur leur `container.register(...)`. On pouvait donc oublier d'enregistrer une clé déclarée dans le cradle sans que TypeScript ne bronche — encore un risque de `NameNotFound` à l'exécution.

3. **Pattern `Record<keyof X, unknown>` dupliqué** — le même bout de type était copié-collé dans les 20 fichiers module. Ça fonctionne, mais c'est du bruit : on perd en lisibilité et ça masque l'intention ("vérifier que tout le cradle est enregistré"). `VerifyCradle<T>` nomme cette intention.

## Test plan

- [x] `npx tsc --noEmit` passe sans erreur

🤖 Generated with [Claude Code](https://claude.com/claude-code)