### PR TITLE
feat: tableau évolution temporelle valeurs d'avancement (PIL-1315)

### DIFF
--- a/src/client/components/_commons/Widget/WidgetCartographieValeurAvancement/TableauEvolutionVA.tsx
+++ b/src/client/components/_commons/Widget/WidgetCartographieValeurAvancement/TableauEvolutionVA.tsx
@@ -52,7 +52,7 @@ export const TableauEvolutionVA = ({
   });
   const lignes: LigneTerritoire[] = useMemo(() => {
     return territoiresSelectionnes.map((territoire) => {
-      const détails = récupérerDétailsSurUnTerritoire(
+      const details = récupérerDétailsSurUnTerritoire(
         territoire.territoireCode,
       );
       const cellules = new Map<number, CelluleJalon>();
@@ -74,7 +74,7 @@ export const TableauEvolutionVA = ({
 
       return {
         territoireCode: territoire.territoireCode,
-        nom: détails?.nomAffiché ?? territoire.territoireCode,
+        nom: details?.nomAffiché ?? territoire.territoireCode,
         couleur: getCouleurTerritoireParCode(territoire.territoireCode),
         estInitial: territoire.territoireCode === territoireCode,
         cellules,

--- a/src/client/components/_commons/Widget/WidgetCartographieValeurAvancement/TableauEvolutionVA.tsx
+++ b/src/client/components/_commons/Widget/WidgetCartographieValeurAvancement/TableauEvolutionVA.tsx
@@ -1,0 +1,170 @@
+import { useMemo } from "react";
+import { récupérerDétailsSurUnTerritoire } from "@/client/constants/territoires";
+import { getCouleurTerritoireParCode } from "@/client/utils/couleur/paletteTerritoires";
+import { TerritoireLabel } from "@/components/_commons/Widget/TerritoireLabel";
+import { PiloteDateFormatter } from "@/utils/PiloteDateFormatter";
+import { ValeurAvancementIndicateurTerritoire } from "@/server/chantiers/infrastructure/queries/RecupererValeursAvancementIndicateurTerritoiresQuery";
+import { useValeursAvancementParJalon } from "@/components/_commons/Widget/WidgetCartographieValeurAvancement/useValeursAvancementParJalon";
+
+const formatValeur = (
+  valeur: number | null,
+  unite: string | null,
+): string | null => {
+  if (valeur === null) return null;
+  const unitéAffichée = unite?.toLocaleLowerCase() === "pourcentage" ? "%" : "";
+  return valeur.toLocaleString() + unitéAffichée;
+};
+
+type CelluleJalon = {
+  valeur: string | null;
+  date: string | null;
+  estApplicable: boolean | null;
+};
+
+type LigneTerritoire = {
+  territoireCode: string;
+  nom: string;
+  couleur: string;
+  estInitial: boolean;
+  cellules: Map<number, CelluleJalon>;
+};
+
+export const TableauEvolutionVA = ({
+  indicateurId,
+  chantierId,
+  territoiresSelectionnes,
+  territoireCode,
+  onSupprimerTerritoire,
+  jalonActif,
+  unite,
+}: {
+  indicateurId: string;
+  chantierId: string;
+  territoiresSelectionnes: ValeurAvancementIndicateurTerritoire[];
+  territoireCode: string;
+  onSupprimerTerritoire: (territoireCode: string) => void;
+  jalonActif: number;
+  unite: string | null;
+}) => {
+  const { jalons, donneesParJalon } = useValeursAvancementParJalon({
+    indicateurId,
+    chantierId,
+  });
+  const lignes: LigneTerritoire[] = useMemo(() => {
+    return territoiresSelectionnes.map((territoire) => {
+      const détails = récupérerDétailsSurUnTerritoire(
+        territoire.territoireCode,
+      );
+      const cellules = new Map<number, CelluleJalon>();
+
+      for (const jalon of jalons) {
+        const donnees = donneesParJalon.get(jalon);
+        const donneeTerritoire = donnees?.find(
+          (d) => d.territoireCode === territoire.territoireCode,
+        );
+
+        cellules.set(jalon, {
+          valeur: donneeTerritoire
+            ? formatValeur(donneeTerritoire.valeurAvancement, unite)
+            : null,
+          date: donneeTerritoire?.dateValeurAvancement ?? null,
+          estApplicable: donneeTerritoire?.estApplicable ?? null,
+        });
+      }
+
+      return {
+        territoireCode: territoire.territoireCode,
+        nom: détails?.nomAffiché ?? territoire.territoireCode,
+        couleur: getCouleurTerritoireParCode(territoire.territoireCode),
+        estInitial: territoire.territoireCode === territoireCode,
+        cellules,
+      };
+    });
+  }, [territoiresSelectionnes, donneesParJalon, jalons, unite, territoireCode]);
+
+  return (
+    <div className="overflow-x-auto text-xs">
+      <table className="w-full border-collapse">
+        <thead>
+          <tr>
+            <th className="sticky left-0 bg-white z-10 min-w-[130px]" />
+            {jalons.map((jalon) => (
+              <th
+                key={jalon}
+                className={`px-3 py-2 text-center whitespace-nowrap ${
+                  jalon === jalonActif ? "font-bold" : "font-semibold"
+                }`}
+              >
+                {jalon}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {lignes.map((ligne) => (
+            <tr
+              key={ligne.territoireCode}
+              className="border-t border-dsfr-grey-925"
+            >
+              <td className="sticky left-0 bg-white z-10 min-w-[130px] py-2 pr-2">
+                <TerritoireLabel
+                  nom={ligne.nom}
+                  couleur={ligne.couleur}
+                  onSupprimer={
+                    !ligne.estInitial
+                      ? () => onSupprimerTerritoire(ligne.territoireCode)
+                      : undefined
+                  }
+                />
+              </td>
+              {jalons.map((jalon) => {
+                const cellule = ligne.cellules.get(jalon);
+                const estActif = jalon === jalonActif;
+
+                if (cellule?.estApplicable === false) {
+                  return (
+                    <td
+                      key={jalon}
+                      className="px-3 py-2 text-center text-gray-400 whitespace-nowrap"
+                    >
+                      N/A
+                    </td>
+                  );
+                }
+
+                return (
+                  <td
+                    key={jalon}
+                    className="px-3 py-2 text-center whitespace-nowrap"
+                  >
+                    {cellule?.valeur !== null ? (
+                      <div className="flex flex-col items-center gap-0.5">
+                        <span
+                          className={estActif ? "font-bold" : ""}
+                          style={{ color: ligne.couleur }}
+                        >
+                          {cellule?.valeur}
+                        </span>
+                        {cellule?.date && (
+                          <span className="text-[10px] text-gray-500">
+                            (
+                            {PiloteDateFormatter.isoMonthFranceMetropolitaine(
+                              cellule.date,
+                            )}
+                            )
+                          </span>
+                        )}
+                      </div>
+                    ) : (
+                      <span className="text-gray-400">-</span>
+                    )}
+                  </td>
+                );
+              })}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};

--- a/src/client/components/_commons/Widget/WidgetCartographieValeurAvancement/WidgetCartographieValeurAvancement.tsx
+++ b/src/client/components/_commons/Widget/WidgetCartographieValeurAvancement/WidgetCartographieValeurAvancement.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { startTransition, useMemo, useState } from "react";
 import { MailleInterne } from "@/server/domain/maille/Maille.interface";
 import { PillToggleGroup } from "@/components/shared/PillToggleGroup";
 import { CartographieV2 } from "@/components/_commons/CartographieV2/CartographieV2";
@@ -15,6 +15,7 @@ import { ValeursRemarquables } from "@/components/_commons/Widget/ValeursRemarqu
 import { useDonneesCartographieVA } from "./useDonneesCartographieVA";
 import { LegendeDegradeVA } from "./LegendeDegradeVA";
 import { SuiviValeurAvancement } from "./SuiviValeurAvancement";
+import { TableauEvolutionVA } from "./TableauEvolutionVA";
 
 type VueCartographieVA = "situation" | "tableau" | "courbes";
 
@@ -158,7 +159,11 @@ export const WidgetCartographieValeurAvancement = ({
         type="single"
         value={vueActive}
         onValueChange={(value) => {
-          if (value) setVueActive(value as VueCartographieVA);
+          if (value) {
+            startTransition(() => {
+              setVueActive(value as VueCartographieVA);
+            });
+          }
         }}
       >
         <PillToggleGroup.Item value="situation">
@@ -182,6 +187,17 @@ export const WidgetCartographieValeurAvancement = ({
           territoiresSelectionnes={territoiresSelectionnes}
           unite={unite}
           statistiques={statistiques}
+        />
+      )}
+      {vueActive === "tableau" && (
+        <TableauEvolutionVA
+          indicateurId={indicateurId}
+          chantierId={chantierId}
+          territoiresSelectionnes={territoiresSelectionnes}
+          territoireCode={territoireCode}
+          onSupprimerTerritoire={supprimerTerritoire}
+          jalonActif={jalon}
+          unite={unite}
         />
       )}
       <AjouterTerritoirePicker

--- a/src/client/components/_commons/Widget/WidgetCartographieValeurAvancement/useValeursAvancementParJalon.ts
+++ b/src/client/components/_commons/Widget/WidgetCartographieValeurAvancement/useValeursAvancementParJalon.ts
@@ -31,13 +31,10 @@ export const useValeursAvancementParJalon = ({
     ),
   );
 
-  const donneesParJalon = useMemo(() => {
-    const map = new Map<number, ValeurAvancementIndicateurTerritoire[]>();
-    jalons.forEach((jalon, index) => {
-      map.set(jalon, results[index]);
-    });
-    return map;
-  }, [jalons, results]);
+  const donneesParJalon = useMemo(
+    () => new Map(jalons.map((jalon, index) => [jalon, results[index]])),
+    [jalons, results],
+  );
 
   return { jalons, donneesParJalon };
 };

--- a/src/client/components/_commons/Widget/WidgetCartographieValeurAvancement/useValeursAvancementParJalon.ts
+++ b/src/client/components/_commons/Widget/WidgetCartographieValeurAvancement/useValeursAvancementParJalon.ts
@@ -1,6 +1,5 @@
 import { useMemo } from "react";
 import api from "@/server/infrastructure/api/trpc/api";
-import { ValeurAvancementIndicateurTerritoire } from "@/server/chantiers/infrastructure/queries/RecupererValeursAvancementIndicateurTerritoiresQuery";
 
 const PREMIER_JALON = 2022;
 

--- a/src/client/components/_commons/Widget/WidgetCartographieValeurAvancement/useValeursAvancementParJalon.ts
+++ b/src/client/components/_commons/Widget/WidgetCartographieValeurAvancement/useValeursAvancementParJalon.ts
@@ -1,0 +1,43 @@
+import { useMemo } from "react";
+import api from "@/server/infrastructure/api/trpc/api";
+import { ValeurAvancementIndicateurTerritoire } from "@/server/chantiers/infrastructure/queries/RecupererValeursAvancementIndicateurTerritoiresQuery";
+
+const PREMIER_JALON = 2022;
+
+const buildJalons = (): number[] => {
+  const currentYear = new Date().getFullYear();
+  return Array.from(
+    { length: currentYear - PREMIER_JALON + 1 },
+    (_, i) => PREMIER_JALON + i,
+  );
+};
+
+export const useValeursAvancementParJalon = ({
+  indicateurId,
+  chantierId,
+}: {
+  indicateurId: string;
+  chantierId: string;
+}) => {
+  const jalons = useMemo(() => buildJalons(), []);
+
+  const [results] = api.useSuspenseQueries((t) =>
+    jalons.map((jalon) =>
+      t.indicateur.recupererValeursAvancementTerritoires({
+        indicateurId,
+        chantierId,
+        jalon,
+      }),
+    ),
+  );
+
+  const donneesParJalon = useMemo(() => {
+    const map = new Map<number, ValeurAvancementIndicateurTerritoire[]>();
+    jalons.forEach((jalon, index) => {
+      map.set(jalon, results[index]);
+    });
+    return map;
+  }, [jalons, results]);
+
+  return { jalons, donneesParJalon };
+};


### PR DESCRIPTION
## Summary
- Add the "évolution temporelle – tableau" view to the `WidgetCartographieValeurAvancement` widget
- Table shows selected territories as rows and jalons (2022–2026) as columns, with advancement values and update dates
- Active jalon column is displayed in bold, territory names use DSFR color palette
- Horizontal scroll on mobile via `overflow-x-auto`

## Test plan
- [ ] Navigate to an indicator page with the cartography widget
- [ ] Click "évolution temporelle – tableau" pill and verify table renders
- [ ] Verify values display with colored text and `(MM/yyyy)` dates below
- [ ] Verify the active jalon column has bold values
- [ ] Verify adding/removing territories updates the table
- [ ] Verify horizontal scroll works on narrow viewport

<img width="972" height="1075" alt="image" src="https://github.com/user-attachments/assets/9ef3b77a-26e3-454a-b8b0-ccd69b9e6f4e" />