### PR TITLE
feat: widget cartographie TA indicateur avec comparaison territoriale (PIL-1333)

### DIFF
--- a/src/client/components/PageAccueil/PageChantiers/PageChantiers.tsx
+++ b/src/client/components/PageAccueil/PageChantiers/PageChantiers.tsx
@@ -222,6 +222,7 @@ const PageChantiers: FunctionComponent<PageChantiersProps> = ({
           <TuileWidget titre="Comparaison territoriale et évolution">
             <div />
             <WidgetCartographieTA
+              mode="chantiers"
               chantierIds={chantierIds}
               jalon={jalon}
               maille={mailleQuery}

--- a/src/client/components/PageChantier/ComparaisonTerritoires/PanneauCarte.tsx
+++ b/src/client/components/PageChantier/ComparaisonTerritoires/PanneauCarte.tsx
@@ -60,6 +60,7 @@ export const PanneauCarte = ({
 
       {typeCarte === "ta" ? (
         <WidgetCartographieTA
+          mode="chantiers"
           chantierIds={[chantierId]}
           jalon={jalon}
           maille={maille}

--- a/src/client/components/_commons/IndicateursChantier/Bloc/Détails/IndicateurDétails.tsx
+++ b/src/client/components/_commons/IndicateursChantier/Bloc/Détails/IndicateurDétails.tsx
@@ -10,6 +10,7 @@ import { useBlocIndicateurContext } from "@/components/PageChantier/useBlocIndic
 import { useEnv } from "@/client/hooks/useEnv";
 import { TuileWidget } from "@/components/_commons/Widget/TuileWidget/TuileWidget";
 import { WidgetCartographieValeurAvancement } from "@/components/_commons/Widget/WidgetCartographieValeurAvancement/WidgetCartographieValeurAvancement";
+import { WidgetCartographieTA } from "@/components/_commons/Widget/WidgetCartographieTA/WidgetCartographieTA";
 import { useIndicateurDétails } from "./useIndicateurDétails";
 
 export type CartographieIndicateurType =
@@ -202,9 +203,16 @@ export const IndicateurDétails: FunctionComponent<IndicateurDétailsProps> = ({
       </section>
       {featureComparaisonTerritoires && (
         <div className="fr-mt-2w fr-container">
-          <TuileWidget titre="Comparaison territoriale">
-            <div />
-            <Suspense>
+          <Suspense>
+            <TuileWidget titre="Comparaison territoriale">
+              <WidgetCartographieTA
+                mode="indicateur"
+                indicateurId={indicateur.id}
+                chantierId={chantierId}
+                jalon={jalon}
+                maille={mailleQuery}
+                territoireCode={territoireCode}
+              />
               <WidgetCartographieValeurAvancement
                 indicateurId={indicateur.id}
                 chantierId={chantierId}
@@ -213,8 +221,8 @@ export const IndicateurDétails: FunctionComponent<IndicateurDétailsProps> = ({
                 territoireCode={territoireCode}
                 unite={indicateur.unité}
               />
-            </Suspense>
-          </TuileWidget>
+            </TuileWidget>
+          </Suspense>
         </div>
       )}
     </div>

--- a/src/client/components/_commons/Widget/WidgetCartographieTA/WidgetCartographieTA.tsx
+++ b/src/client/components/_commons/Widget/WidgetCartographieTA/WidgetCartographieTA.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { createContext, ReactNode, useContext, useState } from "react";
 import { PillToggleGroup } from "@/components/shared/PillToggleGroup";
 import { MailleInterne } from "@/server/domain/maille/Maille.interface";
 import { CartographieV2 } from "@/components/_commons/CartographieV2/CartographieV2";
@@ -12,32 +12,101 @@ import { useSelectionTerritoires } from "@/components/_commons/Widget/WidgetCart
 import { AjouterTerritoirePicker } from "@/components/_commons/Widget/AjouterTerritoirePicker";
 import { ValeursRemarquables } from "@/components/_commons/Widget/ValeursRemarquables";
 import { TauxAvancementComparaisonTerritoireViewModel } from "@/server/chantiers/app/contrats/TauxAvancementComparaisonTerritoireViewModel";
+import { AvancementsStatistiques } from "@/components/_commons/Avancements/Avancements.interface";
 import { useDonneesCartographieTA } from "./useDonneesCartographieTA";
 import { useLegendeTA } from "./useLegendeTA";
 import { SuiviTauxAvancement } from "./SuiviTauxAvancement";
 
-type VueCartographieTA = "situation" | "tableau" | "courbes";
+// --- Context ---
 
-type WidgetCartographieTAProps = {
-  maille: MailleInterne;
-  territoireCode: string;
-  jalon: number;
-} & (
-  | { mode: "chantiers"; chantierIds: string[] }
-  | { mode: "indicateur"; indicateurId: string; chantierId: string }
-);
-
-type WidgetCartographieTAContentProps = {
-  maille: MailleInterne;
-  territoireCode: string;
-  jalon: number;
+type WidgetCartographieTAContextValue = {
   territoiresAvancement: TauxAvancementComparaisonTerritoireViewModel[];
-  statistiques: {
-    minimum: number | null | undefined;
-    médiane: number | null | undefined;
-    maximum: number | null | undefined;
-  } | null;
+  statistiques: AvancementsStatistiques;
 };
+
+const WidgetCartographieTAContext =
+  createContext<WidgetCartographieTAContextValue | null>(null);
+
+const useWidgetCartographieTAContext = () => {
+  const ctx = useContext(WidgetCartographieTAContext);
+  if (!ctx) {
+    throw new Error(
+      "useWidgetCartographieTAContext must be used within a WidgetCartographieTA provider",
+    );
+  }
+  return ctx;
+};
+
+// --- Providers ---
+
+const ChantiersProvider = ({
+  chantierIds,
+  maille,
+  jalon,
+  children,
+}: {
+  chantierIds: string[];
+  maille: MailleInterne;
+  jalon: number;
+  children: ReactNode;
+}) => {
+  const [results] = api.useSuspenseQueries((t) => [
+    t.chantier.recupererAvancementsTerritoires({ chantierIds, jalon }),
+    t.chantier.recupererStatistiquesAvancement({ chantierIds, maille, jalon }),
+  ]);
+
+  const [territoiresAvancement, statistiques] = results;
+
+  return (
+    <WidgetCartographieTAContext.Provider
+      value={{ territoiresAvancement, statistiques }}
+    >
+      {children}
+    </WidgetCartographieTAContext.Provider>
+  );
+};
+
+const IndicateurProvider = ({
+  indicateurId,
+  chantierId,
+  maille,
+  jalon,
+  children,
+}: {
+  indicateurId: string;
+  chantierId: string;
+  maille: MailleInterne;
+  jalon: number;
+  children: ReactNode;
+}) => {
+  const [results] = api.useSuspenseQueries((t) => [
+    t.indicateur.recupererTauxAvancementTerritoires({
+      indicateurId,
+      chantierId,
+      jalon,
+    }),
+    t.indicateur.recupererStatistiquesTauxAvancement({
+      indicateurId,
+      chantierId,
+      maille,
+      jalon,
+    }),
+  ]);
+
+  const [territoiresAvancement, statistiques] = results;
+
+  return (
+    <WidgetCartographieTAContext.Provider
+      value={{ territoiresAvancement, statistiques }}
+    >
+      {children}
+    </WidgetCartographieTAContext.Provider>
+  );
+};
+
+// --- Content ---
+
+type VueCartographieTA = "situation" | "tableau" | "courbes";
 
 const formatValeurTA = (valeur: number | null | undefined): string | null => {
   if (valeur === null || valeur === undefined) return null;
@@ -48,9 +117,13 @@ const WidgetCartographieTAContent = ({
   maille,
   territoireCode,
   jalon,
-  territoiresAvancement,
-  statistiques,
-}: WidgetCartographieTAContentProps) => {
+}: {
+  maille: MailleInterne;
+  territoireCode: string;
+  jalon: number;
+}) => {
+  const { territoiresAvancement, statistiques } =
+    useWidgetCartographieTAContext();
   const [vueActive, setVueActive] = useState<VueCartographieTA>("situation");
 
   const valeursRemarquables = {
@@ -139,99 +212,46 @@ const WidgetCartographieTAContent = ({
   );
 };
 
-const WidgetCartographieTAChantiers = ({
-  chantierIds,
-  maille,
-  territoireCode,
-  jalon,
-}: {
-  chantierIds: string[];
+// --- Public API ---
+
+type WidgetCartographieTAProps = {
   maille: MailleInterne;
   territoireCode: string;
   jalon: number;
-}) => {
-  const [territoiresAvancement] =
-    api.chantier.recupererAvancementsTerritoires.useSuspenseQuery({
-      chantierIds,
-      jalon,
-    });
-
-  const [statistiques] =
-    api.chantier.recupererStatistiquesAvancement.useSuspenseQuery({
-      chantierIds,
-      maille,
-      jalon,
-    });
-
-  return (
-    <WidgetCartographieTAContent
-      maille={maille}
-      territoireCode={territoireCode}
-      jalon={jalon}
-      territoiresAvancement={territoiresAvancement}
-      statistiques={statistiques}
-    />
-  );
-};
-
-const WidgetCartographieTAIndicateur = ({
-  indicateurId,
-  chantierId,
-  maille,
-  territoireCode,
-  jalon,
-}: {
-  indicateurId: string;
-  chantierId: string;
-  maille: MailleInterne;
-  territoireCode: string;
-  jalon: number;
-}) => {
-  const [territoiresAvancement] =
-    api.indicateur.recupererTauxAvancementTerritoires.useSuspenseQuery({
-      indicateurId,
-      chantierId,
-      jalon,
-    });
-
-  const [statistiques] =
-    api.indicateur.recupererStatistiquesTauxAvancement.useSuspenseQuery({
-      indicateurId,
-      chantierId,
-      maille,
-      jalon,
-    });
-
-  return (
-    <WidgetCartographieTAContent
-      maille={maille}
-      territoireCode={territoireCode}
-      jalon={jalon}
-      territoiresAvancement={territoiresAvancement}
-      statistiques={statistiques}
-    />
-  );
-};
+} & (
+  | { mode: "chantiers"; chantierIds: string[] }
+  | { mode: "indicateur"; indicateurId: string; chantierId: string }
+);
 
 export const WidgetCartographieTA = (props: WidgetCartographieTAProps) => {
-  if (props.mode === "indicateur") {
-    return (
-      <WidgetCartographieTAIndicateur
-        indicateurId={props.indicateurId}
-        chantierId={props.chantierId}
-        maille={props.maille}
-        territoireCode={props.territoireCode}
-        jalon={props.jalon}
-      />
-    );
-  }
-
-  return (
-    <WidgetCartographieTAChantiers
-      chantierIds={props.chantierIds}
+  const content = (
+    <WidgetCartographieTAContent
       maille={props.maille}
       territoireCode={props.territoireCode}
       jalon={props.jalon}
     />
+  );
+
+  if (props.mode === "indicateur") {
+    return (
+      <IndicateurProvider
+        indicateurId={props.indicateurId}
+        chantierId={props.chantierId}
+        maille={props.maille}
+        jalon={props.jalon}
+      >
+        {content}
+      </IndicateurProvider>
+    );
+  }
+
+  return (
+    <ChantiersProvider
+      chantierIds={props.chantierIds}
+      maille={props.maille}
+      jalon={props.jalon}
+    >
+      {content}
+    </ChantiersProvider>
   );
 };

--- a/src/client/components/_commons/Widget/WidgetCartographieTA/WidgetCartographieTA.tsx
+++ b/src/client/components/_commons/Widget/WidgetCartographieTA/WidgetCartographieTA.tsx
@@ -11,42 +11,47 @@ import api from "@/server/infrastructure/api/trpc/api";
 import { useSelectionTerritoires } from "@/components/_commons/Widget/WidgetCartographieMeteo/useSelectionTerritoires";
 import { AjouterTerritoirePicker } from "@/components/_commons/Widget/AjouterTerritoirePicker";
 import { ValeursRemarquables } from "@/components/_commons/Widget/ValeursRemarquables";
+import { TauxAvancementComparaisonTerritoireViewModel } from "@/server/chantiers/app/contrats/TauxAvancementComparaisonTerritoireViewModel";
 import { useDonneesCartographieTA } from "./useDonneesCartographieTA";
 import { useLegendeTA } from "./useLegendeTA";
 import { SuiviTauxAvancement } from "./SuiviTauxAvancement";
 
 type VueCartographieTA = "situation" | "tableau" | "courbes";
 
-export const WidgetCartographieTA = ({
-  chantierIds,
-  maille,
-  territoireCode,
-  jalon,
-}: {
-  chantierIds: string[];
+type WidgetCartographieTAProps = {
   maille: MailleInterne;
   territoireCode: string;
   jalon: number;
-}) => {
+} & (
+  | { mode: "chantiers"; chantierIds: string[] }
+  | { mode: "indicateur"; indicateurId: string; chantierId: string }
+);
+
+type WidgetCartographieTAContentProps = {
+  maille: MailleInterne;
+  territoireCode: string;
+  jalon: number;
+  territoiresAvancement: TauxAvancementComparaisonTerritoireViewModel[];
+  statistiques: {
+    minimum: number | null | undefined;
+    médiane: number | null | undefined;
+    maximum: number | null | undefined;
+  } | null;
+};
+
+const formatValeurTA = (valeur: number | null | undefined): string | null => {
+  if (valeur === null || valeur === undefined) return null;
+  return `${Math.round(valeur)}%`;
+};
+
+const WidgetCartographieTAContent = ({
+  maille,
+  territoireCode,
+  jalon,
+  territoiresAvancement,
+  statistiques,
+}: WidgetCartographieTAContentProps) => {
   const [vueActive, setVueActive] = useState<VueCartographieTA>("situation");
-
-  const [territoiresAvancement] =
-    api.chantier.recupererAvancementsTerritoires.useSuspenseQuery({
-      chantierIds,
-      jalon,
-    });
-
-  const [statistiques] =
-    api.chantier.recupererStatistiquesAvancement.useSuspenseQuery({
-      chantierIds,
-      maille,
-      jalon,
-    });
-
-  const formatValeurTA = (valeur: number | null | undefined): string | null => {
-    if (valeur === null || valeur === undefined) return null;
-    return `${Math.round(valeur)}%`;
-  };
 
   const valeursRemarquables = {
     minimum: formatValeurTA(statistiques?.minimum),
@@ -131,5 +136,102 @@ export const WidgetCartographieTA = ({
         onAjouterTerritoires={ajouterTerritoires}
       />
     </BaseCartographieWidgetLayout>
+  );
+};
+
+const WidgetCartographieTAChantiers = ({
+  chantierIds,
+  maille,
+  territoireCode,
+  jalon,
+}: {
+  chantierIds: string[];
+  maille: MailleInterne;
+  territoireCode: string;
+  jalon: number;
+}) => {
+  const [territoiresAvancement] =
+    api.chantier.recupererAvancementsTerritoires.useSuspenseQuery({
+      chantierIds,
+      jalon,
+    });
+
+  const [statistiques] =
+    api.chantier.recupererStatistiquesAvancement.useSuspenseQuery({
+      chantierIds,
+      maille,
+      jalon,
+    });
+
+  return (
+    <WidgetCartographieTAContent
+      maille={maille}
+      territoireCode={territoireCode}
+      jalon={jalon}
+      territoiresAvancement={territoiresAvancement}
+      statistiques={statistiques}
+    />
+  );
+};
+
+const WidgetCartographieTAIndicateur = ({
+  indicateurId,
+  chantierId,
+  maille,
+  territoireCode,
+  jalon,
+}: {
+  indicateurId: string;
+  chantierId: string;
+  maille: MailleInterne;
+  territoireCode: string;
+  jalon: number;
+}) => {
+  const [territoiresAvancement] =
+    api.indicateur.recupererTauxAvancementTerritoires.useSuspenseQuery({
+      indicateurId,
+      chantierId,
+      jalon,
+    });
+
+  const [statistiques] =
+    api.indicateur.recupererStatistiquesTauxAvancement.useSuspenseQuery({
+      indicateurId,
+      chantierId,
+      maille,
+      jalon,
+    });
+
+  return (
+    <WidgetCartographieTAContent
+      maille={maille}
+      territoireCode={territoireCode}
+      jalon={jalon}
+      territoiresAvancement={territoiresAvancement}
+      statistiques={statistiques}
+    />
+  );
+};
+
+export const WidgetCartographieTA = (props: WidgetCartographieTAProps) => {
+  if (props.mode === "indicateur") {
+    return (
+      <WidgetCartographieTAIndicateur
+        indicateurId={props.indicateurId}
+        chantierId={props.chantierId}
+        maille={props.maille}
+        territoireCode={props.territoireCode}
+        jalon={props.jalon}
+      />
+    );
+  }
+
+  return (
+    <WidgetCartographieTAChantiers
+      chantierIds={props.chantierIds}
+      maille={props.maille}
+      territoireCode={props.territoireCode}
+      jalon={props.jalon}
+    />
   );
 };

--- a/src/client/components/_commons/Widget/WidgetCartographieTA/WidgetCartographieTA.tsx
+++ b/src/client/components/_commons/Widget/WidgetCartographieTA/WidgetCartographieTA.tsx
@@ -17,15 +17,10 @@ import { useDonneesCartographieTA } from "./useDonneesCartographieTA";
 import { useLegendeTA } from "./useLegendeTA";
 import { SuiviTauxAvancement } from "./SuiviTauxAvancement";
 
-// --- Context ---
-
-type WidgetCartographieTAContextValue = {
+const WidgetCartographieTAContext = createContext<{
   territoiresAvancement: TauxAvancementComparaisonTerritoireViewModel[];
   statistiques: AvancementsStatistiques;
-};
-
-const WidgetCartographieTAContext =
-  createContext<WidgetCartographieTAContextValue | null>(null);
+} | null>(null);
 
 const useWidgetCartographieTAContext = () => {
   const ctx = useContext(WidgetCartographieTAContext);
@@ -36,8 +31,6 @@ const useWidgetCartographieTAContext = () => {
   }
   return ctx;
 };
-
-// --- Providers ---
 
 const ChantiersProvider = ({
   chantierIds,
@@ -50,12 +43,16 @@ const ChantiersProvider = ({
   jalon: number;
   children: ReactNode;
 }) => {
-  const [results] = api.useSuspenseQueries((t) => [
-    t.chantier.recupererAvancementsTerritoires({ chantierIds, jalon }),
-    t.chantier.recupererStatistiquesAvancement({ chantierIds, maille, jalon }),
-  ]);
-
-  const [territoiresAvancement, statistiques] = results;
+  const [[territoiresAvancement, statistiques]] = api.useSuspenseQueries(
+    (t) => [
+      t.chantier.recupererAvancementsTerritoires({ chantierIds, jalon }),
+      t.chantier.recupererStatistiquesAvancement({
+        chantierIds,
+        maille,
+        jalon,
+      }),
+    ],
+  );
 
   return (
     <WidgetCartographieTAContext.Provider
@@ -79,21 +76,21 @@ const IndicateurProvider = ({
   jalon: number;
   children: ReactNode;
 }) => {
-  const [results] = api.useSuspenseQueries((t) => [
-    t.indicateur.recupererTauxAvancementTerritoires({
-      indicateurId,
-      chantierId,
-      jalon,
-    }),
-    t.indicateur.recupererStatistiquesTauxAvancement({
-      indicateurId,
-      chantierId,
-      maille,
-      jalon,
-    }),
-  ]);
-
-  const [territoiresAvancement, statistiques] = results;
+  const [[territoiresAvancement, statistiques]] = api.useSuspenseQueries(
+    (t) => [
+      t.indicateur.recupererTauxAvancementTerritoires({
+        indicateurId,
+        chantierId,
+        jalon,
+      }),
+      t.indicateur.recupererStatistiquesTauxAvancement({
+        indicateurId,
+        chantierId,
+        maille,
+        jalon,
+      }),
+    ],
+  );
 
   return (
     <WidgetCartographieTAContext.Provider

--- a/src/client/components/_commons/Widget/WidgetCartographieTA/WidgetCartographieTA.tsx
+++ b/src/client/components/_commons/Widget/WidgetCartographieTA/WidgetCartographieTA.tsx
@@ -45,7 +45,10 @@ const ChantiersProvider = ({
 }) => {
   const [[territoiresAvancement, statistiques]] = api.useSuspenseQueries(
     (t) => [
-      t.chantier.recupererAvancementsTerritoires({ chantierIds, jalon }),
+      t.chantier.recupererTauxAvancementTerritoires({
+        chantierIds,
+        jalon,
+      }),
       t.chantier.recupererStatistiquesAvancement({
         chantierIds,
         maille,

--- a/src/server/chantiers/__tests__/infrastructure/queries/GetStatistiquesTauxAvancementIndicateurTerritoiresQuery.integration.test.ts
+++ b/src/server/chantiers/__tests__/infrastructure/queries/GetStatistiquesTauxAvancementIndicateurTerritoiresQuery.integration.test.ts
@@ -249,9 +249,9 @@ describe("GetStatistiquesTauxAvancementIndicateurTerritoiresQuery", () => {
   );
 
   it(
-    "calcule la médiane pour un nombre pair de valeurs",
+    "filtre par maille départementale en ignorant les territoires régionaux",
     createIntegrationTest(async () => {
-      // given
+      // given — 3 DEPT + 1 REG
       await créerIndicateurAvecTerritoires("CH-013", "IND-013", [
         {
           code: "DEPT-75",
@@ -302,11 +302,74 @@ describe("GetStatistiquesTauxAvancementIndicateurTerritoiresQuery", () => {
         profil: ProfilEnum.DITP_ADMIN,
       });
 
-      // then — median of [20, 40, 60] = 40 (3 DEPT values, odd count)
+      // then — median of [20, 40, 60] = 40 (3 DEPT values, REG-11 excluded)
       expect(result).toEqual({
         minimum: 20,
         médiane: 40,
         maximum: 60,
+      });
+    }),
+  );
+
+  it(
+    "calcule la médiane pour un nombre pair de valeurs",
+    createIntegrationTest(async () => {
+      // given — 4 DEPT values
+      await créerIndicateurAvecTerritoires("CH-014", "IND-014", [
+        {
+          code: "DEPT-75",
+          codeInsee: "75",
+          maille: "DEPT",
+          zoneId: "D75",
+          tauxAvancement: 20,
+          estApplicable: true,
+        },
+        {
+          code: "DEPT-92",
+          codeInsee: "92",
+          maille: "DEPT",
+          zoneId: "D92",
+          tauxAvancement: 40,
+          estApplicable: true,
+        },
+        {
+          code: "DEPT-93",
+          codeInsee: "93",
+          maille: "DEPT",
+          zoneId: "D93",
+          tauxAvancement: 60,
+          estApplicable: true,
+        },
+        {
+          code: "DEPT-94",
+          codeInsee: "94",
+          maille: "DEPT",
+          zoneId: "D94",
+          tauxAvancement: 80,
+          estApplicable: true,
+        },
+      ]);
+
+      // when
+      const result = await query.execute({
+        indicateurId: "IND-014",
+        chantierId: "CH-014",
+        maille: "departementale",
+        jalon: 2025,
+        habilitations: habilitationsPourChantier("CH-014", [
+          "DEPT-75",
+          "DEPT-92",
+          "DEPT-93",
+          "DEPT-94",
+        ]),
+        profil: ProfilEnum.DITP_ADMIN,
+      });
+
+      // then — median of [20, 40, 60, 80] = (40 + 60) / 2 = 50
+      expect(result).toEqual({
+        minimum: 20,
+        médiane: 50,
+        maximum: 80,
       });
     }),
   );

--- a/src/server/chantiers/__tests__/infrastructure/queries/GetStatistiquesTauxAvancementIndicateurTerritoiresQuery.integration.test.ts
+++ b/src/server/chantiers/__tests__/infrastructure/queries/GetStatistiquesTauxAvancementIndicateurTerritoiresQuery.integration.test.ts
@@ -1,0 +1,313 @@
+import { $Enums } from "@prisma/client";
+import { ProfilEnum } from "@/server/app/enum/profil.enum";
+import { PrismaIndicateurRepository } from "@/server/chantiers/infrastructure/adapters/PrismaIndicateurRepository";
+import { GetStatistiquesTauxAvancementIndicateurTerritoiresQuery } from "@/server/chantiers/infrastructure/queries/GetStatistiquesTauxAvancementIndicateurTerritoiresQuery";
+import { ListerDetailsIndicateurTerritoireUseCaseV2 } from "@/server/chantiers/usecases/ListerDetailsIndicateurTerritoireUseCaseV2";
+import { DatajobsExecutionQueries } from "@/server/datajobs-execution/DatajobsExecution";
+import { PrismaPilote } from "@/server/db/PrismaPilote";
+import { Habilitations } from "@/server/domain/utilisateur/habilitation/Habilitation.interface";
+import { createIntegrationTest } from "@/server/infrastructure/test/createIntegrationTest";
+import { fixtures } from "@/server/infrastructure/test/fixtures";
+
+function habilitationsPourChantier(
+  chantierId: string,
+  territoires: string[],
+): Habilitations {
+  return {
+    lecture: {
+      chantiers: [chantierId],
+      territoires,
+      périmètres: [],
+    },
+    saisieCommentaire: { chantiers: [], territoires: [], périmètres: [] },
+    saisieIndicateur: { chantiers: [], territoires: [], périmètres: [] },
+    responsabilite: { chantiers: [], territoires: [], périmètres: [] },
+    gestionUtilisateur: { chantiers: [], territoires: [], périmètres: [] },
+  };
+}
+
+async function créerIndicateurAvecTerritoires(
+  chantierId: string,
+  indicateurId: string,
+  territoires: {
+    code: string;
+    codeInsee: string;
+    maille: $Enums.Maille;
+    zoneId: string;
+    tauxAvancement: number | null;
+    estApplicable: boolean;
+  }[],
+) {
+  await fixtures.chantierIdentite({ id: chantierId });
+  await fixtures.indicateurIdentite({
+    id: indicateurId,
+    chantier_id: chantierId,
+    statut: "PUBLIE",
+  });
+
+  for (const t of territoires) {
+    await fixtures.chantierTerritoire({
+      id: chantierId,
+      territoire_code: t.code,
+      maille: t.maille,
+      code_insee: t.codeInsee,
+      zone_id: t.zoneId,
+    });
+    await fixtures.indicateurTerritoire({
+      id: indicateurId,
+      chantier_id: chantierId,
+      territoire_code: t.code,
+      code_insee: t.codeInsee,
+      maille: t.maille,
+      zone_id: t.zoneId,
+      est_applicable: t.estApplicable,
+    });
+    await fixtures.indicateurTerritoireJalon({
+      id: indicateurId,
+      territoire_code: t.code,
+      code_insee: t.codeInsee,
+      maille: t.maille,
+      zone_id: t.zoneId,
+      jalon: 2025,
+      taux_avancement: t.tauxAvancement,
+    });
+  }
+}
+
+describe("GetStatistiquesTauxAvancementIndicateurTerritoiresQuery", () => {
+  const prismaPilote = new PrismaPilote();
+  let query: GetStatistiquesTauxAvancementIndicateurTerritoiresQuery;
+
+  beforeEach(() => {
+    const indicateurRepository = new PrismaIndicateurRepository({
+      prisma: prismaPilote,
+    });
+    const datajobsExecutionQueries = new DatajobsExecutionQueries({
+      prisma: prismaPilote,
+    });
+
+    query = new GetStatistiquesTauxAvancementIndicateurTerritoiresQuery({
+      listerDetailsIndicateurTerritoireUseCaseV2:
+        new ListerDetailsIndicateurTerritoireUseCaseV2({
+          indicateurRepository,
+          datajobsExecutionQueries,
+        }),
+    });
+  });
+
+  it(
+    "calcule minimum, médiane et maximum des taux d'avancement pour des territoires départementaux",
+    createIntegrationTest(async () => {
+      // given
+      await créerIndicateurAvecTerritoires("CH-010", "IND-010", [
+        {
+          code: "DEPT-75",
+          codeInsee: "75",
+          maille: "DEPT",
+          zoneId: "D75",
+          tauxAvancement: 30,
+          estApplicable: true,
+        },
+        {
+          code: "DEPT-92",
+          codeInsee: "92",
+          maille: "DEPT",
+          zoneId: "D92",
+          tauxAvancement: 50,
+          estApplicable: true,
+        },
+        {
+          code: "DEPT-93",
+          codeInsee: "93",
+          maille: "DEPT",
+          zoneId: "D93",
+          tauxAvancement: 70,
+          estApplicable: true,
+        },
+      ]);
+
+      // when
+      const result = await query.execute({
+        indicateurId: "IND-010",
+        chantierId: "CH-010",
+        maille: "departementale",
+        jalon: 2025,
+        habilitations: habilitationsPourChantier("CH-010", [
+          "DEPT-75",
+          "DEPT-92",
+          "DEPT-93",
+        ]),
+        profil: ProfilEnum.DITP_ADMIN,
+      });
+
+      // then
+      expect(result).toEqual({
+        minimum: 30,
+        médiane: 50,
+        maximum: 70,
+      });
+    }),
+  );
+
+  it(
+    "exclut les territoires non applicables du calcul",
+    createIntegrationTest(async () => {
+      // given
+      await créerIndicateurAvecTerritoires("CH-011", "IND-011", [
+        {
+          code: "DEPT-75",
+          codeInsee: "75",
+          maille: "DEPT",
+          zoneId: "D75",
+          tauxAvancement: 10,
+          estApplicable: false,
+        },
+        {
+          code: "DEPT-92",
+          codeInsee: "92",
+          maille: "DEPT",
+          zoneId: "D92",
+          tauxAvancement: 50,
+          estApplicable: true,
+        },
+        {
+          code: "DEPT-93",
+          codeInsee: "93",
+          maille: "DEPT",
+          zoneId: "D93",
+          tauxAvancement: 90,
+          estApplicable: true,
+        },
+      ]);
+
+      // when
+      const result = await query.execute({
+        indicateurId: "IND-011",
+        chantierId: "CH-011",
+        maille: "departementale",
+        jalon: 2025,
+        habilitations: habilitationsPourChantier("CH-011", [
+          "DEPT-75",
+          "DEPT-92",
+          "DEPT-93",
+        ]),
+        profil: ProfilEnum.DITP_ADMIN,
+      });
+
+      // then
+      expect(result).toEqual({
+        minimum: 50,
+        médiane: 70,
+        maximum: 90,
+      });
+    }),
+  );
+
+  it(
+    "filtre par maille régionale en ignorant les territoires départementaux",
+    createIntegrationTest(async () => {
+      // given
+      await créerIndicateurAvecTerritoires("CH-012", "IND-012", [
+        {
+          code: "REG-11",
+          codeInsee: "11",
+          maille: "REG",
+          zoneId: "R11",
+          tauxAvancement: 20,
+          estApplicable: true,
+        },
+        {
+          code: "DEPT-75",
+          codeInsee: "75",
+          maille: "DEPT",
+          zoneId: "D75",
+          tauxAvancement: 99,
+          estApplicable: true,
+        },
+      ]);
+
+      // when
+      const result = await query.execute({
+        indicateurId: "IND-012",
+        chantierId: "CH-012",
+        maille: "regionale",
+        jalon: 2025,
+        habilitations: habilitationsPourChantier("CH-012", [
+          "REG-11",
+          "DEPT-75",
+        ]),
+        profil: ProfilEnum.DITP_ADMIN,
+      });
+
+      // then
+      expect(result).toEqual({
+        minimum: 20,
+        médiane: 20,
+        maximum: 20,
+      });
+    }),
+  );
+
+  it(
+    "calcule la médiane pour un nombre pair de valeurs",
+    createIntegrationTest(async () => {
+      // given
+      await créerIndicateurAvecTerritoires("CH-013", "IND-013", [
+        {
+          code: "DEPT-75",
+          codeInsee: "75",
+          maille: "DEPT",
+          zoneId: "D75",
+          tauxAvancement: 20,
+          estApplicable: true,
+        },
+        {
+          code: "DEPT-92",
+          codeInsee: "92",
+          maille: "DEPT",
+          zoneId: "D92",
+          tauxAvancement: 40,
+          estApplicable: true,
+        },
+        {
+          code: "DEPT-93",
+          codeInsee: "93",
+          maille: "DEPT",
+          zoneId: "D93",
+          tauxAvancement: 60,
+          estApplicable: true,
+        },
+        {
+          code: "REG-11",
+          codeInsee: "11",
+          maille: "REG",
+          zoneId: "R11",
+          tauxAvancement: 80,
+          estApplicable: true,
+        },
+      ]);
+
+      // when — only DEPT territories are used for departementale
+      const result = await query.execute({
+        indicateurId: "IND-013",
+        chantierId: "CH-013",
+        maille: "departementale",
+        jalon: 2025,
+        habilitations: habilitationsPourChantier("CH-013", [
+          "DEPT-75",
+          "DEPT-92",
+          "DEPT-93",
+          "REG-11",
+        ]),
+        profil: ProfilEnum.DITP_ADMIN,
+      });
+
+      // then — median of [20, 40, 60] = 40 (3 DEPT values, odd count)
+      expect(result).toEqual({
+        minimum: 20,
+        médiane: 40,
+        maximum: 60,
+      });
+    }),
+  );
+});

--- a/src/server/chantiers/__tests__/infrastructure/queries/RecupererTauxAvancementIndicateurTerritoiresQuery.integration.test.ts
+++ b/src/server/chantiers/__tests__/infrastructure/queries/RecupererTauxAvancementIndicateurTerritoiresQuery.integration.test.ts
@@ -1,0 +1,321 @@
+import { createIntegrationTest } from "@/server/infrastructure/test/createIntegrationTest";
+import { fixtures } from "@/server/infrastructure/test/fixtures";
+import { RecupererTauxAvancementIndicateurTerritoiresQuery } from "@/server/chantiers/infrastructure/queries/RecupererTauxAvancementIndicateurTerritoiresQuery";
+import { ListerDetailsIndicateurTerritoireUseCaseV2 } from "@/server/chantiers/usecases/ListerDetailsIndicateurTerritoireUseCaseV2";
+import { PrismaIndicateurRepository } from "@/server/chantiers/infrastructure/adapters/PrismaIndicateurRepository";
+import { PrismaTerritoireRepository } from "@/server/chantiers/infrastructure/adapters/PrismaTerritoireRepository";
+import { DatajobsExecutionQueries } from "@/server/datajobs-execution/DatajobsExecution";
+import { PrismaPilote } from "@/server/db/PrismaPilote";
+import { Habilitations } from "@/server/domain/utilisateur/habilitation/Habilitation.interface";
+import { ProfilEnum } from "@/server/app/enum/profil.enum";
+
+function habilitationsPourChantier(
+  chantierId: string,
+  territoires: string[],
+): Habilitations {
+  return {
+    lecture: {
+      chantiers: [chantierId],
+      territoires,
+      périmètres: [],
+    },
+    saisieCommentaire: { chantiers: [], territoires: [], périmètres: [] },
+    saisieIndicateur: { chantiers: [], territoires: [], périmètres: [] },
+    responsabilite: { chantiers: [], territoires: [], périmètres: [] },
+    gestionUtilisateur: { chantiers: [], territoires: [], périmètres: [] },
+  };
+}
+
+describe("RecupererTauxAvancementIndicateurTerritoiresQuery", () => {
+  const prismaPilote = new PrismaPilote();
+  let query: RecupererTauxAvancementIndicateurTerritoiresQuery;
+
+  beforeEach(() => {
+    const indicateurRepository = new PrismaIndicateurRepository({
+      prisma: prismaPilote,
+    });
+    const datajobsExecutionQueries = new DatajobsExecutionQueries({
+      prisma: prismaPilote,
+    });
+    const territoireRepository = new PrismaTerritoireRepository({
+      prisma: prismaPilote,
+    });
+
+    query = new RecupererTauxAvancementIndicateurTerritoiresQuery({
+      listerDetailsIndicateurTerritoireUseCaseV2:
+        new ListerDetailsIndicateurTerritoireUseCaseV2({
+          indicateurRepository,
+          datajobsExecutionQueries,
+        }),
+      territoireRepository,
+    });
+  });
+
+  it(
+    "mappe les détails territoires en taux d'avancement",
+    createIntegrationTest(async () => {
+      // given
+      await fixtures.chantierIdentite({ id: "CH-001" });
+      await fixtures.chantierTerritoire({
+        id: "CH-001",
+        territoire_code: "DEPT-75",
+        maille: "DEPT",
+        code_insee: "75",
+        zone_id: "D75",
+      });
+      await fixtures.indicateurIdentite({
+        id: "IND-001",
+        chantier_id: "CH-001",
+        statut: "PUBLIE",
+      });
+      await fixtures.indicateurTerritoire({
+        id: "IND-001",
+        chantier_id: "CH-001",
+        territoire_code: "DEPT-75",
+        code_insee: "75",
+        maille: "DEPT",
+        zone_id: "D75",
+        est_applicable: true,
+      });
+      await fixtures.indicateurTerritoireJalon({
+        id: "IND-001",
+        territoire_code: "DEPT-75",
+        code_insee: "75",
+        maille: "DEPT",
+        zone_id: "D75",
+        jalon: 2025,
+        valeur_actuelle: 42,
+        valeur_cible: 100,
+        taux_avancement: 42,
+      });
+
+      // when
+      const result = await query.execute({
+        indicateurId: "IND-001",
+        chantierId: "CH-001",
+        jalon: 2025,
+        habilitations: habilitationsPourChantier("CH-001", ["DEPT-75"]),
+        profil: ProfilEnum.DITP_ADMIN,
+      });
+
+      // then
+      expect(result).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            territoireCode: "DEPT-75",
+            tauxAvancementJalon: 42,
+            maille: "DEPT",
+            estApplicable: true,
+          }),
+        ]),
+      );
+    }),
+  );
+
+  it(
+    "retourne estApplicable false pour un territoire non applicable",
+    createIntegrationTest(async () => {
+      // given
+      await fixtures.chantierIdentite({ id: "CH-002" });
+      await fixtures.chantierTerritoire({
+        id: "CH-002",
+        territoire_code: "DEPT-92",
+        maille: "DEPT",
+        code_insee: "92",
+        zone_id: "D92",
+      });
+      await fixtures.indicateurIdentite({
+        id: "IND-002",
+        chantier_id: "CH-002",
+        statut: "PUBLIE",
+      });
+      await fixtures.indicateurTerritoire({
+        id: "IND-002",
+        chantier_id: "CH-002",
+        territoire_code: "DEPT-92",
+        code_insee: "92",
+        maille: "DEPT",
+        zone_id: "D92",
+        est_applicable: false,
+      });
+      await fixtures.indicateurTerritoireJalon({
+        id: "IND-002",
+        territoire_code: "DEPT-92",
+        code_insee: "92",
+        maille: "DEPT",
+        zone_id: "D92",
+        jalon: 2025,
+        valeur_actuelle: null,
+        valeur_cible: null,
+      });
+
+      // when
+      const result = await query.execute({
+        indicateurId: "IND-002",
+        chantierId: "CH-002",
+        jalon: 2025,
+        habilitations: habilitationsPourChantier("CH-002", ["DEPT-92"]),
+        profil: ProfilEnum.DITP_ADMIN,
+      });
+
+      // then
+      expect(result).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            territoireCode: "DEPT-92",
+            tauxAvancementJalon: null,
+            estApplicable: false,
+          }),
+        ]),
+      );
+    }),
+  );
+
+  it(
+    "détermine la maille correctement à partir du code territoire",
+    createIntegrationTest(async () => {
+      // given
+      await fixtures.chantierIdentite({ id: "CH-003" });
+
+      await fixtures.chantierTerritoire({
+        id: "CH-003",
+        territoire_code: "REG-11",
+        maille: "REG",
+        code_insee: "11",
+        zone_id: "R11",
+      });
+      await fixtures.chantierTerritoire({
+        id: "CH-003",
+        territoire_code: "DEPT-75",
+        maille: "DEPT",
+        code_insee: "75",
+        zone_id: "D75",
+      });
+
+      await fixtures.indicateurIdentite({
+        id: "IND-003",
+        chantier_id: "CH-003",
+        statut: "PUBLIE",
+      });
+
+      await fixtures.indicateurTerritoire({
+        id: "IND-003",
+        chantier_id: "CH-003",
+        territoire_code: "REG-11",
+        code_insee: "11",
+        maille: "REG",
+        zone_id: "R11",
+        est_applicable: true,
+      });
+      await fixtures.indicateurTerritoire({
+        id: "IND-003",
+        chantier_id: "CH-003",
+        territoire_code: "DEPT-75",
+        code_insee: "75",
+        maille: "DEPT",
+        zone_id: "D75",
+        est_applicable: true,
+      });
+
+      await fixtures.indicateurTerritoireJalon({
+        id: "IND-003",
+        territoire_code: "REG-11",
+        code_insee: "11",
+        maille: "REG",
+        zone_id: "R11",
+        jalon: 2025,
+        taux_avancement: 60,
+      });
+      await fixtures.indicateurTerritoireJalon({
+        id: "IND-003",
+        territoire_code: "DEPT-75",
+        code_insee: "75",
+        maille: "DEPT",
+        zone_id: "D75",
+        jalon: 2025,
+        taux_avancement: 80,
+      });
+
+      // when
+      const result = await query.execute({
+        indicateurId: "IND-003",
+        chantierId: "CH-003",
+        jalon: 2025,
+        habilitations: habilitationsPourChantier("CH-003", [
+          "REG-11",
+          "DEPT-75",
+        ]),
+        profil: ProfilEnum.DITP_ADMIN,
+      });
+
+      // then
+      const reg = result.find((r) => r.territoireCode === "REG-11");
+      const dept = result.find((r) => r.territoireCode === "DEPT-75");
+
+      expect(reg).toEqual(
+        expect.objectContaining({
+          maille: "REG",
+          tauxAvancementJalon: 60,
+        }),
+      );
+      expect(dept).toEqual(
+        expect.objectContaining({
+          maille: "DEPT",
+          tauxAvancementJalon: 80,
+        }),
+      );
+    }),
+  );
+
+  it(
+    "inclut le nom du territoire",
+    createIntegrationTest(async () => {
+      // given
+      await fixtures.chantierIdentite({ id: "CH-004" });
+      await fixtures.chantierTerritoire({
+        id: "CH-004",
+        territoire_code: "DEPT-75",
+        maille: "DEPT",
+        code_insee: "75",
+        zone_id: "D75",
+      });
+      await fixtures.indicateurIdentite({
+        id: "IND-004",
+        chantier_id: "CH-004",
+        statut: "PUBLIE",
+      });
+      await fixtures.indicateurTerritoire({
+        id: "IND-004",
+        chantier_id: "CH-004",
+        territoire_code: "DEPT-75",
+        code_insee: "75",
+        maille: "DEPT",
+        zone_id: "D75",
+        est_applicable: true,
+      });
+      await fixtures.indicateurTerritoireJalon({
+        id: "IND-004",
+        territoire_code: "DEPT-75",
+        code_insee: "75",
+        maille: "DEPT",
+        zone_id: "D75",
+        jalon: 2025,
+        taux_avancement: 50,
+      });
+
+      // when
+      const result = await query.execute({
+        indicateurId: "IND-004",
+        chantierId: "CH-004",
+        jalon: 2025,
+        habilitations: habilitationsPourChantier("CH-004", ["DEPT-75"]),
+        profil: ProfilEnum.DITP_ADMIN,
+      });
+
+      // then
+      const dept75 = result.find((r) => r.territoireCode === "DEPT-75");
+      expect(dept75).toBeDefined();
+      expect(dept75!.territoireNom).not.toBe("");
+    }),
+  );
+});

--- a/src/server/chantiers/__tests__/infrastructure/queries/RecupererTauxAvancementsChantierTerritoiresQuery.integration.test.ts
+++ b/src/server/chantiers/__tests__/infrastructure/queries/RecupererTauxAvancementsChantierTerritoiresQuery.integration.test.ts
@@ -1,16 +1,16 @@
 import { createIntegrationTest } from "@/server/infrastructure/test/createIntegrationTest";
 import { fixtures } from "@/server/infrastructure/test/fixtures";
-import { RecupererAvancementsTerritoiresQuery } from "@/server/chantiers/infrastructure/queries/RecupererAvancementsTerritoiresQuery";
+import { RecupererTauxAvancementsChantierTerritoiresQuery } from "@/server/chantiers/infrastructure/queries/RecupererTauxAvancementsChantierTerritoiresQuery";
 import { AgregerAvancementsChantiersUseCase } from "@/server/chantiers/usecases/AgregerAvancementsChantiersUseCase";
 import { PrismaTerritoireRepository } from "@/server/chantiers/infrastructure/adapters/PrismaTerritoireRepository";
 import { PrismaPilote } from "@/server/db/PrismaPilote";
 import ChantierSQLRepository from "@/server/infrastructure/accès_données/chantier/ChantierSQLRepository";
 
 const prismaPilote = new PrismaPilote();
-let query: RecupererAvancementsTerritoiresQuery;
+let query: RecupererTauxAvancementsChantierTerritoiresQuery;
 
 beforeEach(() => {
-  query = new RecupererAvancementsTerritoiresQuery({
+  query = new RecupererTauxAvancementsChantierTerritoiresQuery({
     agregerAvancementsChantiersUseCase: new AgregerAvancementsChantiersUseCase({
       chantierRepository: new ChantierSQLRepository({ prisma: prismaPilote }),
     }),

--- a/src/server/chantiers/infrastructure/queries/GetStatistiquesTauxAvancementIndicateurTerritoiresQuery.ts
+++ b/src/server/chantiers/infrastructure/queries/GetStatistiquesTauxAvancementIndicateurTerritoiresQuery.ts
@@ -1,0 +1,51 @@
+import {
+  calculerMediane,
+  valeurMinimum,
+  valeurMaximum,
+} from "@/client/utils/statistiques/statistiques";
+import type { Inject } from "@/server/chantiers/module";
+import { Habilitations } from "@/server/domain/utilisateur/habilitation/Habilitation.interface";
+import { ProfilCode } from "@/server/domain/utilisateur/Utilisateur.interface";
+
+export class GetStatistiquesTauxAvancementIndicateurTerritoiresQuery {
+  constructor(
+    private readonly deps: Inject<"listerDetailsIndicateurTerritoireUseCaseV2">,
+  ) {}
+
+  async execute(params: {
+    indicateurId: string;
+    chantierId: string;
+    maille: "regionale" | "departementale";
+    jalon: number;
+    habilitations: Habilitations;
+    profil: ProfilCode;
+  }) {
+    const result =
+      await this.deps.listerDetailsIndicateurTerritoireUseCaseV2.run(
+        [params.indicateurId],
+        params.chantierId,
+        params.habilitations,
+        params.profil,
+        params.jalon,
+      );
+
+    const details = result[params.indicateurId] ?? {};
+    const prefixeMaille = params.maille === "regionale" ? "REG-" : "DEPT-";
+
+    const valeurs = Object.entries(details)
+      .filter(
+        ([territoireCode, detail]) =>
+          territoireCode !== "NAT-FR" &&
+          territoireCode.startsWith(prefixeMaille) &&
+          detail.estApplicable !== false,
+      )
+      .map(([, detail]) => detail.avancement.annuel)
+      .filter((valeur): valeur is number => valeur !== null);
+
+    const minimum = valeurMinimum(valeurs);
+    const médiane = calculerMediane(valeurs);
+    const maximum = valeurMaximum(valeurs);
+
+    return { minimum, médiane, maximum };
+  }
+}

--- a/src/server/chantiers/infrastructure/queries/RecupererTauxAvancementIndicateurTerritoiresQuery.ts
+++ b/src/server/chantiers/infrastructure/queries/RecupererTauxAvancementIndicateurTerritoiresQuery.ts
@@ -1,23 +1,8 @@
 import { TauxAvancementComparaisonTerritoireViewModel } from "@/server/chantiers/app/contrats/TauxAvancementComparaisonTerritoireViewModel";
 import type { Inject } from "@/server/chantiers/module";
-import { MailleTerritoireSelectionne } from "@/server/domain/maille/Maille.interface";
 import { Habilitations } from "@/server/domain/utilisateur/habilitation/Habilitation.interface";
 import { ProfilCode } from "@/server/domain/utilisateur/Utilisateur.interface";
-
-const MAILLE_PAR_PREFIXE: Record<string, MailleTerritoireSelectionne> = {
-  "NAT-": "NAT",
-  "REG-": "REG",
-  "DEPT-": "DEPT",
-};
-
-const determinerMaille = (
-  territoireCode: string,
-): MailleTerritoireSelectionne => {
-  for (const [prefixe, maille] of Object.entries(MAILLE_PAR_PREFIXE)) {
-    if (territoireCode.startsWith(prefixe)) return maille;
-  }
-  return "DEPT";
-};
+import { territoireCodeVersMailleCodeInsee } from "@/server/utils/territoires";
 
 export class RecupererTauxAvancementIndicateurTerritoiresQuery {
   constructor(
@@ -52,7 +37,7 @@ export class RecupererTauxAvancementIndicateurTerritoiresQuery {
     return Object.entries(details).map(([territoireCode, detail]) => ({
       territoireCode,
       territoireNom: territoiresMap.get(territoireCode)?.nomAffiché ?? "",
-      maille: determinerMaille(territoireCode),
+      maille: territoireCodeVersMailleCodeInsee(territoireCode).maille,
       tauxAvancementJalon: detail.avancement.annuel,
       estApplicable: detail.estApplicable,
       dateTauxAvancementAnnuel: detail.dateValeurAvancement

--- a/src/server/chantiers/infrastructure/queries/RecupererTauxAvancementIndicateurTerritoiresQuery.ts
+++ b/src/server/chantiers/infrastructure/queries/RecupererTauxAvancementIndicateurTerritoiresQuery.ts
@@ -44,16 +44,14 @@ export class RecupererTauxAvancementIndicateurTerritoiresQuery {
 
     const details = result[params.indicateurId] ?? {};
 
-    const territoires =
-      await this.deps.territoireRepository.récupérerTousNew();
+    const territoires = await this.deps.territoireRepository.récupérerTousNew();
     const territoiresMap = new Map(
       territoires.map((territoire) => [territoire.code, territoire]),
     );
 
     return Object.entries(details).map(([territoireCode, detail]) => ({
       territoireCode,
-      territoireNom:
-        territoiresMap.get(territoireCode)?.nomAffiché ?? "",
+      territoireNom: territoiresMap.get(territoireCode)?.nomAffiché ?? "",
       maille: determinerMaille(territoireCode),
       tauxAvancementJalon: detail.avancement.annuel,
       estApplicable: detail.estApplicable,

--- a/src/server/chantiers/infrastructure/queries/RecupererTauxAvancementIndicateurTerritoiresQuery.ts
+++ b/src/server/chantiers/infrastructure/queries/RecupererTauxAvancementIndicateurTerritoiresQuery.ts
@@ -1,0 +1,65 @@
+import { TauxAvancementComparaisonTerritoireViewModel } from "@/server/chantiers/app/contrats/TauxAvancementComparaisonTerritoireViewModel";
+import type { Inject } from "@/server/chantiers/module";
+import { MailleTerritoireSelectionne } from "@/server/domain/maille/Maille.interface";
+import { Habilitations } from "@/server/domain/utilisateur/habilitation/Habilitation.interface";
+import { ProfilCode } from "@/server/domain/utilisateur/Utilisateur.interface";
+
+const MAILLE_PAR_PREFIXE: Record<string, MailleTerritoireSelectionne> = {
+  "NAT-": "NAT",
+  "REG-": "REG",
+  "DEPT-": "DEPT",
+};
+
+const determinerMaille = (
+  territoireCode: string,
+): MailleTerritoireSelectionne => {
+  for (const [prefixe, maille] of Object.entries(MAILLE_PAR_PREFIXE)) {
+    if (territoireCode.startsWith(prefixe)) return maille;
+  }
+  return "DEPT";
+};
+
+export class RecupererTauxAvancementIndicateurTerritoiresQuery {
+  constructor(
+    private readonly deps: Inject<
+      "listerDetailsIndicateurTerritoireUseCaseV2" | "territoireRepository"
+    >,
+  ) {}
+
+  async execute(params: {
+    indicateurId: string;
+    chantierId: string;
+    jalon: number;
+    habilitations: Habilitations;
+    profil: ProfilCode;
+  }): Promise<TauxAvancementComparaisonTerritoireViewModel[]> {
+    const result =
+      await this.deps.listerDetailsIndicateurTerritoireUseCaseV2.run(
+        [params.indicateurId],
+        params.chantierId,
+        params.habilitations,
+        params.profil,
+        params.jalon,
+      );
+
+    const details = result[params.indicateurId] ?? {};
+
+    const territoires =
+      await this.deps.territoireRepository.récupérerTousNew();
+    const territoiresMap = new Map(
+      territoires.map((territoire) => [territoire.code, territoire]),
+    );
+
+    return Object.entries(details).map(([territoireCode, detail]) => ({
+      territoireCode,
+      territoireNom:
+        territoiresMap.get(territoireCode)?.nomAffiché ?? "",
+      maille: determinerMaille(territoireCode),
+      tauxAvancementJalon: detail.avancement.annuel,
+      estApplicable: detail.estApplicable,
+      dateTauxAvancementAnnuel: detail.dateValeurAvancement
+        ? new Date(detail.dateValeurAvancement).toISOString()
+        : null,
+    }));
+  }
+}

--- a/src/server/chantiers/infrastructure/queries/RecupererTauxAvancementsChantierTerritoiresQuery.ts
+++ b/src/server/chantiers/infrastructure/queries/RecupererTauxAvancementsChantierTerritoiresQuery.ts
@@ -6,7 +6,7 @@ import {
   MailleTerritoireSelectionne,
 } from "@/server/domain/maille/Maille.interface";
 
-export class RecupererAvancementsTerritoiresQuery {
+export class RecupererTauxAvancementsChantierTerritoiresQuery {
   constructor(
     private readonly deps: Inject<
       // TODO: cette query de couche infra ne devrait pas dépendre d'un use case — toléré ici pour des raisons legacy

--- a/src/server/chantiers/module.ts
+++ b/src/server/chantiers/module.ts
@@ -37,7 +37,7 @@ import { CreerLesRapportsPropositionsUseCase } from "./usecases/CreerLesRapports
 import { EnvoyerLesRapportsPropositionsUseCase } from "./usecases/EnvoyerLesRapportsPropositionsUseCase";
 import { GetChantierMeteosTerritoiresQuery } from "./infrastructure/queries/GetChantierMeteosTerritoiresQuery";
 import { GetChantierPVACountTerritoiresQuery } from "./infrastructure/queries/GetChantierPVACountTerritoiresQuery";
-import { RecupererAvancementsTerritoiresQuery } from "./infrastructure/queries/RecupererAvancementsTerritoiresQuery";
+import { RecupererTauxAvancementsChantierTerritoiresQuery } from "./infrastructure/queries/RecupererTauxAvancementsChantierTerritoiresQuery";
 import { RecupererValeursAvancementIndicateurTerritoiresQuery } from "./infrastructure/queries/RecupererValeursAvancementIndicateurTerritoiresQuery";
 import { GetValeursRemarquablesValeurAvancementIndicateurTerritoiresQuery } from "./infrastructure/queries/GetValeursRemarquablesValeurAvancementIndicateurTerritoiresQuery";
 import { RecupererTauxAvancementIndicateurTerritoiresQuery } from "./infrastructure/queries/RecupererTauxAvancementIndicateurTerritoiresQuery";
@@ -74,7 +74,7 @@ type ChantierOwnCradle = ChantierExports & {
   envoyerLesRapportsPropositionsUseCase: EnvoyerLesRapportsPropositionsUseCase;
   getChantierMeteosTerritoiresQuery: GetChantierMeteosTerritoiresQuery;
   getChantierPVACountTerritoiresQuery: GetChantierPVACountTerritoiresQuery;
-  recupererAvancementsTerritoiresQuery: RecupererAvancementsTerritoiresQuery;
+  recupererTauxAvancementsChantierTerritoiresQuery: RecupererTauxAvancementsChantierTerritoiresQuery;
   recupererValeursAvancementIndicateurTerritoiresQuery: RecupererValeursAvancementIndicateurTerritoiresQuery;
   getValeursRemarquablesValeurAvancementIndicateurTerritoiresQuery: GetValeursRemarquablesValeurAvancementIndicateurTerritoiresQuery;
   recupererTauxAvancementIndicateurTerritoiresQuery: RecupererTauxAvancementIndicateurTerritoiresQuery;
@@ -148,8 +148,8 @@ export const chantiersModule = defineModule<ChantierExports, ChantierCradle>()({
       getChantierPVACountTerritoiresQuery: asModuleClass(
         GetChantierPVACountTerritoiresQuery,
       ),
-      recupererAvancementsTerritoiresQuery: asModuleClass(
-        RecupererAvancementsTerritoiresQuery,
+      recupererTauxAvancementsChantierTerritoiresQuery: asModuleClass(
+        RecupererTauxAvancementsChantierTerritoiresQuery,
       ),
       recupererValeursAvancementIndicateurTerritoiresQuery: asModuleClass(
         RecupererValeursAvancementIndicateurTerritoiresQuery,

--- a/src/server/chantiers/module.ts
+++ b/src/server/chantiers/module.ts
@@ -40,6 +40,8 @@ import { GetChantierPVACountTerritoiresQuery } from "./infrastructure/queries/Ge
 import { RecupererAvancementsTerritoiresQuery } from "./infrastructure/queries/RecupererAvancementsTerritoiresQuery";
 import { RecupererValeursAvancementIndicateurTerritoiresQuery } from "./infrastructure/queries/RecupererValeursAvancementIndicateurTerritoiresQuery";
 import { GetValeursRemarquablesValeurAvancementIndicateurTerritoiresQuery } from "./infrastructure/queries/GetValeursRemarquablesValeurAvancementIndicateurTerritoiresQuery";
+import { RecupererTauxAvancementIndicateurTerritoiresQuery } from "./infrastructure/queries/RecupererTauxAvancementIndicateurTerritoiresQuery";
+import { GetStatistiquesTauxAvancementIndicateurTerritoiresQuery } from "./infrastructure/queries/GetStatistiquesTauxAvancementIndicateurTerritoiresQuery";
 
 type ChantierExports = {
   recupererChantiersQuery: RecupererChantiersApplicablesParTerritoiresQuery;
@@ -75,6 +77,8 @@ type ChantierOwnCradle = ChantierExports & {
   recupererAvancementsTerritoiresQuery: RecupererAvancementsTerritoiresQuery;
   recupererValeursAvancementIndicateurTerritoiresQuery: RecupererValeursAvancementIndicateurTerritoiresQuery;
   getValeursRemarquablesValeurAvancementIndicateurTerritoiresQuery: GetValeursRemarquablesValeurAvancementIndicateurTerritoiresQuery;
+  recupererTauxAvancementIndicateurTerritoiresQuery: RecupererTauxAvancementIndicateurTerritoiresQuery;
+  getStatistiquesTauxAvancementIndicateurTerritoiresQuery: GetStatistiquesTauxAvancementIndicateurTerritoiresQuery;
 };
 
 type ChantierCradle = ChantierOwnCradle & ChantierImports;
@@ -154,6 +158,12 @@ export const chantiersModule = defineModule<ChantierExports, ChantierCradle>()({
         asModuleClass(
           GetValeursRemarquablesValeurAvancementIndicateurTerritoiresQuery,
         ),
+      recupererTauxAvancementIndicateurTerritoiresQuery: asModuleClass(
+        RecupererTauxAvancementIndicateurTerritoiresQuery,
+      ),
+      getStatistiquesTauxAvancementIndicateurTerritoiresQuery: asModuleClass(
+        GetStatistiquesTauxAvancementIndicateurTerritoiresQuery,
+      ),
     } satisfies VerifyCradle<ChantierOwnCradle>);
   },
 });

--- a/src/server/infrastructure/api/trpc/routes/chantier.ts
+++ b/src/server/infrastructure/api/trpc/routes/chantier.ts
@@ -51,7 +51,7 @@ export const chantierRouter = créerRouteurTRPC({
         .resolve("getChantierPVACountTerritoiresQuery")
         .execute(input);
     }),
-  recupererAvancementsTerritoires: procédureProtégée
+  recupererTauxAvancementTerritoires: procédureProtégée
     .input(
       z.object({
         chantierIds: z.array(z.string()),
@@ -63,7 +63,7 @@ export const chantierRouter = créerRouteurTRPC({
         ctx.session.habilitations.lecture.chantiers.includes(id),
       );
       return getContainer("chantiers")
-        .resolve("recupererAvancementsTerritoiresQuery")
+        .resolve("recupererTauxAvancementsChantierTerritoiresQuery")
         .run({ chantierIds: chantierIdsAutorisés, jalon: input.jalon });
     }),
   recupererStatistiquesAvancement: procédureProtégée

--- a/src/server/infrastructure/api/trpc/routes/indicateur.ts
+++ b/src/server/infrastructure/api/trpc/routes/indicateur.ts
@@ -61,4 +61,46 @@ export const indicateurRouter = créerRouteurTRPC({
           profil: ctx.session.profil,
         });
     }),
+  recupererTauxAvancementTerritoires: procédureProtégée
+    .input(
+      z.object({
+        indicateurId: z.string(),
+        chantierId: z.string(),
+        jalon: z.number(),
+      }),
+    )
+    .query(async ({ input, ctx }) => {
+      return getContainer("chantiers")
+        .resolve("recupererTauxAvancementIndicateurTerritoiresQuery")
+        .execute({
+          indicateurId: input.indicateurId,
+          chantierId: input.chantierId,
+          jalon: input.jalon,
+          habilitations: ctx.session.habilitations,
+          profil: ctx.session.profil,
+        });
+    }),
+  recupererStatistiquesTauxAvancement: procédureProtégée
+    .input(
+      z.object({
+        indicateurId: z.string(),
+        chantierId: z.string(),
+        maille: z.enum(["regionale", "departementale"]),
+        jalon: z.number(),
+      }),
+    )
+    .query(async ({ input, ctx }) => {
+      return getContainer("chantiers")
+        .resolve(
+          "getStatistiquesTauxAvancementIndicateurTerritoiresQuery",
+        )
+        .execute({
+          indicateurId: input.indicateurId,
+          chantierId: input.chantierId,
+          maille: input.maille,
+          jalon: input.jalon,
+          habilitations: ctx.session.habilitations,
+          profil: ctx.session.profil,
+        });
+    }),
 });

--- a/src/server/infrastructure/api/trpc/routes/indicateur.ts
+++ b/src/server/infrastructure/api/trpc/routes/indicateur.ts
@@ -91,9 +91,7 @@ export const indicateurRouter = créerRouteurTRPC({
     )
     .query(async ({ input, ctx }) => {
       return getContainer("chantiers")
-        .resolve(
-          "getStatistiquesTauxAvancementIndicateurTerritoiresQuery",
-        )
+        .resolve("getStatistiquesTauxAvancementIndicateurTerritoiresQuery")
         .execute({
           indicateurId: input.indicateurId,
           chantierId: input.chantierId,


### PR DESCRIPTION
## Summary
- Add backend queries to compute taux d'avancement (TA) per territory for indicateurs (`RecupererTauxAvancementIndicateurTerritoiresQuery` + `GetStatistiquesTauxAvancementIndicateurTerritoiresQuery`)
- Refactor `WidgetCartographieTA` to support both chantiers and indicateur modes via discriminated union props + React context pattern
- Add the TA widget alongside the existing valeur d'avancement widget in `IndicateurDétails`

## Test plan
- [x] Integration tests for `RecupererTauxAvancementIndicateurTerritoiresQuery` (4 tests)
- [x] Integration tests for `GetStatistiquesTauxAvancementIndicateurTerritoiresQuery` (4 tests)
- [ ] Verify existing chantier pages still display the TA cartography correctly
- [ ] Verify indicateur detail page shows both TA and valeur d'avancement widgets

🤖 Generated with [Claude Code](https://claude.com/claude-code)