### PR TITLE
feat: évolution temporelle des taux d'avancement (PIL-1334)

### DIFF
--- a/src/client/components/_commons/SelecteurJalon/useSelecteurJalon.ts
+++ b/src/client/components/_commons/SelecteurJalon/useSelecteurJalon.ts
@@ -1,11 +1,8 @@
 import { getAnneeDateDeBascule } from "@/client/components/_commons/IndicateursChantier/Bloc/ValeurEtDate/getAnneeDateDeBascule";
 import { useEnv } from "@/client/hooks/useEnv";
+import { buildJalons } from "@/client/utils/jalons";
 
-const PREMIER_JALON = 2022;
-const listeJalonAAfficher = Array.from(
-  { length: new Date().getFullYear() - PREMIER_JALON + 1 },
-  (_value, i) => `${PREMIER_JALON + i}`,
-);
+const listeJalonAAfficher = buildJalons().map(String);
 export type JalonsAAfficherType = (typeof listeJalonAAfficher)[number];
 
 export const useSelecteurJalon = () => {

--- a/src/client/components/_commons/Widget/TableauEvolution.tsx
+++ b/src/client/components/_commons/Widget/TableauEvolution.tsx
@@ -1,0 +1,114 @@
+import { TerritoireLabel } from "@/components/_commons/Widget/TerritoireLabel";
+import { PiloteDateFormatter } from "@/utils/PiloteDateFormatter";
+
+export type CelluleJalon = {
+  valeur: string | null;
+  date: string | null;
+  estApplicable: boolean | null;
+};
+
+export type LigneTerritoire = {
+  territoireCode: string;
+  nom: string;
+  couleur: string;
+  estInitial: boolean;
+  cellules: Map<number, CelluleJalon>;
+};
+
+export const TableauEvolution = ({
+  lignes,
+  jalons,
+  jalonActif,
+  onSupprimerTerritoire,
+}: {
+  lignes: LigneTerritoire[];
+  jalons: number[];
+  jalonActif: number;
+  onSupprimerTerritoire: (territoireCode: string) => void;
+}) => {
+  return (
+    <div className="overflow-x-auto text-xs">
+      <table className="w-full border-collapse">
+        <thead>
+          <tr>
+            <th className="sticky left-0 bg-white z-10 min-w-[130px]" />
+            {jalons.map((jalon) => (
+              <th
+                key={jalon}
+                className={`px-3 py-2 text-center whitespace-nowrap ${
+                  jalon === jalonActif ? "font-bold" : "font-semibold"
+                }`}
+              >
+                {jalon}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {lignes.map((ligne) => (
+            <tr
+              key={ligne.territoireCode}
+              className="border-t border-dsfr-grey-925"
+            >
+              <td className="sticky left-0 bg-white z-10 min-w-[130px] py-2 pr-2">
+                <TerritoireLabel
+                  nom={ligne.nom}
+                  couleur={ligne.couleur}
+                  onSupprimer={
+                    !ligne.estInitial
+                      ? () => onSupprimerTerritoire(ligne.territoireCode)
+                      : undefined
+                  }
+                />
+              </td>
+              {jalons.map((jalon) => {
+                const cellule = ligne.cellules.get(jalon);
+                const estActif = jalon === jalonActif;
+
+                if (cellule?.estApplicable === false) {
+                  return (
+                    <td
+                      key={jalon}
+                      className="px-3 py-2 text-center text-gray-400 whitespace-nowrap"
+                    >
+                      N/A
+                    </td>
+                  );
+                }
+
+                return (
+                  <td
+                    key={jalon}
+                    className="px-3 py-2 text-center whitespace-nowrap"
+                  >
+                    {cellule?.valeur !== null ? (
+                      <div className="flex flex-col items-center gap-0.5">
+                        <span
+                          className={estActif ? "font-bold" : ""}
+                          style={{ color: ligne.couleur }}
+                        >
+                          {cellule?.valeur}
+                        </span>
+                        {cellule?.date && (
+                          <span className="text-[10px] text-gray-500">
+                            (
+                            {PiloteDateFormatter.isoMonthFranceMetropolitaine(
+                              cellule.date,
+                            )}
+                            )
+                          </span>
+                        )}
+                      </div>
+                    ) : (
+                      <span className="text-gray-400">-</span>
+                    )}
+                  </td>
+                );
+              })}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};

--- a/src/client/components/_commons/Widget/WidgetCartographieTA/TableauEvolutionTA.tsx
+++ b/src/client/components/_commons/Widget/WidgetCartographieTA/TableauEvolutionTA.tsx
@@ -1,28 +1,17 @@
 import { useMemo } from "react";
 import { récupérerDétailsSurUnTerritoire } from "@/client/constants/territoires";
 import { getCouleurTerritoireParCode } from "@/client/utils/couleur/paletteTerritoires";
-import { TerritoireLabel } from "@/components/_commons/Widget/TerritoireLabel";
-import { PiloteDateFormatter } from "@/utils/PiloteDateFormatter";
 import { TauxAvancementComparaisonTerritoireViewModel } from "@/server/chantiers/app/contrats/TauxAvancementComparaisonTerritoireViewModel";
+import {
+  TableauEvolution,
+  CelluleJalon,
+  LigneTerritoire,
+} from "@/components/_commons/Widget/TableauEvolution";
 import { useTauxAvancementParJalon } from "./useTauxAvancementParJalon";
 
 const formatValeurTA = (valeur: number | null | undefined): string | null => {
   if (valeur === null || valeur === undefined) return null;
   return `${Math.round(valeur)}%`;
-};
-
-type CelluleJalon = {
-  valeur: string | null;
-  date: string | null;
-  estApplicable: boolean | null;
-};
-
-type LigneTerritoire = {
-  territoireCode: string;
-  nom: string;
-  couleur: string;
-  estInitial: boolean;
-  cellules: Map<number, CelluleJalon>;
 };
 
 export const TableauEvolutionTA = ({
@@ -78,88 +67,11 @@ export const TableauEvolutionTA = ({
   }, [territoiresSelectionnes, donneesParJalon, jalons, territoireCode]);
 
   return (
-    <div className="overflow-x-auto text-xs">
-      <table className="w-full border-collapse">
-        <thead>
-          <tr>
-            <th className="sticky left-0 bg-white z-10 min-w-[130px]" />
-            {jalons.map((jalon) => (
-              <th
-                key={jalon}
-                className={`px-3 py-2 text-center whitespace-nowrap ${
-                  jalon === jalonActif ? "font-bold" : "font-semibold"
-                }`}
-              >
-                {jalon}
-              </th>
-            ))}
-          </tr>
-        </thead>
-        <tbody>
-          {lignes.map((ligne) => (
-            <tr
-              key={ligne.territoireCode}
-              className="border-t border-dsfr-grey-925"
-            >
-              <td className="sticky left-0 bg-white z-10 min-w-[130px] py-2 pr-2">
-                <TerritoireLabel
-                  nom={ligne.nom}
-                  couleur={ligne.couleur}
-                  onSupprimer={
-                    !ligne.estInitial
-                      ? () => onSupprimerTerritoire(ligne.territoireCode)
-                      : undefined
-                  }
-                />
-              </td>
-              {jalons.map((jalon) => {
-                const cellule = ligne.cellules.get(jalon);
-                const estActif = jalon === jalonActif;
-
-                if (cellule?.estApplicable === false) {
-                  return (
-                    <td
-                      key={jalon}
-                      className="px-3 py-2 text-center text-gray-400 whitespace-nowrap"
-                    >
-                      N/A
-                    </td>
-                  );
-                }
-
-                return (
-                  <td
-                    key={jalon}
-                    className="px-3 py-2 text-center whitespace-nowrap"
-                  >
-                    {cellule?.valeur !== null ? (
-                      <div className="flex flex-col items-center gap-0.5">
-                        <span
-                          className={estActif ? "font-bold" : ""}
-                          style={{ color: ligne.couleur }}
-                        >
-                          {cellule?.valeur}
-                        </span>
-                        {cellule?.date && (
-                          <span className="text-[10px] text-gray-500">
-                            (
-                            {PiloteDateFormatter.isoMonthFranceMetropolitaine(
-                              cellule.date,
-                            )}
-                            )
-                          </span>
-                        )}
-                      </div>
-                    ) : (
-                      <span className="text-gray-400">-</span>
-                    )}
-                  </td>
-                );
-              })}
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    </div>
+    <TableauEvolution
+      lignes={lignes}
+      jalons={jalons}
+      jalonActif={jalonActif}
+      onSupprimerTerritoire={onSupprimerTerritoire}
+    />
   );
 };

--- a/src/client/components/_commons/Widget/WidgetCartographieTA/TableauEvolutionTA.tsx
+++ b/src/client/components/_commons/Widget/WidgetCartographieTA/TableauEvolutionTA.tsx
@@ -1,0 +1,165 @@
+import { useMemo } from "react";
+import { récupérerDétailsSurUnTerritoire } from "@/client/constants/territoires";
+import { getCouleurTerritoireParCode } from "@/client/utils/couleur/paletteTerritoires";
+import { TerritoireLabel } from "@/components/_commons/Widget/TerritoireLabel";
+import { PiloteDateFormatter } from "@/utils/PiloteDateFormatter";
+import { TauxAvancementComparaisonTerritoireViewModel } from "@/server/chantiers/app/contrats/TauxAvancementComparaisonTerritoireViewModel";
+import { useTauxAvancementParJalon } from "./useTauxAvancementParJalon";
+
+const formatValeurTA = (valeur: number | null | undefined): string | null => {
+  if (valeur === null || valeur === undefined) return null;
+  return `${Math.round(valeur)}%`;
+};
+
+type CelluleJalon = {
+  valeur: string | null;
+  date: string | null;
+  estApplicable: boolean | null;
+};
+
+type LigneTerritoire = {
+  territoireCode: string;
+  nom: string;
+  couleur: string;
+  estInitial: boolean;
+  cellules: Map<number, CelluleJalon>;
+};
+
+export const TableauEvolutionTA = ({
+  indicateurId,
+  chantierId,
+  territoiresSelectionnes,
+  territoireCode,
+  onSupprimerTerritoire,
+  jalonActif,
+}: {
+  indicateurId: string;
+  chantierId: string;
+  territoiresSelectionnes: TauxAvancementComparaisonTerritoireViewModel[];
+  territoireCode: string;
+  onSupprimerTerritoire: (territoireCode: string) => void;
+  jalonActif: number;
+}) => {
+  const { jalons, donneesParJalon } = useTauxAvancementParJalon({
+    indicateurId,
+    chantierId,
+  });
+
+  const lignes: LigneTerritoire[] = useMemo(() => {
+    return territoiresSelectionnes.map((territoire) => {
+      const details = récupérerDétailsSurUnTerritoire(
+        territoire.territoireCode,
+      );
+      const cellules = new Map<number, CelluleJalon>();
+
+      for (const jalon of jalons) {
+        const donnees = donneesParJalon.get(jalon);
+        const donneeTerritoire = donnees?.find(
+          (d) => d.territoireCode === territoire.territoireCode,
+        );
+
+        cellules.set(jalon, {
+          valeur: donneeTerritoire
+            ? formatValeurTA(donneeTerritoire.tauxAvancementJalon)
+            : null,
+          date: donneeTerritoire?.dateTauxAvancementAnnuel ?? null,
+          estApplicable: donneeTerritoire?.estApplicable ?? null,
+        });
+      }
+
+      return {
+        territoireCode: territoire.territoireCode,
+        nom: details?.nomAffiché ?? territoire.territoireCode,
+        couleur: getCouleurTerritoireParCode(territoire.territoireCode),
+        estInitial: territoire.territoireCode === territoireCode,
+        cellules,
+      };
+    });
+  }, [territoiresSelectionnes, donneesParJalon, jalons, territoireCode]);
+
+  return (
+    <div className="overflow-x-auto text-xs">
+      <table className="w-full border-collapse">
+        <thead>
+          <tr>
+            <th className="sticky left-0 bg-white z-10 min-w-[130px]" />
+            {jalons.map((jalon) => (
+              <th
+                key={jalon}
+                className={`px-3 py-2 text-center whitespace-nowrap ${
+                  jalon === jalonActif ? "font-bold" : "font-semibold"
+                }`}
+              >
+                {jalon}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {lignes.map((ligne) => (
+            <tr
+              key={ligne.territoireCode}
+              className="border-t border-dsfr-grey-925"
+            >
+              <td className="sticky left-0 bg-white z-10 min-w-[130px] py-2 pr-2">
+                <TerritoireLabel
+                  nom={ligne.nom}
+                  couleur={ligne.couleur}
+                  onSupprimer={
+                    !ligne.estInitial
+                      ? () => onSupprimerTerritoire(ligne.territoireCode)
+                      : undefined
+                  }
+                />
+              </td>
+              {jalons.map((jalon) => {
+                const cellule = ligne.cellules.get(jalon);
+                const estActif = jalon === jalonActif;
+
+                if (cellule?.estApplicable === false) {
+                  return (
+                    <td
+                      key={jalon}
+                      className="px-3 py-2 text-center text-gray-400 whitespace-nowrap"
+                    >
+                      N/A
+                    </td>
+                  );
+                }
+
+                return (
+                  <td
+                    key={jalon}
+                    className="px-3 py-2 text-center whitespace-nowrap"
+                  >
+                    {cellule?.valeur !== null ? (
+                      <div className="flex flex-col items-center gap-0.5">
+                        <span
+                          className={estActif ? "font-bold" : ""}
+                          style={{ color: ligne.couleur }}
+                        >
+                          {cellule?.valeur}
+                        </span>
+                        {cellule?.date && (
+                          <span className="text-[10px] text-gray-500">
+                            (
+                            {PiloteDateFormatter.isoMonthFranceMetropolitaine(
+                              cellule.date,
+                            )}
+                            )
+                          </span>
+                        )}
+                      </div>
+                    ) : (
+                      <span className="text-gray-400">-</span>
+                    )}
+                  </td>
+                );
+              })}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};

--- a/src/client/components/_commons/Widget/WidgetCartographieTA/WidgetCartographieTA.tsx
+++ b/src/client/components/_commons/Widget/WidgetCartographieTA/WidgetCartographieTA.tsx
@@ -16,6 +16,7 @@ import { AvancementsStatistiques } from "@/components/_commons/Avancements/Avanc
 import { useDonneesCartographieTA } from "./useDonneesCartographieTA";
 import { useLegendeTA } from "./useLegendeTA";
 import { SuiviTauxAvancement } from "./SuiviTauxAvancement";
+import { TableauEvolutionTA } from "./TableauEvolutionTA";
 
 const WidgetCartographieTAContext = createContext<{
   territoiresAvancement: TauxAvancementComparaisonTerritoireViewModel[];
@@ -113,15 +114,19 @@ const formatValeurTA = (valeur: number | null | undefined): string | null => {
   return `${Math.round(valeur)}%`;
 };
 
-const WidgetCartographieTAContent = ({
-  maille,
-  territoireCode,
-  jalon,
-}: {
+type WidgetCartographieTAContentProps = {
   maille: MailleInterne;
   territoireCode: string;
   jalon: number;
-}) => {
+} & (
+  | { mode: "chantiers" }
+  | { mode: "indicateur"; indicateurId: string; chantierId: string }
+);
+
+const WidgetCartographieTAContent = (
+  props: WidgetCartographieTAContentProps,
+) => {
+  const { maille, territoireCode, jalon, mode } = props;
   const { territoiresAvancement, statistiques } =
     useWidgetCartographieTAContext();
   const [vueActive, setVueActive] = useState<VueCartographieTA>("situation");
@@ -173,32 +178,44 @@ const WidgetCartographieTAContent = ({
       }
       titre="Suivi et évolution des taux d'avancement"
     >
-      <PillToggleGroup.Root
-        type="single"
-        value={vueActive}
-        onValueChange={(value) => {
-          if (value) setVueActive(value as VueCartographieTA);
-        }}
-      >
-        <PillToggleGroup.Item value="situation">
-          <EqualizerIcon className="w-3 h-3" />
-          situation en {jalon}
-        </PillToggleGroup.Item>
-        <PillToggleGroup.Item value="tableau">
-          <GridIcon className="w-3 h-3" />
-          évolution temporelle - tableau
-        </PillToggleGroup.Item>
-        <PillToggleGroup.Item value="courbes">
-          <LineChartIcon className="w-3 h-3" />
-          évolution temporelle - courbes
-        </PillToggleGroup.Item>
-      </PillToggleGroup.Root>
+      {mode === "indicateur" && (
+        <PillToggleGroup.Root
+          type="single"
+          value={vueActive}
+          onValueChange={(value) => {
+            if (value) setVueActive(value as VueCartographieTA);
+          }}
+        >
+          <PillToggleGroup.Item value="situation">
+            <EqualizerIcon className="w-3 h-3" />
+            situation en {jalon}
+          </PillToggleGroup.Item>
+          <PillToggleGroup.Item value="tableau">
+            <GridIcon className="w-3 h-3" />
+            évolution temporelle - tableau
+          </PillToggleGroup.Item>
+          <PillToggleGroup.Item value="courbes">
+            <LineChartIcon className="w-3 h-3" />
+            évolution temporelle - courbes
+          </PillToggleGroup.Item>
+        </PillToggleGroup.Root>
+      )}
 
-      {vueActive === "situation" && (
+      {(mode === "chantiers" || vueActive === "situation") && (
         <SuiviTauxAvancement
           territoireCode={territoireCode}
           onSupprimerTerritoire={supprimerTerritoire}
           territoiresSelectionnes={territoiresSelectionnes}
+        />
+      )}
+      {mode === "indicateur" && vueActive === "tableau" && (
+        <TableauEvolutionTA
+          indicateurId={props.indicateurId}
+          chantierId={props.chantierId}
+          territoiresSelectionnes={territoiresSelectionnes}
+          territoireCode={territoireCode}
+          onSupprimerTerritoire={supprimerTerritoire}
+          jalonActif={jalon}
         />
       )}
       <AjouterTerritoirePicker
@@ -224,14 +241,6 @@ type WidgetCartographieTAProps = {
 );
 
 export const WidgetCartographieTA = (props: WidgetCartographieTAProps) => {
-  const content = (
-    <WidgetCartographieTAContent
-      maille={props.maille}
-      territoireCode={props.territoireCode}
-      jalon={props.jalon}
-    />
-  );
-
   if (props.mode === "indicateur") {
     return (
       <IndicateurProvider
@@ -240,7 +249,14 @@ export const WidgetCartographieTA = (props: WidgetCartographieTAProps) => {
         maille={props.maille}
         jalon={props.jalon}
       >
-        {content}
+        <WidgetCartographieTAContent
+          mode="indicateur"
+          indicateurId={props.indicateurId}
+          chantierId={props.chantierId}
+          maille={props.maille}
+          territoireCode={props.territoireCode}
+          jalon={props.jalon}
+        />
       </IndicateurProvider>
     );
   }
@@ -251,7 +267,12 @@ export const WidgetCartographieTA = (props: WidgetCartographieTAProps) => {
       maille={props.maille}
       jalon={props.jalon}
     >
-      {content}
+      <WidgetCartographieTAContent
+        mode="chantiers"
+        maille={props.maille}
+        territoireCode={props.territoireCode}
+        jalon={props.jalon}
+      />
     </ChantiersProvider>
   );
 };

--- a/src/client/components/_commons/Widget/WidgetCartographieTA/useTauxAvancementParJalon.ts
+++ b/src/client/components/_commons/Widget/WidgetCartographieTA/useTauxAvancementParJalon.ts
@@ -1,15 +1,6 @@
 import { useMemo } from "react";
 import api from "@/server/infrastructure/api/trpc/api";
-
-const PREMIER_JALON = 2022;
-
-const buildJalons = (): number[] => {
-  const currentYear = new Date().getFullYear();
-  return Array.from(
-    { length: currentYear - PREMIER_JALON + 1 },
-    (_, i) => PREMIER_JALON + i,
-  );
-};
+import { buildJalons } from "@/client/utils/jalons";
 
 export const useTauxAvancementParJalon = ({
   indicateurId,

--- a/src/client/components/_commons/Widget/WidgetCartographieTA/useTauxAvancementParJalon.ts
+++ b/src/client/components/_commons/Widget/WidgetCartographieTA/useTauxAvancementParJalon.ts
@@ -1,0 +1,39 @@
+import { useMemo } from "react";
+import api from "@/server/infrastructure/api/trpc/api";
+
+const PREMIER_JALON = 2022;
+
+const buildJalons = (): number[] => {
+  const currentYear = new Date().getFullYear();
+  return Array.from(
+    { length: currentYear - PREMIER_JALON + 1 },
+    (_, i) => PREMIER_JALON + i,
+  );
+};
+
+export const useTauxAvancementParJalon = ({
+  indicateurId,
+  chantierId,
+}: {
+  indicateurId: string;
+  chantierId: string;
+}) => {
+  const jalons = useMemo(() => buildJalons(), []);
+
+  const [results] = api.useSuspenseQueries((t) =>
+    jalons.map((jalon) =>
+      t.indicateur.recupererTauxAvancementTerritoires({
+        indicateurId,
+        chantierId,
+        jalon,
+      }),
+    ),
+  );
+
+  const donneesParJalon = useMemo(
+    () => new Map(jalons.map((jalon, index) => [jalon, results[index]])),
+    [jalons, results],
+  );
+
+  return { jalons, donneesParJalon };
+};

--- a/src/client/components/_commons/Widget/WidgetCartographieValeurAvancement/TableauEvolutionVA.tsx
+++ b/src/client/components/_commons/Widget/WidgetCartographieValeurAvancement/TableauEvolutionVA.tsx
@@ -1,9 +1,12 @@
 import { useMemo } from "react";
 import { récupérerDétailsSurUnTerritoire } from "@/client/constants/territoires";
 import { getCouleurTerritoireParCode } from "@/client/utils/couleur/paletteTerritoires";
-import { TerritoireLabel } from "@/components/_commons/Widget/TerritoireLabel";
-import { PiloteDateFormatter } from "@/utils/PiloteDateFormatter";
 import { ValeurAvancementIndicateurTerritoire } from "@/server/chantiers/infrastructure/queries/RecupererValeursAvancementIndicateurTerritoiresQuery";
+import {
+  TableauEvolution,
+  CelluleJalon,
+  LigneTerritoire,
+} from "@/components/_commons/Widget/TableauEvolution";
 import { useValeursAvancementParJalon } from "@/components/_commons/Widget/WidgetCartographieValeurAvancement/useValeursAvancementParJalon";
 
 const formatValeur = (
@@ -13,20 +16,6 @@ const formatValeur = (
   if (valeur === null) return null;
   const unitéAffichée = unite?.toLocaleLowerCase() === "pourcentage" ? "%" : "";
   return valeur.toLocaleString() + unitéAffichée;
-};
-
-type CelluleJalon = {
-  valeur: string | null;
-  date: string | null;
-  estApplicable: boolean | null;
-};
-
-type LigneTerritoire = {
-  territoireCode: string;
-  nom: string;
-  couleur: string;
-  estInitial: boolean;
-  cellules: Map<number, CelluleJalon>;
 };
 
 export const TableauEvolutionVA = ({
@@ -50,6 +39,7 @@ export const TableauEvolutionVA = ({
     indicateurId,
     chantierId,
   });
+
   const lignes: LigneTerritoire[] = useMemo(() => {
     return territoiresSelectionnes.map((territoire) => {
       const details = récupérerDétailsSurUnTerritoire(
@@ -83,88 +73,11 @@ export const TableauEvolutionVA = ({
   }, [territoiresSelectionnes, donneesParJalon, jalons, unite, territoireCode]);
 
   return (
-    <div className="overflow-x-auto text-xs">
-      <table className="w-full border-collapse">
-        <thead>
-          <tr>
-            <th className="sticky left-0 bg-white z-10 min-w-[130px]" />
-            {jalons.map((jalon) => (
-              <th
-                key={jalon}
-                className={`px-3 py-2 text-center whitespace-nowrap ${
-                  jalon === jalonActif ? "font-bold" : "font-semibold"
-                }`}
-              >
-                {jalon}
-              </th>
-            ))}
-          </tr>
-        </thead>
-        <tbody>
-          {lignes.map((ligne) => (
-            <tr
-              key={ligne.territoireCode}
-              className="border-t border-dsfr-grey-925"
-            >
-              <td className="sticky left-0 bg-white z-10 min-w-[130px] py-2 pr-2">
-                <TerritoireLabel
-                  nom={ligne.nom}
-                  couleur={ligne.couleur}
-                  onSupprimer={
-                    !ligne.estInitial
-                      ? () => onSupprimerTerritoire(ligne.territoireCode)
-                      : undefined
-                  }
-                />
-              </td>
-              {jalons.map((jalon) => {
-                const cellule = ligne.cellules.get(jalon);
-                const estActif = jalon === jalonActif;
-
-                if (cellule?.estApplicable === false) {
-                  return (
-                    <td
-                      key={jalon}
-                      className="px-3 py-2 text-center text-gray-400 whitespace-nowrap"
-                    >
-                      N/A
-                    </td>
-                  );
-                }
-
-                return (
-                  <td
-                    key={jalon}
-                    className="px-3 py-2 text-center whitespace-nowrap"
-                  >
-                    {cellule?.valeur !== null ? (
-                      <div className="flex flex-col items-center gap-0.5">
-                        <span
-                          className={estActif ? "font-bold" : ""}
-                          style={{ color: ligne.couleur }}
-                        >
-                          {cellule?.valeur}
-                        </span>
-                        {cellule?.date && (
-                          <span className="text-[10px] text-gray-500">
-                            (
-                            {PiloteDateFormatter.isoMonthFranceMetropolitaine(
-                              cellule.date,
-                            )}
-                            )
-                          </span>
-                        )}
-                      </div>
-                    ) : (
-                      <span className="text-gray-400">-</span>
-                    )}
-                  </td>
-                );
-              })}
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    </div>
+    <TableauEvolution
+      lignes={lignes}
+      jalons={jalons}
+      jalonActif={jalonActif}
+      onSupprimerTerritoire={onSupprimerTerritoire}
+    />
   );
 };

--- a/src/client/components/_commons/Widget/WidgetCartographieValeurAvancement/useValeursAvancementParJalon.ts
+++ b/src/client/components/_commons/Widget/WidgetCartographieValeurAvancement/useValeursAvancementParJalon.ts
@@ -1,15 +1,6 @@
 import { useMemo } from "react";
 import api from "@/server/infrastructure/api/trpc/api";
-
-const PREMIER_JALON = 2022;
-
-const buildJalons = (): number[] => {
-  const currentYear = new Date().getFullYear();
-  return Array.from(
-    { length: currentYear - PREMIER_JALON + 1 },
-    (_, i) => PREMIER_JALON + i,
-  );
-};
+import { buildJalons } from "@/client/utils/jalons";
 
 export const useValeursAvancementParJalon = ({
   indicateurId,

--- a/src/client/utils/jalons.ts
+++ b/src/client/utils/jalons.ts
@@ -1,0 +1,9 @@
+export const PREMIER_JALON = 2022;
+
+export const buildJalons = (): number[] => {
+  const currentYear = new Date().getFullYear();
+  return Array.from(
+    { length: currentYear - PREMIER_JALON + 1 },
+    (_, i) => PREMIER_JALON + i,
+  );
+};


### PR DESCRIPTION
## Summary
- Add temporal evolution table view for the taux d'avancement cartography widget (indicateur mode)
- In chantier mode, remove the PillToggleGroup — only the "situation" view is shown
- In indicateur mode, add a "tableau" toggle to display a year-by-year evolution table per territory
- Extract a shared `TableauEvolution` base component used by both TA and VA widgets to reduce duplication

## Test plan
- [ ] Verify chantier mode: no toggle pills visible, situation view displayed directly
- [ ] Verify indicateur mode: toggle pills visible with "situation" and "tableau" options
- [ ] Verify tableau view displays territories × jalons with correct TA percentages
- [ ] Verify ValeurAvancement tableau still works correctly after refactor
- [ ] Run `npx tsc --noEmit` — passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)