### PR TITLE
chore: upgrade Next.js 16.1.6 → 16.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,7 @@
         "luxon": "^3.7.2",
         "marked": "^15.0.7",
         "mime": "^3.0.0",
-        "next": "^16.1.2",
+        "next": "^16.2.1",
         "next-auth": "5.0.0-beta.30",
         "nextra": "^4.6.1",
         "nextra-theme-docs": "^4.6.1",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "luxon": "^3.7.2",
     "marked": "^15.0.7",
     "mime": "^3.0.0",
-    "next": "^16.1.2",
+    "next": "^16.2.1",
     "next-auth": "5.0.0-beta.30",
     "nextra": "^4.6.1",
     "nextra-theme-docs": "^4.6.1",


### PR DESCRIPTION
## Summary

- Upgrade Next.js de 16.1.6 vers 16.2.1

## Motivation

### Sécurité (3 CVE corrigés en 16.1.7)
- **CVE-2026-27979** : `maxPostponedStateSize` pas toujours respecté
- **CVE-2026-27980** : ajout LRU disk cache pour `next/image` avec `images.maximumDiskCacheSize`
- **CVE-2026-27977** : blocage des connexions WebSocket cross-site en dev

### Performance (16.2.0)
- **25-60% de rendu SSR plus rapide** (contribution React : `JSON.parse` sans reviver)
- **~87% plus rapide** au démarrage `next dev`
- **2x à 20x plus rapide** pour `ImageResponse`

### Turbopack (200+ fixes)
- Server Fast Refresh (67-100% plus rapide)
- Support `postcss.config.ts`
- Subresource Integrity pour JS

### Autres
- Fix server actions en standalone mode avec `cacheComponents`
- Fix lodash CVE-2025-13465
- Hydration diff indicator dans l'error overlay
- Server Function logging en dev

> **Note** : le bug OOM standalone/fetch ([#90433](https://github.com/vercel/next.js/issues/90433)) n'est **pas corrigé** dans cette version.

## Test plan

- [x] 54/54 tests E2E passent avec Next.js 16.2.1
- [ ] Vérifier le build de production
- [ ] Monitorer la mémoire en staging