### PR TITLE
fix: grille 1/3-2/3 tableau info indicateur et extraction composant Champ

### DIFF
--- a/src/client/components/PageIndicateur/FicheIndicateur/SectionTableauIndicateur.tsx
+++ b/src/client/components/PageIndicateur/FicheIndicateur/SectionTableauIndicateur.tsx
@@ -2,24 +2,7 @@ import { FunctionComponent } from "react";
 import { MetadataParametrageIndicateurContrat } from "@/server/app/contrats/MetadataParametrageIndicateurContrat";
 import { InformationHistorisationMetadataIndicateurContrat } from "@/server/parametrage-indicateur/app/InformationDerniereModificationMetadataIndicateurContrat";
 import { formaterDate } from "@/client/utils/date/date";
-
-const Champ = ({
-  label,
-  valeur,
-}: {
-  label: string;
-  valeur: string | null | undefined;
-}) => (
-  <div className="min-w-0">
-    <p className="text-xs text-gray-500 mb-1">{label}</p>
-    <p
-      className="text-sm font-bold text-gray-900 truncate mb-0"
-      title={valeur ?? undefined}
-    >
-      {valeur || "-"}
-    </p>
-  </div>
-);
+import Champ from "@/components/_commons/Champ";
 
 const SectionTableauIndicateur: FunctionComponent<{
   indicateur: MetadataParametrageIndicateurContrat;
@@ -32,11 +15,17 @@ const SectionTableauIndicateur: FunctionComponent<{
     <div className="rounded-lg bg-blue-50 p-6 mb-4">
       <div className="grid grid-cols-3 gap-x-6 gap-y-3">
         <Champ label="Chantier associé" valeur={indicateur.indicParentCh} />
-        <Champ label="Nom du chantier" valeur={indicateur.chantierNom} />
+        <div className="col-span-2">
+          <Champ label="Nom du chantier" valeur={indicateur.chantierNom} />
+        </div>
         <Champ label="Identifiant indicateur" valeur={indicateur.indicId} />
-        <Champ label="Nom de l'indicateur" valeur={indicateur.indicNom} />
+        <div className="col-span-2">
+          <Champ label="Nom de l'indicateur" valeur={indicateur.indicNom} />
+        </div>
         <Champ label="Création de l'indicateur" valeur={creation} />
-        <Champ label="Dernière modification" valeur={derniereModification} />
+        <div className="col-span-2">
+          <Champ label="Dernière modification" valeur={derniereModification} />
+        </div>
       </div>
     </div>
   );

--- a/src/client/components/PageUtilisateur/TableauUtilisateur/TableauUtilisateur.tsx
+++ b/src/client/components/PageUtilisateur/TableauUtilisateur/TableauUtilisateur.tsx
@@ -5,6 +5,7 @@ import {
   getPerimetreLibelle,
   getServiceLibelle,
 } from "@/client/constants/referentiel-services";
+import Champ from "@/components/_commons/Champ";
 
 interface TableauUtilisateurProps {
   utilisateur: {
@@ -22,24 +23,6 @@ interface TableauUtilisateurProps {
     perimetreMinisteriel?: string | null;
   };
 }
-
-const Champ = ({
-  label,
-  valeur,
-}: {
-  label: string;
-  valeur: string | null | undefined;
-}) => (
-  <div className="min-w-0">
-    <p className="text-xs text-gray-500 mb-1">{label}</p>
-    <p
-      className="text-sm font-bold text-gray-900 truncate mb-0"
-      title={valeur ?? undefined}
-    >
-      {valeur || "-"}
-    </p>
-  </div>
-);
 
 const TableauUtilisateur: FunctionComponent<TableauUtilisateurProps> = ({
   utilisateur,

--- a/src/client/components/_commons/Champ.tsx
+++ b/src/client/components/_commons/Champ.tsx
@@ -1,0 +1,18 @@
+import { FunctionComponent } from "react";
+
+const Champ: FunctionComponent<{
+  label: string;
+  valeur: string | null | undefined;
+}> = ({ label, valeur }) => (
+  <div className="min-w-0">
+    <p className="text-xs text-gray-500 mb-1">{label}</p>
+    <p
+      className="text-sm font-bold text-gray-900 truncate mb-0"
+      title={valeur ?? undefined}
+    >
+      {valeur || "-"}
+    </p>
+  </div>
+);
+
+export default Champ;


### PR DESCRIPTION
## Summary
- Passage de la grille du tableau d'information indicateur en layout 1/3 + 2/3 (grid-cols-3 avec col-span-2)
- Extraction du composant `Champ` dupliqué dans `_commons/Champ.tsx` (mutualisé entre `SectionTableauIndicateur` et `TableauUtilisateur`)

## Test plan
- [ ] Vérifier visuellement la fiche indicateur : les colonnes doivent être 1/3 à gauche, 2/3 à droite
- [ ] Vérifier que la page utilisateur affiche toujours correctement le tableau

🤖 Generated with [Claude Code](https://claude.com/claude-code)