### PR TITLE
feat: widget cartographie PVA indicateur avec comparaison territoriale

### DIFF
--- a/src/client/components/PageChantier/ComparaisonTerritoires/ComparaisonTerritoires.tsx
+++ b/src/client/components/PageChantier/ComparaisonTerritoires/ComparaisonTerritoires.tsx
@@ -60,6 +60,7 @@ export const ComparaisonTerritoires = ({
         if (type === "pva") {
           return (
             <WidgetCartographiePVA
+              mode="chantier"
               chantierId={chantierId}
               jalon={jalon}
               maille={maille}

--- a/src/client/components/_commons/IndicateursChantier/Bloc/Détails/ComparaisonTerritoires/ComparaisonTerritoiresIndicateur.tsx
+++ b/src/client/components/_commons/IndicateursChantier/Bloc/Détails/ComparaisonTerritoires/ComparaisonTerritoiresIndicateur.tsx
@@ -1,6 +1,7 @@
 import { MailleInterne } from "@/server/domain/maille/Maille.interface";
 import { WidgetCartographieTA } from "@/components/_commons/Widget/WidgetCartographieTA/WidgetCartographieTA";
 import { WidgetCartographieValeurAvancement } from "@/components/_commons/Widget/WidgetCartographieValeurAvancement/WidgetCartographieValeurAvancement";
+import { WidgetCartographiePVA } from "@/components/_commons/Widget/WidgetCartographiePVA/WidgetCartographiePVA";
 import { ComparaisonTerritoires } from "@/components/_commons/ComparaisonTerritoires/ComparaisonTerritoires";
 
 type ComparaisonTerritoiresIndicateurProps = {
@@ -12,13 +13,17 @@ type ComparaisonTerritoiresIndicateurProps = {
   unite: string | null;
 };
 
-type TypeCarteIndicateur = "ta" | "valeurAvancement";
+type TypeCarteIndicateur = "ta" | "valeurAvancement" | "pva";
 
 const options: (
   jalon: number,
 ) => { value: TypeCarteIndicateur; label: string }[] = (jalon) => [
   { value: "ta", label: `Carte des taux d'avancement ${jalon}` },
   { value: "valeurAvancement", label: "Carte des valeurs d'avancement" },
+  {
+    value: "pva",
+    label: "Carte des propositions de valeur d'avancement",
+  },
 ];
 
 export const ComparaisonTerritoiresIndicateur = ({
@@ -55,6 +60,18 @@ export const ComparaisonTerritoiresIndicateur = ({
             maille={maille}
             territoireCode={territoireCode}
             unite={unite}
+          />
+        );
+      }
+      if (type === "pva") {
+        return (
+          <WidgetCartographiePVA
+            mode="indicateur"
+            indicateurId={indicateurId}
+            chantierId={chantierId}
+            jalon={jalon}
+            maille={maille}
+            territoireCode={territoireCode}
           />
         );
       }

--- a/src/client/components/_commons/Widget/WidgetCartographiePVA/WidgetCartographiePVA.tsx
+++ b/src/client/components/_commons/Widget/WidgetCartographiePVA/WidgetCartographiePVA.tsx
@@ -1,3 +1,4 @@
+import { createContext, ReactNode, useContext } from "react";
 import { MailleInterne } from "@/server/domain/maille/Maille.interface";
 import { CartographieV2 } from "@/components/_commons/CartographieV2/CartographieV2";
 import { LegendeCartographie } from "@/components/_commons/CartographieV2/LegendeCartographie";
@@ -10,29 +11,98 @@ import { AjouterTerritoirePicker } from "@/components/_commons/Widget/AjouterTer
 import { useSelectionTerritoires } from "@/components/_commons/Widget/WidgetCartographieMeteo/useSelectionTerritoires";
 import { ComplementsCartographie } from "@/components/_commons/Widget/ComplementsCartographie";
 import { WidgetCartographieTitle } from "@/components/_commons/Widget/WidgetCartographieTitle";
+import { PVATerritoireViewModel } from "@/server/chantiers/infrastructure/queries/GetChantierPVACountTerritoiresQuery";
 import { NombrePropositionsValeur } from "./NombrePropositionsValeur";
 import { useDonneesCartographiePVA } from "./useDonneesCartographiePVA";
 import { useLegendePVA } from "./useLegendePVA";
 
-export const WidgetCartographiePVA = ({
+// --- Context ---
+
+type ModePVA = "chantier" | "indicateur";
+
+const WidgetCartographiePVAContext = createContext<{
+  territoiresPVA: PVATerritoireViewModel[];
+  mode: ModePVA;
+} | null>(null);
+
+const useWidgetCartographiePVAContext = () => {
+  const ctx = useContext(WidgetCartographiePVAContext);
+  if (!ctx) {
+    throw new Error(
+      "useWidgetCartographiePVAContext must be used within a WidgetCartographiePVA provider",
+    );
+  }
+  return ctx;
+};
+
+// --- Providers ---
+
+const ChantierProvider = ({
   chantierId,
-  maille,
-  territoireCode,
   jalon,
+  children,
 }: {
   chantierId: string;
-  maille: MailleInterne;
-  territoireCode: string;
   jalon: number;
+  children: ReactNode;
 }) => {
   const [territoiresPVA] =
-    api.chantier.recupererPVATerritoires.useSuspenseQuery({
+    api.chantier.recupererPVAChantierTerritoires.useSuspenseQuery({
       chantierId,
       jalon,
     });
 
-  const donneesCartographie = useDonneesCartographiePVA(territoiresPVA);
-  const legende = useLegendePVA(territoiresPVA);
+  return (
+    <WidgetCartographiePVAContext.Provider
+      value={{ territoiresPVA, mode: "chantier" }}
+    >
+      {children}
+    </WidgetCartographiePVAContext.Provider>
+  );
+};
+
+const IndicateurProvider = ({
+  indicateurId,
+  chantierId,
+  jalon,
+  children,
+}: {
+  indicateurId: string;
+  chantierId: string;
+  jalon: number;
+  children: ReactNode;
+}) => {
+  const [territoiresPVA] =
+    api.indicateur.recupererPVATerritoires.useSuspenseQuery({
+      indicateurId,
+      chantierId,
+      jalon,
+    });
+
+  return (
+    <WidgetCartographiePVAContext.Provider
+      value={{ territoiresPVA, mode: "indicateur" }}
+    >
+      {children}
+    </WidgetCartographiePVAContext.Provider>
+  );
+};
+
+// --- Content ---
+
+const WidgetCartographiePVAContent = ({
+  maille,
+  territoireCode,
+  jalon,
+}: {
+  maille: MailleInterne;
+  territoireCode: string;
+  jalon: number;
+}) => {
+  const { territoiresPVA, mode } = useWidgetCartographiePVAContext();
+
+  const donneesCartographie = useDonneesCartographiePVA(territoiresPVA, mode);
+  const legende = useLegendePVA(territoiresPVA, mode);
   const {
     territoiresSelectionnes,
     onSelectTerritoire,
@@ -82,5 +152,44 @@ export const WidgetCartographiePVA = ({
         territoiresSelectionnes={territoiresSelectionnes}
       />
     </BaseCartographieWidgetLayout>
+  );
+};
+
+// --- Public API ---
+
+type WidgetCartographiePVAProps = {
+  maille: MailleInterne;
+  territoireCode: string;
+  jalon: number;
+} & (
+  | { mode: "chantier"; chantierId: string }
+  | { mode: "indicateur"; indicateurId: string; chantierId: string }
+);
+
+export const WidgetCartographiePVA = (props: WidgetCartographiePVAProps) => {
+  const content = (
+    <WidgetCartographiePVAContent
+      maille={props.maille}
+      territoireCode={props.territoireCode}
+      jalon={props.jalon}
+    />
+  );
+
+  if (props.mode === "indicateur") {
+    return (
+      <IndicateurProvider
+        indicateurId={props.indicateurId}
+        chantierId={props.chantierId}
+        jalon={props.jalon}
+      >
+        {content}
+      </IndicateurProvider>
+    );
+  }
+
+  return (
+    <ChantierProvider chantierId={props.chantierId} jalon={props.jalon}>
+      {content}
+    </ChantierProvider>
   );
 };

--- a/src/client/components/_commons/Widget/WidgetCartographiePVA/useDonneesCartographiePVA.tsx
+++ b/src/client/components/_commons/Widget/WidgetCartographiePVA/useDonneesCartographiePVA.tsx
@@ -1,5 +1,8 @@
 import { useMemo } from "react";
-import { ELEMENTS_LEGENDE_PROPOSITION_VALEUR_CHANTIERS } from "@/client/constants/légendes/elementDeLegendesCartographiePropositionValeur";
+import {
+  ELEMENTS_LEGENDE_PROPOSITION_VALEUR_CHANTIERS,
+  ELEMENTS_LEGENDE_PROPOSITION_VALEUR_INDICATEURS,
+} from "@/client/constants/légendes/elementDeLegendesCartographiePropositionValeur";
 import { getLabelTerritoire } from "@/client/constants/territoires";
 import { CartographieV2Donnee } from "@/components/_commons/CartographieV2/types";
 import { PVATerritoireViewModel } from "@/server/chantiers/infrastructure/queries/GetChantierPVACountTerritoiresQuery";
@@ -8,18 +11,24 @@ import { formaterPropositions } from "./formaterPropositions";
 const determinerRemplissage = (
   nombrePropositions: number,
   estApplicable: boolean | null,
+  mode: "chantier" | "indicateur",
 ) => {
+  const legende =
+    mode === "indicateur"
+      ? ELEMENTS_LEGENDE_PROPOSITION_VALEUR_INDICATEURS
+      : ELEMENTS_LEGENDE_PROPOSITION_VALEUR_CHANTIERS;
+
   if (estApplicable === false) {
-    return ELEMENTS_LEGENDE_PROPOSITION_VALEUR_CHANTIERS.NON_APPLICABLE
-      .remplissage;
+    return legende.NON_APPLICABLE.remplissage;
   }
   return nombrePropositions > 0
-    ? ELEMENTS_LEGENDE_PROPOSITION_VALEUR_CHANTIERS.PROPOSITION.remplissage
-    : ELEMENTS_LEGENDE_PROPOSITION_VALEUR_CHANTIERS.DEFAUT.remplissage;
+    ? legende.PROPOSITION.remplissage
+    : legende.DEFAUT.remplissage;
 };
 
 export const useDonneesCartographiePVA = (
   territoires: PVATerritoireViewModel[],
+  mode: "chantier" | "indicateur",
 ) => {
   return useMemo(() => {
     return territoires.reduce(
@@ -29,6 +38,7 @@ export const useDonneesCartographiePVA = (
           remplissage: determinerRemplissage(
             territoire.nombrePropositionsValeur,
             territoire.estApplicable,
+            mode,
           ),
           libelle: getLabelTerritoire(territoire.territoireCode),
           contenuInfoBulle: (
@@ -43,5 +53,5 @@ export const useDonneesCartographiePVA = (
       }),
       {} as Record<string, CartographieV2Donnee>,
     );
-  }, [territoires]);
+  }, [territoires, mode]);
 };

--- a/src/client/components/_commons/Widget/WidgetCartographiePVA/useLegendePVA.ts
+++ b/src/client/components/_commons/Widget/WidgetCartographiePVA/useLegendePVA.ts
@@ -1,9 +1,20 @@
 import { useMemo } from "react";
-import { ELEMENTS_LEGENDE_PROPOSITION_VALEUR_CHANTIERS } from "@/client/constants/légendes/elementDeLegendesCartographiePropositionValeur";
+import {
+  ELEMENTS_LEGENDE_PROPOSITION_VALEUR_CHANTIERS,
+  ELEMENTS_LEGENDE_PROPOSITION_VALEUR_INDICATEURS,
+} from "@/client/constants/légendes/elementDeLegendesCartographiePropositionValeur";
 import { PVATerritoireViewModel } from "@/server/chantiers/infrastructure/queries/GetChantierPVACountTerritoiresQuery";
 
-export const useLegendePVA = (territoires: PVATerritoireViewModel[]) => {
+export const useLegendePVA = (
+  territoires: PVATerritoireViewModel[],
+  mode: "chantier" | "indicateur",
+) => {
   return useMemo(() => {
+    const legende =
+      mode === "indicateur"
+        ? ELEMENTS_LEGENDE_PROPOSITION_VALEUR_INDICATEURS
+        : ELEMENTS_LEGENDE_PROPOSITION_VALEUR_CHANTIERS;
+
     const tousApplicables = territoires.every(
       (territoire) => territoire.estApplicable,
     );
@@ -11,8 +22,8 @@ export const useLegendePVA = (territoires: PVATerritoireViewModel[]) => {
     const clesAExclure = new Set<string>();
     if (tousApplicables) clesAExclure.add("NON_APPLICABLE");
 
-    return Object.entries(ELEMENTS_LEGENDE_PROPOSITION_VALEUR_CHANTIERS)
+    return Object.entries(legende)
       .filter(([cle]) => !clesAExclure.has(cle))
       .map(([, { remplissage, libellé }]) => ({ libellé, remplissage }));
-  }, [territoires]);
+  }, [territoires, mode]);
 };

--- a/src/server/chantiers/__tests__/infrastructure/queries/GetIndicateurPVACountTerritoiresQuery.integration.test.ts
+++ b/src/server/chantiers/__tests__/infrastructure/queries/GetIndicateurPVACountTerritoiresQuery.integration.test.ts
@@ -293,7 +293,7 @@ describe("GetIndicateurPVACountTerritoiresQuery", () => {
   );
 
   it(
-    "retourne une liste vide quand le territoire n'est pas dans les habilitations",
+    "lance une erreur quand le territoire n'est pas dans les habilitations",
     createIntegrationTest(async () => {
       // Given
       await fixtures.chantierIdentite({ id: "CH-005" });
@@ -320,16 +320,16 @@ describe("GetIndicateurPVACountTerritoiresQuery", () => {
       });
 
       // When — territory not in habilitations
-      const result = await query.execute({
-        indicateurId: "IND-005",
-        chantierId: "CH-005",
-        jalon: 2025,
-        habilitations: habilitationsPourChantier("CH-005", ["DEPT-13"]),
-        profil: ProfilEnum.DITP_ADMIN,
-      });
-
       // Then
-      expect(result).toEqual([]);
+      await expect(
+        query.execute({
+          indicateurId: "IND-005",
+          chantierId: "CH-005",
+          jalon: 2025,
+          habilitations: habilitationsPourChantier("CH-005", ["DEPT-13"]),
+          profil: ProfilEnum.DITP_ADMIN,
+        }),
+      ).rejects.toThrow("indicateur 'IND-005' non trouvé");
     }),
   );
 });

--- a/src/server/chantiers/__tests__/infrastructure/queries/GetIndicateurPVACountTerritoiresQuery.integration.test.ts
+++ b/src/server/chantiers/__tests__/infrastructure/queries/GetIndicateurPVACountTerritoiresQuery.integration.test.ts
@@ -1,0 +1,335 @@
+import { createIntegrationTest } from "@/server/infrastructure/test/createIntegrationTest";
+import { fixtures } from "@/server/infrastructure/test/fixtures";
+import { GetIndicateurPVACountTerritoiresQuery } from "@/server/chantiers/infrastructure/queries/GetIndicateurPVACountTerritoiresQuery";
+import { ListerDetailsIndicateurTerritoireUseCaseV2 } from "@/server/chantiers/usecases/ListerDetailsIndicateurTerritoireUseCaseV2";
+import { PrismaIndicateurRepository } from "@/server/chantiers/infrastructure/adapters/PrismaIndicateurRepository";
+import { PrismaTerritoireRepository } from "@/server/chantiers/infrastructure/adapters/PrismaTerritoireRepository";
+import { DatajobsExecutionQueries } from "@/server/datajobs-execution/DatajobsExecution";
+import { PrismaPilote } from "@/server/db/PrismaPilote";
+import { Habilitations } from "@/server/domain/utilisateur/habilitation/Habilitation.interface";
+import { ProfilEnum } from "@/server/app/enum/profil.enum";
+
+function habilitationsPourChantier(
+  chantierId: string,
+  territoires: string[],
+): Habilitations {
+  return {
+    lecture: {
+      chantiers: [chantierId],
+      territoires,
+      périmètres: [],
+    },
+    saisieCommentaire: { chantiers: [], territoires: [], périmètres: [] },
+    saisieIndicateur: { chantiers: [], territoires: [], périmètres: [] },
+    responsabilite: { chantiers: [], territoires: [], périmètres: [] },
+    gestionUtilisateur: { chantiers: [], territoires: [], périmètres: [] },
+  };
+}
+
+describe("GetIndicateurPVACountTerritoiresQuery", () => {
+  const prismaPilote = new PrismaPilote();
+  let query: GetIndicateurPVACountTerritoiresQuery;
+
+  beforeEach(() => {
+    const indicateurRepository = new PrismaIndicateurRepository({
+      prisma: prismaPilote,
+    });
+    const datajobsExecutionQueries = new DatajobsExecutionQueries({
+      prisma: prismaPilote,
+    });
+    const territoireRepository = new PrismaTerritoireRepository({
+      prisma: prismaPilote,
+    });
+
+    query = new GetIndicateurPVACountTerritoiresQuery({
+      listerDetailsIndicateurTerritoireUseCaseV2:
+        new ListerDetailsIndicateurTerritoireUseCaseV2({
+          indicateurRepository,
+          datajobsExecutionQueries,
+        }),
+      territoireRepository,
+    });
+  });
+
+  it(
+    "retourne nombrePropositionsValeur à 1 quand une proposition est active",
+    createIntegrationTest(async () => {
+      // Given
+      const auteur = await fixtures.utilisateur();
+      await fixtures.chantierIdentite({ id: "CH-001" });
+      await fixtures.chantierTerritoire({
+        id: "CH-001",
+        territoire_code: "DEPT-75",
+        code_insee: "75",
+        maille: "DEPT",
+        zone_id: "D75",
+      });
+      await fixtures.indicateurIdentite({
+        id: "IND-001",
+        chantier_id: "CH-001",
+        statut: "PUBLIE",
+      });
+      await fixtures.indicateurTerritoire({
+        id: "IND-001",
+        chantier_id: "CH-001",
+        territoire_code: "DEPT-75",
+        code_insee: "75",
+        maille: "DEPT",
+        zone_id: "D75",
+        est_applicable: true,
+      });
+      await fixtures.indicateurTerritoireValeurEvenement({
+        indic_id: "IND-001",
+        territoire_code: "DEPT-75",
+        id_auteur_modification: auteur.id,
+        type_evenement: "PROPOSITION_VALEUR_CREEE",
+      });
+
+      // When
+      const result = await query.execute({
+        indicateurId: "IND-001",
+        chantierId: "CH-001",
+        jalon: 2025,
+        habilitations: habilitationsPourChantier("CH-001", ["DEPT-75"]),
+        profil: ProfilEnum.DITP_ADMIN,
+      });
+
+      // Then
+      expect(result).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            territoireCode: "DEPT-75",
+            nombrePropositionsValeur: 1,
+          }),
+        ]),
+      );
+    }),
+  );
+
+  it(
+    "retourne nombrePropositionsValeur à 0 quand aucun événement de proposition",
+    createIntegrationTest(async () => {
+      // Given
+      await fixtures.chantierIdentite({ id: "CH-002" });
+      await fixtures.chantierTerritoire({
+        id: "CH-002",
+        territoire_code: "DEPT-75",
+        code_insee: "75",
+        maille: "DEPT",
+        zone_id: "D75",
+      });
+      await fixtures.indicateurIdentite({
+        id: "IND-002",
+        chantier_id: "CH-002",
+        statut: "PUBLIE",
+      });
+      await fixtures.indicateurTerritoire({
+        id: "IND-002",
+        chantier_id: "CH-002",
+        territoire_code: "DEPT-75",
+        code_insee: "75",
+        maille: "DEPT",
+        zone_id: "D75",
+        est_applicable: true,
+      });
+
+      // When
+      const result = await query.execute({
+        indicateurId: "IND-002",
+        chantierId: "CH-002",
+        jalon: 2025,
+        habilitations: habilitationsPourChantier("CH-002", ["DEPT-75"]),
+        profil: ProfilEnum.DITP_ADMIN,
+      });
+
+      // Then
+      expect(result).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            territoireCode: "DEPT-75",
+            nombrePropositionsValeur: 0,
+          }),
+        ]),
+      );
+    }),
+  );
+
+  it(
+    "retourne nombrePropositionsValeur à 0 quand la proposition est terminée",
+    createIntegrationTest(async () => {
+      // Given
+      const auteur = await fixtures.utilisateur();
+      await fixtures.chantierIdentite({ id: "CH-003" });
+      await fixtures.chantierTerritoire({
+        id: "CH-003",
+        territoire_code: "DEPT-75",
+        code_insee: "75",
+        maille: "DEPT",
+        zone_id: "D75",
+      });
+      await fixtures.indicateurIdentite({
+        id: "IND-003",
+        chantier_id: "CH-003",
+        statut: "PUBLIE",
+      });
+      await fixtures.indicateurTerritoire({
+        id: "IND-003",
+        chantier_id: "CH-003",
+        territoire_code: "DEPT-75",
+        code_insee: "75",
+        maille: "DEPT",
+        zone_id: "D75",
+        est_applicable: true,
+      });
+      // Older event: proposition created
+      await fixtures.indicateurTerritoireValeurEvenement({
+        indic_id: "IND-003",
+        territoire_code: "DEPT-75",
+        id_auteur_modification: auteur.id,
+        type_evenement: "PROPOSITION_VALEUR_CREEE",
+        date_creation: new Date("2024-01-01"),
+        ordre: 1,
+      });
+      // Newer event: proposition deleted (terminated)
+      await fixtures.indicateurTerritoireValeurEvenement({
+        indic_id: "IND-003",
+        territoire_code: "DEPT-75",
+        id_auteur_modification: auteur.id,
+        type_evenement: "PROPOSITION_VALEUR_SUPPRIMEE",
+        date_creation: new Date("2024-01-02"),
+        ordre: 1,
+      });
+
+      // When
+      const result = await query.execute({
+        indicateurId: "IND-003",
+        chantierId: "CH-003",
+        jalon: 2025,
+        habilitations: habilitationsPourChantier("CH-003", ["DEPT-75"]),
+        profil: ProfilEnum.DITP_ADMIN,
+      });
+
+      // Then
+      expect(result).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            territoireCode: "DEPT-75",
+            nombrePropositionsValeur: 0,
+          }),
+        ]),
+      );
+    }),
+  );
+
+  it(
+    "retourne estApplicable correctement",
+    createIntegrationTest(async () => {
+      // Given
+      await fixtures.chantierIdentite({ id: "CH-004" });
+      await fixtures.chantierTerritoire({
+        id: "CH-004",
+        territoire_code: "DEPT-75",
+        code_insee: "75",
+        maille: "DEPT",
+        zone_id: "D75",
+      });
+      await fixtures.chantierTerritoire({
+        id: "CH-004",
+        territoire_code: "DEPT-13",
+        code_insee: "13",
+        maille: "DEPT",
+        zone_id: "D13",
+      });
+      await fixtures.indicateurIdentite({
+        id: "IND-004",
+        chantier_id: "CH-004",
+        statut: "PUBLIE",
+      });
+      await fixtures.indicateurTerritoire({
+        id: "IND-004",
+        chantier_id: "CH-004",
+        territoire_code: "DEPT-75",
+        code_insee: "75",
+        maille: "DEPT",
+        zone_id: "D75",
+        est_applicable: true,
+      });
+      await fixtures.indicateurTerritoire({
+        id: "IND-004",
+        chantier_id: "CH-004",
+        territoire_code: "DEPT-13",
+        code_insee: "13",
+        maille: "DEPT",
+        zone_id: "D13",
+        est_applicable: false,
+      });
+
+      // When
+      const result = await query.execute({
+        indicateurId: "IND-004",
+        chantierId: "CH-004",
+        jalon: 2025,
+        habilitations: habilitationsPourChantier("CH-004", [
+          "DEPT-75",
+          "DEPT-13",
+        ]),
+        profil: ProfilEnum.DITP_ADMIN,
+      });
+
+      // Then
+      expect(result).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            territoireCode: "DEPT-75",
+            estApplicable: true,
+          }),
+          expect.objectContaining({
+            territoireCode: "DEPT-13",
+            estApplicable: false,
+          }),
+        ]),
+      );
+    }),
+  );
+
+  it(
+    "retourne une liste vide quand le territoire n'est pas dans les habilitations",
+    createIntegrationTest(async () => {
+      // Given
+      await fixtures.chantierIdentite({ id: "CH-005" });
+      await fixtures.chantierTerritoire({
+        id: "CH-005",
+        territoire_code: "DEPT-75",
+        code_insee: "75",
+        maille: "DEPT",
+        zone_id: "D75",
+      });
+      await fixtures.indicateurIdentite({
+        id: "IND-005",
+        chantier_id: "CH-005",
+        statut: "PUBLIE",
+      });
+      await fixtures.indicateurTerritoire({
+        id: "IND-005",
+        chantier_id: "CH-005",
+        territoire_code: "DEPT-75",
+        code_insee: "75",
+        maille: "DEPT",
+        zone_id: "D75",
+        est_applicable: true,
+      });
+
+      // When — territory not in habilitations
+      const result = await query.execute({
+        indicateurId: "IND-005",
+        chantierId: "CH-005",
+        jalon: 2025,
+        habilitations: habilitationsPourChantier("CH-005", ["DEPT-13"]),
+        profil: ProfilEnum.DITP_ADMIN,
+      });
+
+      // Then
+      expect(result).toEqual([]);
+    }),
+  );
+});

--- a/src/server/chantiers/infrastructure/queries/GetIndicateurPVACountTerritoiresQuery.ts
+++ b/src/server/chantiers/infrastructure/queries/GetIndicateurPVACountTerritoiresQuery.ts
@@ -1,0 +1,47 @@
+import type { Inject } from "@/server/chantiers/module";
+import { Habilitations } from "@/server/domain/utilisateur/habilitation/Habilitation.interface";
+import { ProfilCode } from "@/server/domain/utilisateur/Utilisateur.interface";
+import { territoireCodeVersMailleCodeInsee } from "@/server/utils/territoires";
+import { PVATerritoireViewModel } from "./GetChantierPVACountTerritoiresQuery";
+
+export class GetIndicateurPVACountTerritoiresQuery {
+  constructor(
+    private readonly deps: Inject<
+      "listerDetailsIndicateurTerritoireUseCaseV2" | "territoireRepository"
+    >,
+  ) {}
+
+  async execute(params: {
+    indicateurId: string;
+    chantierId: string;
+    jalon: number;
+    habilitations: Habilitations;
+    profil: ProfilCode;
+  }): Promise<PVATerritoireViewModel[]> {
+    const result =
+      await this.deps.listerDetailsIndicateurTerritoireUseCaseV2.run(
+        [params.indicateurId],
+        params.chantierId,
+        params.habilitations,
+        params.profil,
+        params.jalon,
+      );
+
+    const details = result[params.indicateurId] ?? {};
+
+    const territoires =
+      await this.deps.territoireRepository.récupérerTousNew();
+    const territoiresMap = new Map(
+      territoires.map((territoire) => [territoire.code, territoire]),
+    );
+
+    return Object.entries(details).map(([territoireCode, detail]) => ({
+      territoireCode,
+      territoireNom: territoiresMap.get(territoireCode)?.nomAffiché ?? "",
+      codeInsee: detail.codeInsee,
+      maille: territoireCodeVersMailleCodeInsee(territoireCode).maille,
+      nombrePropositionsValeur: detail.proposition !== null ? 1 : 0,
+      estApplicable: detail.estApplicable,
+    }));
+  }
+}

--- a/src/server/chantiers/infrastructure/queries/GetIndicateurPVACountTerritoiresQuery.ts
+++ b/src/server/chantiers/infrastructure/queries/GetIndicateurPVACountTerritoiresQuery.ts
@@ -29,8 +29,7 @@ export class GetIndicateurPVACountTerritoiresQuery {
 
     const details = result[params.indicateurId] ?? {};
 
-    const territoires =
-      await this.deps.territoireRepository.récupérerTousNew();
+    const territoires = await this.deps.territoireRepository.récupérerTousNew();
     const territoiresMap = new Map(
       territoires.map((territoire) => [territoire.code, territoire]),
     );

--- a/src/server/chantiers/module.ts
+++ b/src/server/chantiers/module.ts
@@ -38,6 +38,7 @@ import { CreerLesRapportsPropositionsUseCase } from "./usecases/CreerLesRapports
 import { EnvoyerLesRapportsPropositionsUseCase } from "./usecases/EnvoyerLesRapportsPropositionsUseCase";
 import { GetChantierMeteosTerritoiresQuery } from "./infrastructure/queries/GetChantierMeteosTerritoiresQuery";
 import { GetChantierPVACountTerritoiresQuery } from "./infrastructure/queries/GetChantierPVACountTerritoiresQuery";
+import { GetIndicateurPVACountTerritoiresQuery } from "./infrastructure/queries/GetIndicateurPVACountTerritoiresQuery";
 import { RecupererTauxAvancementsChantierTerritoiresQuery } from "./infrastructure/queries/RecupererTauxAvancementsChantierTerritoiresQuery";
 import { RecupererValeursAvancementIndicateurTerritoiresQuery } from "./infrastructure/queries/RecupererValeursAvancementIndicateurTerritoiresQuery";
 import { GetValeursRemarquablesValeurAvancementIndicateurTerritoiresQuery } from "./infrastructure/queries/GetValeursRemarquablesValeurAvancementIndicateurTerritoiresQuery";
@@ -79,6 +80,7 @@ type ChantierOwnCradle = ChantierExports & {
   envoyerLesRapportsPropositionsUseCase: EnvoyerLesRapportsPropositionsUseCase;
   getChantierMeteosTerritoiresQuery: GetChantierMeteosTerritoiresQuery;
   getChantierPVACountTerritoiresQuery: GetChantierPVACountTerritoiresQuery;
+  getIndicateurPVACountTerritoiresQuery: GetIndicateurPVACountTerritoiresQuery;
   recupererTauxAvancementsChantierTerritoiresQuery: RecupererTauxAvancementsChantierTerritoiresQuery;
   recupererValeursAvancementIndicateurTerritoiresQuery: RecupererValeursAvancementIndicateurTerritoiresQuery;
   getValeursRemarquablesValeurAvancementIndicateurTerritoiresQuery: GetValeursRemarquablesValeurAvancementIndicateurTerritoiresQuery;
@@ -158,6 +160,9 @@ export const chantiersModule = defineModule<ChantierExports, ChantierCradle>()({
       ),
       getChantierPVACountTerritoiresQuery: asModuleClass(
         GetChantierPVACountTerritoiresQuery,
+      ),
+      getIndicateurPVACountTerritoiresQuery: asModuleClass(
+        GetIndicateurPVACountTerritoiresQuery,
       ),
       recupererTauxAvancementsChantierTerritoiresQuery: asModuleClass(
         RecupererTauxAvancementsChantierTerritoiresQuery,

--- a/src/server/infrastructure/api/trpc/routes/chantier.ts
+++ b/src/server/infrastructure/api/trpc/routes/chantier.ts
@@ -34,7 +34,7 @@ export const chantierRouter = créerRouteurTRPC({
         .resolve("getChantierMeteosTerritoiresQuery")
         .execute(input);
     }),
-  recupererPVATerritoires: procédureProtégée
+  recupererPVAChantierTerritoires: procédureProtégée
     .input(
       z.object({
         chantierId: z.string(),

--- a/src/server/infrastructure/api/trpc/routes/indicateur.ts
+++ b/src/server/infrastructure/api/trpc/routes/indicateur.ts
@@ -80,6 +80,25 @@ export const indicateurRouter = créerRouteurTRPC({
           profil: ctx.session.profil,
         });
     }),
+  recupererPVATerritoires: procédureProtégée
+    .input(
+      z.object({
+        indicateurId: z.string(),
+        chantierId: z.string(),
+        jalon: z.number(),
+      }),
+    )
+    .query(async ({ input, ctx }) => {
+      return getContainer("chantiers")
+        .resolve("getIndicateurPVACountTerritoiresQuery")
+        .execute({
+          indicateurId: input.indicateurId,
+          chantierId: input.chantierId,
+          jalon: input.jalon,
+          habilitations: ctx.session.habilitations,
+          profil: ctx.session.profil,
+        });
+    }),
   recupererStatistiquesTauxAvancement: procédureProtégée
     .input(
       z.object({


### PR DESCRIPTION
## Summary
- Ajout du widget cartographie PVA au niveau indicateur avec comparaison territoriale (nouvelle query `GetIndicateurPVACountTerritoiresQuery`)
- Refactoring des composants de comparaison des territoires en composants génériques réutilisables (extraction dans `_commons/`)
- Ajout du sélecteur de vue widget (`SelecteurVueWidget`) et suppression du zoom cartographique
- Améliorations diverses : responsive, prefetching, légendes, extraction composant `Champ`

## Test plan
- [ ] Vérifier le widget cartographie PVA sur la page indicateur
- [ ] Vérifier la comparaison territoriale au niveau indicateur
- [ ] Vérifier que les widgets cartographie existants (TA, VA, PVA chantier) fonctionnent toujours
- [ ] Vérifier le sélecteur de vue (carousel) sur les différents widgets
- [ ] Vérifier le responsive des widgets cartographie
- [ ] Lancer les tests d'intégration (`GetIndicateurPVACountTerritoiresQuery`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)