### PR TITLE
fix: extraire la prop key du spread JSX dans CartographieSVGContrat

### DIFF
--- a/src/client/components/_commons/Cartographie/SVG/CartographieSVGContrat.tsx
+++ b/src/client/components/_commons/Cartographie/SVG/CartographieSVGContrat.tsx
@@ -1286,14 +1286,14 @@ const createSvgMap = (contenuSVG: SVGG) => {
   [...(contenuSVG.polygon ? [contenuSVG.polygon] : [])]
     .flat()
     .forEach((polygon) => {
-      svgMap.set(polygon["attr-territoire-code"], (props) => (
-        <polygon points={polygon["attr-points"]} {...props} />
+      svgMap.set(polygon["attr-territoire-code"], ({ key, ...props }) => (
+        <polygon key={key} points={polygon["attr-points"]} {...props} />
       ));
     });
 
   [...(contenuSVG.path ? [contenuSVG.path] : [])].flat().forEach((path) => {
-    svgMap.set(path["attr-territoire-code"], (props) => (
-      <path d={path["attr-d"]} {...props} />
+    svgMap.set(path["attr-territoire-code"], ({ key, ...props }) => (
+      <path key={key} d={path["attr-d"]} {...props} />
     ));
   });
 


### PR DESCRIPTION
## Summary
- Corrige le warning React "A props object containing a key prop is being spread into JSX" dans `CartographieSVGContrat.tsx`
- Extrait `key` du destructuring des props pour les éléments `<polygon>` et `<path>` au lieu de le spreader

## Test plan
- [ ] Vérifier que la cartographie SVG s'affiche correctement
- [ ] Vérifier que le warning React n'apparaît plus dans la console