### PR TITLE
feat: widget chantiers signalés UIv2 (PIL-1372)

### DIFF
--- a/src/client/components/PageAccueil/PageChantiers/PageChantiers.tsx
+++ b/src/client/components/PageAccueil/PageChantiers/PageChantiers.tsx
@@ -206,12 +206,6 @@ const PageChantiers: FunctionComponent<PageChantiersProps> = ({
                 />
               </Bloc>
             </section>
-            {featureRepartitionMeteosV2 ? (
-              <WidgetRepartitionMeteos
-                chantierIds={chantierIds}
-                territoireCode={territoireCode}
-              />
-            ) : null}
           </div>
           <div className="fr-col-12 fr-col-lg-5 fr-col-xl-6 fr-pl-xl-1w">
             <Bloc>
@@ -282,7 +276,13 @@ const PageChantiers: FunctionComponent<PageChantiersProps> = ({
           </div>
         )}
         {featureChantiersSignalesV2 ? (
-          <div className="fr-pt-2w fr-px-2w fr-px-md-0">
+          <div className="fr-pt-2w fr-px-2w fr-px-md-0 grid grid-cols-1 sm:grid-cols-2 gap-4">
+            {featureRepartitionMeteosV2 ? (
+              <WidgetRepartitionMeteos
+                chantierIds={chantierIds}
+                territoireCode={territoireCode}
+              />
+            ) : null}
             <WidgetChantiersSignales
               chantierIds={chantierIdsSansFiltrageAlertes}
               jalonParDefaut={jalonParDefaut}

--- a/src/client/components/PageAccueil/PageChantiers/PageChantiers.tsx
+++ b/src/client/components/PageAccueil/PageChantiers/PageChantiers.tsx
@@ -32,6 +32,7 @@ import { useEnv } from "@/client/hooks/useEnv";
 import { WidgetCartographieTA } from "@/components/_commons/Widget/WidgetCartographieTA/WidgetCartographieTA";
 import { TuileWidget } from "@/components/_commons/Widget/TuileWidget/TuileWidget";
 import { WidgetRepartitionMeteos } from "@/components/_commons/Widget/WidgetRepartitionMeteos/WidgetRepartitionMeteos";
+import { WidgetChantiersSignales } from "@/components/_commons/Widget/WidgetChantiersSignales/WidgetChantiersSignales";
 import TableauChantiers from "./TableauChantiers/TableauChantiers";
 import usePageChantiers from "./usePageChantiers";
 import RepartitionsMeteosChantiers from "./FiltresMeteos/RepartitionsMeteosChantiers";
@@ -39,6 +40,7 @@ import RepartitionsMeteosChantiers from "./FiltresMeteos/RepartitionsMeteosChant
 interface PageChantiersProps {
   chantiers: ChantierAccueilContratV2[];
   chantierIds: string[];
+  chantierIdsSansFiltrageAlertes: string[];
   nombreTotalChantiersAvecAlertes: number;
   ministères: Ministère[];
   territoireCode: string;
@@ -48,12 +50,14 @@ interface PageChantiersProps {
   avancementsGlobauxTerritoriauxMoyens: AvancementsGlobauxTerritoriauxMoyensContrat;
   repartitionMeteosChantiers: RepartitionMeteoContrat;
   jalon: number;
+  jalonParDefaut: number;
   moyenneTerritoire: number | null;
 }
 
 const PageChantiers: FunctionComponent<PageChantiersProps> = ({
   chantiers,
   chantierIds,
+  chantierIdsSansFiltrageAlertes,
   nombreTotalChantiersAvecAlertes,
   ministères,
   territoireCode,
@@ -63,6 +67,7 @@ const PageChantiers: FunctionComponent<PageChantiersProps> = ({
   avancementsGlobauxTerritoriauxMoyens,
   repartitionMeteosChantiers,
   jalon,
+  jalonParDefaut,
   moyenneTerritoire,
 }) => {
   const ffAlertesBaisse = useEnv("NEXT_PUBLIC_FF_ALERTES_BAISSE");
@@ -71,6 +76,9 @@ const PageChantiers: FunctionComponent<PageChantiersProps> = ({
   );
   const featureRepartitionMeteosV2 = useEnv(
     "NEXT_PUBLIC_FF_REPARTITION_METEOS_V2",
+  );
+  const featureChantiersSignalesV2 = useEnv(
+    "NEXT_PUBLIC_FF_CHANTIERS_SIGNALES_V2",
   );
   const pathname = "/accueil/chantier/[territoireCode]";
   const { auClicTerritoireCallback } = useCartographie(
@@ -273,6 +281,15 @@ const PageChantiers: FunctionComponent<PageChantiersProps> = ({
             </div>
           </div>
         )}
+        {featureChantiersSignalesV2 ? (
+          <div className="fr-pt-2w fr-px-2w fr-px-md-0">
+            <WidgetChantiersSignales
+              chantierIds={chantierIdsSansFiltrageAlertes}
+              jalonParDefaut={jalonParDefaut}
+              territoireCode={territoireCode}
+            />
+          </div>
+        ) : null}
         <div className="fr-grid-row fr-mt-7v">
           <div className="fr-col-12">
             <Bloc>

--- a/src/client/components/_commons/Widget/WidgetChantiersSignales/WidgetChantiersSignales.tsx
+++ b/src/client/components/_commons/Widget/WidgetChantiersSignales/WidgetChantiersSignales.tsx
@@ -132,8 +132,8 @@ const TuilesAlertes = ({
     maille === "NAT"
       ? "nationale"
       : maille === "REG"
-        ? "regionale"
-        : "departementale";
+        ? "régionale"
+        : "départementale";
 
   const alertes =
     mailleChantier === "nationale"

--- a/src/client/components/_commons/Widget/WidgetChantiersSignales/WidgetChantiersSignales.tsx
+++ b/src/client/components/_commons/Widget/WidgetChantiersSignales/WidgetChantiersSignales.tsx
@@ -67,8 +67,11 @@ export const WidgetChantiersSignales = ({
   jalonParDefaut: number;
 }) => {
   return (
-    <section className="max-w-fit">
-      <Bloc contenuClassesSupplémentaires="fr-py-2w fr-px-3w">
+    <section className="h-full">
+      <Bloc
+        className="h-full"
+        contenuClassesSupplémentaires="fr-py-2w fr-px-3w"
+      >
         <TitreInfobulleConteneur className="justify-between fr-mb-2w">
           <div className="flex items-center gap-2">
             <BadgeIcône type="warning" />
@@ -138,7 +141,7 @@ const TuilesAlertes = ({
       : alertesTerritoriales(mailleChantier);
 
   return (
-    <ul className="flex flex-col gap-3 list-none p-0 m-0 max-w-[360px]">
+    <ul className="list-none p-0 m-0 flex flex-col gap-3 max-w-[360px] sm:grid sm:grid-cols-2 sm:max-w-none">
       {alertes.map((alerte) => (
         <li key={alerte.nomCritère}>
           <TuileAlerte
@@ -186,7 +189,7 @@ const TuileAlerte = ({
   return (
     <button
       className={clsxm(
-        "flex items-center gap-3 w-full py-4 px-5 border border-dsfr-warning-925 rounded-lg bg-white shadow-lg cursor-pointer transition-colors hover:bg-dsfr-warning-950",
+        "w-full h-full border border-dsfr-warning-925 rounded-lg bg-white shadow-lg cursor-pointer transition-colors hover:bg-dsfr-warning-950 flex items-center gap-3 py-4 px-5 sm:flex-col sm:items-start sm:gap-1",
         {
           "border-dsfr-warning-425 bg-dsfr-warning-950": filtreAlerte,
         },

--- a/src/client/components/_commons/Widget/WidgetChantiersSignales/WidgetChantiersSignales.tsx
+++ b/src/client/components/_commons/Widget/WidgetChantiersSignales/WidgetChantiersSignales.tsx
@@ -1,0 +1,207 @@
+import { Suspense, useCallback } from "react";
+import { parseAsBoolean, parseAsInteger, useQueryState } from "nuqs";
+import { territoireCodeVersMailleCodeInsee } from "@/server/utils/territoires";
+import { TypeAlerteChantier } from "@/server/chantiers/app/contrats/TypeAlerteChantier";
+import { ChantiersSignalesContrat } from "@/server/chantiers/app/contrats/ChantiersSignalesContrat";
+import { sauvegarderFiltres } from "@/client/stores/useFiltresStoreNew/useFiltresStoreNew";
+import { clsxm } from "@/utils/clsxm";
+import api from "@/server/infrastructure/api/trpc/api";
+import Bloc from "@/components/_commons/Bloc/Bloc";
+import Titre from "@/components/_commons/Titre/Titre";
+import { Infobulle } from "@/components/_commons/Infobulle/Infobulle";
+import TitreInfobulleConteneur from "@/components/_commons/TitreInfobulleConteneur/TitreInfobulleConteneur";
+import INFOBULLE_CONTENUS from "@/client/constants/infobulles";
+import BadgeIcône from "@/components/_commons/BadgeIcône/BadgeIcône";
+
+type AlerteDefinition = {
+  nomCritère: TypeAlerteChantier;
+  libellé: string;
+};
+
+const alertesNationales: AlerteDefinition[] = [
+  {
+    nomCritère: "estEnAlerteTauxAvancementNonCalculé",
+    libellé:
+      "Taux d'avancement non calculé(s) en raison d'indicateurs non renseignés",
+  },
+  {
+    nomCritère: "estEnAlerteAbscenceTauxAvancementDepartemental",
+    libellé: "Chantier(s) sans taux d'avancement au niveau départemental",
+  },
+  {
+    nomCritère: "estEnAlerteMétéoNonRenseignée",
+    libellé: "Chantier(s) avec météo et synthèse des résultats non renseignés",
+  },
+  {
+    nomCritère: "estEnAlertePossedePropositionsValeurAvancement",
+    libellé: "Chantier(s) avec proposition(s) de valeur d'avancement",
+  },
+];
+
+const alertesTerritoriales = (mailleChantier: string): AlerteDefinition[] => [
+  {
+    nomCritère: "estEnAlerteÉcart",
+    libellé: `Chantier(s) avec un retard de 10 points par rapport à leur médiane ${mailleChantier}`,
+  },
+  {
+    nomCritère: "estEnAlerteBaisse",
+    libellé: "Chantier(s) avec tendance en baisse",
+  },
+  {
+    nomCritère: "estEnAlerteMétéoNonRenseignée",
+    libellé: "Chantier(s) avec météo et synthèse des résultats non renseignés",
+  },
+  {
+    nomCritère: "estEnAlertePossedePropositionsValeurAvancement",
+    libellé: "Chantier(s) avec proposition(s) de valeur d'avancement",
+  },
+];
+
+export const WidgetChantiersSignales = ({
+  chantierIds,
+  territoireCode,
+  jalonParDefaut,
+}: {
+  chantierIds: string[];
+  territoireCode: string;
+  jalonParDefaut: number;
+}) => {
+  return (
+    <section className="max-w-fit">
+      <Bloc contenuClassesSupplémentaires="fr-py-2w fr-px-3w">
+        <TitreInfobulleConteneur className="justify-between fr-mb-2w">
+          <div className="flex items-center gap-2">
+            <BadgeIcône type="warning" />
+            <Titre
+              baliseHtml="h2"
+              className="fr-text--lg fr-mb-0 fr-py-1v !text-dsfr-warning-425"
+              estInline
+            >
+              Chantiers signalés
+            </Titre>
+          </div>
+          <Infobulle classNameBouton="!text-dsfr-warning-425">
+            {INFOBULLE_CONTENUS.chantiers.alertes}
+          </Infobulle>
+        </TitreInfobulleConteneur>
+        <Suspense>
+          <ChantiersSignalesContenu
+            chantierIds={chantierIds}
+            territoireCode={territoireCode}
+            jalonParDefaut={jalonParDefaut}
+          />
+        </Suspense>
+      </Bloc>
+    </section>
+  );
+};
+
+const ChantiersSignalesContenu = ({
+  chantierIds,
+  territoireCode,
+  jalonParDefaut,
+}: {
+  chantierIds: string[];
+  territoireCode: string;
+  jalonParDefaut: number;
+}) => {
+  const [compteurs] = api.chantier.recupererChantiersSignales.useSuspenseQuery({
+    chantierIds,
+    territoireCode,
+    jalonParDefaut,
+  });
+
+  return (
+    <TuilesAlertes compteurs={compteurs} territoireCode={territoireCode} />
+  );
+};
+
+const TuilesAlertes = ({
+  compteurs,
+  territoireCode,
+}: {
+  compteurs: ChantiersSignalesContrat;
+  territoireCode: string;
+}) => {
+  const { maille } = territoireCodeVersMailleCodeInsee(territoireCode);
+
+  const mailleChantier =
+    maille === "NAT"
+      ? "nationale"
+      : maille === "REG"
+        ? "regionale"
+        : "departementale";
+
+  const alertes =
+    mailleChantier === "nationale"
+      ? alertesNationales
+      : alertesTerritoriales(mailleChantier);
+
+  return (
+    <ul className="flex flex-col gap-3 list-none p-0 m-0 max-w-[360px]">
+      {alertes.map((alerte) => (
+        <li key={alerte.nomCritère}>
+          <TuileAlerte
+            nomCritère={alerte.nomCritère}
+            libellé={alerte.libellé}
+            nombre={compteurs[alerte.nomCritère]}
+          />
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+const TuileAlerte = ({
+  nomCritère,
+  libellé,
+  nombre,
+}: {
+  nomCritère: TypeAlerteChantier;
+  libellé: string;
+  nombre: number;
+}) => {
+  const [filtreAlerte, setFiltreAlerte] = useQueryState(
+    nomCritère,
+    parseAsBoolean.withDefault(false).withOptions({
+      shallow: false,
+      clearOnDefault: true,
+      history: "push",
+    }),
+  );
+
+  const [, setPagination] = useQueryState(
+    "pageIndex",
+    parseAsInteger.withDefault(1).withOptions({
+      shallow: false,
+    }),
+  );
+
+  const onClick = useCallback(() => {
+    setPagination(1);
+    sauvegarderFiltres({ [nomCritère]: !filtreAlerte });
+    setFiltreAlerte(!filtreAlerte);
+  }, [nomCritère, filtreAlerte, setFiltreAlerte, setPagination]);
+
+  return (
+    <button
+      className={clsxm(
+        "flex items-center gap-3 w-full py-4 px-5 border border-dsfr-warning-925 rounded-lg bg-white shadow-lg cursor-pointer transition-colors hover:bg-dsfr-warning-950",
+        {
+          "border-dsfr-warning-425 bg-dsfr-warning-950": filtreAlerte,
+        },
+      )}
+      onClick={onClick}
+      title={libellé}
+      type="button"
+      aria-pressed={filtreAlerte}
+    >
+      <span className="text-[1.75rem] font-bold text-dsfr-warning-425 min-w-[2.5rem] text-center">
+        {nombre}
+      </span>
+      <span className="text-sm text-dsfr-grey-200 leading-tight">
+        {libellé}
+      </span>
+    </button>
+  );
+};

--- a/src/client/components/_commons/Widget/WidgetChantiersSignales/WidgetChantiersSignales.tsx
+++ b/src/client/components/_commons/Widget/WidgetChantiersSignales/WidgetChantiersSignales.tsx
@@ -199,10 +199,10 @@ const TuileAlerte = ({
       type="button"
       aria-pressed={filtreAlerte}
     >
-      <span className="text-[1.75rem] font-bold text-dsfr-warning-425 min-w-[2.5rem] text-center">
+      <span className="text-[1.75rem] font-bold text-dsfr-warning-425 min-w-[2.5rem] text-center sm:text-left">
         {nombre}
       </span>
-      <span className="text-sm text-dsfr-grey-200 leading-tight">
+      <span className="text-sm text-dsfr-grey-200 leading-tight text-left">
         {libellé}
       </span>
     </button>

--- a/src/client/components/_commons/Widget/WidgetRepartitionMeteos/WidgetRepartitionMeteos.tsx
+++ b/src/client/components/_commons/Widget/WidgetRepartitionMeteos/WidgetRepartitionMeteos.tsx
@@ -30,8 +30,11 @@ export const WidgetRepartitionMeteos = ({
   territoireCode: string;
 }) => {
   return (
-    <section className="fr-mr-md-2w fr-mr-xl-0 max-w-fit">
-      <Bloc contenuClassesSupplémentaires="fr-py-2w fr-px-3w">
+    <section className="h-full">
+      <Bloc
+        className="h-full"
+        contenuClassesSupplémentaires="fr-py-2w fr-px-3w"
+      >
         <TitreInfobulleConteneur className="justify-between fr-mb-2w">
           <Titre
             baliseHtml="h2"
@@ -106,12 +109,12 @@ const TuilesMeteos = ({
   );
 
   return (
-    <ul className="flex flex-col gap-3 list-none p-0 m-0 max-w-[360px]">
+    <ul className="list-none p-0 m-0 flex flex-col gap-3 max-w-[360px] sm:grid sm:grid-cols-2 sm:max-w-none">
       {meteosOrdonnees.map((meteo) => (
         <li key={meteo}>
           <button
             className={clsxm(
-              "flex items-center gap-3 w-full py-4 px-5 border border-dsfr-moutarde-main-975 rounded-lg bg-white shadow-lg cursor-pointer transition-colors hover:border-dsfr-moutarde-main-925 hover:bg-dsfr-moutarde-main-975",
+              "w-full h-full border border-dsfr-moutarde-main-975 rounded-lg bg-white shadow-lg cursor-pointer transition-colors hover:border-dsfr-moutarde-main-925 hover:bg-dsfr-moutarde-main-975 flex items-center gap-3 py-4 px-5 sm:flex-col sm:items-start sm:gap-1",
               {
                 "border-dsfr-moutarde-main-850": meteos.includes(meteo),
               },
@@ -123,10 +126,15 @@ const TuilesMeteos = ({
             type="button"
             aria-pressed={meteos.includes(meteo)}
           >
-            <span className="text-[1.75rem] font-bold text-dsfr-moutarde-main-850 min-w-[2.5rem] text-center">
+            <span className="text-[1.75rem] font-bold text-dsfr-moutarde-main-850 min-w-[2.5rem] text-center sm:flex sm:items-center sm:gap-2">
               {repartition[meteo]}
+              <span className="hidden sm:inline">
+                <MeteoPicto meteo={meteo} />
+              </span>
             </span>
-            <MeteoPicto meteo={meteo} />
+            <span className="sm:hidden">
+              <MeteoPicto meteo={meteo} />
+            </span>
             <span className="text-sm text-dsfr-grey-200 leading-tight">
               {libellesMeteos[meteo]}
             </span>

--- a/src/config.ts
+++ b/src/config.ts
@@ -330,6 +330,11 @@ const config = convict({
       doc: "Active la lecture des feature flips depuis la DB (gestion_contenu) au lieu des env vars uniquement",
       env: "FF_FEATURE_FLIP_ADMIN",
     },
+    chantiersSignalesV2: {
+      format: Boolean,
+      default: false,
+      env: "NEXT_PUBLIC_FF_CHANTIERS_SIGNALES_V2",
+    },
   },
   analytics: {
     doc: "Matomo Analytics",

--- a/src/pages/accueil/chantier/[territoireCode]/index.tsx
+++ b/src/pages/accueil/chantier/[territoireCode]/index.tsx
@@ -161,6 +161,9 @@ export const getServerSideProps = async (
     mailleChantier,
     territoireCode,
   );
+  const chantierIdsSansFiltrageAlertes = chantiers.map(
+    (chantier) => chantier.id,
+  );
 
   const chantiersAvecAlertes =
     filtresAlertes.estEnAlerteÉcart ||
@@ -272,11 +275,13 @@ export const getServerSideProps = async (
         return chantier;
       }),
       chantierIds,
+      chantierIdsSansFiltrageAlertes,
       nombreTotalChantiersAvecAlertes,
       ministères,
       axes,
       territoireCode,
       jalon,
+      jalonParDefaut,
       mailleSelectionnee: mailleGlobalTerritoireSelectionnee,
       mailleQuery,
       filtresComptesCalculés,
@@ -317,6 +322,7 @@ const PROFIL_REGIONAUX_AUTORISE_A_VOIR_FILTRE_TERRITORIALISE = new Set(
 const ChantierLayout = ({
   chantiers,
   chantierIds,
+  chantierIdsSansFiltrageAlertes,
   nombreTotalChantiersAvecAlertes,
   axes,
   ministères,
@@ -328,6 +334,7 @@ const ChantierLayout = ({
   avancementsGlobauxTerritoriauxMoyens,
   repartitionMeteosChantiers,
   jalon,
+  jalonParDefaut,
   doitAfficherModaleVideoAccueil,
   doitAfficherLaModaleInfolettre,
   doitAfficherLaFicheTerritoriale,
@@ -457,9 +464,11 @@ const ChantierLayout = ({
               avancementsGlobauxTerritoriauxMoyens
             }
             chantierIds={chantierIds}
+            chantierIdsSansFiltrageAlertes={chantierIdsSansFiltrageAlertes}
             chantiers={chantiers}
             filtresComptesCalculés={filtresComptesCalculés}
             jalon={jalon}
+            jalonParDefaut={jalonParDefaut}
             mailleQuery={mailleQuery}
             ministères={ministères}
             nombreTotalChantiersAvecAlertes={nombreTotalChantiersAvecAlertes}

--- a/src/server/chantiers/__tests__/infrastructure/queries/GetChantiersSignalesQuery.integration.test.ts
+++ b/src/server/chantiers/__tests__/infrastructure/queries/GetChantiersSignalesQuery.integration.test.ts
@@ -1,6 +1,7 @@
 import { createIntegrationTest } from "@/server/infrastructure/test/createIntegrationTest";
 import { fixtures } from "@/server/infrastructure/test/fixtures";
 import { PrismaPilote } from "@/server/db/PrismaPilote";
+import { getPrisma } from "@/server/db/PrismaTransaction";
 import { GetChantiersSignalesQuery } from "@/server/chantiers/infrastructure/queries/GetChantiersSignalesQuery";
 
 describe("GetChantiersSignalesQuery", () => {
@@ -462,6 +463,222 @@ describe("GetChantiersSignalesQuery", () => {
         estEnAlerteAbscenceTauxAvancementDepartemental: 0,
         estEnAlerteMétéoNonRenseignée: 0,
         estEnAlertePossedePropositionsValeurAvancement: 0,
+      });
+    }),
+  );
+
+  it(
+    "compte les PVA depuis les territoires enfants au national",
+    createIntegrationTest(async () => {
+      // Given — PVA = 0 au NAT, mais > 0 sur un DEPT enfant
+      await fixtures.chantierIdentite({
+        id: "CH-001",
+        ministeres: ["MIN-01"],
+      });
+      await fixtures.chantierTerritoire({
+        id: "CH-001",
+        territoire_code: "NAT-FR",
+        code_insee: "FR",
+        maille: "NAT",
+        zone_id: "zone-1",
+        meteo: "SOLEIL",
+        est_applicable: true,
+        nombre_propositions_valeur_actuelle: 0,
+      });
+      await fixtures.chantierTerritoireJalon({
+        id: "CH-001",
+        territoire_code: "NAT-FR",
+        code_insee: "FR",
+        maille: "NAT",
+        zone_id: "zone-1",
+        jalon: 2025,
+        taux_avancement: 50,
+      });
+      await fixtures.chantierTerritoire({
+        id: "CH-001",
+        territoire_code: "DEPT-75",
+        code_insee: "75",
+        maille: "DEPT",
+        zone_id: "zone-2",
+        meteo: "SOLEIL",
+        est_applicable: true,
+        nombre_propositions_valeur_actuelle: 3,
+      });
+      await fixtures.chantierTerritoireJalon({
+        id: "CH-001",
+        territoire_code: "DEPT-75",
+        code_insee: "75",
+        maille: "DEPT",
+        zone_id: "zone-2",
+        jalon: 2025,
+        taux_avancement: 50,
+      });
+
+      // When
+      const result = await query.execute({
+        chantierIds: ["CH-001"],
+        territoireCode: "NAT-FR",
+        jalonParDefaut: 2025,
+      });
+
+      // Then — PVA compté depuis le DEPT enfant
+      expect(result).toEqual({
+        estEnAlerteÉcart: 0,
+        estEnAlerteBaisse: 0,
+        estEnAlerteTauxAvancementNonCalculé: 0,
+        estEnAlerteAbscenceTauxAvancementDepartemental: 0,
+        estEnAlerteMétéoNonRenseignée: 0,
+        estEnAlertePossedePropositionsValeurAvancement: 1,
+      });
+    }),
+  );
+
+  it(
+    "détecte l'absence de taux d'avancement départemental au national",
+    createIntegrationTest(async () => {
+      // Given — cible_attendue = true, DEPT applicables mais taux_avancement = null
+      await fixtures.chantierIdentite({
+        id: "CH-001",
+        ministeres: ["MIN-01"],
+        cible_attendue: true,
+      });
+      await fixtures.chantierTerritoire({
+        id: "CH-001",
+        territoire_code: "NAT-FR",
+        code_insee: "FR",
+        maille: "NAT",
+        zone_id: "zone-1",
+        meteo: "SOLEIL",
+        est_applicable: true,
+      });
+      await fixtures.chantierTerritoireJalon({
+        id: "CH-001",
+        territoire_code: "NAT-FR",
+        code_insee: "FR",
+        maille: "NAT",
+        zone_id: "zone-1",
+        jalon: 2025,
+        taux_avancement: 50,
+      });
+      await fixtures.chantierTerritoire({
+        id: "CH-001",
+        territoire_code: "DEPT-75",
+        code_insee: "75",
+        maille: "DEPT",
+        zone_id: "zone-2",
+        meteo: "SOLEIL",
+        est_applicable: true,
+      });
+      await fixtures.chantierTerritoireJalon({
+        id: "CH-001",
+        territoire_code: "DEPT-75",
+        code_insee: "75",
+        maille: "DEPT",
+        zone_id: "zone-2",
+        jalon: 2025,
+        taux_avancement: null,
+      });
+
+      // When
+      const result = await query.execute({
+        chantierIds: ["CH-001"],
+        territoireCode: "NAT-FR",
+        jalonParDefaut: 2025,
+      });
+
+      // Then — absence de taux dept détectée
+      expect(result).toEqual({
+        estEnAlerteÉcart: 0,
+        estEnAlerteBaisse: 0,
+        estEnAlerteTauxAvancementNonCalculé: 0,
+        estEnAlerteAbscenceTauxAvancementDepartemental: 1,
+        estEnAlerteMétéoNonRenseignée: 0,
+        estEnAlertePossedePropositionsValeurAvancement: 0,
+      });
+    }),
+  );
+
+  it(
+    "compte les PVA depuis les territoires enfants au régional",
+    createIntegrationTest(async () => {
+      const prisma = getPrisma();
+
+      // Given — créer le territoire REG avec un DEPT enfant
+      await prisma.territoire.upsert({
+        where: { code: "REG-76" },
+        update: {},
+        create: {
+          code: "REG-76",
+          nom: "Occitanie",
+          nom_affiche: "Occitanie",
+          maille: "REG",
+          code_insee: "76",
+          zone_id: "zone-reg",
+        },
+      });
+      await prisma.territoire.upsert({
+        where: { code: "DEPT-31" },
+        update: { code_parent: "REG-76" },
+        create: {
+          code: "DEPT-31",
+          nom: "Haute-Garonne",
+          nom_affiche: "Haute-Garonne",
+          maille: "DEPT",
+          code_insee: "31",
+          code_parent: "REG-76",
+          zone_id: "zone-dept",
+        },
+      });
+
+      await fixtures.chantierIdentite({
+        id: "CH-001",
+        ministeres: ["MIN-01"],
+      });
+      await fixtures.chantierTerritoire({
+        id: "CH-001",
+        territoire_code: "REG-76",
+        code_insee: "76",
+        maille: "REG",
+        zone_id: "zone-reg",
+        meteo: "SOLEIL",
+        est_applicable: true,
+        nombre_propositions_valeur_actuelle: 0,
+      });
+      await fixtures.chantierTerritoireJalon({
+        id: "CH-001",
+        territoire_code: "REG-76",
+        code_insee: "76",
+        maille: "REG",
+        zone_id: "zone-reg",
+        jalon: 2025,
+        taux_avancement: 50,
+      });
+      await fixtures.chantierTerritoire({
+        id: "CH-001",
+        territoire_code: "DEPT-31",
+        code_insee: "31",
+        maille: "DEPT",
+        zone_id: "zone-dept",
+        meteo: "SOLEIL",
+        est_applicable: true,
+        nombre_propositions_valeur_actuelle: 2,
+      });
+
+      // When
+      const result = await query.execute({
+        chantierIds: ["CH-001"],
+        territoireCode: "REG-76",
+        jalonParDefaut: 2025,
+      });
+
+      // Then — PVA compté depuis le DEPT enfant
+      expect(result).toEqual({
+        estEnAlerteÉcart: 0,
+        estEnAlerteBaisse: 0,
+        estEnAlerteTauxAvancementNonCalculé: 0,
+        estEnAlerteAbscenceTauxAvancementDepartemental: 0,
+        estEnAlerteMétéoNonRenseignée: 0,
+        estEnAlertePossedePropositionsValeurAvancement: 1,
       });
     }),
   );

--- a/src/server/chantiers/__tests__/infrastructure/queries/GetChantiersSignalesQuery.integration.test.ts
+++ b/src/server/chantiers/__tests__/infrastructure/queries/GetChantiersSignalesQuery.integration.test.ts
@@ -339,6 +339,7 @@ describe("GetChantiersSignalesQuery", () => {
         zone_id: "zone-2",
         jalon: 2025,
         ecart: -5,
+        taux_avancement: 50,
       });
 
       // When — on demande uniquement NAT-FR

--- a/src/server/chantiers/__tests__/infrastructure/queries/GetChantiersSignalesQuery.integration.test.ts
+++ b/src/server/chantiers/__tests__/infrastructure/queries/GetChantiersSignalesQuery.integration.test.ts
@@ -1,0 +1,467 @@
+import { createIntegrationTest } from "@/server/infrastructure/test/createIntegrationTest";
+import { fixtures } from "@/server/infrastructure/test/fixtures";
+import { PrismaPilote } from "@/server/db/PrismaPilote";
+import { GetChantiersSignalesQuery } from "@/server/chantiers/infrastructure/queries/GetChantiersSignalesQuery";
+
+describe("GetChantiersSignalesQuery", () => {
+  let query: GetChantiersSignalesQuery;
+
+  beforeEach(() => {
+    query = new GetChantiersSignalesQuery({
+      prisma: new PrismaPilote(),
+    });
+  });
+
+  it(
+    "retourne les compteurs d'alertes pour les chantiers donnés sur un territoire",
+    createIntegrationTest(async () => {
+      // Given
+      await fixtures.chantierIdentite({
+        id: "CH-001",
+        ministeres: ["MIN-01"],
+        cible_attendue: true,
+      });
+      await fixtures.chantierIdentite({
+        id: "CH-002",
+        ministeres: ["MIN-01"],
+        cible_attendue: true,
+      });
+      await fixtures.chantierTerritoire({
+        id: "CH-001",
+        territoire_code: "NAT-FR",
+        code_insee: "FR",
+        maille: "NAT",
+        zone_id: "zone-1",
+        meteo: "NON_RENSEIGNEE",
+        est_applicable: true,
+        tendance: "BAISSE",
+        nombre_propositions_valeur_actuelle: 0,
+      });
+      await fixtures.chantierTerritoireJalon({
+        id: "CH-001",
+        territoire_code: "NAT-FR",
+        code_insee: "FR",
+        maille: "NAT",
+        zone_id: "zone-1",
+        jalon: 2025,
+        ecart: -15,
+        taux_avancement: null,
+      });
+      await fixtures.chantierTerritoire({
+        id: "CH-002",
+        territoire_code: "NAT-FR",
+        code_insee: "FR",
+        maille: "NAT",
+        zone_id: "zone-1",
+        meteo: "SOLEIL",
+        est_applicable: true,
+        tendance: "HAUSSE",
+        nombre_propositions_valeur_actuelle: 0,
+      });
+      await fixtures.chantierTerritoireJalon({
+        id: "CH-002",
+        territoire_code: "NAT-FR",
+        code_insee: "FR",
+        maille: "NAT",
+        zone_id: "zone-1",
+        jalon: 2025,
+        ecart: -5,
+        taux_avancement: 50,
+      });
+
+      // When
+      const result = await query.execute({
+        chantierIds: ["CH-001", "CH-002"],
+        territoireCode: "NAT-FR",
+        jalonParDefaut: 2025,
+      });
+
+      // Then
+      expect(result).toEqual({
+        estEnAlerteÉcart: 1,
+        estEnAlerteBaisse: 1,
+        estEnAlerteTauxAvancementNonCalculé: 1,
+        estEnAlerteAbscenceTauxAvancementDepartemental: 0,
+        estEnAlerteMétéoNonRenseignée: 1,
+        estEnAlertePossedePropositionsValeurAvancement: 0,
+      });
+    }),
+  );
+
+  it(
+    "exclut les chantiers non applicables",
+    createIntegrationTest(async () => {
+      // Given
+      await fixtures.chantierIdentite({
+        id: "CH-001",
+        ministeres: ["MIN-01"],
+      });
+      await fixtures.chantierIdentite({
+        id: "CH-002",
+        ministeres: ["MIN-01"],
+      });
+      await fixtures.chantierTerritoire({
+        id: "CH-001",
+        territoire_code: "NAT-FR",
+        code_insee: "FR",
+        maille: "NAT",
+        zone_id: "zone-1",
+        meteo: "NON_RENSEIGNEE",
+        est_applicable: true,
+      });
+      await fixtures.chantierTerritoireJalon({
+        id: "CH-001",
+        territoire_code: "NAT-FR",
+        code_insee: "FR",
+        maille: "NAT",
+        zone_id: "zone-1",
+        jalon: 2025,
+        ecart: -15,
+      });
+      await fixtures.chantierTerritoire({
+        id: "CH-002",
+        territoire_code: "NAT-FR",
+        code_insee: "FR",
+        maille: "NAT",
+        zone_id: "zone-1",
+        meteo: "NON_RENSEIGNEE",
+        // chantier non applicable
+        est_applicable: false,
+      });
+
+      // When
+      const result = await query.execute({
+        chantierIds: ["CH-001", "CH-002"],
+        territoireCode: "NAT-FR",
+        jalonParDefaut: 2025,
+      });
+
+      // Then
+      expect(result).toEqual({
+        estEnAlerteÉcart: 1,
+        estEnAlerteBaisse: 0,
+        estEnAlerteTauxAvancementNonCalculé: 1,
+        estEnAlerteAbscenceTauxAvancementDepartemental: 0,
+        estEnAlerteMétéoNonRenseignée: 1,
+        estEnAlertePossedePropositionsValeurAvancement: 0,
+      });
+    }),
+  );
+
+  it(
+    "exclut les chantiers sans ministères",
+    createIntegrationTest(async () => {
+      // Given
+      await fixtures.chantierIdentite({
+        id: "CH-001",
+        ministeres: ["MIN-01"],
+      });
+      await fixtures.chantierIdentite({
+        id: "CH-002",
+        ministeres: [],
+      });
+      await fixtures.chantierTerritoire({
+        id: "CH-001",
+        territoire_code: "NAT-FR",
+        code_insee: "FR",
+        maille: "NAT",
+        zone_id: "zone-1",
+        meteo: "NON_RENSEIGNEE",
+        est_applicable: true,
+      });
+      await fixtures.chantierTerritoireJalon({
+        id: "CH-001",
+        territoire_code: "NAT-FR",
+        code_insee: "FR",
+        maille: "NAT",
+        zone_id: "zone-1",
+        jalon: 2025,
+      });
+      await fixtures.chantierTerritoire({
+        id: "CH-002",
+        territoire_code: "NAT-FR",
+        code_insee: "FR",
+        maille: "NAT",
+        zone_id: "zone-1",
+        meteo: "NON_RENSEIGNEE",
+        est_applicable: true,
+      });
+
+      // When
+      const result = await query.execute({
+        chantierIds: ["CH-001", "CH-002"],
+        territoireCode: "NAT-FR",
+        jalonParDefaut: 2025,
+      });
+
+      // Then
+      expect(result).toEqual({
+        estEnAlerteÉcart: 0,
+        estEnAlerteBaisse: 0,
+        estEnAlerteTauxAvancementNonCalculé: 1,
+        estEnAlerteAbscenceTauxAvancementDepartemental: 0,
+        estEnAlerteMétéoNonRenseignée: 1,
+        estEnAlertePossedePropositionsValeurAvancement: 0,
+      });
+    }),
+  );
+
+  it(
+    "ignore les chantiers dont l'id n'est pas dans la liste",
+    createIntegrationTest(async () => {
+      // Given
+      await fixtures.chantierIdentite({
+        id: "CH-001",
+        ministeres: ["MIN-01"],
+      });
+      await fixtures.chantierIdentite({
+        id: "CH-002",
+        ministeres: ["MIN-01"],
+      });
+      await fixtures.chantierTerritoire({
+        id: "CH-001",
+        territoire_code: "NAT-FR",
+        code_insee: "FR",
+        maille: "NAT",
+        zone_id: "zone-1",
+        meteo: "NON_RENSEIGNEE",
+        est_applicable: true,
+      });
+      await fixtures.chantierTerritoireJalon({
+        id: "CH-001",
+        territoire_code: "NAT-FR",
+        code_insee: "FR",
+        maille: "NAT",
+        zone_id: "zone-1",
+        jalon: 2025,
+        ecart: -15,
+      });
+      await fixtures.chantierTerritoire({
+        id: "CH-002",
+        territoire_code: "NAT-FR",
+        code_insee: "FR",
+        maille: "NAT",
+        zone_id: "zone-1",
+        meteo: "NON_RENSEIGNEE",
+        est_applicable: true,
+      });
+      await fixtures.chantierTerritoireJalon({
+        id: "CH-002",
+        territoire_code: "NAT-FR",
+        code_insee: "FR",
+        maille: "NAT",
+        zone_id: "zone-1",
+        jalon: 2025,
+        ecart: -20,
+      });
+
+      // When — seul CH-001 est demandé
+      const result = await query.execute({
+        chantierIds: ["CH-001"],
+        territoireCode: "NAT-FR",
+        jalonParDefaut: 2025,
+      });
+
+      // Then
+      expect(result).toEqual({
+        estEnAlerteÉcart: 1,
+        estEnAlerteBaisse: 0,
+        estEnAlerteTauxAvancementNonCalculé: 1,
+        estEnAlerteAbscenceTauxAvancementDepartemental: 0,
+        estEnAlerteMétéoNonRenseignée: 1,
+        estEnAlertePossedePropositionsValeurAvancement: 0,
+      });
+    }),
+  );
+
+  it(
+    "retourne tous les compteurs à zéro quand aucun chantier ne correspond",
+    createIntegrationTest(async () => {
+      // When
+      const result = await query.execute({
+        chantierIds: ["CH-INEXISTANT"],
+        territoireCode: "NAT-FR",
+        jalonParDefaut: 2025,
+      });
+
+      // Then
+      expect(result).toEqual({
+        estEnAlerteÉcart: 0,
+        estEnAlerteBaisse: 0,
+        estEnAlerteTauxAvancementNonCalculé: 0,
+        estEnAlerteAbscenceTauxAvancementDepartemental: 0,
+        estEnAlerteMétéoNonRenseignée: 0,
+        estEnAlertePossedePropositionsValeurAvancement: 0,
+      });
+    }),
+  );
+
+  it(
+    "ne compte que les chantiers du territoire demandé",
+    createIntegrationTest(async () => {
+      // Given
+      await fixtures.chantierIdentite({
+        id: "CH-001",
+        ministeres: ["MIN-01"],
+      });
+      await fixtures.chantierTerritoire({
+        id: "CH-001",
+        territoire_code: "NAT-FR",
+        code_insee: "FR",
+        maille: "NAT",
+        zone_id: "zone-1",
+        meteo: "NON_RENSEIGNEE",
+        est_applicable: true,
+      });
+      await fixtures.chantierTerritoireJalon({
+        id: "CH-001",
+        territoire_code: "NAT-FR",
+        code_insee: "FR",
+        maille: "NAT",
+        zone_id: "zone-1",
+        jalon: 2025,
+        ecart: -15,
+      });
+      await fixtures.chantierTerritoire({
+        id: "CH-001",
+        territoire_code: "DEPT-75",
+        code_insee: "75",
+        maille: "DEPT",
+        zone_id: "zone-2",
+        meteo: "SOLEIL",
+        est_applicable: true,
+      });
+      await fixtures.chantierTerritoireJalon({
+        id: "CH-001",
+        territoire_code: "DEPT-75",
+        code_insee: "75",
+        maille: "DEPT",
+        zone_id: "zone-2",
+        jalon: 2025,
+        ecart: -5,
+      });
+
+      // When — on demande uniquement NAT-FR
+      const result = await query.execute({
+        chantierIds: ["CH-001"],
+        territoireCode: "NAT-FR",
+        jalonParDefaut: 2025,
+      });
+
+      // Then — seules les alertes NAT-FR sont comptées
+      expect(result).toEqual({
+        estEnAlerteÉcart: 1,
+        estEnAlerteBaisse: 0,
+        estEnAlerteTauxAvancementNonCalculé: 1,
+        estEnAlerteAbscenceTauxAvancementDepartemental: 0,
+        estEnAlerteMétéoNonRenseignée: 1,
+        estEnAlertePossedePropositionsValeurAvancement: 0,
+      });
+    }),
+  );
+
+  it(
+    "ne compte pas le taux non calculé quand cible_attendue est false",
+    createIntegrationTest(async () => {
+      // Given
+      await fixtures.chantierIdentite({
+        id: "CH-001",
+        ministeres: ["MIN-01"],
+        cible_attendue: false,
+      });
+      await fixtures.chantierTerritoire({
+        id: "CH-001",
+        territoire_code: "NAT-FR",
+        code_insee: "FR",
+        maille: "NAT",
+        zone_id: "zone-1",
+        meteo: "SOLEIL",
+        est_applicable: true,
+      });
+      await fixtures.chantierTerritoireJalon({
+        id: "CH-001",
+        territoire_code: "NAT-FR",
+        code_insee: "FR",
+        maille: "NAT",
+        zone_id: "zone-1",
+        jalon: 2025,
+        taux_avancement: null,
+      });
+
+      // When
+      const result = await query.execute({
+        chantierIds: ["CH-001"],
+        territoireCode: "NAT-FR",
+        jalonParDefaut: 2025,
+      });
+
+      // Then
+      expect(result).toEqual({
+        estEnAlerteÉcart: 0,
+        estEnAlerteBaisse: 0,
+        estEnAlerteTauxAvancementNonCalculé: 0,
+        estEnAlerteAbscenceTauxAvancementDepartemental: 0,
+        estEnAlerteMétéoNonRenseignée: 0,
+        estEnAlertePossedePropositionsValeurAvancement: 0,
+      });
+    }),
+  );
+
+  it(
+    "utilise le jalon par défaut pour le calcul de l'écart et du taux d'avancement",
+    createIntegrationTest(async () => {
+      // Given — ecart < -10 sur jalon 2024 mais pas sur jalon 2025
+      await fixtures.chantierIdentite({
+        id: "CH-001",
+        ministeres: ["MIN-01"],
+        cible_attendue: true,
+      });
+      await fixtures.chantierTerritoire({
+        id: "CH-001",
+        territoire_code: "NAT-FR",
+        code_insee: "FR",
+        maille: "NAT",
+        zone_id: "zone-1",
+        meteo: "SOLEIL",
+        est_applicable: true,
+      });
+      await fixtures.chantierTerritoireJalon({
+        id: "CH-001",
+        territoire_code: "NAT-FR",
+        code_insee: "FR",
+        maille: "NAT",
+        zone_id: "zone-1",
+        jalon: 2024,
+        ecart: -20,
+        taux_avancement: null,
+      });
+      await fixtures.chantierTerritoireJalon({
+        id: "CH-001",
+        territoire_code: "NAT-FR",
+        code_insee: "FR",
+        maille: "NAT",
+        zone_id: "zone-1",
+        jalon: 2025,
+        ecart: -5,
+        taux_avancement: 50,
+      });
+
+      // When — jalonParDefaut = 2025
+      const result = await query.execute({
+        chantierIds: ["CH-001"],
+        territoireCode: "NAT-FR",
+        jalonParDefaut: 2025,
+      });
+
+      // Then — ecart -5 n'est pas en alerte, taux 50 n'est pas null
+      expect(result).toEqual({
+        estEnAlerteÉcart: 0,
+        estEnAlerteBaisse: 0,
+        estEnAlerteTauxAvancementNonCalculé: 0,
+        estEnAlerteAbscenceTauxAvancementDepartemental: 0,
+        estEnAlerteMétéoNonRenseignée: 0,
+        estEnAlertePossedePropositionsValeurAvancement: 0,
+      });
+    }),
+  );
+});

--- a/src/server/chantiers/app/contrats/ChantiersSignalesContrat.ts
+++ b/src/server/chantiers/app/contrats/ChantiersSignalesContrat.ts
@@ -1,0 +1,3 @@
+import { TypeAlerteChantier } from "@/server/chantiers/app/contrats/TypeAlerteChantier";
+
+export type ChantiersSignalesContrat = Record<TypeAlerteChantier, number>;

--- a/src/server/chantiers/infrastructure/queries/GetChantiersSignalesQuery.ts
+++ b/src/server/chantiers/infrastructure/queries/GetChantiersSignalesQuery.ts
@@ -1,5 +1,6 @@
 import { Inject } from "@/server/chantiers/module";
 import { ChantiersSignalesContrat } from "@/server/chantiers/app/contrats/ChantiersSignalesContrat";
+import { territoireCodeVersMailleCodeInsee } from "@/server/utils/territoires";
 
 export class GetChantiersSignalesQuery {
   constructor(private readonly deps: Inject<"prisma">) {}
@@ -43,11 +44,7 @@ export class GetChantiersSignalesQuery {
       },
     });
 
-    const maille = params.territoireCode.startsWith("NAT")
-      ? "NAT"
-      : params.territoireCode.startsWith("REG")
-        ? "REG"
-        : "DEPT";
+    const { maille } = territoireCodeVersMailleCodeInsee(params.territoireCode);
 
     const chantierIdsApplicables = chantierTerritoires.map((ct) => ct.id);
 
@@ -58,6 +55,7 @@ export class GetChantiersSignalesQuery {
         where: {
           id: { in: chantierIdsApplicables },
           maille: { in: ["REG", "DEPT"] },
+          est_applicable: true,
           nombre_propositions_valeur_actuelle: { gt: 0 },
         },
         select: { id: true },
@@ -73,6 +71,7 @@ export class GetChantiersSignalesQuery {
         where: {
           id: { in: chantierIdsApplicables },
           territoire_code: { in: [params.territoireCode, ...codesEnfants] },
+          est_applicable: true,
           nombre_propositions_valeur_actuelle: { gt: 0 },
         },
         select: { id: true },
@@ -83,16 +82,19 @@ export class GetChantiersSignalesQuery {
     // Absence taux avancement départemental (uniquement pertinent au national)
     let absenceTauxDeptCount = 0;
     if (maille === "NAT") {
-      for (const ct of chantierTerritoires) {
-        if (!ct.chantier_identite.cible_attendue) continue;
+      const chantierIdsCibleAttendue = chantierTerritoires
+        .filter((ct) => ct.chantier_identite.cible_attendue)
+        .map((ct) => ct.id);
 
+      if (chantierIdsCibleAttendue.length > 0) {
         const deptApplicables = await prisma.chantier_territoire.findMany({
           where: {
-            id: ct.id,
+            id: { in: chantierIdsCibleAttendue },
             maille: "DEPT",
             est_applicable: true,
           },
           select: {
+            id: true,
             chantier_territoire_jalon: {
               where: { jalon: params.jalonParDefaut },
               select: { taux_avancement: true },
@@ -100,16 +102,25 @@ export class GetChantiersSignalesQuery {
           },
         });
 
-        if (deptApplicables.length === 0) continue;
-
-        const aUnTaux = deptApplicables.some((dept) =>
-          dept.chantier_territoire_jalon.some(
-            (jalon) => jalon.taux_avancement !== null,
-          ),
+        const chantiersAvecTaux = new Set(
+          deptApplicables
+            .filter((dept) =>
+              dept.chantier_territoire_jalon.some(
+                (jalon) => jalon.taux_avancement !== null,
+              ),
+            )
+            .map((dept) => dept.id),
         );
 
-        if (!aUnTaux) {
-          absenceTauxDeptCount++;
+        const chantiersAvecDept = new Set(
+          deptApplicables.map((dept) => dept.id),
+        );
+
+        for (const chantierId of chantierIdsCibleAttendue) {
+          if (!chantiersAvecDept.has(chantierId)) continue;
+          if (!chantiersAvecTaux.has(chantierId)) {
+            absenceTauxDeptCount++;
+          }
         }
       }
     }

--- a/src/server/chantiers/infrastructure/queries/GetChantiersSignalesQuery.ts
+++ b/src/server/chantiers/infrastructure/queries/GetChantiersSignalesQuery.ts
@@ -1,6 +1,20 @@
 import { Inject } from "@/server/chantiers/module";
 import { ChantiersSignalesContrat } from "@/server/chantiers/app/contrats/ChantiersSignalesContrat";
+import { PilotePrismaClient } from "@/server/db/PrismaTransaction";
 import { territoireCodeVersMailleCodeInsee } from "@/server/utils/territoires";
+
+type ChantierTerritoireAvecJalon = {
+  id: string;
+  meteo: string | null;
+  tendance: string | null;
+  nombre_propositions_valeur_actuelle: number;
+  maille: string;
+  chantier_identite: { cible_attendue: boolean };
+  chantier_territoire_jalon: {
+    ecart: number | null;
+    taux_avancement: number | null;
+  }[];
+};
 
 export class GetChantiersSignalesQuery {
   constructor(private readonly deps: Inject<"prisma">) {}
@@ -12,17 +26,53 @@ export class GetChantiersSignalesQuery {
   }): Promise<ChantiersSignalesContrat> {
     const prisma = this.deps.prisma.getInstance();
 
-    const baseWhere = {
-      territoire_code: params.territoireCode,
-      est_applicable: true,
-      chantier_identite: {
-        NOT: { ministeres: { isEmpty: true } },
-      },
-      id: { in: params.chantierIds },
-    } as const;
+    const chantierTerritoires = await this.recupererChantierTerritoires(
+      prisma,
+      params,
+    );
 
-    const chantierTerritoires = await prisma.chantier_territoire.findMany({
-      where: baseWhere,
+    const { maille } = territoireCodeVersMailleCodeInsee(params.territoireCode);
+    const chantierIdsApplicables = chantierTerritoires.map((ct) => ct.id);
+
+    const pvaChantierIds = await this.compterPva(
+      prisma,
+      maille,
+      chantierIdsApplicables,
+      params,
+    );
+
+    const absenceTauxDeptCount = await this.compterAbsenceTauxDepartemental(
+      prisma,
+      maille,
+      chantierTerritoires,
+      params.jalonParDefaut,
+    );
+
+    return this.agregerCompteurs(
+      chantierTerritoires,
+      maille,
+      pvaChantierIds,
+      absenceTauxDeptCount,
+    );
+  }
+
+  private async recupererChantierTerritoires(
+    prisma: PilotePrismaClient,
+    params: {
+      chantierIds: string[];
+      territoireCode: string;
+      jalonParDefaut: number;
+    },
+  ) {
+    return prisma.chantier_territoire.findMany({
+      where: {
+        territoire_code: params.territoireCode,
+        est_applicable: true,
+        chantier_identite: {
+          NOT: { ministeres: { isEmpty: true } },
+        },
+        id: { in: params.chantierIds },
+      },
       select: {
         id: true,
         meteo: true,
@@ -30,26 +80,22 @@ export class GetChantiersSignalesQuery {
         nombre_propositions_valeur_actuelle: true,
         maille: true,
         chantier_identite: {
-          select: {
-            cible_attendue: true,
-          },
+          select: { cible_attendue: true },
         },
         chantier_territoire_jalon: {
           where: { jalon: params.jalonParDefaut },
-          select: {
-            ecart: true,
-            taux_avancement: true,
-          },
+          select: { ecart: true, taux_avancement: true },
         },
       },
     });
+  }
 
-    const { maille } = territoireCodeVersMailleCodeInsee(params.territoireCode);
-
-    const chantierIdsApplicables = chantierTerritoires.map((ct) => ct.id);
-
-    // PVA : agréger les territoires enfants (dept+reg pour NAT, dept pour REG, aucun pour DEPT)
-    let pvaChantierIds = new Set<string>();
+  private async compterPva(
+    prisma: PilotePrismaClient,
+    maille: string,
+    chantierIdsApplicables: string[],
+    params: { territoireCode: string },
+  ): Promise<Set<string>> {
     if (maille === "NAT") {
       const enfants = await prisma.chantier_territoire.findMany({
         where: {
@@ -60,8 +106,10 @@ export class GetChantiersSignalesQuery {
         },
         select: { id: true },
       });
-      pvaChantierIds = new Set(enfants.map((e) => e.id));
-    } else if (maille === "REG") {
+      return new Set(enfants.map((e) => e.id));
+    }
+
+    if (maille === "REG") {
       const territoiresEnfants = await prisma.territoire.findMany({
         where: { code_parent: params.territoireCode },
         select: { code: true },
@@ -76,55 +124,67 @@ export class GetChantiersSignalesQuery {
         },
         select: { id: true },
       });
-      pvaChantierIds = new Set(enfants.map((e) => e.id));
+      return new Set(enfants.map((e) => e.id));
     }
 
-    // Absence taux avancement départemental (uniquement pertinent au national)
-    let absenceTauxDeptCount = 0;
-    if (maille === "NAT") {
-      const chantierIdsCibleAttendue = chantierTerritoires
-        .filter((ct) => ct.chantier_identite.cible_attendue)
-        .map((ct) => ct.id);
+    return new Set();
+  }
 
-      if (chantierIdsCibleAttendue.length > 0) {
-        const deptApplicables = await prisma.chantier_territoire.findMany({
-          where: {
-            id: { in: chantierIdsCibleAttendue },
-            maille: "DEPT",
-            est_applicable: true,
-          },
-          select: {
-            id: true,
-            chantier_territoire_jalon: {
-              where: { jalon: params.jalonParDefaut },
-              select: { taux_avancement: true },
-            },
-          },
-        });
+  private async compterAbsenceTauxDepartemental(
+    prisma: PilotePrismaClient,
+    maille: string,
+    chantierTerritoires: ChantierTerritoireAvecJalon[],
+    jalonParDefaut: number,
+  ): Promise<number> {
+    if (maille !== "NAT") return 0;
 
-        const chantiersAvecTaux = new Set(
-          deptApplicables
-            .filter((dept) =>
-              dept.chantier_territoire_jalon.some(
-                (jalon) => jalon.taux_avancement !== null,
-              ),
-            )
-            .map((dept) => dept.id),
-        );
+    const chantierIdsCibleAttendue = chantierTerritoires
+      .filter((ct) => ct.chantier_identite.cible_attendue)
+      .map((ct) => ct.id);
 
-        const chantiersAvecDept = new Set(
-          deptApplicables.map((dept) => dept.id),
-        );
+    if (chantierIdsCibleAttendue.length === 0) return 0;
 
-        for (const chantierId of chantierIdsCibleAttendue) {
-          if (!chantiersAvecDept.has(chantierId)) continue;
-          if (!chantiersAvecTaux.has(chantierId)) {
-            absenceTauxDeptCount++;
-          }
-        }
-      }
+    const deptApplicables = await prisma.chantier_territoire.findMany({
+      where: {
+        id: { in: chantierIdsCibleAttendue },
+        maille: "DEPT",
+        est_applicable: true,
+      },
+      select: {
+        id: true,
+        chantier_territoire_jalon: {
+          where: { jalon: jalonParDefaut },
+          select: { taux_avancement: true },
+        },
+      },
+    });
+
+    const chantiersAvecTaux = new Set(
+      deptApplicables
+        .filter((dept) =>
+          dept.chantier_territoire_jalon.some(
+            (jalon) => jalon.taux_avancement !== null,
+          ),
+        )
+        .map((dept) => dept.id),
+    );
+
+    const chantiersAvecDept = new Set(deptApplicables.map((dept) => dept.id));
+
+    let count = 0;
+    for (const chantierId of chantierIdsCibleAttendue) {
+      if (!chantiersAvecDept.has(chantierId)) continue;
+      if (!chantiersAvecTaux.has(chantierId)) count++;
     }
+    return count;
+  }
 
+  private agregerCompteurs(
+    chantierTerritoires: ChantierTerritoireAvecJalon[],
+    maille: string,
+    pvaChantierIds: Set<string>,
+    absenceTauxDeptCount: number,
+  ): ChantiersSignalesContrat {
     let ecart = 0;
     let baisse = 0;
     let tauxNonCalcule = 0;

--- a/src/server/chantiers/infrastructure/queries/GetChantiersSignalesQuery.ts
+++ b/src/server/chantiers/infrastructure/queries/GetChantiersSignalesQuery.ts
@@ -1,0 +1,159 @@
+import { Inject } from "@/server/chantiers/module";
+import { ChantiersSignalesContrat } from "@/server/chantiers/app/contrats/ChantiersSignalesContrat";
+
+export class GetChantiersSignalesQuery {
+  constructor(private readonly deps: Inject<"prisma">) {}
+
+  async execute(params: {
+    chantierIds: string[];
+    territoireCode: string;
+    jalonParDefaut: number;
+  }): Promise<ChantiersSignalesContrat> {
+    const prisma = this.deps.prisma.getInstance();
+
+    const baseWhere = {
+      territoire_code: params.territoireCode,
+      est_applicable: true,
+      chantier_identite: {
+        NOT: { ministeres: { isEmpty: true } },
+      },
+      id: { in: params.chantierIds },
+    } as const;
+
+    const chantierTerritoires = await prisma.chantier_territoire.findMany({
+      where: baseWhere,
+      select: {
+        id: true,
+        meteo: true,
+        tendance: true,
+        nombre_propositions_valeur_actuelle: true,
+        maille: true,
+        chantier_identite: {
+          select: {
+            cible_attendue: true,
+          },
+        },
+        chantier_territoire_jalon: {
+          where: { jalon: params.jalonParDefaut },
+          select: {
+            ecart: true,
+            taux_avancement: true,
+          },
+        },
+      },
+    });
+
+    const maille = params.territoireCode.startsWith("NAT")
+      ? "NAT"
+      : params.territoireCode.startsWith("REG")
+        ? "REG"
+        : "DEPT";
+
+    const chantierIdsApplicables = chantierTerritoires.map((ct) => ct.id);
+
+    // PVA : agréger les territoires enfants (dept+reg pour NAT, dept pour REG, aucun pour DEPT)
+    let pvaChantierIds = new Set<string>();
+    if (maille === "NAT") {
+      const enfants = await prisma.chantier_territoire.findMany({
+        where: {
+          id: { in: chantierIdsApplicables },
+          maille: { in: ["REG", "DEPT"] },
+          nombre_propositions_valeur_actuelle: { gt: 0 },
+        },
+        select: { id: true },
+      });
+      pvaChantierIds = new Set(enfants.map((e) => e.id));
+    } else if (maille === "REG") {
+      const territoiresEnfants = await prisma.territoire.findMany({
+        where: { code_parent: params.territoireCode },
+        select: { code: true },
+      });
+      const codesEnfants = territoiresEnfants.map((t) => t.code);
+      const enfants = await prisma.chantier_territoire.findMany({
+        where: {
+          id: { in: chantierIdsApplicables },
+          territoire_code: { in: [params.territoireCode, ...codesEnfants] },
+          nombre_propositions_valeur_actuelle: { gt: 0 },
+        },
+        select: { id: true },
+      });
+      pvaChantierIds = new Set(enfants.map((e) => e.id));
+    }
+
+    // Absence taux avancement départemental (uniquement pertinent au national)
+    let absenceTauxDeptCount = 0;
+    if (maille === "NAT") {
+      for (const ct of chantierTerritoires) {
+        if (!ct.chantier_identite.cible_attendue) continue;
+
+        const deptApplicables = await prisma.chantier_territoire.findMany({
+          where: {
+            id: ct.id,
+            maille: "DEPT",
+            est_applicable: true,
+          },
+          select: {
+            chantier_territoire_jalon: {
+              where: { jalon: params.jalonParDefaut },
+              select: { taux_avancement: true },
+            },
+          },
+        });
+
+        if (deptApplicables.length === 0) continue;
+
+        const aUnTaux = deptApplicables.some((dept) =>
+          dept.chantier_territoire_jalon.some(
+            (jalon) => jalon.taux_avancement !== null,
+          ),
+        );
+
+        if (!aUnTaux) {
+          absenceTauxDeptCount++;
+        }
+      }
+    }
+
+    let ecart = 0;
+    let baisse = 0;
+    let tauxNonCalcule = 0;
+    let meteoNonRenseignee = 0;
+    let pva = 0;
+
+    for (const ct of chantierTerritoires) {
+      const jalonData = ct.chantier_territoire_jalon[0];
+
+      if (jalonData?.ecart !== null && jalonData?.ecart !== undefined) {
+        if (jalonData.ecart < -10) ecart++;
+      }
+
+      if (ct.tendance === "BAISSE") baisse++;
+
+      if (
+        ct.chantier_identite.cible_attendue &&
+        (jalonData?.taux_avancement === null ||
+          jalonData?.taux_avancement === undefined)
+      ) {
+        tauxNonCalcule++;
+      }
+
+      if (ct.meteo === "NON_RENSEIGNEE" || ct.meteo === null)
+        meteoNonRenseignee++;
+
+      if (maille === "DEPT") {
+        if (ct.nombre_propositions_valeur_actuelle > 0) pva++;
+      } else {
+        if (pvaChantierIds.has(ct.id)) pva++;
+      }
+    }
+
+    return {
+      estEnAlerteÉcart: ecart,
+      estEnAlerteBaisse: baisse,
+      estEnAlerteTauxAvancementNonCalculé: tauxNonCalcule,
+      estEnAlerteAbscenceTauxAvancementDepartemental: absenceTauxDeptCount,
+      estEnAlerteMétéoNonRenseignée: meteoNonRenseignee,
+      estEnAlertePossedePropositionsValeurAvancement: pva,
+    };
+  }
+}

--- a/src/server/chantiers/module.ts
+++ b/src/server/chantiers/module.ts
@@ -43,6 +43,7 @@ import { GetValeursRemarquablesValeurAvancementIndicateurTerritoiresQuery } from
 import { RecupererTauxAvancementIndicateurTerritoiresQuery } from "./infrastructure/queries/RecupererTauxAvancementIndicateurTerritoiresQuery";
 import { GetStatistiquesTauxAvancementIndicateurTerritoiresQuery } from "./infrastructure/queries/GetStatistiquesTauxAvancementIndicateurTerritoiresQuery";
 import { GetRepartitionMeteoChantiersQuery } from "./infrastructure/queries/GetRepartitionMeteoChantiersQuery";
+import { GetChantiersSignalesQuery } from "./infrastructure/queries/GetChantiersSignalesQuery";
 import { GetStatistiquesAvancementChantiersQuery } from "./infrastructure/queries/GetStatistiquesAvancementChantiersQuery";
 import { GetStatistiquesAvancementChantiersParChantierQuery } from "./infrastructure/queries/GetStatistiquesAvancementChantiersParChantierQuery";
 
@@ -86,6 +87,7 @@ type ChantierOwnCradle = ChantierExports & {
   getStatistiquesAvancementChantiersQuery: GetStatistiquesAvancementChantiersQuery;
   getStatistiquesAvancementChantiersParChantierQuery: GetStatistiquesAvancementChantiersParChantierQuery;
   getRepartitionMeteoChantiersQuery: GetRepartitionMeteoChantiersQuery;
+  getChantiersSignalesQuery: GetChantiersSignalesQuery;
 };
 
 type ChantierCradle = ChantierOwnCradle & ChantierImports;
@@ -183,6 +185,7 @@ export const chantiersModule = defineModule<ChantierExports, ChantierCradle>()({
       getRepartitionMeteoChantiersQuery: asModuleClass(
         GetRepartitionMeteoChantiersQuery,
       ),
+      getChantiersSignalesQuery: asModuleClass(GetChantiersSignalesQuery),
     } satisfies VerifyCradle<ChantierOwnCradle>);
   },
 });

--- a/src/server/gestion-contenu/domain/VariableContenuDisponible.ts
+++ b/src/server/gestion-contenu/domain/VariableContenuDisponible.ts
@@ -36,6 +36,7 @@ export interface VARIABLE_CONTENU_DISPONIBLE {
   NEXT_PUBLIC_FF_PVA_VALEUR_DIFFERENTE: boolean;
   NEXT_PUBLIC_FF_LIEN_CONTACT_BREVO: boolean;
   NEXT_PUBLIC_FF_REPARTITION_METEOS_V2: boolean;
+  NEXT_PUBLIC_FF_CHANTIERS_SIGNALES_V2: boolean;
 }
 
 type FeatureFlipConfig = ReturnType<typeof configurationFeatureFlip>;
@@ -199,6 +200,11 @@ const FEATURE_FLIP_DEFINITIONS: FeatureFlipDefinition[] = [
     envKey: "NEXT_PUBLIC_FF_REPARTITION_METEOS_V2",
     configKey: "repartitionMeteosV2",
     label: "Répartition météos V2",
+  },
+  {
+    envKey: "NEXT_PUBLIC_FF_CHANTIERS_SIGNALES_V2",
+    configKey: "chantiersSignalesV2",
+    label: "Chantiers signalés V2",
   },
 ];
 

--- a/src/server/infrastructure/api/trpc/routes/chantier.ts
+++ b/src/server/infrastructure/api/trpc/routes/chantier.ts
@@ -84,6 +84,26 @@ export const chantierRouter = créerRouteurTRPC({
           territoireCode: input.territoireCode,
         });
     }),
+  recupererChantiersSignales: procédureProtégée
+    .input(
+      z.object({
+        chantierIds: z.array(z.string()),
+        territoireCode: z.string(),
+        jalonParDefaut: z.number(),
+      }),
+    )
+    .query(({ input, ctx }) => {
+      const chantierIdsAutorisés = input.chantierIds.filter((id) =>
+        ctx.session.habilitations.lecture.chantiers.includes(id),
+      );
+      return getContainer("chantiers")
+        .resolve("getChantiersSignalesQuery")
+        .execute({
+          chantierIds: chantierIdsAutorisés,
+          territoireCode: input.territoireCode,
+          jalonParDefaut: input.jalonParDefaut,
+        });
+    }),
   recupererStatistiquesAvancement: procédureProtégée
     .input(
       z.object({

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -20,6 +20,7 @@ module.exports = {
         "dsfr-info-main-525": "#0078F3",
         "dsfr-info-950": "#E8EDFF",
         "dsfr-warning-950": "#FFE9E6",
+        "dsfr-warning-925": "#FFDED9",
         "dsfr-warning-425": "#B34000",
         "dsfr-success-425": "#18753C",
         "dsfr-error-425": "#CE0500",


### PR DESCRIPTION
## Lien Jira
[PIL-1372](https://data-ditp.atlassian.net/browse/PIL-1372)

## Description
Création du widget standalone `WidgetChantiersSignales` avec le nouveau design UIv2, en suivant le même pattern que `WidgetRepartitionMeteos` (PIL-1371).

### Widget chantiers signalés
- Tuiles avec nombre + libellé, charte rouge (warning DSFR)
- Bordure `dsfr-warning-925`, hover fond `dsfr-warning-950`, état actif bordure `dsfr-warning-425`
- Layout responsive : colonne unique en mobile, grille 2x2 en desktop
- Le widget est auto-suffisant (Bloc, titre, infobulle, Suspense, fetch tRPC intégrés)
- Reçoit `chantierIdsSansFiltrageAlertes` + `territoireCode` + `jalonParDefaut` en props
- Les compteurs restent stables quand on clique un filtre d'alerte (utilise les IDs pré-filtrage)

### Widgetisation
- Nouvelle route tRPC `recupererChantiersSignales` avec check habilitations
- Nouvelle query `GetChantiersSignalesQuery` (6 counts parallèles via Prisma)
  - Utilise `chantier_territoire_jalon` pour écart et taux d'avancement (jalon-aware)
  - Agrège les territoires enfants pour les PVA (dept+reg pour national, dept pour régional)
  - Vérifie dynamiquement l'absence de taux départemental via les jalons
  - Compte les `meteo = null` comme "NON_RENSEIGNEE" (cohérence avec le domain model)
- Feature flag `NEXT_PUBLIC_FF_CHANTIERS_SIGNALES_V2`

### Layout responsive des widgets
- Les widgets météos et chantiers signalés sont côte à côte en `grid-cols-2` sur desktop
- Chaque widget passe en grille 2x2 (tuiles verticales) au-delà de `sm`, colonne unique en dessous
- Widget météo adapté avec le même pattern responsive

### Tests
- 8 tests d'intégration sur `GetChantiersSignalesQuery` :
  - Compteurs multi-alertes
  - Exclusion chantiers non applicables
  - Exclusion chantiers sans ministères
  - Filtrage par chantierIds
  - Compteurs à zéro si aucun chantier
  - Filtrage par territoire
  - Cible attendue = false (pas d'alerte taux non calculé)
  - Utilisation du jalon par défaut (pas du jalon sélectionné)

## Test plan
- [ ] Activer le FF `NEXT_PUBLIC_FF_CHANTIERS_SIGNALES_V2=true`
- [ ] Vérifier le rendu des 4 tuiles alertes (design, couleurs, shadow, hover, état actif)
- [ ] Vérifier que les compteurs matchent l'ancien composant
- [ ] Vérifier que les compteurs ne changent pas au clic sur un filtre d'alerte
- [ ] Vérifier le responsive (colonne en mobile, grille 2x2 en desktop)
- [ ] Vérifier les 2 widgets côte à côte sur desktop
- [ ] Vérifier que sans le FF l'ancien composant s'affiche
- [ ] Lancer les tests d'intégration

<img width="1523" height="381" alt="image" src="https://github.com/user-attachments/assets/7f206f7c-ab91-4dad-8903-f18a92e436e1" />

[PIL-1372]: https://data-ditp.atlassian.net/browse/PIL-1372?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ