### PR TITLE
feat: étendre l'envoi du rapport hebdomadaire aux utilisateurs SECRETARIAT_GENERAL (PIL-1325)

### DIFF
--- a/src/server/chantiers/__tests__/infrastructure/adapters/PrismaUtilisateurRepository.integration.test.ts
+++ b/src/server/chantiers/__tests__/infrastructure/adapters/PrismaUtilisateurRepository.integration.test.ts
@@ -296,10 +296,13 @@ describe("PrismaUtilisateurRepository", () => {
         );
 
       // Then
-      expect(utilisateurs).toEqual([
-        expect.objectContaining({ email: "dir.projet.mp@test.com" }),
-        expect.objectContaining({ email: "sec.general.mp@test.com" }),
-      ]);
+      expect(utilisateurs).toHaveLength(2);
+      expect(utilisateurs).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ email: "dir.projet.mp@test.com" }),
+          expect.objectContaining({ email: "sec.general.mp@test.com" }),
+        ]),
+      );
     });
 
     it("ne doit pas récupérer les utilisateurs ayant uniquement des périmètres sans chantiers correspondants", async () => {

--- a/src/server/chantiers/__tests__/infrastructure/adapters/PrismaUtilisateurRepository.integration.test.ts
+++ b/src/server/chantiers/__tests__/infrastructure/adapters/PrismaUtilisateurRepository.integration.test.ts
@@ -90,7 +90,7 @@ describe("PrismaUtilisateurRepository", () => {
       // When
       const utilisateurs =
         await prismaUtilisateurRepository.recupererUtilisateursParProfilEtChantierIds(
-          "EQUIPE_DIR_PROJET",
+          ["EQUIPE_DIR_PROJET"],
           ["CH-001", "CH-004"],
         );
       // Then
@@ -163,7 +163,7 @@ describe("PrismaUtilisateurRepository", () => {
       // When
       const utilisateurs =
         await prismaUtilisateurRepository.recupererUtilisateursParProfilEtChantierIds(
-          "EQUIPE_DIR_PROJET",
+          ["EQUIPE_DIR_PROJET"],
           ["CH-100", "CH-101"],
         );
 
@@ -223,7 +223,7 @@ describe("PrismaUtilisateurRepository", () => {
       // When
       const utilisateurs =
         await prismaUtilisateurRepository.recupererUtilisateursParProfilEtChantierIds(
-          "EQUIPE_DIR_PROJET",
+          ["EQUIPE_DIR_PROJET"],
           ["CH-200", "CH-201", "CH-202"],
         );
 
@@ -234,6 +234,71 @@ describe("PrismaUtilisateurRepository", () => {
         "CH-202",
         "CH-200",
         "CH-201",
+      ]);
+    });
+
+    it("doit récupérer les utilisateurs de plusieurs profils en même temps", async () => {
+      // Given
+      await prisma.utilisateur.createMany({
+        data: [
+          {
+            id: "a3f1e2d4-0001-4000-8000-000000000001",
+            email: "dir.projet.mp@test.com",
+            nom: "Projet",
+            prenom: "Dir",
+            profilCode: "EQUIPE_DIR_PROJET",
+            date_creation: new Date(),
+          },
+          {
+            id: "a3f1e2d4-0002-4000-8000-000000000002",
+            email: "sec.general.mp@test.com",
+            nom: "General",
+            prenom: "Sec",
+            profilCode: "SECRETARIAT_GENERAL",
+            date_creation: new Date(),
+          },
+          {
+            id: "a3f1e2d4-0003-4000-8000-000000000003",
+            email: "coord.region.mp@test.com",
+            nom: "Region",
+            prenom: "Coord",
+            profilCode: "COORDINATEUR_REGION",
+            date_creation: new Date(),
+          },
+        ],
+      });
+
+      await prisma.habilitation.createMany({
+        data: [
+          {
+            utilisateurId: "a3f1e2d4-0001-4000-8000-000000000001",
+            scopeCode: "lecture",
+            chantiers: ["CH-MP-001"],
+          },
+          {
+            utilisateurId: "a3f1e2d4-0002-4000-8000-000000000002",
+            scopeCode: "lecture",
+            chantiers: ["CH-MP-001"],
+          },
+          {
+            utilisateurId: "a3f1e2d4-0003-4000-8000-000000000003",
+            scopeCode: "lecture",
+            chantiers: ["CH-MP-001"],
+          },
+        ],
+      });
+
+      // When
+      const utilisateurs =
+        await prismaUtilisateurRepository.recupererUtilisateursParProfilEtChantierIds(
+          ["EQUIPE_DIR_PROJET", "SECRETARIAT_GENERAL"],
+          ["CH-MP-001"],
+        );
+
+      // Then
+      expect(utilisateurs).toEqual([
+        expect.objectContaining({ email: "dir.projet.mp@test.com" }),
+        expect.objectContaining({ email: "sec.general.mp@test.com" }),
       ]);
     });
 
@@ -270,7 +335,7 @@ describe("PrismaUtilisateurRepository", () => {
       // When
       const utilisateurs =
         await prismaUtilisateurRepository.recupererUtilisateursParProfilEtChantierIds(
-          "EQUIPE_DIR_PROJET",
+          ["EQUIPE_DIR_PROJET"],
           ["CH-300"],
         );
 

--- a/src/server/chantiers/__tests__/usecases/CreerLesRapportsPropositionsUseCase.unit.test.ts
+++ b/src/server/chantiers/__tests__/usecases/CreerLesRapportsPropositionsUseCase.unit.test.ts
@@ -487,6 +487,12 @@ describe("CreerLesRapportsPropositionsUseCase", () => {
 
     // Then
     expect(
+      utilisateurRepository.recupererUtilisateursParProfilEtChantierIds,
+    ).toHaveBeenCalledWith(
+      ["EQUIPE_DIR_PROJET", "SECRETARIAT_GENERAL"],
+      expect.any(Array),
+    );
+    expect(
       rapportPropositionsAvancementRepository.sauvegarder,
     ).toHaveBeenCalledTimes(2);
     expect(resultat).toEqual({

--- a/src/server/chantiers/__tests__/usecases/CreerLesRapportsPropositionsUseCase.unit.test.ts
+++ b/src/server/chantiers/__tests__/usecases/CreerLesRapportsPropositionsUseCase.unit.test.ts
@@ -428,6 +428,73 @@ describe("CreerLesRapportsPropositionsUseCase", () => {
     });
   });
 
+  it("crée des rapports pour des utilisateurs de profils EQUIPE_DIR_PROJET et SECRETARIAT_GENERAL", async () => {
+    // Given
+    const propositionsParChantier = creerPropositionsParChantier([
+      {
+        chantierId: "CH-001",
+        indicateurId: "IND-001",
+        proposition: {
+          indicateurId: "IND-001",
+          territoireCode: "DEPT-01",
+          dateValeurAvancement: "2026-02-01",
+          valeurAvancementProposee: "75",
+          valeurAvancementReference: "70",
+          nomIndicateur: "Indicateur 1",
+          uniteIndicateur: "%",
+          nomTerritoire: "Ain",
+        },
+      },
+    ]);
+
+    indicateurTerritoireValeurEvenementRepository.recupererLesPropositionsEnCoursParChantierIds.mockResolvedValue(
+      propositionsParChantier,
+    );
+    indicateurRepository.recupererIndicateursNonAJourParChantierId.mockResolvedValue(
+      new Map(),
+    );
+    utilisateurRepository.recupererUtilisateursParProfilEtChantierIds.mockResolvedValue(
+      [
+        Utilisateur.creerUtilisateur({
+          id: "user-dir",
+          email: "directeur@test.com",
+          nom: "Dupont",
+          prenom: "Jean",
+          listeChantiers: ["CH-001"],
+        }),
+        Utilisateur.creerUtilisateur({
+          id: "user-sec",
+          email: "secgeneral@test.com",
+          nom: "Martin",
+          prenom: "Claire",
+          listeChantiers: ["CH-001"],
+        }),
+      ],
+    );
+    chantierRepository.recupererListePropositionValeurAvancementChantierInformationParChantiersIds.mockResolvedValue(
+      [
+        {
+          id: "CH-001",
+          nom: "Chantier 1",
+          statut: "PUBLIE",
+          conseillerMail: "conseiller@test.com",
+        },
+      ],
+    );
+
+    // When
+    const resultat = await useCase.run();
+
+    // Then
+    expect(
+      rapportPropositionsAvancementRepository.sauvegarder,
+    ).toHaveBeenCalledTimes(2);
+    expect(resultat).toEqual({
+      rapportsCrees: 2,
+      erreursCreation: 0,
+    });
+  });
+
   it("stoppe le script si une erreur survient avant la boucle de création", async () => {
     // Given
     indicateurTerritoireValeurEvenementRepository.recupererLesPropositionsEnCoursParChantierIds.mockRejectedValue(

--- a/src/server/chantiers/domain/ports/UtilisateurRepository.ts
+++ b/src/server/chantiers/domain/ports/UtilisateurRepository.ts
@@ -2,7 +2,7 @@ import { Utilisateur } from "@/server/chantiers/domain/Utilisateur";
 
 export interface UtilisateurRepository {
   recupererUtilisateursParProfilEtChantierIds: (
-    profilCode: string,
+    profilCodes: string[],
     listeChantierIds: string[],
   ) => Promise<Utilisateur[]>;
 }

--- a/src/server/chantiers/infrastructure/adapters/PrismaUtilisateurRepository.ts
+++ b/src/server/chantiers/infrastructure/adapters/PrismaUtilisateurRepository.ts
@@ -4,7 +4,7 @@ import { prisma } from "@/server/db/prisma";
 
 export class PrismaUtilisateurRepository implements UtilisateurRepository {
   async recupererUtilisateursParProfilEtChantierIds(
-    profilCode: string,
+    profilCodes: string[],
     listeChantierIds: string[],
   ): Promise<Utilisateur[]> {
     const chantiers = await prisma.chantier_identite.findMany({
@@ -29,7 +29,7 @@ export class PrismaUtilisateurRepository implements UtilisateurRepository {
 
     const utilisateurs = await prisma.utilisateur.findMany({
       where: {
-        profilCode: profilCode,
+        profilCode: { in: profilCodes },
         date_desactivation: null,
         habilitation: {
           some: {

--- a/src/server/chantiers/usecases/CreerLesRapportsPropositionsUseCase.ts
+++ b/src/server/chantiers/usecases/CreerLesRapportsPropositionsUseCase.ts
@@ -45,7 +45,7 @@ export class CreerLesRapportsPropositionsUseCase {
       ]),
     ];
 
-    const listeDirecteursDeProjet =
+    const listeDestinatairesRapport =
       await this.dependencies.utilisateurRepository.recupererUtilisateursParProfilEtChantierIds(
         ["EQUIPE_DIR_PROJET", "SECRETARIAT_GENERAL"],
         listeChantiersIdsRapport,
@@ -63,11 +63,11 @@ export class CreerLesRapportsPropositionsUseCase {
     let rapportsCrees = 0;
     let erreursCreation = 0;
 
-    for (const directeur of listeDirecteursDeProjet) {
+    for (const destinataire of listeDestinatairesRapport) {
       try {
         if (
           !this.directeurADesChantiersConcernes(
-            directeur.listeChantiers,
+            destinataire.listeChantiers,
             propositionsParChantier,
             indicateursNonAJourParChantier,
             indicateursAParametrerParChantier,
@@ -77,7 +77,7 @@ export class CreerLesRapportsPropositionsUseCase {
         }
 
         const contenuRapport = genererParametresEnvoieRapportProposition(
-          directeur.listeChantiers,
+          destinataire.listeChantiers,
           mapChantiersPropositionInformation,
           propositionsParChantier,
           indicateursNonAJourParChantier,
@@ -86,8 +86,8 @@ export class CreerLesRapportsPropositionsUseCase {
 
         const rapport = creerRapportPropositionsAvancement({
           utilisateur: {
-            id: directeur.id,
-            email: directeur.email,
+            id: destinataire.id,
+            email: destinataire.email,
           },
           contenuRapport,
           dateCreation: new Date(),
@@ -99,7 +99,7 @@ export class CreerLesRapportsPropositionsUseCase {
         rapportsCrees++;
       } catch (error) {
         logger.error(
-          `Erreur lors de la création du rapport pour ${directeur.email}:`,
+          `Erreur lors de la création du rapport pour ${destinataire.email}:`,
           error,
         );
         erreursCreation++;

--- a/src/server/chantiers/usecases/CreerLesRapportsPropositionsUseCase.ts
+++ b/src/server/chantiers/usecases/CreerLesRapportsPropositionsUseCase.ts
@@ -47,7 +47,7 @@ export class CreerLesRapportsPropositionsUseCase {
 
     const listeDirecteursDeProjet =
       await this.dependencies.utilisateurRepository.recupererUtilisateursParProfilEtChantierIds(
-        "EQUIPE_DIR_PROJET",
+        ["EQUIPE_DIR_PROJET", "SECRETARIAT_GENERAL"],
         listeChantiersIdsRapport,
       );
 


### PR DESCRIPTION
## Contexte

[PIL-1325](https://ditp-pilotage.atlassian.net/browse/PIL-1325)

Le rapport hebdomadaire de propositions d'avancement était envoyé uniquement aux utilisateurs `EQUIPE_DIR_PROJET`. Cette PR étend l'envoi aux utilisateurs `SECRETARIAT_GENERAL`.

## Changements

- `UtilisateurRepository` — `recupererUtilisateursParProfilEtChantierIds` accepte désormais `profilCodes: string[]` au lieu d'un seul `profilCode: string`
- `PrismaUtilisateurRepository` — clause Prisma mise à jour : `profilCode: { in: profilCodes }`
- `CreerLesRapportsPropositionsUseCase` — appel avec `["EQUIPE_DIR_PROJET", "SECRETARIAT_GENERAL"]` en une seule requête
- Tests d'intégration : 4 appels existants mis à jour + 1 test multi-profils ajouté
- Tests unitaires : 1 test ajouté pour les profils mixtes

## Test plan

- [ ] `npm run test:server` — tests unitaires et d'intégration passent
- [ ] `npm run lint` — aucune erreur

[PIL-1325]: https://data-ditp.atlassian.net/browse/PIL-1325?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ