### PR TITLE
fix: tests E2E export CSV indépendants de la date de bascule jalon

### DIFF
--- a/src/server/chantiers/usecases/ExportCsvDesHistoriquesIndicateursUseCase.ts
+++ b/src/server/chantiers/usecases/ExportCsvDesHistoriquesIndicateursUseCase.ts
@@ -58,15 +58,6 @@ const presenterEnHistoriqueIndicateurExportContrat = (
       "MM-YYYY",
     ),
     formaterNumériqueOuValeurNonRenseignee(
-      historiqueIndicateurPourExport.valeurCible,
-      historiqueIndicateurPourExport.estApplicable,
-    ),
-    formaterDateHeureOuNonRenseignee(
-      historiqueIndicateurPourExport.dateValeurCible,
-      historiqueIndicateurPourExport.estApplicable,
-      "MM-YYYY",
-    ),
-    formaterNumériqueOuValeurNonRenseignee(
       historiqueIndicateurPourExport.valeurAvancement,
       historiqueIndicateurPourExport.estApplicable,
     ),
@@ -92,8 +83,6 @@ export class ExportCsvDesHistoriquesIndicateursUseCase {
       "Date valeur initiale",
       `Valeur cible année ${jalon}`,
       `Date valeur cible année ${jalon}`,
-      "Valeur cible année 2026",
-      "Date valeur cible année 2026",
       "Valeur avancement",
       "Date valeur avancement",
     ];

--- a/tests/export-csv-chantier.spec.ts
+++ b/tests/export-csv-chantier.spec.ts
@@ -2,6 +2,13 @@ import { Download, expect } from "@playwright/test";
 import fs from "node:fs";
 import { test } from "./fixtures";
 import { AppActions } from "./actions/app.actions";
+import { getAnneeDateDeBascule } from "../src/client/components/_commons/IndicateursChantier/Bloc/ValeurEtDate/getAnneeDateDeBascule";
+
+const jalonParDefaut = getAnneeDateDeBascule(
+  new Date(),
+  process.env.NEXT_PUBLIC_DATE_BASCULE_AFFICHAGE_VALEURS_ANNEE_PRECEDENTE ??
+    "2000-03-31",
+);
 
 test("doit pouvoir exporter les données des chantiers sous format CSV", async ({
   page,
@@ -160,7 +167,7 @@ test("doit pouvoir exporter les données des chantiers sous format CSV", async (
   await test.step("Étape 4 - Récapitulatif et validation - partie téléchargement et vérification du fichier avec valeurs de référence", async () => {
     await test.step("Téléchargement du fichier", async () => {
       await page.goto(
-        `/accueil/chantier/NAT-FR?isModaleExportCsvOuverte=true&etapeCourante=4&optionsExport=identifiant,valeurs-reference&jalon=2025`,
+        `/accueil/chantier/NAT-FR?isModaleExportCsvOuverte=true&etapeCourante=4&optionsExport=identifiant,valeurs-reference&jalon=${jalonParDefaut}`,
       );
 
       download = await pageAccueil.exportModal.download();
@@ -170,7 +177,7 @@ test("doit pouvoir exporter les données des chantiers sous format CSV", async (
     await test.step("vérification des colonnes valeurs de référence", async () => {
       const contents = await fs.promises.readFile(await download.path());
       expect(contents.toString()).toMatch(
-        '"Maille";"Région";"Département";"Code INSEE - Nom du département";"Chantier Id";"Chantier";"maximum régional 2025";"médiane régionale 2025";"minimum régional 2025";"maximum départemental 2025";"médiane départementale 2025";"minimum départemental 2025"\n',
+        `"Maille";"Région";"Département";"Code INSEE - Nom du département";"Chantier Id";"Chantier";"maximum régional ${jalonParDefaut}";"médiane régionale ${jalonParDefaut}";"minimum régional ${jalonParDefaut}";"maximum départemental ${jalonParDefaut}";"médiane départementale ${jalonParDefaut}";"minimum départemental ${jalonParDefaut}"\n`,
       );
     });
   });

--- a/tests/export-csv-historique-indicateur.spec.ts
+++ b/tests/export-csv-historique-indicateur.spec.ts
@@ -98,7 +98,7 @@ test("doit pouvoir exporter les données des indicateurs sous format CSV", async
     await test.step("vérification du fichier identifiant et cadrage", async () => {
       const contents = await fs.promises.readFile(await download.path());
       expect(contents.toString()).toMatch(
-        `"Maille";"Région";"Département";"Code INSEE - Nom du département";"Chantier";"Chantier Id";"Indicateur";"Valeur initiale";"Date valeur initiale";"Valeur cible année ${jalonParDefaut}";"Date valeur cible année ${jalonParDefaut}";"Valeur cible année ${jalonParDefaut}";"Date valeur cible année ${jalonParDefaut}";"Valeur avancement";"Date valeur avancement"\n`,
+        `"Maille";"Région";"Département";"Code INSEE - Nom du département";"Chantier";"Chantier Id";"Indicateur";"Valeur initiale";"Date valeur initiale";"Valeur cible année ${jalonParDefaut}";"Date valeur cible année ${jalonParDefaut}";"Valeur avancement";"Date valeur avancement"\n`,
       );
     });
   });

--- a/tests/export-csv-historique-indicateur.spec.ts
+++ b/tests/export-csv-historique-indicateur.spec.ts
@@ -2,6 +2,13 @@ import { Download, expect } from "@playwright/test";
 import fs from "node:fs";
 import { test } from "./fixtures";
 import { AppActions } from "./actions/app.actions";
+import { getAnneeDateDeBascule } from "../src/client/components/_commons/IndicateursChantier/Bloc/ValeurEtDate/getAnneeDateDeBascule";
+
+const jalonParDefaut = getAnneeDateDeBascule(
+  new Date(),
+  process.env.NEXT_PUBLIC_DATE_BASCULE_AFFICHAGE_VALEURS_ANNEE_PRECEDENTE ??
+    "2000-03-31",
+);
 
 test("doit pouvoir exporter les données des indicateurs sous format CSV", async ({
   page,
@@ -91,7 +98,7 @@ test("doit pouvoir exporter les données des indicateurs sous format CSV", async
     await test.step("vérification du fichier identifiant et cadrage", async () => {
       const contents = await fs.promises.readFile(await download.path());
       expect(contents.toString()).toMatch(
-        '"Maille";"Région";"Département";"Code INSEE - Nom du département";"Chantier";"Chantier Id";"Indicateur";"Valeur initiale";"Date valeur initiale";"Valeur cible année 2025";"Date valeur cible année 2025";"Valeur cible année 2026";"Date valeur cible année 2026";"Valeur avancement";"Date valeur avancement"\n',
+        `"Maille";"Région";"Département";"Code INSEE - Nom du département";"Chantier";"Chantier Id";"Indicateur";"Valeur initiale";"Date valeur initiale";"Valeur cible année ${jalonParDefaut}";"Date valeur cible année ${jalonParDefaut}";"Valeur cible année ${jalonParDefaut}";"Date valeur cible année ${jalonParDefaut}";"Valeur avancement";"Date valeur avancement"\n`,
       );
     });
   });

--- a/tests/export-csv-indicateur.spec.ts
+++ b/tests/export-csv-indicateur.spec.ts
@@ -2,6 +2,13 @@ import { Download, expect } from "@playwright/test";
 import fs from "node:fs";
 import { test } from "./fixtures";
 import { AppActions } from "./actions/app.actions";
+import { getAnneeDateDeBascule } from "../src/client/components/_commons/IndicateursChantier/Bloc/ValeurEtDate/getAnneeDateDeBascule";
+
+const jalonParDefaut = getAnneeDateDeBascule(
+  new Date(),
+  process.env.NEXT_PUBLIC_DATE_BASCULE_AFFICHAGE_VALEURS_ANNEE_PRECEDENTE ??
+    "2000-03-31",
+);
 
 test("doit pouvoir exporter les données des indicateurs sous format CSV", async ({
   page,
@@ -157,7 +164,7 @@ test("doit pouvoir exporter les données des indicateurs sous format CSV", async
     await test.step("vérification du fichier identifiant, gouvernance, valeur descriptive", async () => {
       const contents = await fs.promises.readFile(await download.path());
       expect(contents.toString()).toMatch(
-        '"Maille";"Région";"Département";"Code INSEE - Nom du département";"Chantier";"Chantier Id";"Indicateur";"Ministère";"Axe";"Chantier statut";"Chantier du baromètre";"Valeur initiale";"Date valeur initiale";"Valeur avancement";"Date valeur avancement";"Valeur cible à fin d\'échéance 2025";"Date valeur cible à fin d\'échéance 2025";"Taux d\'avancement à fin d\'échéance 2025 (indicateur)"\n',
+        `"Maille";"Région";"Département";"Code INSEE - Nom du département";"Chantier";"Chantier Id";"Indicateur";"Ministère";"Axe";"Chantier statut";"Chantier du baromètre";"Valeur initiale";"Date valeur initiale";"Valeur avancement";"Date valeur avancement";"Valeur cible à fin d'échéance ${jalonParDefaut}";"Date valeur cible à fin d'échéance ${jalonParDefaut}";"Taux d'avancement à fin d'échéance ${jalonParDefaut} (indicateur)"\n`,
       );
     });
   });


### PR DESCRIPTION
## Description
### Tests E2E export CSV indépendants de la date de bascule
Les tests E2E d'export CSV (`export-csv-indicateur`, `export-csv-historique-indicateur`, `export-csv-chantier`) échouent depuis le 31 mars 2026 car les headers CSV contiennent le jalon par défaut (maintenant 2026) alors que les assertions hardcodaient "2025".

**Cause** : La date de bascule `NEXT_PUBLIC_DATE_BASCULE_AFFICHAGE_VALEURS_ANNEE_PRECEDENTE=2000-03-31` fait basculer le jalon par défaut de `année - 1` à `année courante` à partir du 31 mars.

**Correction** : Utilisation de `getAnneeDateDeBascule()` (la même fonction que le code applicatif) avec la variable d'env pour calculer dynamiquement le jalon attendu dans les assertions.

### Suppression colonne mandat dupliquée dans l'export historique indicateurs
L'export CSV historique indicateurs contenait une colonne "Valeur cible année 2026" hardcodée (valeur mandat) qui dupliquait la colonne dynamique du jalon sélectionné. Suppression de cette colonne et de ses données associées.

## Fichiers modifiés
- `tests/export-csv-indicateur.spec.ts` — jalon dynamique
- `tests/export-csv-historique-indicateur.spec.ts` — jalon dynamique + suppression colonne mandat
- `tests/export-csv-chantier.spec.ts` — jalon dynamique
- `src/server/chantiers/usecases/ExportCsvDesHistoriquesIndicateursUseCase.ts` — suppression colonne mandat

## Test plan
- [ ] Vérifier que les 3 tests E2E d'export CSV passent
- [ ] Vérifier que l'export historique indicateurs n'a plus de colonne dupliquée
- [ ] Vérifier que les tests passent indépendamment de la date (avant et après le 31 mars)