### PR TITLE
fix: stabiliser les tests E2E flaky (PVA + admin gestion utilisateurs)

### DIFF
--- a/tests/admin-gestion-utilisateurs.spec.ts
+++ b/tests/admin-gestion-utilisateurs.spec.ts
@@ -440,7 +440,7 @@ test.describe("Gestion des comptes utilisateurs", () => {
       await page
         .getByRole("button", { name: /Réinitialiser les filtres/ })
         .click();
-      await page.waitForTimeout(600);
+      await page.waitForTimeout(1000);
     });
 
     await test.step("Réinitialisation avec filtres combinés", async () => {

--- a/tests/pages/admin/page-utilisateurs.ts
+++ b/tests/pages/admin/page-utilisateurs.ts
@@ -83,13 +83,12 @@ export class PageAdminUtilisateurs extends BasePage {
 
   async rechercherUtilisateur(texte: string): Promise<void> {
     await this.barreRecherche.fill(texte);
-    // attendre le throttle de la recherche
-    await this.page.waitForTimeout(600);
+    await this.page.waitForTimeout(1000);
   }
 
   async effacerRecherche(): Promise<void> {
     await this.barreRecherche.clear();
-    await this.page.waitForTimeout(600);
+    await this.page.waitForTimeout(1000);
   }
 
   async filtrerParStatut(
@@ -101,7 +100,7 @@ export class PageAdminUtilisateurs extends BasePage {
       desactives: this.tagDesactives,
     };
     await tags[statut].click();
-    await this.page.waitForTimeout(600);
+    await this.page.waitForTimeout(1000);
   }
 
   async filtrerParProfil(nomProfil: string): Promise<void> {
@@ -111,7 +110,7 @@ export class PageAdminUtilisateurs extends BasePage {
       .check({ force: true });
     // fermer le dropdown en cliquant ailleurs
     await this.page.getByRole("heading", { level: 1 }).click();
-    await this.page.waitForTimeout(600);
+    await this.page.waitForTimeout(1000);
   }
 
   async expectColonneVisible(nomColonne: string): Promise<void> {
@@ -134,13 +133,13 @@ export class PageAdminUtilisateurs extends BasePage {
   async expectUtilisateurDansTableau(email: string): Promise<void> {
     await expect(
       this.tableau.getByRole("row").filter({ hasText: email }),
-    ).toBeVisible();
+    ).toBeVisible({ timeout: 15_000 });
   }
 
   async expectUtilisateurAbsentDuTableau(email: string): Promise<void> {
     await expect(
       this.tableau.getByRole("row").filter({ hasText: email }),
-    ).not.toBeVisible();
+    ).not.toBeVisible({ timeout: 15_000 });
   }
 
   async expectProfilDansFiltre(nomProfil: string): Promise<void> {

--- a/tests/proposition-valeur-avancement.spec.ts
+++ b/tests/proposition-valeur-avancement.spec.ts
@@ -350,7 +350,7 @@ test.describe("Proposition de valeur d'avancement (PVA)", () => {
       await modal.passerEtapeSuivante();
 
       await modal.expectContient(/la proposition est modifiée/);
-      await modal.expectContient("60 ()");
+      await modal.expectContient(/60 \(/);
 
       await modal.accepterAvecModification();
       await modal.expectConfirmationEtFermer(


### PR DESCRIPTION
## Description
Correction de 2 tests E2E instables.

### Test PVA — assertion valeur modifiée
Le test "Direction accepte avec modification (valeur 60)" cherchait `"60 ()"` dans la modale, mais le seed inclut maintenant une date pour la valeur actuelle de l'indicateur. La modale affiche donc `"60 (06/2025)"`.
- Remplacement de l'assertion exacte par une regex `/60 \(/` pour matcher indépendamment de la date.

### Tests admin gestion utilisateurs — flaky sur filtres/recherche
Les tests de filtrage et recherche dans la gestion des comptes échouaient de manière intermittente car :
- Le throttle de recherche (600ms) ne suffisait pas quand le dev server Next.js recompile en parallèle
- Les assertions sur le tableau avaient un timeout de 5s trop court

Corrections :
- Timeout d'attente après filtrage/recherche augmenté de 600ms à 1s
- Timeout des assertions `expectUtilisateurDansTableau` / `expectUtilisateurAbsentDuTableau` augmenté à 15s

## Fichiers modifiés
- `tests/proposition-valeur-avancement.spec.ts`
- `tests/pages/admin/page-utilisateurs.ts`
- `tests/admin-gestion-utilisateurs.spec.ts`

## Test plan
- [ ] Vérifier que le test PVA "Direction accepte avec modification" passe
- [ ] Vérifier que les tests admin gestion utilisateurs passent sans flaky (run x3)
- [ ] Vérifier qu'aucune régression sur les autres tests E2E