### PR TITLE
fix: corriger les sélecteurs E2E des tests PVA après refonte page chantier

### DIFF
--- a/tests/information-chantier.spec.ts
+++ b/tests/information-chantier.spec.ts
@@ -298,9 +298,9 @@ test.describe("Cartographie PVA — Comparaison territoriale", () => {
   }
 
   async function selectionnerCartePVA(page: import("@playwright/test").Page) {
-    const sectionComparaison = page.locator("div.fr-card").filter({
-      hasText: "Comparaison territoriale et évolution",
-    });
+    const sectionComparaison = page
+      .getByText("Comparaison territoriale et évolution", { exact: true })
+      .locator("..");
 
     await sectionComparaison.getByRole("combobox").first().click();
 
@@ -308,6 +308,7 @@ test.describe("Cartographie PVA — Comparaison territoriale", () => {
       .getByRole("option", {
         name: "Carte des propositions de valeur d'avancement",
       })
+      .first()
       .click();
   }
 


### PR DESCRIPTION
## Summary
- Les tests E2E "Cartographie PVA — Comparaison territoriale" échouaient depuis la refonte PIL-1369
- Le sélecteur `div.fr-card` n'existe plus (remplacé par des classes Tailwind)
- Utilise `getByText("Comparaison territoriale et évolution")` pour cibler la section de manière user-centric
- Ajoute `.first()` sur l'option pour éviter un strict mode violation (2 panneaux = 2 listes d'options)

## Test plan
- [x] Les 2 tests PVA passent (`npm run test:e2e -- --grep "Cartographie PVA"`)
- [x] Les 52 autres tests E2E ne sont pas impactés

🤖 Generated with [Claude Code](https://claude.com/claude-code)