### PR TITLE
fix: masquer slider graphique export widgets (PIL-000)

### DIFF
--- a/src/client/components/_commons/ComparaisonTerritoires/ModeExportContext.tsx
+++ b/src/client/components/_commons/ComparaisonTerritoires/ModeExportContext.tsx
@@ -1,0 +1,5 @@
+import { createContext, useContext } from "react";
+
+export const ModeExportContext = createContext(false);
+
+export const useModeExport = () => useContext(ModeExportContext);

--- a/src/client/components/_commons/ComparaisonTerritoires/PanneauCarte.tsx
+++ b/src/client/components/_commons/ComparaisonTerritoires/PanneauCarte.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useRef } from "react";
+import { ReactNode, useCallback, useRef, useState } from "react";
 import { toBlob, toPng } from "html-to-image";
 import { toast } from "sonner";
 import { Icone } from "@/components/_commons/Icone";
@@ -6,6 +6,7 @@ import { DeleteIcon } from "@/components/_commons/Icones/DeleteIcon";
 import { Download1Icon } from "@/components/_commons/Icones/Download1Icon";
 import { ClipboardIcon } from "@/components/_commons/Icones/ClipboardIcon";
 import { SelecteurTypeCarte } from "./SelecteurTypeCarte";
+import { ModeExportContext } from "./ModeExportContext";
 
 type PanneauCarteProps<T extends string> = {
   typeCarte: T;
@@ -29,6 +30,7 @@ export const PanneauCarte = <T extends string>({
   nomFichier,
 }: PanneauCarteProps<T>) => {
   const carteRef = useRef<HTMLDivElement>(null);
+  const [modeExport, setModeExport] = useState(false);
 
   const filtreExport = (node: Node) =>
     !(node instanceof Element) ||
@@ -40,11 +42,29 @@ export const PanneauCarte = <T extends string>({
     filter: filtreExport,
   };
 
-  const enregistrerCommeImage = async () => {
-    if (!carteRef.current) return;
+  const attendreRendu = () =>
+    new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
 
+  const capturerImage = useCallback(
+    async <T,>(capturer: () => Promise<T>): Promise<T | null> => {
+      if (!carteRef.current) return null;
+      setModeExport(true);
+      await attendreRendu();
+      try {
+        return await capturer();
+      } finally {
+        setModeExport(false);
+      }
+    },
+    [],
+  );
+
+  const enregistrerCommeImage = async () => {
     try {
-      const dataUrl = await toPng(carteRef.current, optionsExport);
+      const dataUrl = await capturerImage(() =>
+        toPng(carteRef.current!, optionsExport),
+      );
+      if (!dataUrl) return;
 
       const lien = document.createElement("a");
       lien.download = `${nomFichier}.png`;
@@ -57,10 +77,10 @@ export const PanneauCarte = <T extends string>({
   };
 
   const copierDansLePressePapiers = async () => {
-    if (!carteRef.current) return;
-
     try {
-      const blob = await toBlob(carteRef.current, optionsExport);
+      const blob = await capturerImage(() =>
+        toBlob(carteRef.current!, optionsExport),
+      );
       if (blob == null) return;
 
       await navigator.clipboard.write([
@@ -101,7 +121,9 @@ export const PanneauCarte = <T extends string>({
         )}
       </div>
 
-      <div ref={carteRef}>{renderCarte(typeCarte)}</div>
+      <ModeExportContext.Provider value={modeExport}>
+        <div ref={carteRef}>{renderCarte(typeCarte)}</div>
+      </ModeExportContext.Provider>
 
       <div className="flex items-center justify-end">
         <span className="text-primary text-sm">exporter :</span>

--- a/src/client/components/_commons/ComparaisonTerritoires/PanneauCarte.tsx
+++ b/src/client/components/_commons/ComparaisonTerritoires/PanneauCarte.tsx
@@ -46,12 +46,14 @@ export const PanneauCarte = <T extends string>({
     new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
 
   const capturerImage = useCallback(
-    async <T,>(capturer: () => Promise<T>): Promise<T | null> => {
+    async <T,>(
+      capturer: (element: HTMLDivElement) => Promise<T>,
+    ): Promise<T | null> => {
       if (!carteRef.current) return null;
       setModeExport(true);
       await attendreRendu();
       try {
-        return await capturer();
+        return await capturer(carteRef.current);
       } finally {
         setModeExport(false);
       }
@@ -61,8 +63,8 @@ export const PanneauCarte = <T extends string>({
 
   const enregistrerCommeImage = async () => {
     try {
-      const dataUrl = await capturerImage(() =>
-        toPng(carteRef.current!, optionsExport),
+      const dataUrl = await capturerImage((element) =>
+        toPng(element, optionsExport),
       );
       if (!dataUrl) return;
 
@@ -78,8 +80,8 @@ export const PanneauCarte = <T extends string>({
 
   const copierDansLePressePapiers = async () => {
     try {
-      const blob = await capturerImage(() =>
-        toBlob(carteRef.current!, optionsExport),
+      const blob = await capturerImage((element) =>
+        toBlob(element, optionsExport),
       );
       if (blob == null) return;
 

--- a/src/client/components/_commons/ComparaisonTerritoires/PanneauCarte.tsx
+++ b/src/client/components/_commons/ComparaisonTerritoires/PanneauCarte.tsx
@@ -1,5 +1,6 @@
 import { ReactNode, useCallback, useRef, useState } from "react";
 import { toBlob, toPng } from "html-to-image";
+import { flushSync } from "react-dom";
 import { toast } from "sonner";
 import { Icone } from "@/components/_commons/Icone";
 import { DeleteIcon } from "@/components/_commons/Icones/DeleteIcon";
@@ -42,17 +43,18 @@ export const PanneauCarte = <T extends string>({
     filter: filtreExport,
   };
 
-  const attendreRendu = () =>
-    new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
-
   const capturerImage = useCallback(
     async <T,>(
       capturer: (element: HTMLDivElement) => Promise<T>,
     ): Promise<T | null> => {
       if (!carteRef.current) return null;
-      setModeExport(true);
-      await attendreRendu();
+
+      flushSync(() => {
+        setModeExport(true);
+      });
+
       try {
+        await new Promise((resolve) => setTimeout(resolve, 100));
         return await capturer(carteRef.current);
       } finally {
         setModeExport(false);

--- a/src/client/components/_commons/IndicateursChantier/Bloc/Détails/Évolution/LineChart/LineChartLegende/LineChartLegende.tsx
+++ b/src/client/components/_commons/IndicateursChantier/Bloc/Détails/Évolution/LineChart/LineChartLegende/LineChartLegende.tsx
@@ -79,10 +79,7 @@ const LineChartLegende: FunctionComponent<LineChartLegendeProps> = ({
               onChange={() => setAfficherLesCibles(!afficherLesCibles)}
             />
           ) : null}
-          <div
-            className="flex items-center flex-wrap gap-2"
-            data-html-to-image-ignore="true"
-          >
+          <div className="flex items-center flex-wrap gap-2">
             <span className="text-sm">zoomer sur : </span>
             {periodesSelectionnablesZoom.map((periode) => (
               <button

--- a/src/client/components/_commons/Widget/WidgetCartographieTA/EvolutionCourbesTauxAvancement.tsx
+++ b/src/client/components/_commons/Widget/WidgetCartographieTA/EvolutionCourbesTauxAvancement.tsx
@@ -3,6 +3,7 @@ import api from "@/server/infrastructure/api/trpc/api";
 import type { TerritoireEvolutionDonnees } from "@/components/_commons/IndicateursChantier/Bloc/Détails/Évolution/types";
 import useIndicateurEvolutionNew from "@/components/_commons/IndicateursChantier/Bloc/Détails/Évolution/useIndicateurEvolutionNew";
 import LineChart from "@/components/_commons/IndicateursChantier/Bloc/Détails/Évolution/LineChart/LineChart";
+import { useModeExport } from "@/components/_commons/ComparaisonTerritoires/ModeExportContext";
 
 export const EvolutionCourbesTauxAvancement = ({
   indicateurId,
@@ -39,6 +40,8 @@ export const EvolutionCourbesTauxAvancement = ({
         }));
     }, [evolutionData, territoiresSelectionnesCodes]);
 
+  const modeExport = useModeExport();
+
   const {
     afficherLesCibles,
     setAfficherLesCibles,
@@ -64,6 +67,7 @@ export const EvolutionCourbesTauxAvancement = ({
       changerLaPeriodeSelectionnee={changerLaPeriodeSelectionnee}
       chartDisplayMode="compact"
       getOptions={getOptions}
+      modeImpression={modeExport}
       periodeSelectionnee={periodeSelectionnee}
       periodesSelectionnablesZoom={periodesSelectionnablesZoom}
       setAfficherLesCibles={setAfficherLesCibles}

--- a/src/client/components/_commons/Widget/WidgetCartographieValeurAvancement/EvolutionCourbesValeursAvancement.tsx
+++ b/src/client/components/_commons/Widget/WidgetCartographieValeurAvancement/EvolutionCourbesValeursAvancement.tsx
@@ -3,6 +3,7 @@ import api from "@/server/infrastructure/api/trpc/api";
 import type { TerritoireEvolutionDonnees } from "@/components/_commons/IndicateursChantier/Bloc/Détails/Évolution/types";
 import useIndicateurEvolutionNew from "@/components/_commons/IndicateursChantier/Bloc/Détails/Évolution/useIndicateurEvolutionNew";
 import LineChart from "@/components/_commons/IndicateursChantier/Bloc/Détails/Évolution/LineChart/LineChart";
+import { useModeExport } from "@/components/_commons/ComparaisonTerritoires/ModeExportContext";
 
 export const EvolutionCourbesValeursAvancement = ({
   indicateurId,
@@ -39,6 +40,8 @@ export const EvolutionCourbesValeursAvancement = ({
         }));
     }, [evolutionData, territoiresSelectionnesCodes]);
 
+  const modeExport = useModeExport();
+
   const {
     afficherLesCibles,
     setAfficherLesCibles,
@@ -64,6 +67,7 @@ export const EvolutionCourbesValeursAvancement = ({
       changerLaPeriodeSelectionnee={changerLaPeriodeSelectionnee}
       chartDisplayMode="compact"
       getOptions={getOptions}
+      modeImpression={modeExport}
       periodeSelectionnee={periodeSelectionnee}
       periodesSelectionnablesZoom={periodesSelectionnablesZoom}
       setAfficherLesCibles={setAfficherLesCibles}


### PR DESCRIPTION
## Summary

- Masquer le slider (zoom) des graphiques ECharts lors de l'export image des widgets cartographie
- Introduit un `ModeExportContext` pour propager l'état d'export aux composants enfants
- Réutilise la prop `modeImpression` existante sur `LineChart` pour désactiver le slider et les animations

## Fichiers modifiés

- `ModeExportContext.tsx` — nouveau contexte React pour le mode export
- `PanneauCarte.tsx` — wrapper `capturerImage` qui active le mode export avant capture
- `EvolutionCourbesTauxAvancement.tsx` / `EvolutionCourbesValeursAvancement.tsx` — consomment le contexte et passent `modeImpression` au `LineChart`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Resultat

Introduit un état temporaire pendant l'impression pour masquer le slider du graphique (voir vidéo)

https://github.com/user-attachments/assets/b6d598a8-cf78-4cee-9b63-322f8be23968

