### PR TITLE
chore: supprimer .eslintignore déprécié

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,0 @@
-jest.config.js


### PR DESCRIPTION
## Summary

- Suppression du fichier `.eslintignore` qui génère un warning de dépréciation à chaque `npm run lint`
- Le flat config `eslint.config.mjs` gère déjà les ignores (dont `*.config.js` qui couvre `jest.config.js`, seule entrée du `.eslintignore`)

## Test plan

- [x] `npm run lint` passe sans erreur et sans warning de dépréciation

🤖 Generated with [Claude Code](https://claude.com/claude-code)