### PR TITLE
fix(centre-aide): lire les FF via useEnv pour respecter le panel admin (PIL-1449)

### DIFF
--- a/src/pages/centre-aide-pilote.tsx
+++ b/src/pages/centre-aide-pilote.tsx
@@ -3,12 +3,12 @@ import { GetServerSideProps } from "next";
 import { FunctionComponent } from "react";
 import { auth } from "@/server/infrastructure/api/auth/[...nextauth]";
 import { PageCentreAidePilote } from "@/components/PageCentreAidePilote/PageCentreAidePilote";
-import { configurationFeatureFlip } from "@/config";
+import { useEnv } from "@/client/hooks/useEnv";
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
   const session = await auth(context);
 
-  if (!session || !configurationFeatureFlip().centreAidePilote) {
+  if (!session) {
     return {
       redirect: {
         destination: "/",
@@ -23,6 +23,12 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
 };
 
 const NextPageCentreAidePilote: FunctionComponent = () => {
+  const ffCentreAidePilote = useEnv("NEXT_PUBLIC_FF_CENTRE_AIDE_PILOTE");
+
+  if (!ffCentreAidePilote) {
+    return null;
+  }
+
   return (
     <>
       <Head>

--- a/src/pages/panel-administrateur/centre-aide.tsx
+++ b/src/pages/panel-administrateur/centre-aide.tsx
@@ -3,19 +3,18 @@ import { GetServerSideProps } from "next";
 import { auth } from "@/server/infrastructure/api/auth/[...nextauth]";
 import { NextPanelAdministrateurLayout } from "@/components/PagePanelAdministrateur/PanelAdministrateurLayout/layout";
 import { PagePanelAdministrateurCentreAide } from "@/components/PagePanelAdministrateur/PagePanelAdministrateurCentreAide/PagePanelAdministrateurCentreAide";
-import { configurationFeatureFlip } from "@/config";
+import { useEnv } from "@/client/hooks/useEnv";
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
   const session = await auth(context);
-  const redirigerVersPageAccueil = {
-    redirect: {
-      destination: "/",
-      permanent: false,
-    },
-  };
 
-  if (!session || !configurationFeatureFlip().centreAideAdmin) {
-    return redirigerVersPageAccueil;
+  if (!session) {
+    return {
+      redirect: {
+        destination: "/",
+        permanent: false,
+      },
+    };
   }
 
   return {
@@ -24,6 +23,12 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
 };
 
 const NextPagePanelAdministrateurCentreAide = () => {
+  const ffCentreAideAdmin = useEnv("NEXT_PUBLIC_FF_CENTRE_AIDE_ADMIN");
+
+  if (!ffCentreAideAdmin) {
+    return null;
+  }
+
   return (
     <>
       <Head>


### PR DESCRIPTION
## Summary
- Les guards SSR des pages centre-aide (`src/pages/panel-administrateur/centre-aide.tsx` + `src/pages/centre-aide-pilote.tsx`) lisaient les feature flips via `configurationFeatureFlip()` (convict → env vars uniquement), ignorant les overrides stockés en DB par le panel admin.
- Conséquence : activer les flags `NEXT_PUBLIC_FF_CENTRE_AIDE_ADMIN` / `NEXT_PUBLIC_FF_CENTRE_AIDE_PILOTE` depuis le panel FF n'avait aucun effet, l'accès à la page redirigeait vers `/`.
- Les deux pages lisent désormais les FF via `useEnv` côté client (qui passe par `RecupererToutesLesVariablesContenuUseCase` et merge `DB > config`), en cohérence avec le pattern du menu latéral et de la navigation. Le guard SSR ne conserve que le check de session.

## Test plan
- [ ] Vérifier que le lien "Centre d'aide" du menu latéral admin est affiché quand le FF `NEXT_PUBLIC_FF_CENTRE_AIDE_ADMIN` est activé uniquement via le panel FF admin (DB)
- [ ] Cliquer sur le lien → la page s'affiche sans redirection vers `/`
- [ ] Désactiver le FF via le panel admin → la page rend `null` et le lien disparaît du menu
- [ ] Même scénario pour `NEXT_PUBLIC_FF_CENTRE_AIDE_PILOTE` via la navigation pilote