### PR TITLE
bugfix: fiabiliser les tests E2E flaky sur page utilisateurs et page chantier

### DIFF
--- a/tests/pages/admin/page-utilisateurs.ts
+++ b/tests/pages/admin/page-utilisateurs.ts
@@ -83,12 +83,10 @@ export class PageAdminUtilisateurs extends BasePage {
 
   async rechercherUtilisateur(texte: string): Promise<void> {
     await this.barreRecherche.fill(texte);
-    await this.page.waitForTimeout(1000);
   }
 
   async effacerRecherche(): Promise<void> {
     await this.barreRecherche.clear();
-    await this.page.waitForTimeout(1000);
   }
 
   async filtrerParStatut(
@@ -100,7 +98,6 @@ export class PageAdminUtilisateurs extends BasePage {
       desactives: this.tagDesactives,
     };
     await tags[statut].click();
-    await this.page.waitForTimeout(1000);
   }
 
   async filtrerParProfil(nomProfil: string): Promise<void> {
@@ -110,7 +107,6 @@ export class PageAdminUtilisateurs extends BasePage {
       .check({ force: true });
     // fermer le dropdown en cliquant ailleurs
     await this.page.getByRole("heading", { level: 1 }).click();
-    await this.page.waitForTimeout(1000);
   }
 
   async expectColonneVisible(nomColonne: string): Promise<void> {

--- a/tests/pages/page-chantier.ts
+++ b/tests/pages/page-chantier.ts
@@ -54,9 +54,11 @@ export class PageChantier extends BasePage {
     const accordionButton = this.page.getByRole("button", {
       name: /Autres indicateurs/,
     });
+    await accordionButton.waitFor({ state: "visible" });
     const isExpanded = await accordionButton.getAttribute("aria-expanded");
     if (isExpanded !== "true") {
       await accordionButton.click();
+      await expect(accordionButton).toHaveAttribute("aria-expanded", "true");
     }
   }
 


### PR DESCRIPTION
## Summary

- Retire les `waitForTimeout(1000)` arbitraires dans `PageAdminUtilisateurs` (recherche, effacer recherche, filtres statut & profil) — ils masquaient des races et ralentissaient les tests sans les fiabiliser.
- Dans `PageChantier.toggleAutresIndicateurs`, attend explicitement la visibilité du bouton de l'accordéon avant de lire son état, puis vérifie via `expect(...).toHaveAttribute("aria-expanded", "true")` que l'accordéon est bien ouvert après le clic.

## Test plan

- [ ] Lancer la suite E2E complète avec `E2E_VIDEO=on` plusieurs fois d'affilée pour vérifier la disparition de la flakyness.
- [ ] Vérifier que les scénarios admin utilisateurs (recherche, filtres statut, filtres profil) restent verts.
- [ ] Vérifier que les scénarios de page chantier qui ouvrent l'accordéon "Autres indicateurs" restent verts.