### PR TITLE
feat: désactiver l'option Fichiers numériques dans l'EditeurSimple

### DIFF
--- a/src/client/components/_commons/EditeurRiche/EditeurRiche.tsx
+++ b/src/client/components/_commons/EditeurRiche/EditeurRiche.tsx
@@ -18,6 +18,7 @@ export interface EditeurRicheProps {
   placeholder?: string;
   estEnLectureSeule?: boolean;
   editeurRef?: RefObject<TextareaRef | null>;
+  avecFichiersNumeriques?: boolean;
 }
 
 export const EditeurRiche: FunctionComponent<EditeurRicheProps> = ({
@@ -29,6 +30,7 @@ export const EditeurRiche: FunctionComponent<EditeurRicheProps> = ({
   estEnLectureSeule = false,
   editeurRef,
   onFocus,
+  avecFichiersNumeriques = true,
 }) => {
   const editor = useEditor({
     extensions: [
@@ -56,7 +58,10 @@ export const EditeurRiche: FunctionComponent<EditeurRicheProps> = ({
 
   return (
     <div className="relative flex flex-1 flex-col h-full overflow-y-auto !bg-dsfr-contrast-grey">
-      <MenuBar editor={editor} />
+      <MenuBar
+        avecFichiersNumeriques={avecFichiersNumeriques}
+        editor={editor}
+      />
       <EditorContent
         className="flex-1 [&_.tiptap]:min-h-full [&_.tiptap]:p-2"
         editor={editor}

--- a/src/client/components/_commons/EditeurRiche/EditeurSimple.tsx
+++ b/src/client/components/_commons/EditeurRiche/EditeurSimple.tsx
@@ -22,5 +22,11 @@ const extensions = [
 export const EditeurSimple: FunctionComponent<
   Omit<EditeurRicheProps, "extensions">
 > = (props) => {
-  return <EditeurRiche extensions={extensions} {...props} />;
+  return (
+    <EditeurRiche
+      avecFichiersNumeriques={false}
+      extensions={extensions}
+      {...props}
+    />
+  );
 };

--- a/src/client/components/_commons/EditeurRiche/MenuBar.tsx
+++ b/src/client/components/_commons/EditeurRiche/MenuBar.tsx
@@ -33,7 +33,13 @@ import { ModaleInsertionUrl } from "./ModaleInsertionUrl";
 import { ModaleInsertionIcone } from "./ModaleInsertionIcone";
 import { ModaleInsertionComposant } from "./ModaleInsertionComposant";
 
-export const MenuBar = ({ editor }: { editor: Editor }) => {
+export const MenuBar = ({
+  editor,
+  avecFichiersNumeriques = true,
+}: {
+  editor: Editor;
+  avecFichiersNumeriques?: boolean;
+}) => {
   const [modaleImage, setModaleImage] = useState(false);
   const [modaleLien, setModaleLien] = useState(false);
   const [modaleVideo, setModaleVideo] = useState(false);
@@ -501,6 +507,7 @@ export const MenuBar = ({ editor }: { editor: Editor }) => {
         type="image"
       />
       <ModaleInsertionUrl
+        avecFichiersNumeriques={avecFichiersNumeriques}
         onOpenChange={setModaleLien}
         onValider={(url) => {
           editor

--- a/src/client/components/_commons/EditeurRiche/ModaleInsertionUrl.tsx
+++ b/src/client/components/_commons/EditeurRiche/ModaleInsertionUrl.tsx
@@ -37,12 +37,14 @@ export const ModaleInsertionUrl = ({
   onValider,
   titre,
   type,
+  avecFichiersNumeriques = true,
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onValider: (url: string) => void;
   titre: string;
   type: TypeInsertion;
+  avecFichiersNumeriques?: boolean;
 }) => {
   const [mode, setMode] = useState<"direct" | "constructeur" | "email">(
     "direct",
@@ -145,16 +147,18 @@ export const ModaleInsertionUrl = ({
           >
             URL directe
           </button>
-          <button
-            className={`px-3 py-1 rounded text-sm border ${mode === "constructeur" ? "!bg-primary !text-white !border-primary" : "!bg-white !text-dsfr-grey-200 !border-dsfr-grey-900"}`}
-            onClick={() => {
-              setMode("constructeur");
-              setErreur("");
-            }}
-            type="button"
-          >
-            Fichiers numériques
-          </button>
+          {avecFichiersNumeriques && (
+            <button
+              className={`px-3 py-1 rounded text-sm border ${mode === "constructeur" ? "!bg-primary !text-white !border-primary" : "!bg-white !text-dsfr-grey-200 !border-dsfr-grey-900"}`}
+              onClick={() => {
+                setMode("constructeur");
+                setErreur("");
+              }}
+              type="button"
+            >
+              Fichiers numériques
+            </button>
+          )}
           {type === "lien" && (
             <button
               className={`px-3 py-1 rounded text-sm border ${mode === "email" ? "!bg-primary !text-white !border-primary" : "!bg-white !text-dsfr-grey-200 !border-dsfr-grey-900"}`}


### PR DESCRIPTION
## Contexte

L'`EditeurSimple` (version light de l'éditeur riche) exposait à tort l'onglet **Fichiers numériques** dans la modale d'insertion de lien, option réservée aux éditeurs complets.

## Changements

- `ModaleInsertionUrl` : ajout de la prop `avecFichiersNumeriques?: boolean` (défaut `true`) — le bouton "Fichiers numériques" est conditionnel à cette valeur
- `MenuBar` : réception et transmission de `avecFichiersNumeriques` à la modale lien
- `EditeurRiche` : ajout de `avecFichiersNumeriques` dans `EditeurRicheProps`, transmis à `MenuBar`
- `EditeurSimple` : passe `avecFichiersNumeriques={false}` en dur — les éditeurs complets (`EditeurCentreAide`, `EditeurNouveauté`) gardent le comportement par défaut

## Test plan

- [ ] Ouvrir un composant utilisant `EditeurSimple` et cliquer sur le bouton d'insertion de lien → seuls les onglets "URL directe" et "Email" apparaissent
- [ ] Vérifier qu'un éditeur complet (`EditeurCentreAide`) affiche toujours les trois onglets