### PR TITLE
bugfix: réinitialiser toutes les dates de désactivation lors de la réactivation d'un compte

### DIFF
--- a/src/server/gestion-utilisateur/__tests__/infrastructure/adapters/UtilisateurSQLRepository.integration.test.ts
+++ b/src/server/gestion-utilisateur/__tests__/infrastructure/adapters/UtilisateurSQLRepository.integration.test.ts
@@ -208,6 +208,42 @@ describe("PrismaUtilisateurRepository", () => {
         );
       }),
     );
+
+    it(
+      "si l'email existe, réinitialise toutes les dates liées au cycle de désactivation",
+      createIntegrationTest(async (tx) => {
+        // Given
+        const auteur = await fixtures.utilisateur();
+        // Utilisateur dont le compte a été désactivé par le cron avec toutes les dates de relance renseignées
+        const utilisateur = await fixtures.utilisateur({
+          date_desactivation: new Date("2026-01-31"),
+          date_premiere_relance_desactivation: new Date("2026-01-01"),
+          date_deuxieme_relance_desactivation: new Date("2026-01-15"),
+          date_desactivation_programee: new Date("2026-01-31"),
+        });
+
+        // When
+        await repository.reactiver(utilisateur.email, auteur.id);
+
+        // Then
+        const utilisateurReactive = await tx.utilisateur.findFirst({
+          where: { email: utilisateur.email },
+        });
+
+        expect(utilisateurReactive).not.toBeNull();
+        expect(utilisateurReactive?.date_desactivation).toBeNull();
+        expect(
+          utilisateurReactive?.date_premiere_relance_desactivation,
+        ).toBeNull();
+        expect(
+          utilisateurReactive?.date_deuxieme_relance_desactivation,
+        ).toBeNull();
+        expect(utilisateurReactive?.date_desactivation_programee).toBeNull();
+        expect(
+          utilisateurReactive?.date_derniere_connexion?.toDateString(),
+        ).toStrictEqual(new Date().toDateString());
+      }),
+    );
   });
 
   describe("recupererComptesInactifs", function () {

--- a/src/server/gestion-utilisateur/infrastructure/adapters/PrismaUtilisateurRepository.ts
+++ b/src/server/gestion-utilisateur/infrastructure/adapters/PrismaUtilisateurRepository.ts
@@ -279,6 +279,10 @@ export class PrismaUtilisateurRepository implements UtilisateurRepository {
       },
       data: {
         date_desactivation: null,
+        date_premiere_relance_desactivation: null,
+        date_deuxieme_relance_desactivation: null,
+        date_desactivation_programee: null,
+        date_derniere_connexion: new Date(),
         date_modification: new Date(),
         auteur_id_modification: auteurId,
       },


### PR DESCRIPTION
## Contexte

Lors de la réactivation d'un compte via l'interface admin, seule `date_desactivation` était remise à `null`. Les champs `date_premiere_relance_desactivation`, `date_deuxieme_relance_desactivation` et `date_desactivation_programee` restaient valorisés.

Conséquence : à la prochaine exécution du cron `desactivation-comptes`, le compte réactivé était immédiatement re-désactivé car ces dates résiduelles faisaient croire que l'utilisateur était dans un cycle de désactivation en cours.

## Changements

- `PrismaUtilisateurRepository.reactiver` : remise à `null` de `date_premiere_relance_desactivation`, `date_deuxieme_relance_desactivation` et `date_desactivation_programee` + mise à jour de `date_derniere_connexion` à la date courante
- Ajout d'un test d'intégration couvrant le scénario complet : réactivation d'un compte désactivé par le cron avec toutes les dates renseignées

## Test plan

- [ ] Lancer `npm run test:server` et vérifier que les tests du describe `reactiver` passent
- [ ] Vérifier manuellement sur un environnement de test : réactiver un compte désactivé par le cron → le compte ne doit pas être re-désactivé à la prochaine exécution du cron