### PR TITLE
feat: subagent dashboard — composition UI déléguée via structured output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ public/_pagefind/
 
 #submodules
 src/content/
+.devtools

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
   "dependencies": {
     "@ai-sdk/devtools": "^0.0.15",
     "@ai-sdk/openai": "^3.0.26",
+    "@ai-sdk/provider": "^3.0.8",
     "@ai-sdk/react": "^3.0.93",
     "@faker-js/faker": "^7.6.0",
     "@getbrevo/brevo": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     ]
   },
   "dependencies": {
+    "@ai-sdk/devtools": "^0.0.15",
     "@ai-sdk/openai": "^3.0.26",
     "@ai-sdk/react": "^3.0.93",
     "@faker-js/faker": "^7.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@ai-sdk/openai':
         specifier: ^3.0.26
         version: 3.0.53(zod@3.25.76)
+      '@ai-sdk/provider':
+        specifier: ^3.0.8
+        version: 3.0.8
       '@ai-sdk/react':
         specifier: ^3.0.93
         version: 3.0.163(react@19.2.5)(zod@3.25.76)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@ai-sdk/devtools':
+        specifier: ^0.0.15
+        version: 0.0.15
       '@ai-sdk/openai':
         specifier: ^3.0.26
         version: 3.0.53(zod@3.25.76)
@@ -461,6 +464,10 @@ packages:
 
   '@adobe/css-tools@4.4.4':
     resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
+
+  '@ai-sdk/devtools@0.0.15':
+    resolution: {integrity: sha512-zRF+ClRh0fcmvoKclOcmy2hmTDN48ZfHD3y1fC3Lx0vIYaX55uywssiyaA18WlV2mD+N9H4fgPxq+9JeGfMGlQ==}
+    hasBin: true
 
   '@ai-sdk/gateway@3.0.98':
     resolution: {integrity: sha512-Ol+nP8PIlj8FjN8qKlxhE89N0woqAaGi9CUBGp1boe3RafpphJ7WMuq/RErSvxtwTqje03TP+zIdzP113krxRg==}
@@ -1033,6 +1040,12 @@ packages:
     peerDependencies:
       react: ^18 || ^19 || ^19.0.0-rc
       react-dom: ^18 || ^19 || ^19.0.0-rc
+
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
 
   '@hookform/devtools@4.4.0':
     resolution: {integrity: sha512-Mtlic+uigoYBPXlfvPBfiYYUZuyMrD3pTjDpVIhL6eCZTvQkHsKBSKeZCvXWUZr8fqrkzDg27N+ZuazLKq6Vmg==}
@@ -4973,6 +4986,10 @@ packages:
   hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
 
+  hono@4.12.14:
+    resolution: {integrity: sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==}
+    engines: {node: '>=16.9.0'}
+
   html-encoding-sniffer@4.0.0:
     resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
     engines: {node: '>=18'}
@@ -7953,6 +7970,12 @@ snapshots:
 
   '@adobe/css-tools@4.4.4': {}
 
+  '@ai-sdk/devtools@0.0.15':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@hono/node-server': 1.19.14(hono@4.12.14)
+      hono: 4.12.14
+
   '@ai-sdk/gateway@3.0.98(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
@@ -8540,6 +8563,10 @@ snapshots:
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
       use-sync-external-store: 1.6.0(react@19.2.5)
+
+  '@hono/node-server@1.19.14(hono@4.12.14)':
+    dependencies:
+      hono: 4.12.14
 
   '@hookform/devtools@4.4.0(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
@@ -13119,6 +13146,8 @@ snapshots:
   hoist-non-react-statics@3.3.2:
     dependencies:
       react-is: 16.13.1
+
+  hono@4.12.14: {}
 
   html-encoding-sniffer@4.0.0:
     dependencies:

--- a/prd/LLM_SUBAGENT_DASHBOARD.md
+++ b/prd/LLM_SUBAGENT_DASHBOARD.md
@@ -1,0 +1,893 @@
+# Subagent Dashboard — Composition UI déléguée
+
+**Statut** : exploration
+
+---
+
+## 1. Contexte
+
+### 1.1 Problème actuel
+
+Le system prompt d'Albert concentre aujourd'hui l'ensemble des responsabilités :
+analyse métier, glossaire territorial, protocoles d'orchestration des tools,
+**et** toutes les règles de composition de dashboard (12 types de widgets, grille
+4 colonnes, contraintes de layout, exemples JSON).
+
+Ce constat est documenté dans `SYSTEM_PROMPT.md` qui qualifie le prompt de
+"solide mais surchargé" et recommande de le découper en couches :
+
+> A (invariants), B (politique de dialogue), C (orchestration), D (rendu)
+
+La couche D (rendu / dashboard) est la plus volumineuse et la plus autonome.
+Elle n'a pas besoin du contexte conversationnel complet pour fonctionner :
+elle reçoit une intention ("montre-moi l'avancement de la Bretagne") et produit
+une structure JSON déclarative.
+
+### 1.2 Opportunité
+
+Le AI SDK (Vercel) propose depuis peu un pattern **subagent** (`ToolLoopAgent`) :
+un agent spécialisé, invoqué comme un tool par l'agent principal, qui tourne dans
+son propre contexte et retourne un résultat structuré.
+
+cf. https://ai-sdk.dev/docs/agents/subagents
+
+Ce pattern correspond exactement au cas de la composition dashboard :
+- Tâche autonome et bien définie
+- Résultat déclaratif (références, pas données)
+- Instructions volumineuses et spécialisées
+- Bénéfice direct à isoler du contexte principal
+
+---
+
+## 2. Objectifs
+
+- **Alléger le system prompt principal** en extrayant toutes les instructions de
+  composition dashboard vers un prompt dédié
+- **Améliorer la qualité des dashboards** en donnant au subagent un prompt focalisé,
+  enrichi d'exemples et de patterns de layout
+- **Préserver l'UX existante** : du point de vue utilisateur, le comportement ne change
+  pas (placeholder → dashboard rendu)
+- **Simplifier l'évolutivité** : ajouter un widget ou modifier une règle de layout
+  ne touche que le subagent, pas l'agent principal
+
+---
+
+## 3. Principe
+
+### 3.1 Vue d'ensemble
+
+```
+Utilisateur : "Montre-moi un dashboard pour la Bretagne"
+      │
+      ▼
+┌─────────────────────────────────────────────┐
+│  Agent Principal (Albert)                   │
+│                                             │
+│  System prompt allégé :                     │
+│  - identité, glossaire, règles métier       │
+│  - protocole synthèse                       │
+│  - PAS de règles dashboard                  │
+│                                             │
+│  Tools :                                    │
+│  - get_taux_avancement_territoire           │
+│  - get_chantiers_en_retard                  │
+│  - get_chantiers_en_difficulte              │
+│  - get_chantier_indicateurs                 │
+│  - display_choices                          │
+│  - export_rapport                           │
+│  - create_dashboard  ◄── NOUVEAU            │
+│                                             │
+└──────────────┬──────────────────────────────┘
+               │ appel tool create_dashboard
+               │ input: { task: "Dashboard avancement Bretagne" }
+               ▼
+┌─────────────────────────────────────────────┐
+│  Subagent Dashboard                         │
+│                                             │
+│  System prompt dédié :                      │
+│  - catalogue des 12 widgets                 │
+│  - règles de grille (4 colonnes)            │
+│  - patterns de composition                  │
+│  - exemples few-shot                        │
+│  - contraintes (pas de chiffres dans titres)│
+│                                             │
+│  Tools :                                    │
+│  - compose_dashboard                        │
+│  - get_taux_avancement_territoire           │
+│  - get_chantiers_en_retard                  │
+│  - get_chantiers_en_difficulte              │
+│  - get_chantier_indicateurs                 │
+│                                             │
+│  Exécution autonome :                       │
+│  1. Appelle les tools data si nécessaire    │
+│  2. Compose le dashboard via compose_dashboard│
+│  3. Retourne le JSON au parent              │
+└──────────────┬──────────────────────────────┘
+               │ output: { titre, containers, ... }
+               ▼
+┌─────────────────────────────────────────────┐
+│  Client                                     │
+│                                             │
+│  1. Voit tool call "create_dashboard"       │
+│     state: input-available                  │
+│     → affiche placeholder                   │
+│                                             │
+│  2. Tool call terminé                       │
+│     state: output-available                 │
+│     → render le dashboard (même composants) │
+└─────────────────────────────────────────────┘
+```
+
+### 3.2 Pas de streaming intermédiaire
+
+Le subagent utilise `generate` (pas `stream`). Le client ne voit pas les étapes
+internes du subagent (appels data, composition). Il voit uniquement :
+
+1. **Tool call démarre** (`state: input-available`) → placeholder "Composition du dashboard..."
+2. **Tool call terminé** (`state: output-available`) → JSON dashboard → rendu
+
+**Raison** : la latence additionnelle est acceptable car le client affiche déjà un
+placeholder pendant les tool calls. Streamer les étapes internes ajouterait de la
+complexité sans bénéfice UX perceptible.
+
+---
+
+## 4. Architecture technique
+
+### 4.1 Subagent Dashboard
+
+```typescript
+// src/server/albert/subagents/dashboardSubagent.ts
+
+import { ToolLoopAgent } from 'ai';
+
+export type CreateDashboardSubagentDeps = {
+  model: LanguageModel;
+  composeDashboardTool: Tool;
+  getTauxAvancementTerritoireTool: Tool;
+  getChantiersEnRetardTool: Tool;
+  getChantiersEnDifficulteTool: Tool;
+  getChantierIndicateursTool: Tool;
+};
+
+export function createDashboardSubagent(deps: CreateDashboardSubagentDeps) {
+  return new ToolLoopAgent({
+    model: deps.model,
+    instructions: buildDashboardSystemPrompt(),
+    tools: {
+      compose_dashboard: deps.composeDashboardTool,
+      get_taux_avancement_territoire: deps.getTauxAvancementTerritoireTool,
+      get_chantiers_en_retard: deps.getChantiersEnRetardTool,
+      get_chantiers_en_difficulte: deps.getChantiersEnDifficulteTool,
+      get_chantier_indicateurs: deps.getChantierIndicateursTool,
+    },
+  });
+}
+```
+
+### 4.2 Tool `create_dashboard`
+
+Exposé à l'agent principal, il encapsule l'appel au subagent :
+
+```typescript
+// src/server/albert/tools/createDashboard.ts
+
+import { tool } from 'ai';
+import { z } from 'zod';
+
+export function createCreateDashboardTool(subagent: ToolLoopAgent) {
+  return tool({
+    description: `Délègue la composition d'un dashboard à un agent spécialisé.
+Utilise ce tool quand l'utilisateur demande un dashboard, un cockpit,
+ou un tableau de bord visuel.`,
+    parameters: z.object({
+      task: z.string().describe(
+        "Description de ce que l'utilisateur veut visualiser, "
+        + "incluant le(s) territoire(s), le jalon, et le type d'analyse souhaitée."
+      ),
+    }),
+    execute: async ({ task }, { abortSignal }) => {
+      const result = await subagent.generate({
+        prompt: task,
+        abortSignal,
+      });
+      return extractDashboardOutput(result);
+    },
+  });
+}
+```
+
+### 4.3 Extraction du résultat
+
+Le subagent produit potentiellement du texte + des tool calls. On extrait
+l'output du tool `compose_dashboard` :
+
+```typescript
+function extractDashboardOutput(result: GenerateResult): DashboardOutput {
+  // Chercher le dernier tool call compose_dashboard dans les steps
+  const composeDashboardCall = result.steps
+    .flatMap(step => step.toolCalls)
+    .findLast(call => call.toolName === 'compose_dashboard');
+
+  if (!composeDashboardCall) {
+    return { error: 'Le subagent n\'a pas pu composer de dashboard.' };
+  }
+
+  return composeDashboardCall.result;
+}
+```
+
+### 4.4 System prompt du subagent
+
+Le prompt du subagent est **focalisé uniquement sur la composition dashboard**.
+Il contient :
+
+| Section | Contenu |
+|---|---|
+| Identité | "Tu es un spécialiste de la composition de dashboards PILOTE" |
+| Catalogue widgets | Les 12 types avec description, paramètres, `default_width` |
+| Règles de grille | 4 colonnes, containers empilés verticalement |
+| Patterns de composition | Par type de demande (mono-territoire, comparaison, focus chantier) |
+| Exemples few-shot | 2-3 dashboards complets en JSON |
+| Contraintes | Pas de chiffres dans `widget_titre_section`, permissions territoire |
+| Protocole | Appeler les tools data d'abord si besoin de contexte, puis `compose_dashboard` |
+
+**Ce qui n'est PAS dans ce prompt** : glossaire métier détaillé, règles de synthèse,
+protocole de dialogue, gestion d'erreurs conversationnelles. Le subagent n'interagit
+pas avec l'utilisateur.
+
+### 4.5 Injection des dépendances
+
+Les tools data du subagent sont les **mêmes instances** que ceux de l'agent principal,
+construits avec les mêmes habilitations et territoires accessibles :
+
+```typescript
+// Dans la route API /api/albert/chat
+
+const tools = {
+  get_taux_avancement_territoire: createGetTauxTool({ habilitations, ... }),
+  get_chantiers_en_retard: createGetRetardTool({ habilitations, ... }),
+  // ...
+};
+
+const dashboardSubagent = createDashboardSubagent({
+  model,
+  composeDashboardTool: tools.compose_dashboard,
+  getTauxAvancementTerritoireTool: tools.get_taux_avancement_territoire,
+  getChantiersEnRetardTool: tools.get_chantiers_en_retard,
+  getChantiersEnDifficulteTool: tools.get_chantiers_en_difficulte,
+  getChantierIndicateursTool: tools.get_chantier_indicateurs,
+});
+
+const createDashboardTool = createCreateDashboardTool(dashboardSubagent);
+
+// L'agent principal reçoit create_dashboard au lieu de compose_dashboard
+const mainTools = {
+  ...tools,
+  create_dashboard: createDashboardTool,
+  // compose_dashboard n'est plus exposé au parent
+};
+```
+
+---
+
+## 5. Changements de prompts — Avant / Après
+
+### 5.1 Où vivent les instructions dashboard aujourd'hui
+
+Les instructions de composition dashboard sont réparties en **deux endroits** :
+
+| Emplacement | Contenu | Volume |
+|---|---|---|
+| `systemPrompt.ts` | Références à `compose_dashboard` dans la règle pseudo-code (l.316) et le protocole d'outils | ~5 lignes |
+| `composeDashboard.ts` (tool description) | Catalogue des 12 widgets, structure recommandée, règles JSON, 3 exemples complets | ~70 lignes |
+
+Le gros du savoir dashboard est dans la **description du tool**, pas dans le system prompt.
+Mais cette description est injectée dans le contexte du LLM principal à chaque message
+(dès que `capacities.dashboard = true`), même si l'utilisateur ne demande pas de dashboard
+dans ce tour.
+
+### 5.2 System prompt principal — Avant / Après
+
+**AVANT** (extrait des sections impactées) :
+
+```
+# Protocole d'utilisation des outils
+
+## Règle générale
+
+⚠️ **RÈGLE CRITIQUE — Jamais d'appel d'outil en pseudo-code**
+[...] N'écris JAMAIS de syntaxe comme `display_choices({...})`,
+`compose_dashboard({...})`, `export_rapport({...})` [...]
+                             ^^^^^^^^^^^^^^^^^^^
+                             référence directe
+
+## display_choices
+[...]
+```
+
+**APRÈS** :
+
+```
+# Protocole d'utilisation des outils
+
+## Règle générale
+
+⚠️ **RÈGLE CRITIQUE — Jamais d'appel d'outil en pseudo-code**
+[...] N'écris JAMAIS de syntaxe comme `display_choices({...})`,
+`create_dashboard({...})`, `export_rapport({...})` [...]
+                            ^^^^^^^^^^^^^^^^^^^
+                            renommé
+
+## create_dashboard
+Quand l'utilisateur demande un dashboard, un cockpit ou un tableau de bord,
+appelle `create_dashboard` en décrivant ce que l'utilisateur veut visualiser.
+L'agent spécialisé se charge de la composition. Ne commente pas les chiffres
+du dashboard dans ta réponse textuelle (les valeurs sont résolues côté client).
+
+## display_choices
+[...]
+```
+
+**Delta** : on remplace `compose_dashboard` par `create_dashboard` dans la règle pseudo-code,
+et on ajoute 4 lignes d'instruction pour `create_dashboard` (au lieu des ~70 lignes
+actuellement dans la description du tool `compose_dashboard`).
+
+### 5.3 Tool `compose_dashboard` — Avant / Après
+
+**AVANT** — description = ~70 lignes injectées dans le contexte LLM :
+
+```
+Compose un tableau de bord dynamique à partir d'une liste de containers...
+
+## Concept de container
+[...]
+
+## Catalogue de widgets (12 intentions métier nominales)
+| Widget | Intention | Paramètres | default_width | allowed_widths |
+[... 12 lignes ...]
+
+## Structure recommandée d'un cockpit territoire
+[... 6 lignes ...]
+
+## Règles JSON strictes
+[... 7 lignes ...]
+
+## Exemples de dashboards valides
+### Exemple 1 — Cockpit synthétique d'un territoire
+[... JSON ~5 lignes compactes ...]
+### Exemple 2 — Ventilation par sous-territoires
+[... JSON ~5 lignes compactes ...]
+### Exemple 3 — Focus chantier sur un territoire
+[... JSON ~5 lignes compactes ...]
+```
+
+**APRÈS** — la description du tool `compose_dashboard` est **simplifiée**.
+Le tool existe toujours (utilisé par le subagent), mais sa description n'a plus
+besoin de porter tout le contexte pédagogique — c'est le system prompt du subagent
+qui s'en charge :
+
+```
+Compose un tableau de bord dynamique à partir d'une liste de containers de widgets.
+Uniquement des références (territoire_code, chantier_id, jalon, maille),
+jamais de valeurs chiffrées. Les valeurs sont résolues au rendu côté client.
+```
+
+Le schema Zod reste identique — c'est lui qui porte la validation structurelle.
+Les `.describe()` sur chaque champ du schema restent aussi (ils documentent
+les paramètres pour le LLM).
+
+### 5.4 Nouveau tool `create_dashboard` — description
+
+Ce tool est vu par l'**agent principal**. Sa description est courte :
+
+```
+Délègue la composition d'un dashboard à un agent spécialisé.
+Utilise ce tool quand l'utilisateur demande un dashboard, un cockpit,
+ou un tableau de bord visuel. Décris précisément ce que l'utilisateur
+veut visualiser : territoire(s), jalon, type d'analyse.
+```
+
+Un seul paramètre : `task: string`.
+
+### 5.5 System prompt du subagent — Nouveau
+
+Ce prompt concentre tout le savoir dashboard qui était auparavant dispersé :
+
+```
+Tu es un spécialiste de la composition de dashboards pour PILOTE,
+l'outil de suivi des politiques prioritaires du gouvernement français.
+
+# Ta mission
+
+Tu reçois une description de ce que l'utilisateur veut visualiser.
+Tu dois composer un dashboard structuré en appelant `compose_dashboard`.
+
+Si tu as besoin de contexte pour décider quels widgets inclure
+(ex: savoir quels chantiers sont en retard), appelle d'abord les outils
+de données disponibles, puis compose le dashboard.
+
+# Catalogue de widgets
+
+| Widget | Intention | Paramètres | default_width | allowed_widths |
+|---|---|---|---|---|
+| widget_taux_avancement_territoire | TA agrégé d'un territoire | territoire_code, jalon | 1 | [1,2] |
+| widget_mediane_avancement_territoire | Médiane du TA | territoire_code, jalon | 1 | [1,2] |
+| widget_nombre_chantiers_en_retard | Nombre en retard | territoire_code, jalon | 1 | [1,2] |
+| widget_nombre_chantiers_en_difficulte | Nombre en difficulté | territoire_code, jalon | 1 | [1,2] |
+| widget_valeurs_remarquables_avancement | Min/médiane/max du TA | territoire_code, jalon | 2 | [2,3,4] |
+| widget_tableau_indicateurs_chantier | VI/VA/VC/TA d'un chantier | chantier_id, territoire_code, jalon | 4 | [4] |
+| widget_liste_chantiers_en_retard | Liste chantiers en retard | territoire_code, jalon | 2 | [2,4] |
+| widget_liste_chantiers_en_difficulte | Liste chantiers en difficulté | territoire_code, jalon | 2 | [2,4] |
+| widget_cartographie_taux_avancement | Carte du TA | maille, territoire_code, jalon, chantier_ids | 2 | [2,3,4] |
+| widget_cartographie_meteo | Carte des météos | maille, territoire_code, chantier_id, jalon | 2 | [2,3,4] |
+| widget_cartographie_propositions_valeur_avancement | Carte des PVA | maille, territoire_code, chantier_id, jalon | 2 | [2,3,4] |
+| widget_titre_section | Titre + description (AUCUN chiffre) | titre, description? | 4 | [2,4] |
+
+# Règles de composition
+
+## Grille
+- Un dashboard = liste ordonnée de containers empilés verticalement
+- Chaque container a un grid interne de 4 colonnes
+- Les widgets sont placés selon leur `width` (par défaut `default_width`)
+- Un widget seul dans un container de 4 colonnes gâche de la place
+  si sa default_width < 4. Regroupe les widgets compatibles.
+
+## widget_titre_section
+- JAMAIS de chiffres (%, points, pts) dans le titre ou la description
+- Utilise un widget KPI atomique pour afficher un chiffre
+
+## Patterns recommandés
+
+### Cockpit synthétique (mono-territoire)
+1. Container : `widget_titre_section`
+2. Container : `widget_taux_avancement_territoire` (1) + `widget_nombre_chantiers_en_retard` (1) + `widget_valeurs_remarquables_avancement` (2) = 4 colonnes
+3. Container : `widget_cartographie_taux_avancement` (4)
+4. Container : `widget_liste_chantiers_en_retard` (2) + `widget_liste_chantiers_en_difficulte` (2)
+
+### Ventilation par sous-territoires
+Pour chaque sous-territoire, répéter :
+1. Container : `widget_titre_section` avec nom du sous-territoire
+2. Container : 3 KPI compacts (1+1+1=3, 4e colonne vide)
+
+### Focus chantier
+1. Container : `widget_titre_section` avec nom du chantier
+2. Container : `widget_tableau_indicateurs_chantier` (4)
+3. Container : cartographies thématiques (météo, TA, PVA)
+
+# Exemples
+
+[mêmes 3 exemples JSON que l'actuel compose_dashboard description]
+
+# Protocole
+
+1. Analyse la demande
+2. Si tu as besoin de contexte (quels chantiers sont en retard, etc.),
+   appelle les outils de données
+3. Appelle `compose_dashboard` avec la structure complète
+4. Ta réponse textuelle finale sera ignorée — seul le résultat
+   de `compose_dashboard` est retourné au parent
+```
+
+### 5.6 Résumé du transfert
+
+```
+                      AVANT                              APRÈS
+                ┌──────────────┐                  ┌──────────────┐
+                │  System      │                  │  System      │
+                │  prompt      │                  │  prompt      │
+                │  principal   │                  │  principal   │
+                │              │                  │              │
+                │  ~5 lignes   │    ─────────►    │  ~4 lignes   │
+                │  dashboard   │    simplifié     │  create_     │
+                │              │                  │  dashboard   │
+                └──────────────┘                  └──────────────┘
+
+                ┌──────────────┐                  ┌──────────────┐
+                │  compose_    │                  │  compose_    │
+                │  dashboard   │                  │  dashboard   │
+                │  tool desc   │                  │  tool desc   │
+                │              │                  │              │
+                │  ~70 lignes  │    ─────────►    │  ~3 lignes   │
+                │  catalogue   │    transféré     │  (schéma     │
+                │  exemples    │                  │   suffit)    │
+                │  patterns    │                  │              │
+                └──────────────┘                  └──────────────┘
+
+                                                  ┌──────────────┐
+                                                  │  Subagent    │
+                                     NOUVEAU      │  system      │
+                                   ◄─────────     │  prompt      │
+                                                  │              │
+                                                  │  ~80 lignes  │
+                                                  │  catalogue   │
+                                                  │  patterns    │
+                                                  │  exemples    │
+                                                  │  protocole   │
+                                                  └──────────────┘
+```
+
+**Bilan tokens par message (quand dashboard activé)** :
+
+| | Avant | Après |
+|---|---|---|
+| System prompt principal | ~375 lignes | ~310 lignes (-65) |
+| Tool desc `compose_dashboard` | ~70 lignes | ~3 lignes (-67) |
+| Tool desc `create_dashboard` | — | ~4 lignes (+4) |
+| **Total injecté par message** | **~445 lignes** | **~317 lignes (-128)** |
+| Subagent (uniquement si invoqué) | — | ~80 lignes |
+
+Le subagent prompt (~80 lignes) n'est consommé que lorsque l'utilisateur demande
+effectivement un dashboard — pas à chaque message de la conversation.
+
+---
+
+## 6. Principe — tout affichage visuel passe par le dashboard
+
+### 6.1 Décision
+
+Aujourd'hui, certains tools data ont un double rôle : fournir de la donnée **et**
+déclencher un rendu visuel côté client. C'est le cas de `get_chantier_indicateurs`
+avec son paramètre `afficher` :
+
+- `afficher=true` (défaut) → le client rend un tableau d'indicateurs sous le tool call
+- `afficher=false` → données récupérées silencieusement (pour export rapport)
+
+**Nouveau principe** : les tools data sont des **fournisseurs de données pures**.
+Tout affichage visuel à destination de l'utilisateur passe par `create_dashboard`.
+
+Cela signifie :
+- Le paramètre `afficher` de `get_chantier_indicateurs` **disparaît**
+- Pour afficher les indicateurs d'un chantier, l'agent principal appelle
+  `create_dashboard` qui utilisera un `widget_tableau_indicateurs_chantier`
+- Les tools data ne déclenchent plus de rendu côté client — leur output
+  n'est visible que par le LLM (texte) ou par le subagent (composition)
+
+### 6.2 Avant / Après
+
+**Avant** — l'utilisateur demande "montre-moi les indicateurs de CH-064 en Bretagne" :
+
+```
+Agent principal
+  │
+  ├── appelle get_chantier_indicateurs(CH-064, REG-53, 2025, afficher=true)
+  │   └── output rendu comme tableau côté client  ◄── rendu direct
+  │
+  └── texte: "Voici les indicateurs du chantier CH-064."
+```
+
+**Après** — même demande :
+
+```
+Agent principal
+  │
+  ├── appelle create_dashboard({ task: "Indicateurs CH-064 en Bretagne" })
+  │   │
+  │   └── Subagent Dashboard
+  │       ├── (optionnel) appelle get_chantier_indicateurs pour contexte
+  │       └── appelle compose_dashboard({
+  │             titre: "Indicateurs CH-064 – Bretagne",
+  │             containers: [{
+  │               widgets: [{ type: "widget_tableau_indicateurs_chantier",
+  │                           chantier_id: "CH-064",
+  │                           territoire_code: "REG-53",
+  │                           jalon: 2025 }]
+  │             }]
+  │           })
+  │
+  └── texte: "Voici les indicateurs du chantier CH-064."
+```
+
+### 6.3 Impact sur les tools data
+
+| Tool | Avant | Après |
+|---|---|---|
+| `get_chantier_indicateurs` | Paramètre `afficher` (true/false), rendu conditionnel côté client | Suppression de `afficher`, données pures uniquement, pas de rendu client |
+| `get_taux_avancement_territoire` | Données pures | Inchangé |
+| `get_chantiers_en_retard` | Données pures | Inchangé |
+| `get_chantiers_en_difficulte` | Données pures | Inchangé |
+
+### 6.4 Impact sur `PiloteUITools`
+
+Le type `PiloteUITools` (consommé par le client) se simplifie :
+
+```typescript
+// Avant — le client doit savoir rendre chaque tool
+export type PiloteUITools = {
+  display_choices: { input: ...; output: ... };
+  get_taux_avancement_territoire: { input: ...; output: ... };
+  get_chantiers_en_retard: { input: ...; output: ... };
+  get_chantiers_en_difficulte: { input: ...; output: ... };
+  get_chantier_indicateurs: { input: ...; output: ... };   // ◄── rendu client
+  compose_dashboard: { input: ...; output: ... };           // ◄── rendu client
+  export_rapport: { input: ...; output: ... };
+};
+
+// Après — seuls les tools avec rendu visuel restent
+export type PiloteUITools = {
+  display_choices: { input: ...; output: ... };
+  create_dashboard: { input: ...; output: CreateDashboardOutput };
+  export_rapport: { input: ...; output: ... };
+};
+```
+
+Les tools data (`get_taux_avancement_territoire`, `get_chantiers_en_retard`,
+`get_chantiers_en_difficulte`, `get_chantier_indicateurs`) **disparaissent de
+`PiloteUITools`** car le client n'a plus besoin de les rendre.
+
+**Bénéfice** : le client n'a plus que 3 types de rendu à gérer (choices,
+dashboard, export) au lieu de 7. Moins de composants, moins de cas à maintenir.
+
+### 6.5 Impact sur le system prompt
+
+Le system prompt principal doit orienter l'agent vers `create_dashboard` pour
+tout affichage visuel :
+
+```
+## create_dashboard
+Quand l'utilisateur demande de visualiser des données (dashboard, indicateurs,
+cartographie, comparaison visuelle), appelle `create_dashboard`.
+C'est le seul canal d'affichage visuel. Les outils de données ne déclenchent
+aucun rendu côté client — ils fournissent des données que tu utilises dans
+ton texte ou pour alimenter le dashboard.
+```
+
+Le workflow "rapport complet" (§c du protocole actuel) évolue aussi :
+- Avant : `get_chantier_indicateurs(afficher=false)` + `export_rapport`
+- Après : `get_chantier_indicateurs` (plus de `afficher`) + `export_rapport`
+
+---
+
+## 7. Impact sur le code existant
+
+### 7.1 Ce qui change
+
+| Composant | Avant | Après |
+|---|---|---|
+| System prompt principal | Contient les règles dashboard (~100 lignes) | Allégé, mentionne juste "utilise `create_dashboard`" |
+| Tool exposé au parent | `compose_dashboard` | `create_dashboard` (encapsule le subagent) |
+| `detecteurIntention.ts` | `capacities.dashboard` active `compose_dashboard` | `capacities.dashboard` active `create_dashboard` |
+| `get_chantier_indicateurs` | Paramètre `afficher`, rendu conditionnel client | Données pures, `afficher` supprimé |
+| Client : nom du tool | Rend `compose_dashboard` + `get_chantier_indicateurs` | Rend `create_dashboard` uniquement |
+| Client : structure output | `{ titre, containers }` | Identique : `{ titre, containers }` |
+
+### 7.2 Ce qui ne change pas
+
+- **Catalogue de widgets** : les 12 types restent identiques
+- **`compose_dashboard` tool** : existe toujours, utilisé en interne par le subagent
+- **Composants React de rendu du dashboard** : inchangés, reçoivent la même structure JSON
+- **Tools data** : inchangés (sauf suppression de `afficher`), mêmes factories, mêmes habilitations
+- **`_output_instructions`** : pattern conservé dans les tools data
+- **Module DI** : les factories restent dans `albertModule`, on ajoute le subagent
+
+### 7.3 Client
+
+Le client se simplifie : seuls 3 tools ont un rendu visuel.
+
+```typescript
+// Avant — 7 tools à gérer côté client
+switch (part.toolName) {
+  case 'display_choices': ...
+  case 'get_taux_avancement_territoire': ...
+  case 'get_chantiers_en_retard': ...
+  case 'get_chantiers_en_difficulte': ...
+  case 'get_chantier_indicateurs': ...      // ◄── supprimé
+  case 'compose_dashboard': ...              // ◄── remplacé
+  case 'export_rapport': ...
+}
+
+// Après — 3 tools à gérer côté client
+switch (part.toolName) {
+  case 'display_choices': ...
+  case 'create_dashboard': ...               // ◄── nouveau
+  case 'export_rapport': ...
+}
+```
+
+Le placeholder affiché pendant le chargement du dashboard peut exploiter
+`part.input.task` pour donner du contexte :
+
+```
+"Composition du dashboard : avancement de la Bretagne..."
+```
+
+### 7.4 Type safety — `PiloteUIMessage`
+
+Le fichier `PiloteUIMessage.ts` définit le type `PiloteUITools` qui mappe chaque
+tool name vers ses types `input`/`output`. C'est ce type qui assure la type safety
+côté client quand on consomme les `ToolCallPart`.
+
+**Avant** :
+
+```typescript
+export type PiloteUITools = {
+  display_choices: {
+    input: z.input<typeof displayChoicesInputSchema>;
+    output: { question: string; choices: DisplayChoice[] };
+  };
+  get_taux_avancement_territoire: {
+    input: z.input<typeof getTauxAvancementTerritoireInputSchema>;
+    output: GetTauxAvancementTerritoireOutput;
+  };
+  get_chantiers_en_retard: {
+    input: z.input<typeof getChantiersEnRetardInputSchema>;
+    output: GetChantiersEnRetardOutput;
+  };
+  get_chantiers_en_difficulte: {
+    input: z.input<typeof getChantiersEnDifficulteInputSchema>;
+    output: GetChantiersEnDifficulteOutput;
+  };
+  get_chantier_indicateurs: {
+    input: z.input<typeof getChantierIndicateursInputSchema>;
+    output: GetChantierIndicateursOutput;
+  };
+  compose_dashboard: {
+    input: z.input<typeof composeDashboardInputSchema>;
+    output: ComposeDashboardOutput;
+  };
+  export_rapport: {
+    input: z.input<typeof exportRapportInputSchema>;
+    output: ExportRapportOutput;
+  };
+};
+```
+
+**Après** :
+
+```typescript
+import { createDashboardInputSchema, type CreateDashboardOutput }
+  from "@/server/albert/tools/createDashboard";
+
+export type PiloteUITools = {
+  display_choices: {
+    input: z.input<typeof displayChoicesInputSchema>;
+    output: { question: string; choices: DisplayChoice[] };
+  };
+  create_dashboard: {
+    input: z.input<typeof createDashboardInputSchema>;
+    output: CreateDashboardOutput;
+  };
+  export_rapport: {
+    input: z.input<typeof exportRapportInputSchema>;
+    output: ExportRapportOutput;
+  };
+};
+```
+
+Avec :
+
+```typescript
+// src/server/albert/tools/createDashboard.ts
+
+export const createDashboardInputSchema = z.object({
+  task: z.string(),
+});
+
+// L'output est le même que ComposeDashboardOutput — c'est le résultat
+// extrait du tool call compose_dashboard interne au subagent
+export type CreateDashboardOutput = ComposeDashboardOutput;
+```
+
+**Conséquence** : `PiloteUITools` passe de 7 entrées à 3. Le client est typé
+de bout en bout — `part.output` pour `create_dashboard` est
+`{ titre: string; containers: ContainerDefinition[]; _output_instructions: string }`.
+
+**Type `input` visible dans le placeholder** : `{ task: string }` permet d'afficher
+un message contextuel pendant le chargement, par exemple `part.input.task`.
+
+---
+
+## 8. Considérations
+
+### 8.1 Latence
+
+Le subagent ajoute un appel LLM supplémentaire. En pratique :
+
+- L'agent principal fait déjà plusieurs tool calls avant de composer le dashboard
+- Le subagent remplace la composition directe par le principal (pas d'appel en plus pour la composition elle-même)
+- Le surcoût net est le temps de "réflexion" du subagent pour décider quels tools data appeler et comment composer
+
+**Mitigation** : le placeholder côté client masque la latence perçue.
+
+### 8.2 Tokens
+
+Le subagent a son propre contexte. Le system prompt dashboard (~300 tokens estimés
+avec exemples) est consommé à chaque invocation du subagent, indépendamment du
+contexte principal.
+
+**Avantage** : le contexte principal est allégé des ~100 lignes de règles dashboard
+à chaque message, même quand l'utilisateur ne demande pas de dashboard.
+
+### 8.3 `ToolLoopAgent` — disponibilité
+
+`ToolLoopAgent` est une API récente du AI SDK. Si la version utilisée dans le projet
+ne la supporte pas encore, le même pattern peut être implémenté manuellement :
+
+```typescript
+// Fallback sans ToolLoopAgent
+async function runDashboardSubagent(prompt: string, tools: Tools, signal: AbortSignal) {
+  const result = await generateText({
+    model,
+    system: buildDashboardSystemPrompt(),
+    prompt,
+    tools,
+    maxSteps: 10,
+    abortSignal: signal,
+  });
+  return extractDashboardOutput(result);
+}
+```
+
+### 8.4 Erreurs
+
+Si le subagent échoue (timeout, pas de `compose_dashboard` dans les steps),
+le tool `create_dashboard` retourne une erreur structurée. L'agent principal
+peut alors informer l'utilisateur ou retenter avec des instructions ajustées.
+
+### 8.5 `needsApproval`
+
+La doc AI SDK précise que les tools d'un subagent ne peuvent pas utiliser
+`needsApproval`. Ce n'est pas un problème : aucun tool actuel ne l'utilise.
+
+---
+
+## 9. Evolutions futures
+
+### 8.1 Subagent Export Rapport
+
+Le même pattern peut s'appliquer à `export_rapport` : un subagent spécialisé
+dans la rédaction et la mise en forme de rapports (markdown/PDF), avec son propre
+prompt contenant des exemples de bons rapports et des règles de rédaction.
+
+### 8.2 Enrichissement du prompt dashboard
+
+Une fois le subagent en place, on peut enrichir son prompt sans impacter l'agent
+principal :
+- Plus d'exemples few-shot
+- Patterns de layout par type de demande (comparaison, focus, vue d'ensemble)
+- Règles de responsive / adaptation au nombre de territoires
+- Instructions de mise en page avancées
+
+### 8.3 Modèle dédié
+
+Le subagent pourrait utiliser un modèle différent de l'agent principal : un modèle
+plus petit et rapide suffirait pour la composition structurée, réduisant la latence
+et le coût.
+
+---
+
+## 10. Critères d'acceptation
+
+### Fonctionnel
+
+- [ ] L'utilisateur peut demander un dashboard en langage naturel et obtenir le même résultat qu'aujourd'hui
+- [ ] Le placeholder "Composition du dashboard..." s'affiche pendant l'exécution du subagent
+- [ ] Le dashboard rendu est identique en structure et en widgets à l'implémentation actuelle
+- [ ] Les permissions territoriales sont respectées par le subagent
+- [ ] En cas d'erreur du subagent, l'agent principal informe l'utilisateur
+- [ ] L'affichage des indicateurs d'un chantier passe par un dashboard (`widget_tableau_indicateurs_chantier`)
+
+### Technique
+
+- [ ] Le system prompt principal ne contient plus de règles de composition dashboard
+- [ ] Le subagent a son propre system prompt focalisé
+- [ ] Les tools data sont partagés (mêmes instances, mêmes habilitations)
+- [ ] Le tool `create_dashboard` est conditionné par `capacities.dashboard`
+- [ ] Le client rend le dashboard via le même composant, branché sur `create_dashboard`
+- [ ] Le `compose_dashboard` tool n'est plus exposé à l'agent principal
+- [ ] Le paramètre `afficher` de `get_chantier_indicateurs` est supprimé
+- [ ] Les tools data ne déclenchent plus de rendu côté client
+- [ ] `PiloteUITools` ne contient que les tools avec rendu visuel (`display_choices`, `create_dashboard`, `export_rapport`)
+
+---
+
+## 11. Questions ouvertes
+
+- **Faut-il passer l'historique de conversation au subagent ?** Par défaut non (isolation).
+  Mais si le contexte conversationnel est nécessaire (ex: "ajoute les indicateurs du
+  chantier dont on parlait"), on pourrait injecter un résumé dans le prompt du subagent.
+- **Quel `maxSteps` pour le subagent ?** Le subagent fait au maximum ~5 tool calls
+  (4 data + 1 compose). Un `maxSteps: 10` semble suffisant.
+- **Faut-il un fallback vers la composition directe ?** Si le subagent échoue
+  systématiquement, on pourrait revenir au mode actuel (compose_dashboard exposé
+  au parent). A évaluer après les premiers tests.

--- a/prd/LLM_SUBAGENT_DASHBOARD.md
+++ b/prd/LLM_SUBAGENT_DASHBOARD.md
@@ -1,6 +1,6 @@
 # Subagent Dashboard — Composition UI déléguée
 
-**Statut** : exploration
+**Statut** : implémenté
 
 ---
 
@@ -8,9 +8,9 @@
 
 ### 1.1 Problème actuel
 
-Le system prompt d'Albert concentre aujourd'hui l'ensemble des responsabilités :
+Le system prompt d'Albert concentrait l'ensemble des responsabilités :
 analyse métier, glossaire territorial, protocoles d'orchestration des tools,
-**et** toutes les règles de composition de dashboard (12 types de widgets, grille
+**et** toutes les règles de composition de dashboard (13 types de widgets, grille
 4 colonnes, contraintes de layout, exemples JSON).
 
 Ce constat est documenté dans `SYSTEM_PROMPT.md` qui qualifie le prompt de
@@ -25,17 +25,16 @@ une structure JSON déclarative.
 
 ### 1.2 Opportunité
 
-Le AI SDK (Vercel) propose depuis peu un pattern **subagent** (`ToolLoopAgent`) :
-un agent spécialisé, invoqué comme un tool par l'agent principal, qui tourne dans
-son propre contexte et retourne un résultat structuré.
-
-cf. https://ai-sdk.dev/docs/agents/subagents
+Le AI SDK (Vercel) propose un pattern **structured output** via `Output.object()` :
+un appel `generateText` qui retourne directement un objet JSON validé par un schéma Zod,
+sans tool loop.
 
 Ce pattern correspond exactement au cas de la composition dashboard :
 - Tâche autonome et bien définie
 - Résultat déclaratif (références, pas données)
 - Instructions volumineuses et spécialisées
 - Bénéfice direct à isoler du contexte principal
+- Un seul appel LLM suffit (pas besoin d'outils internes)
 
 ---
 
@@ -66,7 +65,7 @@ Utilisateur : "Montre-moi un dashboard pour la Bretagne"
 │  System prompt allégé :                     │
 │  - identité, glossaire, règles métier       │
 │  - protocole synthèse                       │
-│  - PAS de règles dashboard                  │
+│  - PAS de règles dashboard détaillées       │
 │                                             │
 │  Tools :                                    │
 │  - get_taux_avancement_territoire           │
@@ -79,29 +78,30 @@ Utilisateur : "Montre-moi un dashboard pour la Bretagne"
 │                                             │
 └──────────────┬──────────────────────────────┘
                │ appel tool create_dashboard
-               │ input: { task: "Dashboard avancement Bretagne" }
+               │ input: { task, territoire_codes,
+               │          jalons, chantiers? }
                ▼
 ┌─────────────────────────────────────────────┐
-│  Subagent Dashboard                         │
+│  Subagent Dashboard (1 appel LLM)           │
 │                                             │
 │  System prompt dédié :                      │
-│  - catalogue des 12 widgets                 │
+│  - catalogue des 13 widgets                 │
 │  - règles de grille (4 colonnes)            │
 │  - patterns de composition                  │
 │  - exemples few-shot                        │
 │  - contraintes (pas de chiffres dans titres)│
 │                                             │
-│  Tools :                                    │
-│  - compose_dashboard                        │
-│  - get_taux_avancement_territoire           │
-│  - get_chantiers_en_retard                  │
-│  - get_chantiers_en_difficulte              │
-│  - get_chantier_indicateurs                 │
+│  Pas de tools — structured output :         │
+│  Output.object({ schema:                    │
+│    composeDashboardInputSchema })           │
 │                                             │
-│  Exécution autonome :                       │
-│  1. Appelle les tools data si nécessaire    │
-│  2. Compose le dashboard via compose_dashboard│
-│  3. Retourne le JSON au parent              │
+│  Reçoit un prompt avec bloc <context>       │
+│  contenant territoire_codes, jalons,        │
+│  chantiers (id, nom, statut, meteo,         │
+│  commentaire)                               │
+│                                             │
+│  Post-validation :                          │
+│  validateDashboardIdentifiers()             │
 └──────────────┬──────────────────────────────┘
                │ output: { titre, containers, ... }
                ▼
@@ -120,8 +120,8 @@ Utilisateur : "Montre-moi un dashboard pour la Bretagne"
 
 ### 3.2 Pas de streaming intermédiaire
 
-Le subagent utilise `generate` (pas `stream`). Le client ne voit pas les étapes
-internes du subagent (appels data, composition). Il voit uniquement :
+Le subagent utilise `generateText` (pas `streamText`). Le client ne voit pas
+l'exécution interne du subagent. Il voit uniquement :
 
 1. **Tool call démarre** (`state: input-available`) → placeholder "Composition du dashboard..."
 2. **Tool call terminé** (`state: output-available`) → JSON dashboard → rendu
@@ -134,35 +134,25 @@ complexité sans bénéfice UX perceptible.
 
 ## 4. Architecture technique
 
-### 4.1 Subagent Dashboard
+### 4.1 Approche retenue : Structured Output (pas ToolLoopAgent)
+
+L'exploration initiale envisageait `ToolLoopAgent` (un subagent avec ses propres tools
+data). En pratique, un **seul appel LLM** avec `Output.object()` suffit : l'agent
+principal collecte d'abord les données (chantiers en retard, météo, etc.) puis les
+passe au subagent dans un bloc `<context>` du prompt. Le subagent n'a besoin d'aucun
+outil — il compose le JSON directement.
 
 ```typescript
-// src/server/albert/subagents/dashboardSubagent.ts
+// src/server/albert/tools/createDashboard.ts
 
-import { ToolLoopAgent } from 'ai';
-
-export type CreateDashboardSubagentDeps = {
-  model: LanguageModel;
-  composeDashboardTool: Tool;
-  getTauxAvancementTerritoireTool: Tool;
-  getChantiersEnRetardTool: Tool;
-  getChantiersEnDifficulteTool: Tool;
-  getChantierIndicateursTool: Tool;
-};
-
-export function createDashboardSubagent(deps: CreateDashboardSubagentDeps) {
-  return new ToolLoopAgent({
-    model: deps.model,
-    instructions: buildDashboardSystemPrompt(),
-    tools: {
-      compose_dashboard: deps.composeDashboardTool,
-      get_taux_avancement_territoire: deps.getTauxAvancementTerritoireTool,
-      get_chantiers_en_retard: deps.getChantiersEnRetardTool,
-      get_chantiers_en_difficulte: deps.getChantiersEnDifficulteTool,
-      get_chantier_indicateurs: deps.getChantierIndicateursTool,
-    },
-  });
-}
+const result = await generateText({
+  model: withOptionalDevTools(albertProvider.chat("openweight-large")),
+  system: buildDashboardSystemPrompt(),
+  prompt: buildSubagentPrompt(task, territoire_codes, jalons, chantiers),
+  stopWhen: stepCountIs(5),
+  output: Output.object({ schema: composeDashboardInputSchema }),
+  abortSignal,
+});
 ```
 
 ### 4.2 Tool `create_dashboard`
@@ -172,100 +162,103 @@ Exposé à l'agent principal, il encapsule l'appel au subagent :
 ```typescript
 // src/server/albert/tools/createDashboard.ts
 
-import { tool } from 'ai';
-import { z } from 'zod';
-
-export function createCreateDashboardTool(subagent: ToolLoopAgent) {
-  return tool({
-    description: `Délègue la composition d'un dashboard à un agent spécialisé.
-Utilise ce tool quand l'utilisateur demande un dashboard, un cockpit,
-ou un tableau de bord visuel.`,
-    parameters: z.object({
-      task: z.string().describe(
-        "Description de ce que l'utilisateur veut visualiser, "
-        + "incluant le(s) territoire(s), le jalon, et le type d'analyse souhaitée."
-      ),
-    }),
-    execute: async ({ task }, { abortSignal }) => {
-      const result = await subagent.generate({
-        prompt: task,
-        abortSignal,
-      });
-      return extractDashboardOutput(result);
-    },
-  });
-}
+export const createDashboardInputSchema = z.object({
+  task: z.string().describe("Description de ce que l'utilisateur veut visualiser."),
+  territoire_codes: z.array(z.string()).min(1).describe("Codes des territoires concernés."),
+  jalons: z.array(z.number().int()).min(1).describe("Années des jalons."),
+  chantiers: z.array(chantierContextSchema).optional().describe(
+    "Chantiers ciblés avec nom, statut, meteo, commentaire."
+  ),
+});
 ```
 
-### 4.3 Extraction du résultat
+L'agent principal résout les identifiants (territoires, jalons, chantiers) et les
+passe au subagent. Le subagent ne fait que composer le layout à partir de ces données.
 
-Le subagent produit potentiellement du texte + des tool calls. On extrait
-l'output du tool `compose_dashboard` :
+### 4.3 Bloc `<context>` et prompt du subagent
+
+Le prompt du subagent est construit par `buildSubagentPrompt()` qui injecte un bloc
+`<context>` contenant les identifiants résolus :
 
 ```typescript
-function extractDashboardOutput(result: GenerateResult): DashboardOutput {
-  // Chercher le dernier tool call compose_dashboard dans les steps
-  const composeDashboardCall = result.steps
-    .flatMap(step => step.toolCalls)
-    .findLast(call => call.toolName === 'compose_dashboard');
-
-  if (!composeDashboardCall) {
-    return { error: 'Le subagent n\'a pas pu composer de dashboard.' };
-  }
-
-  return composeDashboardCall.result;
+function buildSubagentPrompt(
+  task: string,
+  territoireCodes: string[],
+  jalons: number[],
+  chantiers: ChantierContext[] | undefined,
+): string {
+  const contextLines = [
+    "<context>",
+    `territoire_codes: ${JSON.stringify(territoireCodes)}`,
+    `jalons: ${JSON.stringify(jalons)}`,
+    ...(chantiers?.length ? [`chantiers: ${JSON.stringify(chantiers)}`] : []),
+    "</context>",
+  ];
+  return `${task}\n\n${contextLines.join("\n")}`;
 }
 ```
 
 ### 4.4 System prompt du subagent
 
-Le prompt du subagent est **focalisé uniquement sur la composition dashboard**.
-Il contient :
+Le prompt du subagent (`src/server/albert/subagents/dashboardSystemPrompt.ts`) est
+**focalisé uniquement sur la composition dashboard**. Il contient :
 
 | Section | Contenu |
 |---|---|
 | Identité | "Tu es un spécialiste de la composition de dashboards PILOTE" |
-| Catalogue widgets | Les 12 types avec description, paramètres, `default_width` |
+| Bloc `<context>` | Explication du format (territoire_codes, jalons, chantiers) |
+| Catalogue widgets | Les 13 types avec description, paramètres, `default_width` |
 | Règles de grille | 4 colonnes, containers empilés verticalement |
-| Patterns de composition | Par type de demande (mono-territoire, comparaison, focus chantier) |
-| Exemples few-shot | 2-3 dashboards complets en JSON |
-| Contraintes | Pas de chiffres dans `widget_titre_section`, permissions territoire |
-| Protocole | Appeler les tools data d'abord si besoin de contexte, puis `compose_dashboard` |
+| `widget_titre_section` | Jamais de chiffres, format du titre chantier |
+| `widget_paragraph` | Contenu string[], règle anti-newlines, météo + commentaire, variant warning |
+| Patterns de composition | Cockpit mono-territoire, ventilation sous-territoires, focus chantier, indicateurs |
+| Exemples few-shot | 2 dashboards complets en JSON |
+| Protocole | Utiliser exclusivement les identifiants du `<context>` |
 
 **Ce qui n'est PAS dans ce prompt** : glossaire métier détaillé, règles de synthèse,
 protocole de dialogue, gestion d'erreurs conversationnelles. Le subagent n'interagit
-pas avec l'utilisateur.
+pas avec l'utilisateur et n'a pas accès à des outils.
 
-### 4.5 Injection des dépendances
+### 4.5 Validation post-génération
 
-Les tools data du subagent sont les **mêmes instances** que ceux de l'agent principal,
-construits avec les mêmes habilitations et territoires accessibles :
+Après que le subagent a produit le JSON dashboard, `validateDashboardIdentifiers()`
+vérifie que tous les identifiants utilisés dans les widgets sont bien dans le périmètre
+autorisé :
 
 ```typescript
-// Dans la route API /api/albert/chat
+export function validateDashboardIdentifiers(
+  output: ComposeDashboardInput,
+  allowedTerritoires: string[],
+  allowedJalons: number[],
+  allowedChantiers: ChantierContext[] | undefined,
+): void
+```
+
+Cette validation parcourt tous les widgets et vérifie :
+- `territoire_code` ∈ `allowedTerritoires`
+- `jalon` ∈ `allowedJalons`
+- `chantier_id` et `chantier_ids` ∈ `allowedChantiers` (et que `allowedChantiers` est défini)
+
+En cas de violation, une erreur est levée et le subagent échoue proprement.
+
+### 4.6 Câblage dans la route API
+
+Le subagent ne nécessite pas d'injection de dépendances — il crée son propre provider
+et n'a pas de tools :
+
+```typescript
+// src/app/api/albert/chat/route.ts
+
+const createDashboard = createCreateDashboardTool();
 
 const tools = {
-  get_taux_avancement_territoire: createGetTauxTool({ habilitations, ... }),
-  get_chantiers_en_retard: createGetRetardTool({ habilitations, ... }),
-  // ...
-};
-
-const dashboardSubagent = createDashboardSubagent({
-  model,
-  composeDashboardTool: tools.compose_dashboard,
-  getTauxAvancementTerritoireTool: tools.get_taux_avancement_territoire,
-  getChantiersEnRetardTool: tools.get_chantiers_en_retard,
-  getChantiersEnDifficulteTool: tools.get_chantiers_en_difficulte,
-  getChantierIndicateursTool: tools.get_chantier_indicateurs,
-});
-
-const createDashboardTool = createCreateDashboardTool(dashboardSubagent);
-
-// L'agent principal reçoit create_dashboard au lieu de compose_dashboard
-const mainTools = {
-  ...tools,
-  create_dashboard: createDashboardTool,
-  // compose_dashboard n'est plus exposé au parent
+  get_taux_avancement_territoire: getTauxAvancementTerritoire,
+  get_chantiers_en_retard: getChantiersEnRetard,
+  get_chantiers_en_difficulte: getChantiersEnDifficulte,
+  get_chantier_indicateurs: getChantierIndicateurs,
+  display_choices: displayChoicesTool,
+  ...(capacities.dashboard ? { create_dashboard: createDashboard } : {}),
+  ...(capacities.exportRapport ? { export_rapport: exportRapport } : {}),
 };
 ```
 
@@ -280,7 +273,7 @@ Les instructions de composition dashboard sont réparties en **deux endroits** :
 | Emplacement | Contenu | Volume |
 |---|---|---|
 | `systemPrompt.ts` | Références à `compose_dashboard` dans la règle pseudo-code (l.316) et le protocole d'outils | ~5 lignes |
-| `composeDashboard.ts` (tool description) | Catalogue des 12 widgets, structure recommandée, règles JSON, 3 exemples complets | ~70 lignes |
+| `composeDashboard.ts` (tool description) | Catalogue des 13 widgets, structure recommandée, règles JSON, 3 exemples complets | ~70 lignes |
 
 Le gros du savoir dashboard est dans la **description du tool**, pas dans le system prompt.
 Mais cette description est injectée dans le contexte du LLM principal à chaque message
@@ -384,90 +377,31 @@ Ce tool est vu par l'**agent principal**. Sa description est courte :
 ```
 Délègue la composition d'un dashboard à un agent spécialisé.
 Utilise ce tool quand l'utilisateur demande un dashboard, un cockpit,
-ou un tableau de bord visuel. Décris précisément ce que l'utilisateur
-veut visualiser : territoire(s), jalon, type d'analyse.
+un tableau de bord visuel, ou d'afficher les indicateurs d'un chantier.
+Fournis la description de ce que l'utilisateur veut visualiser ainsi que
+les identifiants résolus (territoire_codes, jalons, chantiers).
 ```
 
-Un seul paramètre : `task: string`.
+Paramètres :
+- `task: string` — description de ce que l'utilisateur veut visualiser
+- `territoire_codes: string[]` — codes des territoires concernés (obligatoire)
+- `jalons: number[]` — années des jalons (obligatoire)
+- `chantiers?: ChantierContext[]` — chantiers ciblés avec `{id, nom, statut?, meteo?, commentaire?}`
 
 ### 5.5 System prompt du subagent — Nouveau
 
-Ce prompt concentre tout le savoir dashboard qui était auparavant dispersé :
+Ce prompt (`src/server/albert/subagents/dashboardSystemPrompt.ts`) concentre tout
+le savoir dashboard qui était auparavant dispersé. Le subagent n'a **pas de tools** —
+il reçoit un prompt avec un bloc `<context>` et produit directement la structure JSON
+via structured output.
 
-```
-Tu es un spécialiste de la composition de dashboards pour PILOTE,
-l'outil de suivi des politiques prioritaires du gouvernement français.
-
-# Ta mission
-
-Tu reçois une description de ce que l'utilisateur veut visualiser.
-Tu dois composer un dashboard structuré en appelant `compose_dashboard`.
-
-Si tu as besoin de contexte pour décider quels widgets inclure
-(ex: savoir quels chantiers sont en retard), appelle d'abord les outils
-de données disponibles, puis compose le dashboard.
-
-# Catalogue de widgets
-
-| Widget | Intention | Paramètres | default_width | allowed_widths |
-|---|---|---|---|---|
-| widget_taux_avancement_territoire | TA agrégé d'un territoire | territoire_code, jalon | 1 | [1,2] |
-| widget_mediane_avancement_territoire | Médiane du TA | territoire_code, jalon | 1 | [1,2] |
-| widget_nombre_chantiers_en_retard | Nombre en retard | territoire_code, jalon | 1 | [1,2] |
-| widget_nombre_chantiers_en_difficulte | Nombre en difficulté | territoire_code, jalon | 1 | [1,2] |
-| widget_valeurs_remarquables_avancement | Min/médiane/max du TA | territoire_code, jalon | 2 | [2,3,4] |
-| widget_tableau_indicateurs_chantier | VI/VA/VC/TA d'un chantier | chantier_id, territoire_code, jalon | 4 | [4] |
-| widget_liste_chantiers_en_retard | Liste chantiers en retard | territoire_code, jalon | 2 | [2,4] |
-| widget_liste_chantiers_en_difficulte | Liste chantiers en difficulté | territoire_code, jalon | 2 | [2,4] |
-| widget_cartographie_taux_avancement | Carte du TA | maille, territoire_code, jalon, chantier_ids | 2 | [2,3,4] |
-| widget_cartographie_meteo | Carte des météos | maille, territoire_code, chantier_id, jalon | 2 | [2,3,4] |
-| widget_cartographie_propositions_valeur_avancement | Carte des PVA | maille, territoire_code, chantier_id, jalon | 2 | [2,3,4] |
-| widget_titre_section | Titre + description (AUCUN chiffre) | titre, description? | 4 | [2,4] |
-
-# Règles de composition
-
-## Grille
-- Un dashboard = liste ordonnée de containers empilés verticalement
-- Chaque container a un grid interne de 4 colonnes
-- Les widgets sont placés selon leur `width` (par défaut `default_width`)
-- Un widget seul dans un container de 4 colonnes gâche de la place
-  si sa default_width < 4. Regroupe les widgets compatibles.
-
-## widget_titre_section
-- JAMAIS de chiffres (%, points, pts) dans le titre ou la description
-- Utilise un widget KPI atomique pour afficher un chiffre
-
-## Patterns recommandés
-
-### Cockpit synthétique (mono-territoire)
-1. Container : `widget_titre_section`
-2. Container : `widget_taux_avancement_territoire` (1) + `widget_nombre_chantiers_en_retard` (1) + `widget_valeurs_remarquables_avancement` (2) = 4 colonnes
-3. Container : `widget_cartographie_taux_avancement` (4)
-4. Container : `widget_liste_chantiers_en_retard` (2) + `widget_liste_chantiers_en_difficulte` (2)
-
-### Ventilation par sous-territoires
-Pour chaque sous-territoire, répéter :
-1. Container : `widget_titre_section` avec nom du sous-territoire
-2. Container : 3 KPI compacts (1+1+1=3, 4e colonne vide)
-
-### Focus chantier
-1. Container : `widget_titre_section` avec nom du chantier
-2. Container : `widget_tableau_indicateurs_chantier` (4)
-3. Container : cartographies thématiques (météo, TA, PVA)
-
-# Exemples
-
-[mêmes 3 exemples JSON que l'actuel compose_dashboard description]
-
-# Protocole
-
-1. Analyse la demande
-2. Si tu as besoin de contexte (quels chantiers sont en retard, etc.),
-   appelle les outils de données
-3. Appelle `compose_dashboard` avec la structure complète
-4. Ta réponse textuelle finale sera ignorée — seul le résultat
-   de `compose_dashboard` est retourné au parent
-```
+Sections clés du prompt :
+- **Bloc `<context>`** : format des données (territoire_codes, jalons, chantiers avec id/nom/statut/meteo/commentaire)
+- **Règle anti-hallucination** : utiliser exclusivement les identifiants du `<context>`
+- **Catalogue de 13 widgets** (12 originaux + `widget_paragraph`)
+- **`widget_paragraph`** : contenu string[], règle anti-newlines, météo + commentaire d'un chantier, variant warning pour incohérences
+- **Patterns de composition** : cockpit, ventilation, focus chantier, indicateurs
+- **Exemples few-shot** : 2 dashboards JSON complets
 
 ### 5.6 Résumé du transfert
 
@@ -499,7 +433,7 @@ Pour chaque sous-territoire, répéter :
                                      NOUVEAU      │  system      │
                                    ◄─────────     │  prompt      │
                                                   │              │
-                                                  │  ~80 lignes  │
+                                                  │  ~137 lignes │
                                                   │  catalogue   │
                                                   │  patterns    │
                                                   │  exemples    │
@@ -515,9 +449,9 @@ Pour chaque sous-territoire, répéter :
 | Tool desc `compose_dashboard` | ~70 lignes | ~3 lignes (-67) |
 | Tool desc `create_dashboard` | — | ~4 lignes (+4) |
 | **Total injecté par message** | **~445 lignes** | **~317 lignes (-128)** |
-| Subagent (uniquement si invoqué) | — | ~80 lignes |
+| Subagent (uniquement si invoqué) | — | ~137 lignes |
 
-Le subagent prompt (~80 lignes) n'est consommé que lorsque l'utilisateur demande
+Le subagent prompt (~137 lignes) n'est consommé que lorsque l'utilisateur demande
 effectivement un dashboard — pas à chaque message de la conversation.
 
 ---
@@ -589,34 +523,24 @@ Agent principal
 
 ### 6.4 Impact sur `PiloteUITools`
 
-Le type `PiloteUITools` (consommé par le client) se simplifie :
+Le type `PiloteUITools` conserve les 7 entrées (les tools data restent déclarés
+car le client affiche un `ToolCallIndicator` pour chaque appel de données) :
 
 ```typescript
-// Avant — le client doit savoir rendre chaque tool
 export type PiloteUITools = {
   display_choices: { input: ...; output: ... };
   get_taux_avancement_territoire: { input: ...; output: ... };
   get_chantiers_en_retard: { input: ...; output: ... };
   get_chantiers_en_difficulte: { input: ...; output: ... };
-  get_chantier_indicateurs: { input: ...; output: ... };   // ◄── rendu client
-  compose_dashboard: { input: ...; output: ... };           // ◄── rendu client
-  export_rapport: { input: ...; output: ... };
-};
-
-// Après — seuls les tools avec rendu visuel restent
-export type PiloteUITools = {
-  display_choices: { input: ...; output: ... };
-  create_dashboard: { input: ...; output: CreateDashboardOutput };
+  get_chantier_indicateurs: { input: ...; output: ... };
+  create_dashboard: { input: ...; output: CreateDashboardOutput };  // ◄── remplace compose_dashboard
   export_rapport: { input: ...; output: ... };
 };
 ```
 
-Les tools data (`get_taux_avancement_territoire`, `get_chantiers_en_retard`,
-`get_chantiers_en_difficulte`, `get_chantier_indicateurs`) **disparaissent de
-`PiloteUITools`** car le client n'a plus besoin de les rendre.
-
-**Bénéfice** : le client n'a plus que 3 types de rendu à gérer (choices,
-dashboard, export) au lieu de 7. Moins de composants, moins de cas à maintenir.
+Le changement principal : `compose_dashboard` est remplacé par `create_dashboard`.
+Les tools data ne déclenchent plus de rendu riche (tableau, carte) mais affichent
+un indicateur compact (nom de l'outil + état).
 
 ### 6.5 Impact sur le system prompt
 
@@ -645,16 +569,17 @@ Le workflow "rapport complet" (§c du protocole actuel) évolue aussi :
 | Composant | Avant | Après |
 |---|---|---|
 | System prompt principal | Contient les règles dashboard (~100 lignes) | Allégé, mentionne juste "utilise `create_dashboard`" |
-| Tool exposé au parent | `compose_dashboard` | `create_dashboard` (encapsule le subagent) |
-| `detecteurIntention.ts` | `capacities.dashboard` active `compose_dashboard` | `capacities.dashboard` active `create_dashboard` |
+| Tool exposé au parent | `compose_dashboard` | `create_dashboard` (structured output via subagent) |
+| `detecteurIntention.ts` | `capacities.dashboard` active `compose_dashboard` | `capacities.dashboard` active `create_dashboard`, mots-clés "indicateur"/"indicateurs" ajoutés |
 | `get_chantier_indicateurs` | Paramètre `afficher`, rendu conditionnel client | Données pures, `afficher` supprimé |
 | Client : nom du tool | Rend `compose_dashboard` + `get_chantier_indicateurs` | Rend `create_dashboard` uniquement |
 | Client : structure output | `{ titre, containers }` | Identique : `{ titre, containers }` |
+| Nouveau widget | — | `widget_paragraph` (contenu string[], variant warning) |
 
 ### 7.2 Ce qui ne change pas
 
-- **Catalogue de widgets** : les 12 types restent identiques
-- **`compose_dashboard` tool** : existe toujours, utilisé en interne par le subagent
+- **Catalogue de widgets** : les 12 types originaux restent identiques, `widget_paragraph` ajouté (13 total)
+- **`compose_dashboard` tool** : existe toujours, son schéma Zod sert de contrat pour le structured output
 - **Composants React de rendu du dashboard** : inchangés, reçoivent la même structure JSON
 - **Tools data** : inchangés (sauf suppression de `afficher`), mêmes factories, mêmes habilitations
 - **`_output_instructions`** : pattern conservé dans les tools data
@@ -662,26 +587,17 @@ Le workflow "rapport complet" (§c du protocole actuel) évolue aussi :
 
 ### 7.3 Client
 
-Le client se simplifie : seuls 3 tools ont un rendu visuel.
+Le client se simplifie côté rendu riche : les tools data n'affichent plus qu'un
+`ToolCallIndicator` (icône + état) au lieu d'un rendu complet.
 
 ```typescript
-// Avant — 7 tools à gérer côté client
-switch (part.toolName) {
-  case 'display_choices': ...
-  case 'get_taux_avancement_territoire': ...
-  case 'get_chantiers_en_retard': ...
-  case 'get_chantiers_en_difficulte': ...
-  case 'get_chantier_indicateurs': ...      // ◄── supprimé
-  case 'compose_dashboard': ...              // ◄── remplacé
-  case 'export_rapport': ...
-}
+// Avant — rendu riche pour get_chantier_indicateurs et compose_dashboard
+case 'get_chantier_indicateurs': // tableau d'indicateurs  ◄── supprimé
+case 'compose_dashboard': // dashboard complet              ◄── remplacé
 
-// Après — 3 tools à gérer côté client
-switch (part.toolName) {
-  case 'display_choices': ...
-  case 'create_dashboard': ...               // ◄── nouveau
-  case 'export_rapport': ...
-}
+// Après — seul create_dashboard a un rendu dashboard
+case 'create_dashboard': // dashboard complet               ◄── nouveau
+// get_chantier_indicateurs → simple ToolCallIndicator
 ```
 
 Le placeholder affiché pendant le chargement du dashboard peut exploiter
@@ -697,61 +613,13 @@ Le fichier `PiloteUIMessage.ts` définit le type `PiloteUITools` qui mappe chaqu
 tool name vers ses types `input`/`output`. C'est ce type qui assure la type safety
 côté client quand on consomme les `ToolCallPart`.
 
-**Avant** :
+**Changement** : `compose_dashboard` est remplacé par `create_dashboard` dans `PiloteUITools`.
+Les tools data restent dans le type (pour les `ToolCallIndicator`).
 
 ```typescript
-export type PiloteUITools = {
-  display_choices: {
-    input: z.input<typeof displayChoicesInputSchema>;
-    output: { question: string; choices: DisplayChoice[] };
-  };
-  get_taux_avancement_territoire: {
-    input: z.input<typeof getTauxAvancementTerritoireInputSchema>;
-    output: GetTauxAvancementTerritoireOutput;
-  };
-  get_chantiers_en_retard: {
-    input: z.input<typeof getChantiersEnRetardInputSchema>;
-    output: GetChantiersEnRetardOutput;
-  };
-  get_chantiers_en_difficulte: {
-    input: z.input<typeof getChantiersEnDifficulteInputSchema>;
-    output: GetChantiersEnDifficulteOutput;
-  };
-  get_chantier_indicateurs: {
-    input: z.input<typeof getChantierIndicateursInputSchema>;
-    output: GetChantierIndicateursOutput;
-  };
-  compose_dashboard: {
-    input: z.input<typeof composeDashboardInputSchema>;
-    output: ComposeDashboardOutput;
-  };
-  export_rapport: {
-    input: z.input<typeof exportRapportInputSchema>;
-    output: ExportRapportOutput;
-  };
-};
-```
-
-**Après** :
-
-```typescript
-import { createDashboardInputSchema, type CreateDashboardOutput }
-  from "@/server/albert/tools/createDashboard";
-
-export type PiloteUITools = {
-  display_choices: {
-    input: z.input<typeof displayChoicesInputSchema>;
-    output: { question: string; choices: DisplayChoice[] };
-  };
-  create_dashboard: {
-    input: z.input<typeof createDashboardInputSchema>;
-    output: CreateDashboardOutput;
-  };
-  export_rapport: {
-    input: z.input<typeof exportRapportInputSchema>;
-    output: ExportRapportOutput;
-  };
-};
+// Remplacement dans PiloteUITools
+- compose_dashboard: { input: composeDashboardInputSchema; output: ComposeDashboardOutput }
++ create_dashboard: { input: createDashboardInputSchema; output: CreateDashboardOutput }
 ```
 
 Avec :
@@ -761,19 +629,17 @@ Avec :
 
 export const createDashboardInputSchema = z.object({
   task: z.string(),
+  territoire_codes: z.array(z.string()).min(1),
+  jalons: z.array(z.number().int()).min(1),
+  chantiers: z.array(chantierContextSchema).optional(),
 });
 
-// L'output est le même que ComposeDashboardOutput — c'est le résultat
-// extrait du tool call compose_dashboard interne au subagent
+// L'output est le même que ComposeDashboardOutput
 export type CreateDashboardOutput = ComposeDashboardOutput;
 ```
 
-**Conséquence** : `PiloteUITools` passe de 7 entrées à 3. Le client est typé
-de bout en bout — `part.output` pour `create_dashboard` est
-`{ titre: string; containers: ContainerDefinition[]; _output_instructions: string }`.
-
-**Type `input` visible dans le placeholder** : `{ task: string }` permet d'afficher
-un message contextuel pendant le chargement, par exemple `part.input.task`.
+**Type `input` visible dans le placeholder** : `{ task, territoire_codes, jalons, chantiers? }`
+permet d'afficher un message contextuel pendant le chargement, par exemple `part.input.task`.
 
 ---
 
@@ -781,11 +647,11 @@ un message contextuel pendant le chargement, par exemple `part.input.task`.
 
 ### 8.1 Latence
 
-Le subagent ajoute un appel LLM supplémentaire. En pratique :
+Le subagent ajoute un appel LLM supplémentaire (un seul `generateText`). En pratique :
 
 - L'agent principal fait déjà plusieurs tool calls avant de composer le dashboard
 - Le subagent remplace la composition directe par le principal (pas d'appel en plus pour la composition elle-même)
-- Le surcoût net est le temps de "réflexion" du subagent pour décider quels tools data appeler et comment composer
+- Le surcoût net est le temps du structured output (1 appel LLM sans tools)
 
 **Mitigation** : le placeholder côté client masque la latence perçue.
 
@@ -798,48 +664,34 @@ contexte principal.
 **Avantage** : le contexte principal est allégé des ~100 lignes de règles dashboard
 à chaque message, même quand l'utilisateur ne demande pas de dashboard.
 
-### 8.3 `ToolLoopAgent` — disponibilité
+### 8.3 Choix de `Output.object()` plutôt que `ToolLoopAgent`
 
-`ToolLoopAgent` est une API récente du AI SDK. Si la version utilisée dans le projet
-ne la supporte pas encore, le même pattern peut être implémenté manuellement :
+L'exploration initiale envisageait `ToolLoopAgent` (subagent avec ses propres tools data).
+En pratique, `Output.object()` (structured output) a été retenu :
 
-```typescript
-// Fallback sans ToolLoopAgent
-async function runDashboardSubagent(prompt: string, tools: Tools, signal: AbortSignal) {
-  const result = await generateText({
-    model,
-    system: buildDashboardSystemPrompt(),
-    prompt,
-    tools,
-    maxSteps: 10,
-    abortSignal: signal,
-  });
-  return extractDashboardOutput(result);
-}
-```
+- Le subagent n'a pas besoin de tools — l'agent principal collecte les données en amont
+- Un seul appel LLM suffit, pas de boucle d'outils
+- Le schéma Zod (`composeDashboardInputSchema`) valide directement le JSON retourné
+- `stepCountIs(5)` sert de garde-fou (retries internes du structured output)
 
 ### 8.4 Erreurs
 
-Si le subagent échoue (timeout, pas de `compose_dashboard` dans les steps),
-le tool `create_dashboard` retourne une erreur structurée. L'agent principal
-peut alors informer l'utilisateur ou retenter avec des instructions ajustées.
-
-### 8.5 `needsApproval`
-
-La doc AI SDK précise que les tools d'un subagent ne peuvent pas utiliser
-`needsApproval`. Ce n'est pas un problème : aucun tool actuel ne l'utilise.
+Si le subagent échoue (timeout, structured output non parsable après retries),
+le tool `create_dashboard` lève une erreur. L'agent principal peut alors informer
+l'utilisateur. La validation post-génération (`validateDashboardIdentifiers`) peut
+aussi rejeter un dashboard contenant des identifiants hallucinés.
 
 ---
 
 ## 9. Evolutions futures
 
-### 8.1 Subagent Export Rapport
+### 9.1 Subagent Export Rapport
 
 Le même pattern peut s'appliquer à `export_rapport` : un subagent spécialisé
 dans la rédaction et la mise en forme de rapports (markdown/PDF), avec son propre
 prompt contenant des exemples de bons rapports et des règles de rédaction.
 
-### 8.2 Enrichissement du prompt dashboard
+### 9.2 Enrichissement du prompt dashboard
 
 Une fois le subagent en place, on peut enrichir son prompt sans impacter l'agent
 principal :
@@ -848,7 +700,7 @@ principal :
 - Règles de responsive / adaptation au nombre de territoires
 - Instructions de mise en page avancées
 
-### 8.3 Modèle dédié
+### 9.3 Modèle dédié
 
 Le subagent pourrait utiliser un modèle différent de l'agent principal : un modèle
 plus petit et rapide suffirait pour la composition structurée, réduisant la latence
@@ -860,24 +712,27 @@ et le coût.
 
 ### Fonctionnel
 
-- [ ] L'utilisateur peut demander un dashboard en langage naturel et obtenir le même résultat qu'aujourd'hui
-- [ ] Le placeholder "Composition du dashboard..." s'affiche pendant l'exécution du subagent
-- [ ] Le dashboard rendu est identique en structure et en widgets à l'implémentation actuelle
-- [ ] Les permissions territoriales sont respectées par le subagent
-- [ ] En cas d'erreur du subagent, l'agent principal informe l'utilisateur
-- [ ] L'affichage des indicateurs d'un chantier passe par un dashboard (`widget_tableau_indicateurs_chantier`)
+- [x] L'utilisateur peut demander un dashboard en langage naturel et obtenir le même résultat qu'aujourd'hui
+- [x] Le placeholder "Composition du dashboard..." s'affiche pendant l'exécution du subagent
+- [x] Le dashboard rendu est identique en structure et en widgets à l'implémentation actuelle
+- [x] Les permissions territoriales sont respectées par le subagent (validation post-génération)
+- [x] En cas d'erreur du subagent, l'agent principal informe l'utilisateur
+- [x] L'affichage des indicateurs d'un chantier passe par un dashboard (`widget_tableau_indicateurs_chantier`)
+- [x] Météo + commentaire de synthèse affichés sous chaque chantier via `widget_paragraph`
+- [x] Incohérence météo/statut signalée via variant `warning` sur `widget_paragraph`
 
 ### Technique
 
-- [ ] Le system prompt principal ne contient plus de règles de composition dashboard
-- [ ] Le subagent a son propre system prompt focalisé
-- [ ] Les tools data sont partagés (mêmes instances, mêmes habilitations)
-- [ ] Le tool `create_dashboard` est conditionné par `capacities.dashboard`
-- [ ] Le client rend le dashboard via le même composant, branché sur `create_dashboard`
-- [ ] Le `compose_dashboard` tool n'est plus exposé à l'agent principal
-- [ ] Le paramètre `afficher` de `get_chantier_indicateurs` est supprimé
-- [ ] Les tools data ne déclenchent plus de rendu côté client
-- [ ] `PiloteUITools` ne contient que les tools avec rendu visuel (`display_choices`, `create_dashboard`, `export_rapport`)
+- [x] Le system prompt principal ne contient plus de règles de composition dashboard
+- [x] Le subagent a son propre system prompt focalisé (`dashboardSystemPrompt.ts`)
+- [x] Le subagent utilise `Output.object()` (structured output) — pas de tools internes
+- [x] Le tool `create_dashboard` est conditionné par `capacities.dashboard`
+- [x] Le client rend le dashboard via le même composant, branché sur `create_dashboard`
+- [x] Le `compose_dashboard` tool n'est plus exposé à l'agent principal
+- [x] Le paramètre `afficher` de `get_chantier_indicateurs` est supprimé
+- [x] Les tools data ne déclenchent plus de rendu riche côté client (simple `ToolCallIndicator`)
+- [x] `validateDashboardIdentifiers` vérifie les identifiants post-génération
+- [x] `widget_paragraph` ajouté au catalogue (contenu string[], variant warning)
 
 ---
 
@@ -886,8 +741,6 @@ et le coût.
 - **Faut-il passer l'historique de conversation au subagent ?** Par défaut non (isolation).
   Mais si le contexte conversationnel est nécessaire (ex: "ajoute les indicateurs du
   chantier dont on parlait"), on pourrait injecter un résumé dans le prompt du subagent.
-- **Quel `maxSteps` pour le subagent ?** Le subagent fait au maximum ~5 tool calls
-  (4 data + 1 compose). Un `maxSteps: 10` semble suffisant.
 - **Faut-il un fallback vers la composition directe ?** Si le subagent échoue
   systématiquement, on pourrait revenir au mode actuel (compose_dashboard exposé
-  au parent). A évaluer après les premiers tests.
+  au parent). À évaluer après les premiers tests en conditions réelles.

--- a/src/app/api/albert/chat/route.ts
+++ b/src/app/api/albert/chat/route.ts
@@ -1,6 +1,7 @@
 import { validateUIMessages } from "ai";
 import { z } from "zod";
-import { Albert, displayChoicesTool } from "@/server/albert/Albert";
+import { Albert } from "@/server/albert/Albert";
+import { displayChoicesTool } from "@/server/albert/tools/displayChoices";
 import { auth } from "@/server/infrastructure/api/auth/[...nextauth]";
 import { buildChatSystemPrompt } from "@/server/albert/systemPrompt";
 import {

--- a/src/app/api/albert/chat/route.ts
+++ b/src/app/api/albert/chat/route.ts
@@ -52,9 +52,6 @@ export async function POST(request: Request) {
     const createGetChantierIndicateursTool = container.resolve(
       "createGetChantierIndicateursTool",
     );
-    const createComposeDashboardTool = container.resolve(
-      "createComposeDashboardTool",
-    );
     const createExportRapportTool = container.resolve(
       "createExportRapportTool",
     );
@@ -86,9 +83,6 @@ export async function POST(request: Request) {
     const getChantierIndicateurs = createGetChantierIndicateursTool({
       territoiresAccessibles,
     });
-    const composeDashboard = createComposeDashboardTool({
-      habilitations: session.habilitations,
-    });
     const exportRapport = createExportRapportTool({
       userId: session.user.id,
     });
@@ -98,13 +92,10 @@ export async function POST(request: Request) {
       get_chantiers_en_retard: getChantiersEnRetard,
       get_chantiers_en_difficulte: getChantiersEnDifficulte,
       get_chantier_indicateurs: getChantierIndicateurs,
-      compose_dashboard: composeDashboard,
     };
 
     const createDashboard = createCreateDashboardTool({
       subagentTools: subagentDataTools,
-      userId: session.user.id,
-      chatId: body.id,
     });
 
     const tools = {

--- a/src/app/api/albert/chat/route.ts
+++ b/src/app/api/albert/chat/route.ts
@@ -87,16 +87,7 @@ export async function POST(request: Request) {
       userId: session.user.id,
     });
 
-    const subagentDataTools = {
-      get_taux_avancement_territoire: getTauxAvancementTerritoire,
-      get_chantiers_en_retard: getChantiersEnRetard,
-      get_chantiers_en_difficulte: getChantiersEnDifficulte,
-      get_chantier_indicateurs: getChantierIndicateurs,
-    };
-
-    const createDashboard = createCreateDashboardTool({
-      subagentTools: subagentDataTools,
-    });
+    const createDashboard = createCreateDashboardTool();
 
     const tools = {
       get_taux_avancement_territoire: getTauxAvancementTerritoire,

--- a/src/app/api/albert/chat/route.ts
+++ b/src/app/api/albert/chat/route.ts
@@ -11,6 +11,7 @@ import {
 } from "@/server/albert/detecteurIntention";
 import type { PiloteUIMessage } from "@/server/albert/PiloteUIMessage";
 import { getContainer } from "@/server/dependances";
+import { createCreateDashboardTool } from "@/server/albert/tools/createDashboard";
 
 const chatRequestSchema = z
   .object({
@@ -92,13 +93,27 @@ export async function POST(request: Request) {
       userId: session.user.id,
     });
 
+    const subagentDataTools = {
+      get_taux_avancement_territoire: getTauxAvancementTerritoire,
+      get_chantiers_en_retard: getChantiersEnRetard,
+      get_chantiers_en_difficulte: getChantiersEnDifficulte,
+      get_chantier_indicateurs: getChantierIndicateurs,
+      compose_dashboard: composeDashboard,
+    };
+
+    const createDashboard = createCreateDashboardTool({
+      subagentTools: subagentDataTools,
+      userId: session.user.id,
+      chatId: body.id,
+    });
+
     const tools = {
       get_taux_avancement_territoire: getTauxAvancementTerritoire,
       get_chantiers_en_retard: getChantiersEnRetard,
       get_chantiers_en_difficulte: getChantiersEnDifficulte,
       get_chantier_indicateurs: getChantierIndicateurs,
       display_choices: displayChoicesTool,
-      ...(capacities.dashboard ? { compose_dashboard: composeDashboard } : {}),
+      ...(capacities.dashboard ? { create_dashboard: createDashboard } : {}),
       ...(capacities.exportRapport ? { export_rapport: exportRapport } : {}),
     };
 

--- a/src/client/components/PageAccueil/BoutonSyntheseTerritoire.tsx
+++ b/src/client/components/PageAccueil/BoutonSyntheseTerritoire.tsx
@@ -53,7 +53,7 @@ export const BoutonSyntheseTerritoire = ({
           },
           {
             label: "Tableau de bord du territoire",
-            message: `Compose un tableau de bord pour ${territoire.nomAffiché}. Commence par une première section contenant le taux d'avancement du territoire, le nombre de chantiers en retard, le nombre de chantiers en difficulté et la cartographie du taux d'avancement. Ensuite, récupère la liste des chantiers en difficulté et en retard sur ce territoire, et pour chacun, ajoute une section dédiée avec un titre reprenant le nom du chantier, la cartographie météo en pleine largeur et le tableau de ses indicateurs.`,
+            message: `Compose un tableau de bord pour ${territoire.nomAffiché}. Commence par une première section contenant le taux d'avancement du territoire, le nombre de chantiers en retard, le nombre de chantiers en difficulté et la cartographie du taux d'avancement. Ensuite, récupère la liste des chantiers en difficulté et en retard sur ce territoire, et pour chacun, ajoute une section dédiée avec un titre reprenant le nom du chantier, la météo et le commentaire de synthèse, la cartographie météo en pleine largeur et le tableau de ses indicateurs.`,
             mode: "send",
           },
         ],

--- a/src/client/components/PageAccueil/BoutonSyntheseTerritoire.tsx
+++ b/src/client/components/PageAccueil/BoutonSyntheseTerritoire.tsx
@@ -53,7 +53,7 @@ export const BoutonSyntheseTerritoire = ({
           },
           {
             label: "Tableau de bord du territoire",
-            message: `Compose un tableau de bord pour ${territoire.nomAffiché}. Commence par une première section contenant le taux d'avancement du territoire, le nombre de chantiers en retard, le nombre de chantiers en difficulté et la cartographie du taux d'avancement. Ensuite, récupère la liste des chantiers en difficulté sur ce territoire, et pour chacun, ajoute une section dédiée avec un titre reprenant le nom du chantier, la cartographie météo en pleine largeur et le tableau de ses indicateurs.`,
+            message: `Compose un tableau de bord pour ${territoire.nomAffiché}. Commence par une première section contenant le taux d'avancement du territoire, le nombre de chantiers en retard, le nombre de chantiers en difficulté et la cartographie du taux d'avancement. Ensuite, récupère la liste des chantiers en difficulté et en retard sur ce territoire, et pour chacun, ajoute une section dédiée avec un titre reprenant le nom du chantier, la cartographie météo en pleine largeur et le tableau de ses indicateurs.`,
             mode: "send",
           },
         ],

--- a/src/client/components/_commons/ChatUI/AssistantMessage.tsx
+++ b/src/client/components/_commons/ChatUI/AssistantMessage.tsx
@@ -1,13 +1,10 @@
-import { Fragment, memo } from "react";
+import { memo } from "react";
 import { toast } from "sonner";
 import { PiloteUIMessage } from "@/server/albert/PiloteUIMessage";
 import { ToolCallIndicator } from "@/components/_commons/ChatUI/ToolCallIndicator";
 import { AssistantMessageText } from "@/components/_commons/ChatUI/AssistantMessageText";
 import { AssistantLoader } from "@/components/_commons/ChatUI/AssistantLoader";
-import { BaseDisplayTool } from "@/components/_commons/ChatUI/BaseDisplayTool";
 import { ExportRapportDownload } from "@/components/_commons/ChatUI/ExportRapportDownload";
-import { ChantierIndicateursTable } from "@/components/_commons/ChatUI/ChantierIndicateursTable";
-import { ChantierIndicateursSkeleton } from "@/components/_commons/ChatUI/ChantierIndicateursSkeleton";
 import { DashboardRender } from "@/components/_commons/ChatUI/DashboardRender";
 import { DashboardLoader } from "@/components/_commons/ChatUI/DashboardWidgets/DashboardLoader";
 import { extractMessageText } from "@/components/_commons/ChatUI/utils";
@@ -23,6 +20,7 @@ export const AssistantMessage = memo(function AssistantMessage({
   message: PiloteUIMessage;
   isStreaming: boolean;
 }) {
+  console.log(message);
   const shouldHideText = message.parts?.some((part) => {
     const toolName = part.type.startsWith("tool-") ? part.type.slice(5) : null;
     return (
@@ -55,31 +53,10 @@ export const AssistantMessage = memo(function AssistantMessage({
           if (
             part.type === "tool-get_taux_avancement_territoire" ||
             part.type === "tool-get_chantiers_en_retard" ||
-            part.type === "tool-get_chantiers_en_difficulte"
+            part.type === "tool-get_chantiers_en_difficulte" ||
+            part.type === "tool-get_chantier_indicateurs"
           ) {
             return <ToolCallIndicator key={index} part={part} />;
-          }
-          if (part.type === "tool-get_chantier_indicateurs") {
-            const shouldDisplay =
-              part.state !== "input-streaming" &&
-              part.input?.afficher !== false;
-            return (
-              <Fragment key={index}>
-                <ToolCallIndicator part={part} />
-                {shouldDisplay &&
-                  (part.state === "output-available" ? (
-                    <BaseDisplayTool>
-                      <ChantierIndicateursTable
-                        indicateurs={part.output.resultats.indicateurs}
-                      />
-                    </BaseDisplayTool>
-                  ) : part.state !== "output-error" ? (
-                    <BaseDisplayTool>
-                      <ChantierIndicateursSkeleton />
-                    </BaseDisplayTool>
-                  ) : null)}
-              </Fragment>
-            );
           }
           return null;
         })}
@@ -122,7 +99,7 @@ export const AssistantMessage = memo(function AssistantMessage({
           );
         }
 
-        if (part.type === "tool-compose_dashboard") {
+        if (part.type === "tool-create_dashboard") {
           if (part.state === "output-error") return null;
           if (part.state === "output-available") {
             return (

--- a/src/client/components/_commons/ChatUI/AssistantMessage.tsx
+++ b/src/client/components/_commons/ChatUI/AssistantMessage.tsx
@@ -20,7 +20,6 @@ export const AssistantMessage = memo(function AssistantMessage({
   message: PiloteUIMessage;
   isStreaming: boolean;
 }) {
-  console.log(message);
   const shouldHideText = message.parts?.some((part) => {
     const toolName = part.type.startsWith("tool-") ? part.type.slice(5) : null;
     return (

--- a/src/client/components/_commons/ChatUI/AssistantMessageText.tsx
+++ b/src/client/components/_commons/ChatUI/AssistantMessageText.tsx
@@ -8,6 +8,7 @@ const remarkPlugins = [remarkGfm];
 // à la ToolSet dans src/app/api/albert/chat/route.ts.
 const TOOL_NAMES = [
   "display_choices",
+  "create_dashboard",
   "compose_dashboard",
   "export_rapport",
   "get_taux_avancement_territoire",

--- a/src/client/components/_commons/ChatUI/ChoicesPanel.tsx
+++ b/src/client/components/_commons/ChatUI/ChoicesPanel.tsx
@@ -1,5 +1,5 @@
 import { FormEvent, useState } from "react";
-import type { DisplayChoice } from "@/server/albert/Albert";
+import type { DisplayChoice } from "@/server/albert/tools/displayChoices";
 import { useChatContext } from "@/components/_commons/ChatUI/ChatContext";
 import { ArrowLineIcon } from "@/components/_commons/Icones/ArrowLineIcon";
 

--- a/src/client/components/_commons/ChatUI/DashboardWidgets/DashboardCardShell.tsx
+++ b/src/client/components/_commons/ChatUI/DashboardWidgets/DashboardCardShell.tsx
@@ -1,5 +1,6 @@
 import { ReactNode } from "react";
 import { DashboardPanel } from "./DashboardPanel";
+import { DashboardWidgetTitle } from "./DashboardWidgetTitle";
 
 export const DashboardCardShell = ({
   label,
@@ -11,7 +12,7 @@ export const DashboardCardShell = ({
   children: ReactNode;
 }) => (
   <DashboardPanel className="flex flex-col justify-between">
-    <div className="text-xs uppercase tracking-wide text-gray-500">{label}</div>
+    <DashboardWidgetTitle segments={[label]} />
     <div className="flex-1 flex items-center justify-center mt-2">
       {children}
     </div>

--- a/src/client/components/_commons/ChatUI/DashboardWidgets/DashboardChantiersListe.tsx
+++ b/src/client/components/_commons/ChatUI/DashboardWidgets/DashboardChantiersListe.tsx
@@ -1,4 +1,5 @@
 import { DashboardPanel } from "./DashboardPanel";
+import { DashboardWidgetTitle } from "./DashboardWidgetTitle";
 
 const METEO_LABELS: Record<string, string> = {
   SOLEIL: "☀️ Soleil",
@@ -45,9 +46,7 @@ export const DashboardChantiersListe = ({
   lignes: DashboardChantierLigne[];
 }) => (
   <DashboardPanel>
-    <div className="text-xs uppercase tracking-wide text-gray-500 mb-3">
-      {titre} · {territoireCode}
-    </div>
+    <DashboardWidgetTitle segments={[titre, territoireCode]} className="mb-3" />
     {lignes.length === 0 ? (
       <div className="text-sm text-gray-500">Aucun chantier signalé.</div>
     ) : (

--- a/src/client/components/_commons/ChatUI/DashboardWidgets/DashboardWidgetParagraph.tsx
+++ b/src/client/components/_commons/ChatUI/DashboardWidgets/DashboardWidgetParagraph.tsx
@@ -4,8 +4,20 @@ function normalizeNewlines(text: string): string {
   return text.replace(/[⏎↵\u23CE\u21B5]/g, "\n");
 }
 
-export const DashboardWidgetParagraph = ({ contenu }: { contenu: string }) => (
-  <DashboardPanel>
+export const DashboardWidgetParagraph = ({
+  contenu,
+  variant = "default",
+}: {
+  contenu: string;
+  variant?: "default" | "warning";
+}) => (
+  <DashboardPanel
+    className={
+      variant === "warning"
+        ? "border-yellow-400 bg-yellow-50"
+        : undefined
+    }
+  >
     <p className="text-sm text-gray-700 whitespace-pre-wrap fr-mb-0">
       {normalizeNewlines(contenu)}
     </p>

--- a/src/client/components/_commons/ChatUI/DashboardWidgets/DashboardWidgetParagraph.tsx
+++ b/src/client/components/_commons/ChatUI/DashboardWidgets/DashboardWidgetParagraph.tsx
@@ -1,0 +1,13 @@
+import { DashboardPanel } from "./DashboardPanel";
+
+function normalizeNewlines(text: string): string {
+  return text.replace(/[⏎↵\u23CE\u21B5]/g, "\n");
+}
+
+export const DashboardWidgetParagraph = ({ contenu }: { contenu: string }) => (
+  <DashboardPanel>
+    <p className="text-sm text-gray-700 whitespace-pre-wrap fr-mb-0">
+      {normalizeNewlines(contenu)}
+    </p>
+  </DashboardPanel>
+);

--- a/src/client/components/_commons/ChatUI/DashboardWidgets/DashboardWidgetParagraph.tsx
+++ b/src/client/components/_commons/ChatUI/DashboardWidgets/DashboardWidgetParagraph.tsx
@@ -1,25 +1,24 @@
+import { clsxm } from "@/utils/clsxm";
 import { DashboardPanel } from "./DashboardPanel";
-
-function normalizeNewlines(text: string): string {
-  return text.replace(/[⏎↵\u23CE\u21B5]/g, "\n");
-}
 
 export const DashboardWidgetParagraph = ({
   contenu,
   variant = "default",
 }: {
-  contenu: string;
+  contenu: string[];
   variant?: "default" | "warning";
 }) => (
   <DashboardPanel
-    className={
-      variant === "warning"
-        ? "border-yellow-400 bg-yellow-50"
-        : undefined
-    }
+    className={clsxm({
+      "border-yellow-400 bg-yellow-50": variant === "warning",
+    })}
   >
-    <p className="text-sm text-gray-700 whitespace-pre-wrap fr-mb-0">
-      {normalizeNewlines(contenu)}
-    </p>
+    <div className="space-y-2">
+      {contenu.map((part, index) => (
+        <p key={index} className="text-sm text-gray-700 fr-mb-0">
+          {part}
+        </p>
+      ))}
+    </div>
   </DashboardPanel>
 );

--- a/src/client/components/_commons/ChatUI/DashboardWidgets/DashboardWidgetRegistry.tsx
+++ b/src/client/components/_commons/ChatUI/DashboardWidgets/DashboardWidgetRegistry.tsx
@@ -111,6 +111,11 @@ export const DashboardWidgetRegistry = ({
         />
       );
     case "widget_paragraph":
-      return <DashboardWidgetParagraph contenu={widget.contenu} />;
+      return (
+        <DashboardWidgetParagraph
+          contenu={widget.contenu}
+          variant={widget.variant}
+        />
+      );
   }
 };

--- a/src/client/components/_commons/ChatUI/DashboardWidgets/DashboardWidgetRegistry.tsx
+++ b/src/client/components/_commons/ChatUI/DashboardWidgets/DashboardWidgetRegistry.tsx
@@ -11,6 +11,7 @@ import { DashboardWidgetCartographieTauxAvancement } from "./DashboardWidgetCart
 import { DashboardWidgetCartographieMeteo } from "./DashboardWidgetCartographieMeteo";
 import { DashboardWidgetCartographiePropositionsValeurAvancement } from "./DashboardWidgetCartographiePropositionsValeurAvancement";
 import { DashboardWidgetTitreSection } from "./DashboardWidgetTitreSection";
+import { DashboardWidgetParagraph } from "./DashboardWidgetParagraph";
 
 export const DashboardWidgetRegistry = ({
   widget,
@@ -109,5 +110,7 @@ export const DashboardWidgetRegistry = ({
           description={widget.description}
         />
       );
+    case "widget_paragraph":
+      return <DashboardWidgetParagraph contenu={widget.contenu} />;
   }
 };

--- a/src/client/components/_commons/ChatUI/DashboardWidgets/DashboardWidgetTableauIndicateursChantier.tsx
+++ b/src/client/components/_commons/ChatUI/DashboardWidgets/DashboardWidgetTableauIndicateursChantier.tsx
@@ -2,6 +2,7 @@ import api from "@/server/infrastructure/api/trpc/api";
 import { WIDGET_STALE_TIME } from "@/components/_commons/Widget/constants";
 import { ChantierIndicateursTable } from "@/components/_commons/ChatUI/ChantierIndicateursTable";
 import { DashboardPanel } from "./DashboardPanel";
+import { DashboardWidgetTitle } from "./DashboardWidgetTitle";
 
 export const DashboardWidgetTableauIndicateursChantier = ({
   chantierId,
@@ -19,9 +20,10 @@ export const DashboardWidgetTableauIndicateursChantier = ({
 
   return (
     <DashboardPanel>
-      <div className="text-xs uppercase tracking-wide text-gray-500 mb-3">
-        Indicateurs · {chantierId} · {territoireCode} · {jalon}
-      </div>
+      <DashboardWidgetTitle
+        segments={["Indicateurs", chantierId, territoireCode, String(jalon)]}
+        className="mb-3"
+      />
       {data.indicateurs.length === 0 ? (
         <div className="text-sm text-gray-500">
           Aucun indicateur disponible.

--- a/src/client/components/_commons/ChatUI/DashboardWidgets/DashboardWidgetTableauIndicateursChantier.tsx
+++ b/src/client/components/_commons/ChatUI/DashboardWidgets/DashboardWidgetTableauIndicateursChantier.tsx
@@ -20,7 +20,7 @@ export const DashboardWidgetTableauIndicateursChantier = ({
   return (
     <DashboardPanel>
       <div className="text-xs uppercase tracking-wide text-gray-500 mb-3">
-        Indicateurs · {chantierId} · {territoireCode}
+        Indicateurs · {chantierId} · {territoireCode} · {jalon}
       </div>
       {data.indicateurs.length === 0 ? (
         <div className="text-sm text-gray-500">

--- a/src/client/components/_commons/ChatUI/DashboardWidgets/DashboardWidgetTitle.tsx
+++ b/src/client/components/_commons/ChatUI/DashboardWidgets/DashboardWidgetTitle.tsx
@@ -1,0 +1,18 @@
+import { clsxm } from "@/utils/clsxm";
+
+export const DashboardWidgetTitle = ({
+  segments,
+  className,
+}: {
+  segments: string[];
+  className?: string;
+}) => (
+  <div
+    className={clsxm(
+      "text-xs uppercase tracking-wide text-gray-500",
+      className,
+    )}
+  >
+    {segments.join(" · ")}
+  </div>
+);

--- a/src/config.ts
+++ b/src/config.ts
@@ -516,6 +516,12 @@ const config = convict({
       doc: "Clé API pour le service Albert (LLM Etalab)",
       env: "ALBERT_API_KEY",
     },
+    devTools: {
+      format: Boolean,
+      default: false,
+      doc: "Active le middleware devTools pour le monitoring des appels LLM Albert",
+      env: "ALBERT_DEV_TOOLS",
+    },
   },
 });
 

--- a/src/server/albert/Albert.ts
+++ b/src/server/albert/Albert.ts
@@ -129,13 +129,14 @@ export class Albert {
     });
   }
 
-  static async generateText({
+  static async generateText<OUTPUT>({
     chatId,
     prompt,
     systemPrompt,
     tools,
     userId,
     abortSignal,
+    output,
   }: {
     chatId: string;
     prompt: string;
@@ -143,6 +144,7 @@ export class Albert {
     tools?: ToolSet;
     userId: string;
     abortSignal?: AbortSignal;
+    output?: OUTPUT;
   }) {
     const albertProvider = this.createProvider();
 
@@ -154,6 +156,7 @@ export class Albert {
       onFinish: (event) => Albert.saveLlmCall({ chatId, userId, event }),
       tools,
       abortSignal,
+      output: output as Parameters<typeof aiGenerateText>[0]["output"],
     });
   }
 

--- a/src/server/albert/Albert.ts
+++ b/src/server/albert/Albert.ts
@@ -86,7 +86,7 @@ export const displayChoicesTool = tool({
 const DEFAULT_MODEL = "openweight-large";
 
 export class Albert {
-  private static createProvider() {
+  static createProvider() {
     return createOpenAI({
       baseURL: "https://albert.api.etalab.gouv.fr/v1",
       apiKey: configuration().albert.apiKey,
@@ -135,27 +135,26 @@ export class Albert {
     systemPrompt,
     tools,
     userId,
+    abortSignal,
   }: {
     chatId: string;
     prompt: string;
     systemPrompt: string;
     tools?: ToolSet;
     userId: string;
+    abortSignal?: AbortSignal;
   }) {
     const albertProvider = this.createProvider();
 
-    const response = await aiGenerateText({
+    return aiGenerateText({
       model: albertProvider.chat(DEFAULT_MODEL),
       system: systemPrompt,
       prompt: prompt,
-      stopWhen: stepCountIs(5),
+      stopWhen: stepCountIs(50),
       onFinish: (event) => Albert.saveLlmCall({ chatId, userId, event }),
       tools,
+      abortSignal,
     });
-
-    return {
-      text: response.text,
-    };
   }
 
   static async streamText({

--- a/src/server/albert/Albert.ts
+++ b/src/server/albert/Albert.ts
@@ -1,6 +1,8 @@
 import { createOpenAI } from "@ai-sdk/openai";
 import {
   convertToModelMessages,
+  generateText,
+  Output,
   stepCountIs,
   streamText as aiStreamText,
   ToolSet,
@@ -10,6 +12,7 @@ import {
 import type { LanguageModelV3 } from "@ai-sdk/provider";
 import { Prisma } from "@prisma/client";
 import { devToolsMiddleware } from "@ai-sdk/devtools";
+import { z } from "zod";
 import { configuration } from "@/config";
 import { prisma } from "@/server/db/prisma";
 
@@ -64,6 +67,29 @@ export class Albert {
         utilisateur_id: userId,
       },
     });
+  }
+
+  static async generateStructuredOutput<T extends z.ZodType>({
+    systemPrompt,
+    prompt,
+    schema,
+    abortSignal,
+  }: {
+    systemPrompt: string;
+    prompt: string;
+    schema: T;
+    abortSignal?: AbortSignal;
+  }): Promise<z.infer<T>> {
+    const albertProvider = this.createProvider();
+    const result = await generateText({
+      model: withOptionalDevTools(albertProvider.chat(DEFAULT_MODEL)),
+      system: systemPrompt,
+      prompt,
+      stopWhen: stepCountIs(5),
+      output: Output.object({ schema }),
+      abortSignal,
+    });
+    return result.output;
   }
 
   static async streamText({

--- a/src/server/albert/Albert.ts
+++ b/src/server/albert/Albert.ts
@@ -12,52 +12,14 @@ import type { LanguageModelV3 } from "@ai-sdk/provider";
 import { z } from "zod";
 import { Prisma } from "@prisma/client";
 import { devToolsMiddleware } from "@ai-sdk/devtools";
-import { randomUUID } from "crypto";
 import { configuration } from "@/config";
 import { prisma } from "@/server/db/prisma";
-import { genererRapportPDF } from "@/server/albert/pdf/genererRapportPDF";
-import { buildRapportMarkdown } from "@/server/albert/markdown/buildRapportMarkdown";
-import type { RapportFileStorage } from "@/server/albert/domain/RapportFileStorage";
-import {
-  exportRapportInputSchema,
-  ExportRapportOutput,
-} from "@/server/albert/exportRapportSchema";
 
 export function withOptionalDevTools(model: LanguageModelV3): LanguageModelV3 {
   if (!configuration().albert.devTools) {
     return model;
   }
   return wrapLanguageModel({ model, middleware: devToolsMiddleware() });
-}
-
-// TODO : extraire dans son propre fichier
-export function createExportRapportTool({
-  rapportFileStorage,
-}: {
-  rapportFileStorage: RapportFileStorage;
-}) {
-  return ({ userId }: { userId: string }) => {
-    return tool({
-      description:
-        "Génère un rapport structuré synthétisant la discussion. Appelle cet outil quand l'utilisateur demande d'exporter ou télécharger un rapport. Le rapport doit contenir un titre, une date, un résumé et des sections structurées reprenant les données clés de la conversation.",
-      inputSchema: exportRapportInputSchema,
-      execute: async (input): Promise<ExportRapportOutput> => {
-        const shortId = randomUUID().slice(0, 8);
-        const ext = input.format === "pdf" ? "pdf" : "md";
-        const filename = `${input.nom_fichier}-${shortId}.${ext}`;
-
-        if (input.format === "pdf") {
-          const buffer = await genererRapportPDF(input);
-          const url = await rapportFileStorage.save(userId, filename, buffer);
-          return { url, format: "pdf" };
-        }
-
-        const markdown = buildRapportMarkdown(input);
-        const url = await rapportFileStorage.save(userId, filename, markdown);
-        return { url, format: "markdown" };
-      },
-    });
-  };
 }
 
 // TODO : extraire dans son propre fichier

--- a/src/server/albert/Albert.ts
+++ b/src/server/albert/Albert.ts
@@ -3,13 +3,11 @@ import {
   convertToModelMessages,
   stepCountIs,
   streamText as aiStreamText,
-  tool,
   ToolSet,
   UIMessage,
   wrapLanguageModel,
 } from "ai";
 import type { LanguageModelV3 } from "@ai-sdk/provider";
-import { z } from "zod";
 import { Prisma } from "@prisma/client";
 import { devToolsMiddleware } from "@ai-sdk/devtools";
 import { configuration } from "@/config";
@@ -21,40 +19,6 @@ export function withOptionalDevTools(model: LanguageModelV3): LanguageModelV3 {
   }
   return wrapLanguageModel({ model, middleware: devToolsMiddleware() });
 }
-
-// TODO : extraire dans son propre fichier
-export const displayChoicesInputSchema = z.object({
-  question: z
-    .string()
-    .describe("Question affichée en haut du panneau de choix"),
-  choices: z
-    .array(
-      z.object({
-        label: z.string().describe("Texte à afficher sur le bouton"),
-        value: z
-          .string()
-          .describe("Valeur à renvoyer lorsque le bouton est cliqué"),
-      }),
-    )
-    .describe("Liste des choix à proposer"),
-});
-
-export type DisplayChoice = z.infer<
-  typeof displayChoicesInputSchema
->["choices"][number];
-
-export const displayChoicesTool = tool({
-  description:
-    "Affiche des choix dans un panneau pour l'utilisateur. Le paramètre 'question' est la question affichée en haut du panneau. Utilise cet outil quand tu veux proposer des options à l'utilisateur. IMPORTANT : écris toujours ton message textuel AVANT d'appeler cet outil. Ne l'appelle jamais sans avoir d'abord rédigé le texte d'accompagnement.",
-  inputSchema: displayChoicesInputSchema,
-  execute: async ({
-    question,
-    choices,
-  }): Promise<{ question: string; choices: DisplayChoice[] }> => ({
-    question,
-    choices,
-  }),
-});
 
 const DEFAULT_MODEL = "openweight-large";
 

--- a/src/server/albert/Albert.ts
+++ b/src/server/albert/Albert.ts
@@ -1,7 +1,6 @@
 import { createOpenAI } from "@ai-sdk/openai";
 import {
   convertToModelMessages,
-  generateText as aiGenerateText,
   stepCountIs,
   streamText as aiStreamText,
   tool,
@@ -31,6 +30,7 @@ export function withOptionalDevTools(model: LanguageModelV3): LanguageModelV3 {
   return wrapLanguageModel({ model, middleware: devToolsMiddleware() });
 }
 
+// TODO : extraire dans son propre fichier
 export function createExportRapportTool({
   rapportFileStorage,
 }: {
@@ -60,6 +60,7 @@ export function createExportRapportTool({
   };
 }
 
+// TODO : extraire dans son propre fichier
 export const displayChoicesInputSchema = z.object({
   question: z
     .string()
@@ -136,37 +137,6 @@ export class Albert {
         output_tokens: usage?.outputTokens ?? 0,
         utilisateur_id: userId,
       },
-    });
-  }
-
-  static async generateText<OUTPUT>({
-    chatId,
-    prompt,
-    systemPrompt,
-    tools,
-    userId,
-    abortSignal,
-    output,
-  }: {
-    chatId: string;
-    prompt: string;
-    systemPrompt: string;
-    tools?: ToolSet;
-    userId: string;
-    abortSignal?: AbortSignal;
-    output?: OUTPUT;
-  }) {
-    const albertProvider = this.createProvider();
-
-    return aiGenerateText({
-      model: albertProvider.chat(DEFAULT_MODEL),
-      system: systemPrompt,
-      prompt: prompt,
-      stopWhen: stepCountIs(50),
-      onFinish: (event) => Albert.saveLlmCall({ chatId, userId, event }),
-      tools,
-      abortSignal,
-      output: output as Parameters<typeof aiGenerateText>[0]["output"],
     });
   }
 

--- a/src/server/albert/Albert.ts
+++ b/src/server/albert/Albert.ts
@@ -1,15 +1,18 @@
 import { createOpenAI } from "@ai-sdk/openai";
 import {
+  convertToModelMessages,
   generateText as aiGenerateText,
-  streamText as aiStreamText,
   stepCountIs,
+  streamText as aiStreamText,
   tool,
   ToolSet,
   UIMessage,
-  convertToModelMessages,
+  wrapLanguageModel,
 } from "ai";
+import type { LanguageModelV3 } from "@ai-sdk/provider";
 import { z } from "zod";
 import { Prisma } from "@prisma/client";
+import { devToolsMiddleware } from "@ai-sdk/devtools";
 import { randomUUID } from "crypto";
 import { configuration } from "@/config";
 import { prisma } from "@/server/db/prisma";
@@ -20,6 +23,13 @@ import {
   exportRapportInputSchema,
   ExportRapportOutput,
 } from "@/server/albert/exportRapportSchema";
+
+export function withOptionalDevTools(model: LanguageModelV3): LanguageModelV3 {
+  if (!configuration().albert.devTools) {
+    return model;
+  }
+  return wrapLanguageModel({ model, middleware: devToolsMiddleware() });
+}
 
 export function createExportRapportTool({
   rapportFileStorage,
@@ -179,7 +189,7 @@ export class Albert {
     const modelMessages = await convertToModelMessages(messages);
 
     return aiStreamText({
-      model: albertProvider.chat(model),
+      model: withOptionalDevTools(albertProvider.chat(model)),
       system: systemPrompt,
       messages: modelMessages,
       tools,

--- a/src/server/albert/PiloteUIMessage.ts
+++ b/src/server/albert/PiloteUIMessage.ts
@@ -1,7 +1,9 @@
 import type { UIDataTypes, UIMessage } from "ai";
 import type { z } from "zod";
-import { displayChoicesInputSchema } from "@/server/albert/Albert";
-import type { DisplayChoice } from "@/server/albert/Albert";
+import {
+  displayChoicesInputSchema,
+  type DisplayChoice,
+} from "@/server/albert/tools/displayChoices";
 import {
   exportRapportInputSchema,
   type ExportRapportOutput,

--- a/src/server/albert/PiloteUIMessage.ts
+++ b/src/server/albert/PiloteUIMessage.ts
@@ -7,6 +7,10 @@ import {
   type ExportRapportOutput,
 } from "@/server/albert/exportRapportSchema";
 import {
+  createDashboardInputSchema,
+  type CreateDashboardOutput,
+} from "@/server/albert/tools/createDashboard";
+import {
   getTauxAvancementTerritoireInputSchema,
   type GetTauxAvancementTerritoireOutput,
 } from "@/server/albert/tools/getTauxAvancementTerritoire";
@@ -22,10 +26,6 @@ import {
   getChantierIndicateursInputSchema,
   type GetChantierIndicateursOutput,
 } from "@/server/albert/tools/getChantierIndicateurs";
-import {
-  composeDashboardInputSchema,
-  type ComposeDashboardOutput,
-} from "@/server/albert/tools/composeDashboard";
 
 export type PiloteUITools = {
   display_choices: {
@@ -48,9 +48,9 @@ export type PiloteUITools = {
     input: z.input<typeof getChantierIndicateursInputSchema>;
     output: GetChantierIndicateursOutput;
   };
-  compose_dashboard: {
-    input: z.input<typeof composeDashboardInputSchema>;
-    output: ComposeDashboardOutput;
+  create_dashboard: {
+    input: z.input<typeof createDashboardInputSchema>;
+    output: CreateDashboardOutput;
   };
   export_rapport: {
     input: z.input<typeof exportRapportInputSchema>;

--- a/src/server/albert/__tests__/detecteurIntention.test.ts
+++ b/src/server/albert/__tests__/detecteurIntention.test.ts
@@ -82,6 +82,26 @@ describe("detecterCapacities", () => {
     expect(result.dashboard).toBe(true);
   });
 
+  it("détecte une demande de dashboard via 'indicateurs'", () => {
+    // when
+    const result = detecterCapacities(
+      "Montre-moi les indicateurs du chantier CH-064",
+    );
+
+    // then
+    expect(result.dashboard).toBe(true);
+  });
+
+  it("détecte une demande de dashboard via 'indicateur'", () => {
+    // when
+    const result = detecterCapacities(
+      "Affiche l'indicateur principal du territoire",
+    );
+
+    // then
+    expect(result.dashboard).toBe(true);
+  });
+
   it("détecte un export via 'exporte'", () => {
     // when
     const result = detecterCapacities("Exporte ce rapport en PDF");

--- a/src/server/albert/__tests__/detecteurIntention.test.ts
+++ b/src/server/albert/__tests__/detecteurIntention.test.ts
@@ -244,7 +244,11 @@ describe("dashboardDejaCompose", () => {
             type: "tool-create_dashboard",
             toolCallId: "call-1",
             state: "output-available",
-            input: { task: "Cockpit Bretagne" },
+            input: {
+              task: "Cockpit Bretagne",
+              territoire_codes: ["REG-53"],
+              jalons: [2026],
+            },
             output: {
               titre: "Test",
               containers: [],

--- a/src/server/albert/__tests__/detecteurIntention.test.ts
+++ b/src/server/albert/__tests__/detecteurIntention.test.ts
@@ -227,7 +227,7 @@ describe("dashboardDejaCompose", () => {
     expect(result).toBe(false);
   });
 
-  it("retourne true quand un message assistant contient un tool-compose_dashboard", () => {
+  it("retourne true quand un message assistant contient un tool-create_dashboard", () => {
     // given
     const messages: PiloteUIMessage[] = [
       {
@@ -241,10 +241,10 @@ describe("dashboardDejaCompose", () => {
         parts: [
           { type: "text", text: "Voici le dashboard demandé." },
           {
-            type: "tool-compose_dashboard",
+            type: "tool-create_dashboard",
             toolCallId: "call-1",
             state: "output-available",
-            input: { titre: "Test", containers: [] },
+            input: { task: "Cockpit Bretagne" },
             output: {
               titre: "Test",
               containers: [],

--- a/src/server/albert/__tests__/tools/validateDashboardIdentifiers.test.ts
+++ b/src/server/albert/__tests__/tools/validateDashboardIdentifiers.test.ts
@@ -1,0 +1,215 @@
+import {
+  validateDashboardIdentifiers,
+  type ChantierContext,
+} from "@/server/albert/tools/createDashboard";
+import type { ComposeDashboardInput } from "@/server/albert/tools/composeDashboard";
+
+describe("validateDashboardIdentifiers", () => {
+  it("ne lève pas d'erreur pour un dashboard valide", () => {
+    // given
+    const output: ComposeDashboardInput = {
+      titre: "Cockpit Bretagne",
+      containers: [
+        {
+          widgets: [
+            {
+              type: "widget_taux_avancement_territoire",
+              territoire_code: "REG-53",
+              jalon: 2025,
+            },
+          ],
+        },
+      ],
+    };
+
+    // when / then
+    expect(() =>
+      validateDashboardIdentifiers(output, ["REG-53"], [2025], undefined),
+    ).not.toThrow();
+  });
+
+  it("lève une erreur pour un territoire_code non autorisé", () => {
+    // given
+    const output: ComposeDashboardInput = {
+      titre: "Cockpit",
+      containers: [
+        {
+          widgets: [
+            {
+              type: "widget_taux_avancement_territoire",
+              territoire_code: "REG-99",
+              jalon: 2025,
+            },
+          ],
+        },
+      ],
+    };
+
+    // when / then
+    expect(() =>
+      validateDashboardIdentifiers(output, ["REG-53"], [2025], undefined),
+    ).toThrow(/territoire non autorisé : REG-99/);
+  });
+
+  it("lève une erreur pour un jalon non autorisé", () => {
+    // given
+    const output: ComposeDashboardInput = {
+      titre: "Cockpit",
+      containers: [
+        {
+          widgets: [
+            {
+              type: "widget_taux_avancement_territoire",
+              territoire_code: "REG-53",
+              jalon: 2024,
+            },
+          ],
+        },
+      ],
+    };
+
+    // when / then
+    expect(() =>
+      validateDashboardIdentifiers(output, ["REG-53"], [2025], undefined),
+    ).toThrow(/jalon non autorisé : 2024/);
+  });
+
+  it("lève une erreur quand chantier_id est utilisé sans chantiers fournis", () => {
+    // given
+    const output: ComposeDashboardInput = {
+      titre: "Cockpit",
+      containers: [
+        {
+          widgets: [
+            {
+              type: "widget_cartographie_meteo",
+              maille: "departementale",
+              territoire_code: "REG-53",
+              chantier_id: "CH-001",
+              jalon: 2025,
+            },
+          ],
+        },
+      ],
+    };
+
+    // when / then
+    expect(() =>
+      validateDashboardIdentifiers(output, ["REG-53"], [2025], undefined),
+    ).toThrow(/chantier_id.*aucun.*fourni/i);
+  });
+
+  it("lève une erreur quand chantier_id n'est pas dans la liste autorisée", () => {
+    // given
+    const chantiers: ChantierContext[] = [
+      { id: "CH-001", nom: "Chantier 1" },
+    ];
+    const output: ComposeDashboardInput = {
+      titre: "Cockpit",
+      containers: [
+        {
+          widgets: [
+            {
+              type: "widget_cartographie_meteo",
+              maille: "departementale",
+              territoire_code: "REG-53",
+              chantier_id: "CH-999",
+              jalon: 2025,
+            },
+          ],
+        },
+      ],
+    };
+
+    // when / then
+    expect(() =>
+      validateDashboardIdentifiers(output, ["REG-53"], [2025], chantiers),
+    ).toThrow(/chantier_id non autorisé : CH-999/);
+  });
+
+  it("lève une erreur quand chantier_ids contient un id inconnu", () => {
+    // given
+    const chantiers: ChantierContext[] = [
+      { id: "CH-001", nom: "Chantier 1" },
+    ];
+    const output: ComposeDashboardInput = {
+      titre: "Cockpit",
+      containers: [
+        {
+          widgets: [
+            {
+              type: "widget_cartographie_taux_avancement",
+              maille: "regionale",
+              territoire_code: "REG-53",
+              jalon: 2025,
+              chantier_ids: ["CH-001", "CH-999"],
+            },
+          ],
+        },
+      ],
+    };
+
+    // when / then
+    expect(() =>
+      validateDashboardIdentifiers(output, ["REG-53"], [2025], chantiers),
+    ).toThrow(/chantier_id non autorisé : CH-999/);
+  });
+
+  it("ne lève pas d'erreur pour des widgets sans identifiants", () => {
+    // given
+    const output: ComposeDashboardInput = {
+      titre: "Cockpit",
+      containers: [
+        {
+          widgets: [
+            {
+              type: "widget_titre_section",
+              titre: "Section titre",
+            },
+          ],
+        },
+      ],
+    };
+
+    // when / then
+    expect(() =>
+      validateDashboardIdentifiers(output, ["REG-53"], [2025], undefined),
+    ).not.toThrow();
+  });
+
+  it("ne lève pas d'erreur pour des containers avec widgets valides mixtes", () => {
+    // given
+    const chantiers: ChantierContext[] = [
+      { id: "CH-001", nom: "Chantier 1" },
+    ];
+    const output: ComposeDashboardInput = {
+      titre: "Cockpit",
+      containers: [
+        {
+          widgets: [{ type: "widget_titre_section", titre: "Intro" }],
+        },
+        {
+          widgets: [
+            {
+              type: "widget_taux_avancement_territoire",
+              territoire_code: "REG-53",
+              jalon: 2025,
+            },
+            {
+              type: "widget_cartographie_meteo",
+              maille: "departementale",
+              territoire_code: "REG-53",
+              chantier_id: "CH-001",
+              jalon: 2025,
+            },
+          ],
+        },
+      ],
+    };
+
+    // when / then
+    expect(() =>
+      validateDashboardIdentifiers(output, ["REG-53"], [2025], chantiers),
+    ).not.toThrow();
+  });
+});

--- a/src/server/albert/__tests__/tools/validateDashboardIdentifiers.test.ts
+++ b/src/server/albert/__tests__/tools/validateDashboardIdentifiers.test.ts
@@ -101,9 +101,7 @@ describe("validateDashboardIdentifiers", () => {
 
   it("lève une erreur quand chantier_id n'est pas dans la liste autorisée", () => {
     // given
-    const chantiers: ChantierContext[] = [
-      { id: "CH-001", nom: "Chantier 1" },
-    ];
+    const chantiers: ChantierContext[] = [{ id: "CH-001", nom: "Chantier 1" }];
     const output: ComposeDashboardInput = {
       titre: "Cockpit",
       containers: [
@@ -129,9 +127,7 @@ describe("validateDashboardIdentifiers", () => {
 
   it("lève une erreur quand chantier_ids contient un id inconnu", () => {
     // given
-    const chantiers: ChantierContext[] = [
-      { id: "CH-001", nom: "Chantier 1" },
-    ];
+    const chantiers: ChantierContext[] = [{ id: "CH-001", nom: "Chantier 1" }];
     const output: ComposeDashboardInput = {
       titre: "Cockpit",
       containers: [
@@ -179,9 +175,7 @@ describe("validateDashboardIdentifiers", () => {
 
   it("ne lève pas d'erreur pour des containers avec widgets valides mixtes", () => {
     // given
-    const chantiers: ChantierContext[] = [
-      { id: "CH-001", nom: "Chantier 1" },
-    ];
+    const chantiers: ChantierContext[] = [{ id: "CH-001", nom: "Chantier 1" }];
     const output: ComposeDashboardInput = {
       titre: "Cockpit",
       containers: [

--- a/src/server/albert/detecteurIntention.ts
+++ b/src/server/albert/detecteurIntention.ts
@@ -26,6 +26,8 @@ const MOTS_CLES_DASHBOARD = [
   "affiche",
   "montre",
   "visualise",
+  "indicateur",
+  "indicateurs",
 ];
 
 const MOTS_CLES_EXPORT = [

--- a/src/server/albert/detecteurIntention.ts
+++ b/src/server/albert/detecteurIntention.ts
@@ -78,7 +78,7 @@ export function dashboardDejaCompose(messages: PiloteUIMessage[]): boolean {
     (message) =>
       message.role === "assistant" &&
       (message.parts ?? []).some(
-        (part) => part.type === "tool-compose_dashboard",
+        (part) => part.type === "tool-create_dashboard",
       ),
   );
 }

--- a/src/server/albert/module.ts
+++ b/src/server/albert/module.ts
@@ -7,7 +7,7 @@ import type { ChantierExports } from "@/server/chantiers/module";
 import { EvaluerChatUseCase } from "@/server/albert/usecases/EvaluerChatUseCase";
 import { PrismaTerritoireResolver } from "@/server/albert/infrastructure/PrismaTerritoireResolver";
 import { FsRapportFileStorage } from "@/server/albert/infrastructure/FsRapportFileStorage";
-import { createExportRapportTool } from "@/server/albert/Albert";
+import { createExportRapportTool } from "@/server/albert/tools/exportRapport";
 import type { TerritoireResolver } from "@/server/albert/domain/TerritoireResolver";
 import type { RapportFileStorage } from "@/server/albert/domain/RapportFileStorage";
 import {

--- a/src/server/albert/subagents/dashboardSystemPrompt.ts
+++ b/src/server/albert/subagents/dashboardSystemPrompt.ts
@@ -5,11 +5,8 @@ l'outil de suivi des politiques prioritaires du gouvernement français.
 # Ta mission
 
 Tu reçois une description de ce que l'utilisateur veut visualiser.
-Tu dois composer un dashboard structuré en appelant \`compose_dashboard\`.
-
-Si tu as besoin de contexte pour décider quels widgets inclure
-(ex: savoir quels chantiers sont en retard pour construire un focus chantier),
-appelle d'abord les outils de données disponibles, puis compose le dashboard.
+Tu dois produire la structure JSON d'un dashboard conforme au schéma (titre + containers + widgets).
+Ta réponse sera parsée automatiquement comme structured output.
 
 # Catalogue de widgets
 
@@ -90,7 +87,7 @@ Pattern : titre du chantier, tableau d'indicateurs, puis cartographies thématiq
 
 # Protocole
 
-1. Analyse la demande
-2. Si tu as besoin de contexte (quels chantiers sont en retard, etc.), appelle les outils de données
-3. Produis ta réponse finale : le JSON du dashboard conforme au schéma (titre + containers + widgets). Ta réponse sera parsée automatiquement comme structured output.`;
+1. Analyse la demande reçue
+2. Compose la structure du dashboard en JSON conforme au schéma (titre + containers + widgets)
+3. Tu n'as pas accès à des outils — base-toi uniquement sur la description fournie par l'agent principal`;
 }

--- a/src/server/albert/subagents/dashboardSystemPrompt.ts
+++ b/src/server/albert/subagents/dashboardSystemPrompt.ts
@@ -1,0 +1,97 @@
+export function buildDashboardSystemPrompt(): string {
+  return `Tu es un spécialiste de la composition de dashboards pour PILOTE,
+l'outil de suivi des politiques prioritaires du gouvernement français.
+
+# Ta mission
+
+Tu reçois une description de ce que l'utilisateur veut visualiser.
+Tu dois composer un dashboard structuré en appelant \`compose_dashboard\`.
+
+Si tu as besoin de contexte pour décider quels widgets inclure
+(ex: savoir quels chantiers sont en retard pour construire un focus chantier),
+appelle d'abord les outils de données disponibles, puis compose le dashboard.
+
+# Catalogue de widgets
+
+| Widget | Intention | Paramètres | default_width | allowed_widths |
+|---|---|---|---|---|
+| widget_taux_avancement_territoire | TA agrégé d'un territoire | territoire_code, jalon | 1 | [1,2] |
+| widget_mediane_avancement_territoire | Médiane du TA sur les sous-territoires | territoire_code, jalon | 1 | [1,2] |
+| widget_nombre_chantiers_en_retard | Nombre de chantiers en retard | territoire_code, jalon | 1 | [1,2] |
+| widget_nombre_chantiers_en_difficulte | Nombre de chantiers en difficulté (météo ORAGE/NUAGE) | territoire_code, jalon | 1 | [1,2] |
+| widget_valeurs_remarquables_avancement | Min/médiane/max du TA sur les sous-territoires | territoire_code, jalon | 2 | [2,3,4] |
+| widget_tableau_indicateurs_chantier | VI/VA/VC/TA d'un chantier | chantier_id, territoire_code, jalon | 4 | [4] |
+| widget_liste_chantiers_en_retard | Liste compacte chantiers en retard (écart ≤ -10 pts) | territoire_code, jalon | 2 | [2,4] |
+| widget_liste_chantiers_en_difficulte | Liste compacte chantiers en difficulté (météo ORAGE/NUAGE) | territoire_code, jalon | 2 | [2,4] |
+| widget_cartographie_taux_avancement | Carte de France du TA par territoire | maille, territoire_code, jalon, chantier_ids | 2 | [2,3,4] |
+| widget_cartographie_meteo | Carte de France des météos par territoire | maille, territoire_code, chantier_id, jalon | 2 | [2,3,4] |
+| widget_cartographie_propositions_valeur_avancement | Carte de France des PVA d'un chantier | maille, territoire_code, chantier_id, jalon | 2 | [2,3,4] |
+| widget_titre_section | Titre + description courte (AUCUN chiffre) | titre, description? | 4 | [2,4] |
+
+Le **nom** du widget est l'intention. Aucun enum de métrique, aucun row_group, aucun filler.
+
+# Règles de composition
+
+## Grille
+- Un dashboard = liste ordonnée de containers empilés verticalement
+- Chaque container a un grid interne de 4 colonnes
+- Les widgets sont placés selon leur \`width\` (par défaut \`default_width\`)
+- Un widget seul dans un container de 4 colonnes gâche de la place
+  si sa default_width < 4. Regroupe les widgets compatibles.
+
+## widget_titre_section
+- JAMAIS de chiffres (%, points, pts) dans le titre ou la description
+- Utilise un widget KPI atomique pour afficher un chiffre
+
+## Patterns recommandés
+
+### Cockpit synthétique (mono-territoire)
+1. Container : \`widget_titre_section\`
+2. Container : \`widget_taux_avancement_territoire\` (1) + \`widget_nombre_chantiers_en_retard\` (1) + \`widget_valeurs_remarquables_avancement\` (2) = 4 colonnes
+3. Container : \`widget_cartographie_taux_avancement\` (4)
+4. Container : \`widget_liste_chantiers_en_retard\` (2) + \`widget_liste_chantiers_en_difficulte\` (2)
+
+### Ventilation par sous-territoires
+Pour chaque sous-territoire, répéter :
+1. Container : \`widget_titre_section\` avec nom du sous-territoire
+2. Container : 3 KPI compacts (1+1+1=3, 4e colonne vide)
+
+### Focus chantier
+1. Container : \`widget_titre_section\` avec nom du chantier
+2. Container : \`widget_tableau_indicateurs_chantier\` (4)
+3. Container : cartographies thématiques (météo, TA, PVA)
+
+### Indicateurs d'un chantier
+Quand on te demande d'afficher les indicateurs d'un chantier :
+1. Container : \`widget_titre_section\` avec nom du chantier
+2. Container : \`widget_tableau_indicateurs_chantier\` (4)
+
+# Exemples de dashboards valides
+
+Les trois exemples ci-dessous illustrent les principaux patterns de composition. **Valeurs illustratives** : adapte systématiquement \`territoire_code\`, \`jalon\`, \`chantier_id\` et \`chantier_ids\` aux paramètres réels du contexte utilisateur. Ne réutilise jamais \`REG-76\`, \`DEPT-42\` ou \`2026\` par défaut.
+
+### Exemple 1 — Cockpit synthétique d'un territoire
+Pattern : titre, rangée de KPI compacts (1+1+2=4), carte pleine largeur, deux listes côte à côte.
+\`\`\`json
+{"titre":"Dashboard Occitanie – 2026","containers":[{"widgets":[{"type":"widget_titre_section","titre":"Occitanie – Synthèse 2026","description":"Vue d'ensemble du taux d'avancement et des alertes","width":4}]},{"widgets":[{"type":"widget_taux_avancement_territoire","territoire_code":"REG-76","jalon":2026,"width":1},{"type":"widget_nombre_chantiers_en_retard","territoire_code":"REG-76","jalon":2026,"width":1},{"type":"widget_valeurs_remarquables_avancement","territoire_code":"REG-76","jalon":2026,"width":2}]},{"widgets":[{"type":"widget_cartographie_taux_avancement","maille":"regionale","territoire_code":"REG-76","jalon":2026,"chantier_ids":["CH-071","CH-121","CH-078","CH-166","CH-004","CH-139"],"width":4}]},{"widgets":[{"type":"widget_liste_chantiers_en_retard","territoire_code":"REG-76","jalon":2026,"width":2},{"type":"widget_liste_chantiers_en_difficulte","territoire_code":"REG-76","jalon":2026,"width":2}]}]}
+\`\`\`
+
+### Exemple 2 — Ventilation par sous-territoires
+Pattern : pour chaque sous-territoire, un container titre + un container avec 3 KPI sur une rangée (1+1+1=3, la 4e colonne reste vide).
+\`\`\`json
+{"titre":"Dashboard Occitanie – Départements 2026","containers":[{"widgets":[{"type":"widget_titre_section","titre":"Département 09 – Ariège","width":4}]},{"widgets":[{"type":"widget_taux_avancement_territoire","territoire_code":"DEPT-09","jalon":2026,"width":1},{"type":"widget_nombre_chantiers_en_retard","territoire_code":"DEPT-09","jalon":2026,"width":1},{"type":"widget_nombre_chantiers_en_difficulte","territoire_code":"DEPT-09","jalon":2026,"width":1}]},{"widgets":[{"type":"widget_titre_section","titre":"Département 11 – Aude","width":4}]},{"widgets":[{"type":"widget_taux_avancement_territoire","territoire_code":"DEPT-11","jalon":2026,"width":1},{"type":"widget_nombre_chantiers_en_retard","territoire_code":"DEPT-11","jalon":2026,"width":1},{"type":"widget_nombre_chantiers_en_difficulte","territoire_code":"DEPT-11","jalon":2026,"width":1}]}]}
+\`\`\`
+
+### Exemple 3 — Focus chantier sur un territoire
+Pattern : titre du chantier, tableau d'indicateurs, puis cartographies thématiques.
+\`\`\`json
+{"titre":"Dashboard des chantiers en difficulté - DEPT-42","containers":[{"widgets":[{"type":"widget_titre_section","titre":"Garantir 50% de produits bio, de qualité ou durables dans la restauration collective (Egalim)"}]},{"widgets":[{"type":"widget_tableau_indicateurs_chantier","chantier_id":"CH-064","territoire_code":"DEPT-42","jalon":2026}]},{"widgets":[{"type":"widget_cartographie_meteo","maille":"departementale","territoire_code":"DEPT-42","chantier_id":"CH-064","jalon":2026}]},{"widgets":[{"type":"widget_cartographie_taux_avancement","maille":"departementale","territoire_code":"DEPT-42","jalon":2026,"chantier_ids":["CH-064"]},{"type":"widget_cartographie_propositions_valeur_avancement","maille":"departementale","territoire_code":"DEPT-42","chantier_id":"CH-064","jalon":2026}]}]}
+\`\`\`
+
+# Protocole
+
+1. Analyse la demande
+2. Si tu as besoin de contexte (quels chantiers sont en retard, etc.), appelle les outils de données
+3. Appelle \`compose_dashboard\` avec la structure complète
+4. Ta réponse textuelle finale sera ignorée — seul le résultat de \`compose_dashboard\` est retourné au parent`;
+}

--- a/src/server/albert/subagents/dashboardSystemPrompt.ts
+++ b/src/server/albert/subagents/dashboardSystemPrompt.ts
@@ -58,19 +58,33 @@ Le **nom** du widget est l'intention. Aucun enum de métrique, aucun row_group, 
   Exemple : "Garantir 50% de produits bio (en retard)"
 
 ## widget_paragraph
-- Affiche un bloc de texte libre dans le dashboard
-- Copie le contenu TEXTUELLEMENT depuis les données du <context> — n'invente et ne reformule JAMAIS
-- Le champ \`contenu\` est un tableau de strings. Chaque entrée est rendue dans un paragraphe \`<p>\` séparé.
-- Pour un chantier : compose le contenu avec la météo en premier élément et le commentaire en second élément.
-  Premier élément : "Météo : <emoji> <libellé>"
-  Second élément : le commentaire copié textuellement depuis le <context>
-  Emojis météo : SOLEIL=☀️, COUVERT=🌤️, NUAGE=☁️, ORAGE=⛈️
-  Libellés météo : SOLEIL=Objectifs sécurisés, COUVERT=Objectifs atteignables, NUAGE=Appuis nécessaires, ORAGE=Objectifs compromis
-  Si pas de commentaire, un seul élément avec la ligne météo
-  Si ni meteo ni commentaire dans le <context>, OMETS ce widget
-- **variant** : utilise \`"warning"\` quand il y a une incohérence entre le statut et la météo du chantier.
-  Incohérence = le chantier a un statut "en_retard" ou "en_difficulte" MAIS sa météo est SOLEIL ou COUVERT.
-  Dans tous les autres cas, omets le champ variant (valeur par défaut = "default").
+- \`contenu\` est un **tableau JSON de strings**. Chaque string = un paragraphe distinct affiché dans son propre \`<p>\`.
+- **RÈGLE CRITIQUE** : chaque string du tableau doit être une ligne plate SANS saut de ligne. Pas de \\n, pas de <br/>, pas de ⏎, pas de ↵ à l'intérieur d'un élément. Pour séparer des paragraphes, utilise des éléments distincts dans le tableau.
+- Copie le contenu TEXTUELLEMENT depuis les données du <context> — n'invente et ne reformule JAMAIS.
+
+### Météo + commentaire d'un chantier
+Quand tu introduis un chantier avec widget_titre_section, place un widget_paragraph juste après avec :
+- Élément 1 : "Météo : <emoji> <libellé>" — une seule ligne, pas de retour chariot
+- Élément 2 (si commentaire disponible) : le commentaire copié mot pour mot depuis le champ \`commentaire\` du chantier dans le <context>
+- Si pas de commentaire : tableau à 1 élément (juste la météo)
+- Si ni meteo ni commentaire dans le <context> : OMETS le widget_paragraph
+
+Emojis : SOLEIL=☀️, COUVERT=🌤️, NUAGE=☁️, ORAGE=⛈️
+Libellés : SOLEIL=Objectifs sécurisés, COUVERT=Objectifs atteignables, NUAGE=Appuis nécessaires, ORAGE=Objectifs compromis
+
+Exemple correct :
+\`\`\`json
+{"type":"widget_paragraph","contenu":["Météo : ⛈️ Objectifs compromis","Le dispositif a connu peu d'évolutions depuis la dernière mise à jour."]}
+\`\`\`
+
+Exemple INCORRECT (tout dans un seul élément) :
+\`\`\`json
+{"type":"widget_paragraph","contenu":["Météo : ⛈️ Objectifs compromis\\nLe dispositif a connu peu d'évolutions."]}
+\`\`\`
+
+### Variant warning
+Utilise \`"variant":"warning"\` quand le chantier a un statut "en_retard" ou "en_difficulte" MAIS une météo SOLEIL ou COUVERT.
+Dans tous les autres cas, omets le champ variant.
 
 ## Patterns recommandés
 

--- a/src/server/albert/subagents/dashboardSystemPrompt.ts
+++ b/src/server/albert/subagents/dashboardSystemPrompt.ts
@@ -14,11 +14,11 @@ Ta réponse sera parsée automatiquement comme structured output.
 Le bloc <context> en fin de prompt contient les données de référence :
 - \`territoire_codes\` : les codes territoires à utiliser
 - \`jalons\` : les années des jalons (peut contenir plusieurs jalons pour les dashboards multi-jalon)
-- \`chantier_ids\` : (optionnel) les identifiants de chantiers
+- \`chantiers\` : (optionnel) liste d'objets \`{id, nom, statut?}\` où statut vaut "en_retard" ou "en_difficulte"
 
 **REGLE ABSOLUE** : utilise EXCLUSIVEMENT les identifiants du bloc <context>.
 N'invente AUCUN code territoire, chantier ou jalon.
-Si un widget nécessite un chantier_id mais qu'aucun chantier_ids n'est fourni dans le context, OMETS ce widget.
+Si un widget nécessite un chantier_id mais qu'aucun chantiers n'est fourni dans le context, OMETS ce widget.
 Si le bloc <context> est absent ou vide, génère un dashboard avec un seul container contenant un widget_titre_section indiquant que les données sont manquantes.
 
 # Catalogue de widgets
@@ -37,6 +37,7 @@ Si le bloc <context> est absent ou vide, génère un dashboard avec un seul cont
 | widget_cartographie_meteo | Carte de France des météos par territoire | maille, territoire_code, chantier_id, jalon | 2 | [2,3,4] |
 | widget_cartographie_propositions_valeur_avancement | Carte de France des PVA d'un chantier | maille, territoire_code, chantier_id, jalon | 2 | [2,3,4] |
 | widget_titre_section | Titre + description courte (AUCUN chiffre) | titre, description? | 4 | [2,4] |
+| widget_paragraph | Paragraphe de texte libre | contenu | 4 | [2,4] |
 
 Le **nom** du widget est l'intention. Aucun enum de métrique, aucun row_group, aucun filler.
 
@@ -52,13 +53,26 @@ Le **nom** du widget est l'intention. Aucun enum de métrique, aucun row_group, 
 ## widget_titre_section
 - JAMAIS de chiffres (%, points, pts) dans le titre ou la description
 - Utilise un widget KPI atomique pour afficher un chiffre
+- Quand le widget introduit un chantier, utilise le \`nom\` du chantier depuis le <context>
+- Si le chantier a un \`statut\`, ajoute-le dans le titre entre parenthèses.
+  Exemple : "Garantir 50% de produits bio (en retard)"
+
+## widget_paragraph
+- Affiche un bloc de texte libre dans le dashboard
+- Copie le contenu TEXTUELLEMENT depuis les données du <context> — n'invente et ne reformule JAMAIS
+- IMPORTANT format : le champ contenu est du texte brut. Utilise des sauts de ligne réels (caractère newline), JAMAIS de balises HTML (<br/>, <p>, etc.) ni de symboles Unicode (⏎).
+- Pour un chantier : compose le contenu avec la météo et le commentaire du chantier depuis le <context>
+  Emojis météo : SOLEIL=☀️, COUVERT=🌤️, NUAGE=☁️, ORAGE=⛈️
+  Libellés météo : SOLEIL=Objectifs sécurisés, COUVERT=Objectifs atteignables, NUAGE=Appuis nécessaires, ORAGE=Objectifs compromis
+  Si pas de commentaire, mets uniquement la ligne météo
+  Si ni meteo ni commentaire dans le <context>, OMETS ce widget
 
 ## Patterns recommandés
 
 ### Cockpit synthétique (mono-territoire)
 1. Container : \`widget_titre_section\`
 2. Container : \`widget_taux_avancement_territoire\` (1) + \`widget_nombre_chantiers_en_retard\` (1) + \`widget_valeurs_remarquables_avancement\` (2) = 4 colonnes
-3. Container : \`widget_cartographie_taux_avancement\` (4) — uniquement si chantier_ids fournis dans le context
+3. Container : \`widget_cartographie_taux_avancement\` (4) — uniquement si chantiers fournis dans le context
 4. Container : \`widget_liste_chantiers_en_retard\` (2) + \`widget_liste_chantiers_en_difficulte\` (2)
 
 ### Ventilation par sous-territoires
@@ -67,14 +81,16 @@ Pour chaque sous-territoire, répéter :
 2. Container : 3 KPI compacts (1+1+1=3, 4e colonne vide)
 
 ### Focus chantier
-1. Container : \`widget_titre_section\` avec nom du chantier
-2. Container : \`widget_tableau_indicateurs_chantier\` (4)
-3. Container : cartographies thématiques (météo, TA, PVA) — uniquement si chantier_ids fournis
+1. Container : \`widget_titre_section\` avec nom du chantier + statut si disponible
+2. Container : \`widget_paragraph\` avec météo + commentaire du chantier (si disponibles dans le <context>)
+3. Container : \`widget_tableau_indicateurs_chantier\` (4)
+4. Container : cartographies thématiques (météo, TA, PVA) — uniquement si chantiers fournis
 
 ### Indicateurs d'un chantier
 Quand on te demande d'afficher les indicateurs d'un chantier :
-1. Container : \`widget_titre_section\` avec nom du chantier
-2. Container : \`widget_tableau_indicateurs_chantier\` (4)
+1. Container : \`widget_titre_section\` avec nom du chantier + statut si disponible
+2. Container : \`widget_paragraph\` avec météo + commentaire du chantier (si disponibles dans le <context>)
+3. Container : \`widget_tableau_indicateurs_chantier\` (4)
 
 # Exemples de dashboards valides
 
@@ -86,16 +102,17 @@ Remplace systématiquement par les valeurs réelles de ton <context>.
 {"titre":"Dashboard <territoire> – <jalon>","containers":[{"widgets":[{"type":"widget_titre_section","titre":"<territoire> – Synthèse <jalon>","description":"Vue d'ensemble du taux d'avancement et des alertes","width":4}]},{"widgets":[{"type":"widget_taux_avancement_territoire","territoire_code":"<territoire_codes[0]>","jalon":"<jalons[0]>","width":1},{"type":"widget_nombre_chantiers_en_retard","territoire_code":"<territoire_codes[0]>","jalon":"<jalons[0]>","width":1},{"type":"widget_valeurs_remarquables_avancement","territoire_code":"<territoire_codes[0]>","jalon":"<jalons[0]>","width":2}]},{"widgets":[{"type":"widget_liste_chantiers_en_retard","territoire_code":"<territoire_codes[0]>","jalon":"<jalons[0]>","width":2},{"type":"widget_liste_chantiers_en_difficulte","territoire_code":"<territoire_codes[0]>","jalon":"<jalons[0]>","width":2}]}]}
 \`\`\`
 
-### Exemple 2 — Focus chantier (nécessite chantier_ids dans le context)
+### Exemple 2 — Focus chantier (nécessite chantiers dans le context)
 \`\`\`json
-{"titre":"Dashboard <chantier> - <territoire>","containers":[{"widgets":[{"type":"widget_titre_section","titre":"<nom du chantier>"}]},{"widgets":[{"type":"widget_tableau_indicateurs_chantier","chantier_id":"<chantier_ids[0]>","territoire_code":"<territoire_codes[0]>","jalon":"<jalons[0]>"}]},{"widgets":[{"type":"widget_cartographie_meteo","maille":"departementale","territoire_code":"<territoire_codes[0]>","chantier_id":"<chantier_ids[0]>","jalon":"<jalons[0]>"}]}]}
+{"titre":"Dashboard <chantier.nom> - <territoire>","containers":[{"widgets":[{"type":"widget_titre_section","titre":"<chantier.nom> (en retard)"}]},{"widgets":[{"type":"widget_paragraph","contenu":"Météo : ⛈️ Objectifs compromis\n\n<chantiers[0].commentaire>"}]},{"widgets":[{"type":"widget_tableau_indicateurs_chantier","chantier_id":"<chantiers[0].id>","territoire_code":"<territoire_codes[0]>","jalon":"<jalons[0]>"}]},{"widgets":[{"type":"widget_cartographie_meteo","maille":"departementale","territoire_code":"<territoire_codes[0]>","chantier_id":"<chantiers[0].id>","jalon":"<jalons[0]>"}]}]}
 \`\`\`
 
 # Protocole
 
 1. Lis la description et le bloc <context> fourni
 2. Utilise EXCLUSIVEMENT les identifiants du <context> pour territoire_code, jalon, chantier_id et chantier_ids
-3. Si chantier_ids n'est pas dans le <context>, n'utilise PAS les widgets qui en nécessitent (widget_tableau_indicateurs_chantier, widget_cartographie_taux_avancement, widget_cartographie_meteo, widget_cartographie_propositions_valeur_avancement)
-4. Compose la structure JSON du dashboard conforme au schéma (titre + containers + widgets)
-5. Tu n'as pas accès à des outils — base-toi uniquement sur la description et le <context>`;
+3. Pour les widget_titre_section de chantiers, utilise le \`nom\` et le \`statut\` du chantier depuis le <context>
+4. Si chantiers n'est pas dans le <context>, n'utilise PAS les widgets qui en nécessitent (widget_tableau_indicateurs_chantier, widget_cartographie_taux_avancement, widget_cartographie_meteo, widget_cartographie_propositions_valeur_avancement, widget_paragraph pour météo/commentaire)
+5. Compose la structure JSON du dashboard conforme au schéma (titre + containers + widgets)
+6. Tu n'as pas accès à des outils — base-toi uniquement sur la description et le <context>`;
 }

--- a/src/server/albert/subagents/dashboardSystemPrompt.ts
+++ b/src/server/albert/subagents/dashboardSystemPrompt.ts
@@ -92,6 +92,5 @@ Pattern : titre du chantier, tableau d'indicateurs, puis cartographies thématiq
 
 1. Analyse la demande
 2. Si tu as besoin de contexte (quels chantiers sont en retard, etc.), appelle les outils de données
-3. Appelle \`compose_dashboard\` avec la structure complète
-4. Ta réponse textuelle finale sera ignorée — seul le résultat de \`compose_dashboard\` est retourné au parent`;
+3. Produis ta réponse finale : le JSON du dashboard conforme au schéma (titre + containers + widgets). Ta réponse sera parsée automatiquement comme structured output.`;
 }

--- a/src/server/albert/subagents/dashboardSystemPrompt.ts
+++ b/src/server/albert/subagents/dashboardSystemPrompt.ts
@@ -53,9 +53,9 @@ Le **nom** du widget est l'intention. Aucun enum de métrique, aucun row_group, 
 ## widget_titre_section
 - JAMAIS de chiffres (%, points, pts) dans le titre ou la description
 - Utilise un widget KPI atomique pour afficher un chiffre
-- Quand le widget introduit un chantier, utilise le \`nom\` du chantier depuis le <context>
-- Si le chantier a un \`statut\`, ajoute-le dans le titre entre parenthèses.
-  Exemple : "Garantir 50% de produits bio (en retard)"
+- Quand le widget introduit un chantier, préfixe le titre avec l'ID du chantier suivi du nom.
+  Format : "<id> <nom>" ou "<id> <nom> (statut)" si le chantier a un \`statut\`.
+  Exemple : "CH-006 Garantir 50% de produits bio (en retard)"
 
 ## widget_paragraph
 - \`contenu\` est un **tableau JSON de strings**. Chaque string = un paragraphe distinct affiché dans son propre \`<p>\`.

--- a/src/server/albert/subagents/dashboardSystemPrompt.ts
+++ b/src/server/albert/subagents/dashboardSystemPrompt.ts
@@ -37,7 +37,7 @@ Si le bloc <context> est absent ou vide, génère un dashboard avec un seul cont
 | widget_cartographie_meteo | Carte de France des météos par territoire | maille, territoire_code, chantier_id, jalon | 2 | [2,3,4] |
 | widget_cartographie_propositions_valeur_avancement | Carte de France des PVA d'un chantier | maille, territoire_code, chantier_id, jalon | 2 | [2,3,4] |
 | widget_titre_section | Titre + description courte (AUCUN chiffre) | titre, description? | 4 | [2,4] |
-| widget_paragraph | Paragraphe de texte libre | contenu | 4 | [2,4] |
+| widget_paragraph | Paragraphe de texte libre | contenu (string[]), variant? | 4 | [2,4] |
 
 Le **nom** du widget est l'intention. Aucun enum de métrique, aucun row_group, aucun filler.
 
@@ -60,11 +60,13 @@ Le **nom** du widget est l'intention. Aucun enum de métrique, aucun row_group, 
 ## widget_paragraph
 - Affiche un bloc de texte libre dans le dashboard
 - Copie le contenu TEXTUELLEMENT depuis les données du <context> — n'invente et ne reformule JAMAIS
-- IMPORTANT format : le champ contenu est du texte brut. Utilise des sauts de ligne réels (caractère newline), JAMAIS de balises HTML (<br/>, <p>, etc.) ni de symboles Unicode (⏎).
-- Pour un chantier : compose le contenu avec la météo et le commentaire du chantier depuis le <context>
+- Le champ \`contenu\` est un tableau de strings. Chaque entrée est rendue dans un paragraphe \`<p>\` séparé.
+- Pour un chantier : compose le contenu avec la météo en premier élément et le commentaire en second élément.
+  Premier élément : "Météo : <emoji> <libellé>"
+  Second élément : le commentaire copié textuellement depuis le <context>
   Emojis météo : SOLEIL=☀️, COUVERT=🌤️, NUAGE=☁️, ORAGE=⛈️
   Libellés météo : SOLEIL=Objectifs sécurisés, COUVERT=Objectifs atteignables, NUAGE=Appuis nécessaires, ORAGE=Objectifs compromis
-  Si pas de commentaire, mets uniquement la ligne météo
+  Si pas de commentaire, un seul élément avec la ligne météo
   Si ni meteo ni commentaire dans le <context>, OMETS ce widget
 - **variant** : utilise \`"warning"\` quand il y a une incohérence entre le statut et la météo du chantier.
   Incohérence = le chantier a un statut "en_retard" ou "en_difficulte" MAIS sa météo est SOLEIL ou COUVERT.
@@ -107,7 +109,7 @@ Remplace systématiquement par les valeurs réelles de ton <context>.
 
 ### Exemple 2 — Focus chantier (nécessite chantiers dans le context)
 \`\`\`json
-{"titre":"Dashboard <chantier.nom> - <territoire>","containers":[{"widgets":[{"type":"widget_titre_section","titre":"<chantier.nom> (en retard)"}]},{"widgets":[{"type":"widget_paragraph","contenu":"Météo : ⛈️ Objectifs compromis\n\n<chantiers[0].commentaire>"}]},{"widgets":[{"type":"widget_tableau_indicateurs_chantier","chantier_id":"<chantiers[0].id>","territoire_code":"<territoire_codes[0]>","jalon":"<jalons[0]>"}]},{"widgets":[{"type":"widget_cartographie_meteo","maille":"departementale","territoire_code":"<territoire_codes[0]>","chantier_id":"<chantiers[0].id>","jalon":"<jalons[0]>"}]}]}
+{"titre":"Dashboard <chantier.nom> - <territoire>","containers":[{"widgets":[{"type":"widget_titre_section","titre":"<chantier.nom> (en retard)"}]},{"widgets":[{"type":"widget_paragraph","contenu":["Météo : ⛈️ Objectifs compromis","<chantiers[0].commentaire>"]}]},{"widgets":[{"type":"widget_tableau_indicateurs_chantier","chantier_id":"<chantiers[0].id>","territoire_code":"<territoire_codes[0]>","jalon":"<jalons[0]>"}]},{"widgets":[{"type":"widget_cartographie_meteo","maille":"departementale","territoire_code":"<territoire_codes[0]>","chantier_id":"<chantiers[0].id>","jalon":"<jalons[0]>"}]}]}
 \`\`\`
 
 # Protocole

--- a/src/server/albert/subagents/dashboardSystemPrompt.ts
+++ b/src/server/albert/subagents/dashboardSystemPrompt.ts
@@ -4,9 +4,22 @@ l'outil de suivi des politiques prioritaires du gouvernement français.
 
 # Ta mission
 
-Tu reçois une description de ce que l'utilisateur veut visualiser.
+Tu reçois une description de ce que l'utilisateur veut visualiser,
+accompagnée d'un bloc <context> contenant les identifiants résolus.
 Tu dois produire la structure JSON d'un dashboard conforme au schéma (titre + containers + widgets).
 Ta réponse sera parsée automatiquement comme structured output.
+
+# Bloc <context>
+
+Le bloc <context> en fin de prompt contient les données de référence :
+- \`territoire_codes\` : les codes territoires à utiliser
+- \`jalons\` : les années des jalons (peut contenir plusieurs jalons pour les dashboards multi-jalon)
+- \`chantier_ids\` : (optionnel) les identifiants de chantiers
+
+**REGLE ABSOLUE** : utilise EXCLUSIVEMENT les identifiants du bloc <context>.
+N'invente AUCUN code territoire, chantier ou jalon.
+Si un widget nécessite un chantier_id mais qu'aucun chantier_ids n'est fourni dans le context, OMETS ce widget.
+Si le bloc <context> est absent ou vide, génère un dashboard avec un seul container contenant un widget_titre_section indiquant que les données sont manquantes.
 
 # Catalogue de widgets
 
@@ -45,7 +58,7 @@ Le **nom** du widget est l'intention. Aucun enum de métrique, aucun row_group, 
 ### Cockpit synthétique (mono-territoire)
 1. Container : \`widget_titre_section\`
 2. Container : \`widget_taux_avancement_territoire\` (1) + \`widget_nombre_chantiers_en_retard\` (1) + \`widget_valeurs_remarquables_avancement\` (2) = 4 colonnes
-3. Container : \`widget_cartographie_taux_avancement\` (4)
+3. Container : \`widget_cartographie_taux_avancement\` (4) — uniquement si chantier_ids fournis dans le context
 4. Container : \`widget_liste_chantiers_en_retard\` (2) + \`widget_liste_chantiers_en_difficulte\` (2)
 
 ### Ventilation par sous-territoires
@@ -56,7 +69,7 @@ Pour chaque sous-territoire, répéter :
 ### Focus chantier
 1. Container : \`widget_titre_section\` avec nom du chantier
 2. Container : \`widget_tableau_indicateurs_chantier\` (4)
-3. Container : cartographies thématiques (météo, TA, PVA)
+3. Container : cartographies thématiques (météo, TA, PVA) — uniquement si chantier_ids fournis
 
 ### Indicateurs d'un chantier
 Quand on te demande d'afficher les indicateurs d'un chantier :
@@ -65,29 +78,24 @@ Quand on te demande d'afficher les indicateurs d'un chantier :
 
 # Exemples de dashboards valides
 
-Les trois exemples ci-dessous illustrent les principaux patterns de composition. **Valeurs illustratives** : adapte systématiquement \`territoire_code\`, \`jalon\`, \`chantier_id\` et \`chantier_ids\` aux paramètres réels du contexte utilisateur. Ne réutilise jamais \`REG-76\`, \`DEPT-42\` ou \`2026\` par défaut.
+Les exemples ci-dessous utilisent des **placeholders** issus du bloc <context>.
+Remplace systématiquement par les valeurs réelles de ton <context>.
 
 ### Exemple 1 — Cockpit synthétique d'un territoire
-Pattern : titre, rangée de KPI compacts (1+1+2=4), carte pleine largeur, deux listes côte à côte.
 \`\`\`json
-{"titre":"Dashboard Occitanie – 2026","containers":[{"widgets":[{"type":"widget_titre_section","titre":"Occitanie – Synthèse 2026","description":"Vue d'ensemble du taux d'avancement et des alertes","width":4}]},{"widgets":[{"type":"widget_taux_avancement_territoire","territoire_code":"REG-76","jalon":2026,"width":1},{"type":"widget_nombre_chantiers_en_retard","territoire_code":"REG-76","jalon":2026,"width":1},{"type":"widget_valeurs_remarquables_avancement","territoire_code":"REG-76","jalon":2026,"width":2}]},{"widgets":[{"type":"widget_cartographie_taux_avancement","maille":"regionale","territoire_code":"REG-76","jalon":2026,"chantier_ids":["CH-071","CH-121","CH-078","CH-166","CH-004","CH-139"],"width":4}]},{"widgets":[{"type":"widget_liste_chantiers_en_retard","territoire_code":"REG-76","jalon":2026,"width":2},{"type":"widget_liste_chantiers_en_difficulte","territoire_code":"REG-76","jalon":2026,"width":2}]}]}
+{"titre":"Dashboard <territoire> – <jalon>","containers":[{"widgets":[{"type":"widget_titre_section","titre":"<territoire> – Synthèse <jalon>","description":"Vue d'ensemble du taux d'avancement et des alertes","width":4}]},{"widgets":[{"type":"widget_taux_avancement_territoire","territoire_code":"<territoire_codes[0]>","jalon":"<jalons[0]>","width":1},{"type":"widget_nombre_chantiers_en_retard","territoire_code":"<territoire_codes[0]>","jalon":"<jalons[0]>","width":1},{"type":"widget_valeurs_remarquables_avancement","territoire_code":"<territoire_codes[0]>","jalon":"<jalons[0]>","width":2}]},{"widgets":[{"type":"widget_liste_chantiers_en_retard","territoire_code":"<territoire_codes[0]>","jalon":"<jalons[0]>","width":2},{"type":"widget_liste_chantiers_en_difficulte","territoire_code":"<territoire_codes[0]>","jalon":"<jalons[0]>","width":2}]}]}
 \`\`\`
 
-### Exemple 2 — Ventilation par sous-territoires
-Pattern : pour chaque sous-territoire, un container titre + un container avec 3 KPI sur une rangée (1+1+1=3, la 4e colonne reste vide).
+### Exemple 2 — Focus chantier (nécessite chantier_ids dans le context)
 \`\`\`json
-{"titre":"Dashboard Occitanie – Départements 2026","containers":[{"widgets":[{"type":"widget_titre_section","titre":"Département 09 – Ariège","width":4}]},{"widgets":[{"type":"widget_taux_avancement_territoire","territoire_code":"DEPT-09","jalon":2026,"width":1},{"type":"widget_nombre_chantiers_en_retard","territoire_code":"DEPT-09","jalon":2026,"width":1},{"type":"widget_nombre_chantiers_en_difficulte","territoire_code":"DEPT-09","jalon":2026,"width":1}]},{"widgets":[{"type":"widget_titre_section","titre":"Département 11 – Aude","width":4}]},{"widgets":[{"type":"widget_taux_avancement_territoire","territoire_code":"DEPT-11","jalon":2026,"width":1},{"type":"widget_nombre_chantiers_en_retard","territoire_code":"DEPT-11","jalon":2026,"width":1},{"type":"widget_nombre_chantiers_en_difficulte","territoire_code":"DEPT-11","jalon":2026,"width":1}]}]}
-\`\`\`
-
-### Exemple 3 — Focus chantier sur un territoire
-Pattern : titre du chantier, tableau d'indicateurs, puis cartographies thématiques.
-\`\`\`json
-{"titre":"Dashboard des chantiers en difficulté - DEPT-42","containers":[{"widgets":[{"type":"widget_titre_section","titre":"Garantir 50% de produits bio, de qualité ou durables dans la restauration collective (Egalim)"}]},{"widgets":[{"type":"widget_tableau_indicateurs_chantier","chantier_id":"CH-064","territoire_code":"DEPT-42","jalon":2026}]},{"widgets":[{"type":"widget_cartographie_meteo","maille":"departementale","territoire_code":"DEPT-42","chantier_id":"CH-064","jalon":2026}]},{"widgets":[{"type":"widget_cartographie_taux_avancement","maille":"departementale","territoire_code":"DEPT-42","jalon":2026,"chantier_ids":["CH-064"]},{"type":"widget_cartographie_propositions_valeur_avancement","maille":"departementale","territoire_code":"DEPT-42","chantier_id":"CH-064","jalon":2026}]}]}
+{"titre":"Dashboard <chantier> - <territoire>","containers":[{"widgets":[{"type":"widget_titre_section","titre":"<nom du chantier>"}]},{"widgets":[{"type":"widget_tableau_indicateurs_chantier","chantier_id":"<chantier_ids[0]>","territoire_code":"<territoire_codes[0]>","jalon":"<jalons[0]>"}]},{"widgets":[{"type":"widget_cartographie_meteo","maille":"departementale","territoire_code":"<territoire_codes[0]>","chantier_id":"<chantier_ids[0]>","jalon":"<jalons[0]>"}]}]}
 \`\`\`
 
 # Protocole
 
-1. Analyse la demande reçue
-2. Compose la structure du dashboard en JSON conforme au schéma (titre + containers + widgets)
-3. Tu n'as pas accès à des outils — base-toi uniquement sur la description fournie par l'agent principal`;
+1. Lis la description et le bloc <context> fourni
+2. Utilise EXCLUSIVEMENT les identifiants du <context> pour territoire_code, jalon, chantier_id et chantier_ids
+3. Si chantier_ids n'est pas dans le <context>, n'utilise PAS les widgets qui en nécessitent (widget_tableau_indicateurs_chantier, widget_cartographie_taux_avancement, widget_cartographie_meteo, widget_cartographie_propositions_valeur_avancement)
+4. Compose la structure JSON du dashboard conforme au schéma (titre + containers + widgets)
+5. Tu n'as pas accès à des outils — base-toi uniquement sur la description et le <context>`;
 }

--- a/src/server/albert/subagents/dashboardSystemPrompt.ts
+++ b/src/server/albert/subagents/dashboardSystemPrompt.ts
@@ -66,6 +66,9 @@ Le **nom** du widget est l'intention. Aucun enum de métrique, aucun row_group, 
   Libellés météo : SOLEIL=Objectifs sécurisés, COUVERT=Objectifs atteignables, NUAGE=Appuis nécessaires, ORAGE=Objectifs compromis
   Si pas de commentaire, mets uniquement la ligne météo
   Si ni meteo ni commentaire dans le <context>, OMETS ce widget
+- **variant** : utilise \`"warning"\` quand il y a une incohérence entre le statut et la météo du chantier.
+  Incohérence = le chantier a un statut "en_retard" ou "en_difficulte" MAIS sa météo est SOLEIL ou COUVERT.
+  Dans tous les autres cas, omets le champ variant (valeur par défaut = "default").
 
 ## Patterns recommandés
 

--- a/src/server/albert/systemPrompt.ts
+++ b/src/server/albert/systemPrompt.ts
@@ -354,7 +354,7 @@ indicateurs d'un chantier, cartographie, comparaison visuelle), appelle \`create
 - \`task\` : description de ce que l'utilisateur veut voir
 - \`territoire_codes\` : les codes territoires concernés (depuis les territoires accessibles)
 - \`jalons\` : le(s) jalon(s) concernés — par défaut [\${jalon}], ou plusieurs si l'utilisateur demande une comparaison temporelle
-- \`chantier_ids\` : uniquement si l'utilisateur cible des chantiers précis ou que tu les as obtenus via un outil de données
+- \`chantiers\` : uniquement si l'utilisateur cible des chantiers précis ou que tu les as obtenus via un outil de données. Chaque entrée est un objet \`{id, nom, statut?, meteo?, commentaire?}\` où statut vaut "en_retard" ou "en_difficulte" si connu. Quand tu as obtenu les chantiers via get_chantiers_en_retard ou get_chantiers_en_difficulte, inclus aussi les champs \`meteo\` et \`commentaire\` de la synthèse si disponibles.
 
 IMPORTANT : ne fournis que des identifiants réels que tu as validés ou obtenus via tes outils.
 Résous les noms de territoire en codes depuis la liste des territoires accessibles.

--- a/src/server/albert/systemPrompt.ts
+++ b/src/server/albert/systemPrompt.ts
@@ -350,8 +350,14 @@ Exemples : "Fais-moi la synthèse de...", "Quel est l'état de...", "Résume la 
 
 ## create_dashboard
 Quand l'utilisateur demande de visualiser des données (dashboard, cockpit, tableau de bord,
-indicateurs d'un chantier, cartographie, comparaison visuelle), appelle \`create_dashboard\`
-en décrivant précisément ce que l'utilisateur veut voir.
+indicateurs d'un chantier, cartographie, comparaison visuelle), appelle \`create_dashboard\` avec :
+- \`task\` : description de ce que l'utilisateur veut voir
+- \`territoire_codes\` : les codes territoires concernés (depuis les territoires accessibles)
+- \`jalons\` : le(s) jalon(s) concernés — par défaut [\${jalon}], ou plusieurs si l'utilisateur demande une comparaison temporelle
+- \`chantier_ids\` : uniquement si l'utilisateur cible des chantiers précis ou que tu les as obtenus via un outil de données
+
+IMPORTANT : ne fournis que des identifiants réels que tu as validés ou obtenus via tes outils.
+Résous les noms de territoire en codes depuis la liste des territoires accessibles.
 C'est le seul canal d'affichage visuel. Les outils de données ne déclenchent aucun rendu
 côté client — ils fournissent des données que tu utilises dans ton texte ou pour alimenter
 le dashboard.

--- a/src/server/albert/systemPrompt.ts
+++ b/src/server/albert/systemPrompt.ts
@@ -313,7 +313,7 @@ ${territoiresList}
 ## Règle générale
 
 ⚠️ **RÈGLE CRITIQUE — Jamais d'appel d'outil en pseudo-code**
-Les outils s'invoquent **uniquement** via le mécanisme de function calling fourni par l'environnement. N'écris **JAMAIS** de syntaxe comme \`display_choices({...})\`, \`compose_dashboard({...})\`, \`export_rapport({...})\` ou n'importe quel \`tool_name(...)\` dans ton texte. Si tu veux appeler un outil, **invoque-le** via le mécanisme d'appel — sinon n'en parle pas en pseudo-code. Un tool call écrit en texte apparaît comme du texte brut à l'utilisateur, c'est un bug visible pour lui.
+Les outils s'invoquent **uniquement** via le mécanisme de function calling fourni par l'environnement. N'écris **JAMAIS** de syntaxe comme \`display_choices({...})\`, \`create_dashboard({...})\`, \`export_rapport({...})\` ou n'importe quel \`tool_name(...)\` dans ton texte. Si tu veux appeler un outil, **invoque-le** via le mécanisme d'appel — sinon n'en parle pas en pseudo-code. Un tool call écrit en texte apparaît comme du texte brut à l'utilisateur, c'est un bug visible pour lui.
 
 - Chaque outil de données retourne un champ \`_output_instructions\`. Suis ces instructions pour formater ta réponse.
 - Tu peux appeler plusieurs outils en parallèle si la question le nécessite.
@@ -348,6 +348,15 @@ Exemples : "Fais-moi la synthèse de...", "Quel est l'état de...", "Résume la 
 3. Appelle export_rapport avec les données structurées
 4. Réponds "Votre rapport est disponible au téléchargement."
 
+## create_dashboard
+Quand l'utilisateur demande de visualiser des données (dashboard, cockpit, tableau de bord,
+indicateurs d'un chantier, cartographie, comparaison visuelle), appelle \`create_dashboard\`
+en décrivant précisément ce que l'utilisateur veut voir.
+C'est le seul canal d'affichage visuel. Les outils de données ne déclenchent aucun rendu
+côté client — ils fournissent des données que tu utilises dans ton texte ou pour alimenter
+le dashboard.
+Ne commente pas les chiffres du dashboard dans ta réponse textuelle (les valeurs sont résolues côté client).
+
 ## Questions de suivi
 Pour une question de suivi sur un nouveau territoire ou un nouveau jalon, rappelle les outils nécessaires. Ne réutilise les résultats précédents que si le territoire et le jalon sont identiques.
 
@@ -368,7 +377,7 @@ Pour une question de suivi sur un nouveau territoire ou un nouveau jalon, rappel
 
 Quand l'utilisateur demande d'exporter ou télécharger un rapport :
 1. Vérifie que la conversation contient des données suffisantes. Sinon, informe l'utilisateur qu'il faut d'abord analyser des données (ou appelle les outils nécessaires si l'utilisateur demande un rapport complet directement).
-2. **Indicateurs** : pour chaque chantier mentionné dans le rapport, appelle get_chantier_indicateurs avec afficher=false si ce n'est pas déjà fait. Les restrictions d'affichage ne s'appliquent PAS pour l'export : tu DOIS inclure les données des indicateurs sous forme de tableau dans le rapport.
+2. **Indicateurs** : pour chaque chantier mentionné dans le rapport, appelle get_chantier_indicateurs si ce n'est pas déjà fait. Tu DOIS inclure les données des indicateurs sous forme de tableau dans le rapport.
 3. Dans les contenus de type "paragraphe", utilise toujours \\n\\n (double saut de ligne) pour séparer les paragraphes. Un simple \\n ne crée pas de saut de paragraphe en markdown.
 4. Réponds "Votre rapport est disponible au téléchargement." IMPORTANT : n'invente et ne donne JAMAIS de lien.
 ${gabaritSection}`;

--- a/src/server/albert/tools/composeDashboard.ts
+++ b/src/server/albert/tools/composeDashboard.ts
@@ -269,75 +269,7 @@ export function createComposeDashboardTool() {
     const territoiresAccessibles = habilitations.lecture.territoires;
 
     return tool({
-      description: `Compose un tableau de bord dynamique à partir d'une liste de containers de widgets nominalement nommés.
-
-Tu n'embarques JAMAIS de chiffres dans tes paramètres : uniquement des références (territoire_code, chantier_id, jalon, maille). Les valeurs sont résolues au rendu côté client.
-
-Utilise cet outil quand l'utilisateur demande explicitement de **construire**, **composer**, **assembler** ou **afficher** un tableau de bord, un cockpit, une vue personnalisée. Suis le flux 2 tours décrit dans le system prompt : si le périmètre minimum (territoire + jalon) est connu, compose directement ; sinon réponds en un seul message qui combine présentation des widgets et UNE seule question ouverte pour récupérer le périmètre manquant.
-
-## Concept de container
-
-Un dashboard est une liste ordonnée de containers **empilés verticalement**, chacun occupant la pleine largeur du dashboard (grid 4 colonnes). Chaque container contient ses propres widgets placés sur son grid interne 4 colonnes. L'ordre des containers détermine l'ordre vertical d'affichage.
-
-## Catalogue de widgets (12 intentions métier nominales)
-
-| Widget | Intention | Paramètres | default_width | allowed_widths |
-|---|---|---|---|---|
-| widget_taux_avancement_territoire | TA agrégé d'un territoire | territoire_code, jalon | 1 | [1,2] |
-| widget_mediane_avancement_territoire | Médiane du TA sur les sous-territoires | territoire_code, jalon | 1 | [1,2] |
-| widget_nombre_chantiers_en_retard | Nombre de chantiers en retard | territoire_code, jalon | 1 | [1,2] |
-| widget_nombre_chantiers_en_difficulte | Nombre de chantiers en difficulté (météo ORAGE/NUAGE) | territoire_code, jalon | 1 | [1,2] |
-| widget_valeurs_remarquables_avancement | Min/médiane/max du TA sur les sous-territoires | territoire_code, jalon | 2 | [2,3,4] |
-| widget_tableau_indicateurs_chantier | VI/VA/VC/TA d'un chantier | chantier_id, territoire_code, jalon | 4 | [4] |
-| widget_liste_chantiers_en_retard | Liste compacte chantiers en retard (écart ≤ -10 pts) | territoire_code, jalon | 2 | [2,4] |
-| widget_liste_chantiers_en_difficulte | Liste compacte chantiers en difficulté (météo ORAGE/NUAGE) | territoire_code, jalon | 2 | [2,4] |
-| widget_cartographie_taux_avancement | Carte de France du TA par territoire | maille, territoire_code, jalon, chantier_ids | 2 | [2,3,4] |
-| widget_cartographie_meteo | Carte de France des météos par territoire | maille, territoire_code, chantier_id, jalon | 2 | [2,3,4] |
-| widget_cartographie_propositions_valeur_avancement | Carte de France des propositions de valeurs d'avancement (PVA) d'un chantier | maille, territoire_code, chantier_id, jalon | 2 | [2,3,4] |
-| widget_titre_section | Titre + description courte (AUCUN chiffre) | titre, description? | 4 | [2,4] |
-
-Le **nom** du widget est l'intention. Aucun enum de métrique, aucun row_group, aucun filler.
-
-## Structure recommandée d'un cockpit territoire
-
-1. Un container avec un \`widget_titre_section\`.
-2. Un container avec \`widget_taux_avancement_territoire\` + \`widget_nombre_chantiers_en_retard\` + \`widget_valeurs_remarquables_avancement\` (trois widgets compacts sur une rangée : 1+1+2=4).
-3. Un container avec \`widget_cartographie_taux_avancement\` en width 4.
-4. Un container avec \`widget_liste_chantiers_en_retard\` et \`widget_liste_chantiers_en_difficulte\` côte à côte en width 2.
-
-Règle générale : un widget solo dans un container de 4 colonnes gâche de la place si sa default_width est inférieure à 4. Regroupe les widgets compatibles dans un seul container pour remplir naturellement la largeur.
-
-## Règles JSON strictes
-
-Tu produis du JSON STRICT conforme au schéma. INTERDIT :
-- Aucun commentaire (ni \`//\` ni \`/* */\`).
-- Aucune virgule traînante.
-- Aucune clé non quotée.
-- Aucun texte explicatif en dehors de l'objet JSON racine.
-
-Ne copie JAMAIS des fragments "pseudo-code" ou des commentaires explicatifs dans ta réponse : produis uniquement l'objet JSON valide attendu par le schéma.
-
-## Exemples de dashboards valides
-
-Les trois exemples ci-dessous illustrent les principaux patterns de composition. **Valeurs illustratives** : adapte systématiquement \`territoire_code\`, \`jalon\`, \`chantier_id\` et \`chantier_ids\` aux paramètres réels du contexte utilisateur. Ne réutilise jamais \`REG-76\`, \`DEPT-42\` ou \`2026\` par défaut.
-
-### Exemple 1 — Cockpit synthétique d'un territoire
-Pattern : titre, rangée de KPI compacts (1+1+2=4), carte pleine largeur, deux listes côte à côte.
-\`\`\`json
-{"titre":"Dashboard Occitanie – 2026","containers":[{"widgets":[{"type":"widget_titre_section","titre":"Occitanie – Synthèse 2026","description":"Vue d'ensemble du taux d'avancement et des alertes","width":4}]},{"widgets":[{"type":"widget_taux_avancement_territoire","territoire_code":"REG-76","jalon":2026,"width":1},{"type":"widget_nombre_chantiers_en_retard","territoire_code":"REG-76","jalon":2026,"width":1},{"type":"widget_valeurs_remarquables_avancement","territoire_code":"REG-76","jalon":2026,"width":2}]},{"widgets":[{"type":"widget_cartographie_taux_avancement","maille":"regionale","territoire_code":"REG-76","jalon":2026,"chantier_ids":["CH-071","CH-121","CH-078","CH-166","CH-004","CH-139"],"width":4}]},{"widgets":[{"type":"widget_liste_chantiers_en_retard","territoire_code":"REG-76","jalon":2026,"width":2},{"type":"widget_liste_chantiers_en_difficulte","territoire_code":"REG-76","jalon":2026,"width":2}]}]}
-\`\`\`
-
-### Exemple 2 — Ventilation par sous-territoires
-Pattern : pour chaque sous-territoire, un container titre + un container avec 3 KPI sur une rangée (1+1+1=3, la 4e colonne reste vide). Le bloc *(titre de section + rangée de 3 KPI)* est à **répéter pour chaque sous-territoire demandé** (l'exemple n'en montre que 2 pour rester court, mais tu dois en générer autant que nécessaire).
-\`\`\`json
-{"titre":"Dashboard Occitanie – Départements 2026","containers":[{"widgets":[{"type":"widget_titre_section","titre":"Département 09 – Ariège","width":4}]},{"widgets":[{"type":"widget_taux_avancement_territoire","territoire_code":"DEPT-09","jalon":2026,"width":1},{"type":"widget_nombre_chantiers_en_retard","territoire_code":"DEPT-09","jalon":2026,"width":1},{"type":"widget_nombre_chantiers_en_difficulte","territoire_code":"DEPT-09","jalon":2026,"width":1}]},{"widgets":[{"type":"widget_titre_section","titre":"Département 11 – Aude","width":4}]},{"widgets":[{"type":"widget_taux_avancement_territoire","territoire_code":"DEPT-11","jalon":2026,"width":1},{"type":"widget_nombre_chantiers_en_retard","territoire_code":"DEPT-11","jalon":2026,"width":1},{"type":"widget_nombre_chantiers_en_difficulte","territoire_code":"DEPT-11","jalon":2026,"width":1}]}]}
-\`\`\`
-
-### Exemple 3 — Focus chantier sur un territoire
-Pattern : titre du chantier, tableau d'indicateurs, puis cartographies thématiques. Le champ \`width\` est omis volontairement : la \`default_width\` de chaque widget s'applique automatiquement.
-\`\`\`json
-{"titre":"Dashboard des chantiers en difficulté - DEPT-42","containers":[{"widgets":[{"type":"widget_titre_section","titre":"Garantir 50% de produits bio, de qualité ou durables dans la restauration collective (Egalim)"}]},{"widgets":[{"type":"widget_tableau_indicateurs_chantier","chantier_id":"CH-064","territoire_code":"DEPT-42","jalon":2026}]},{"widgets":[{"type":"widget_cartographie_meteo","maille":"departementale","territoire_code":"DEPT-42","chantier_id":"CH-064","jalon":2026}]},{"widgets":[{"type":"widget_cartographie_taux_avancement","maille":"departementale","territoire_code":"DEPT-42","jalon":2026,"chantier_ids":["CH-064"]},{"type":"widget_cartographie_propositions_valeur_avancement","maille":"departementale","territoire_code":"DEPT-42","chantier_id":"CH-064","jalon":2026}]}]}
-\`\`\``,
+      description: `Compose un tableau de bord dynamique à partir d'une liste de containers de widgets. Uniquement des références (territoire_code, chantier_id, jalon, maille), jamais de valeurs chiffrées. Les valeurs sont résolues au rendu côté client.`,
       inputSchema: composeDashboardInputSchema,
       execute: async (input): Promise<ComposeDashboardOutput> => {
         for (const container of input.containers) {

--- a/src/server/albert/tools/composeDashboard.ts
+++ b/src/server/albert/tools/composeDashboard.ts
@@ -177,7 +177,9 @@ const widgetParagraph = z
     contenu: z
       .array(z.string())
       .min(1)
-      .describe("Parties du paragraphe, chacune rendue dans un <p> séparé."),
+      .describe(
+        "Tableau de paragraphes. Chaque élément = un paragraphe séparé. JAMAIS de saut de ligne dans un élément.",
+      ),
     variant: z
       .enum(["default", "warning"])
       .optional()

--- a/src/server/albert/tools/composeDashboard.ts
+++ b/src/server/albert/tools/composeDashboard.ts
@@ -174,7 +174,10 @@ const widgetCartographiePropositionsValeurAvancement = z
 const widgetParagraph = z
   .object({
     type: z.literal("widget_paragraph"),
-    contenu: z.string().min(1).describe("Contenu textuel du paragraphe."),
+    contenu: z
+      .array(z.string())
+      .min(1)
+      .describe("Parties du paragraphe, chacune rendue dans un <p> séparé."),
     variant: z
       .enum(["default", "warning"])
       .optional()

--- a/src/server/albert/tools/composeDashboard.ts
+++ b/src/server/albert/tools/composeDashboard.ts
@@ -171,6 +171,17 @@ const widgetCartographiePropositionsValeurAvancement = z
   })
   .strict();
 
+const widgetParagraph = z
+  .object({
+    type: z.literal("widget_paragraph"),
+    contenu: z.string().min(1).describe("Contenu textuel du paragraphe."),
+    width: z
+      .union([z.literal(2), z.literal(4)])
+      .optional()
+      .describe("default_width=4, allowed_widths=[2,4]"),
+  })
+  .strict();
+
 const widgetTitreSection = z
   .object({
     type: z.literal("widget_titre_section"),
@@ -209,6 +220,7 @@ const widgetInputSchema = z
     widgetCartographieMeteo,
     widgetCartographiePropositionsValeurAvancement,
     widgetTitreSection,
+    widgetParagraph,
   ])
   .describe(
     "Widget du dashboard. Le type est l'intention métier. Aucune valeur chiffrée n'est jamais passée — uniquement des références (territoire_code, chantier_id, jalon, maille). Les valeurs sont résolues au rendu côté client.",

--- a/src/server/albert/tools/composeDashboard.ts
+++ b/src/server/albert/tools/composeDashboard.ts
@@ -175,6 +175,12 @@ const widgetParagraph = z
   .object({
     type: z.literal("widget_paragraph"),
     contenu: z.string().min(1).describe("Contenu textuel du paragraphe."),
+    variant: z
+      .enum(["default", "warning"])
+      .optional()
+      .describe(
+        "default = neutre, warning = incohérence détectée (ex: chantier en retard mais météo favorable).",
+      ),
     width: z
       .union([z.literal(2), z.literal(4)])
       .optional()

--- a/src/server/albert/tools/composeDashboardLayout.ts
+++ b/src/server/albert/tools/composeDashboardLayout.ts
@@ -10,7 +10,8 @@ export type WidgetType =
   | "widget_cartographie_taux_avancement"
   | "widget_cartographie_meteo"
   | "widget_cartographie_propositions_valeur_avancement"
-  | "widget_titre_section";
+  | "widget_titre_section"
+  | "widget_paragraph";
 
 export const DEFAULT_WIDTHS: Record<WidgetType, number> = {
   widget_taux_avancement_territoire: 1,
@@ -25,4 +26,5 @@ export const DEFAULT_WIDTHS: Record<WidgetType, number> = {
   widget_cartographie_meteo: 2,
   widget_cartographie_propositions_valeur_avancement: 2,
   widget_titre_section: 4,
+  widget_paragraph: 4,
 };

--- a/src/server/albert/tools/createDashboard.ts
+++ b/src/server/albert/tools/createDashboard.ts
@@ -2,6 +2,7 @@ import { generateText, Output, tool } from "ai";
 import { z } from "zod";
 import {
   composeDashboardInputSchema,
+  type ComposeDashboardInput,
   type ComposeDashboardOutput,
 } from "@/server/albert/tools/composeDashboard";
 import { buildDashboardSystemPrompt } from "@/server/albert/subagents/dashboardSystemPrompt";
@@ -11,8 +12,25 @@ export const createDashboardInputSchema = z.object({
   task: z
     .string()
     .describe(
-      "Description de ce que l'utilisateur veut visualiser, " +
-        "incluant le(s) territoire(s), le jalon, et le type d'analyse souhaitée.",
+      "Description de ce que l'utilisateur veut visualiser (type de dashboard, niveau de détail).",
+    ),
+  territoire_codes: z
+    .array(z.string())
+    .min(1)
+    .describe(
+      "Codes des territoires concernés (ex: ['REG-76', 'DEPT-09']). OBLIGATOIRE.",
+    ),
+  jalons: z
+    .array(z.number().int())
+    .min(1)
+    .describe(
+      "Années des jalons pour le dashboard (ex: [2025, 2026]). Supporte le multi-jalon.",
+    ),
+  chantier_ids: z
+    .array(z.string())
+    .optional()
+    .describe(
+      "Identifiants des chantiers ciblés (ex: ['CH-064']). Uniquement si l'utilisateur cible des chantiers précis.",
     ),
 });
 
@@ -23,6 +41,85 @@ Ne reproduis JAMAIS de valeurs chiffrées dans ta réponse textuelle (les chiffr
 Tu peux ajouter une phrase courte d'introduction ("Voici le dashboard demandé.") mais pas de commentaire sur les chiffres.
 Si l'utilisateur demande à modifier le dashboard, rappelle create_dashboard avec une nouvelle description.`;
 
+export function validateDashboardIdentifiers(
+  output: ComposeDashboardInput,
+  allowedTerritoires: string[],
+  allowedJalons: number[],
+  allowedChantierIds: string[] | undefined,
+): void {
+  const territoireSet = new Set(allowedTerritoires);
+  const jalonSet = new Set(allowedJalons);
+  const chantierSet = allowedChantierIds
+    ? new Set(allowedChantierIds)
+    : undefined;
+
+  for (const container of output.containers) {
+    for (const widget of container.widgets) {
+      if (
+        "territoire_code" in widget &&
+        !territoireSet.has(widget.territoire_code)
+      ) {
+        throw new Error(
+          `Le subagent a utilisé un territoire non autorisé : ${widget.territoire_code}. Territoires autorisés : ${allowedTerritoires.join(", ")}`,
+        );
+      }
+
+      if ("jalon" in widget && !jalonSet.has(widget.jalon)) {
+        throw new Error(
+          `Le subagent a utilisé un jalon non autorisé : ${widget.jalon}. Jalons autorisés : ${allowedJalons.join(", ")}`,
+        );
+      }
+
+      if ("chantier_id" in widget) {
+        if (!chantierSet) {
+          throw new Error(
+            `Le subagent a utilisé un chantier_id (${widget.chantier_id}) alors qu'aucun n'a été fourni.`,
+          );
+        }
+        if (!chantierSet.has(widget.chantier_id)) {
+          throw new Error(
+            `Le subagent a utilisé un chantier_id non autorisé : ${widget.chantier_id}. Chantiers autorisés : ${allowedChantierIds!.join(", ")}`,
+          );
+        }
+      }
+
+      if ("chantier_ids" in widget && Array.isArray(widget.chantier_ids)) {
+        for (const id of widget.chantier_ids) {
+          if (!chantierSet) {
+            throw new Error(
+              `Le subagent a utilisé des chantier_ids (${id}) alors qu'aucun n'a été fourni.`,
+            );
+          }
+          if (!chantierSet.has(id)) {
+            throw new Error(
+              `Le subagent a utilisé un chantier_id non autorisé : ${id}. Chantiers autorisés : ${allowedChantierIds!.join(", ")}`,
+            );
+          }
+        }
+      }
+    }
+  }
+}
+
+function buildSubagentPrompt(
+  task: string,
+  territoireCodes: string[],
+  jalons: number[],
+  chantierIds: string[] | undefined,
+): string {
+  const contextLines = [
+    "<context>",
+    `territoire_codes: ${JSON.stringify(territoireCodes)}`,
+    `jalons: ${JSON.stringify(jalons)}`,
+    ...(chantierIds?.length
+      ? [`chantier_ids: ${JSON.stringify(chantierIds)}`]
+      : []),
+    "</context>",
+  ];
+
+  return `${task}\n\n${contextLines.join("\n")}`;
+}
+
 export function createCreateDashboardTool() {
   const albertProvider = Albert.createProvider();
 
@@ -30,13 +127,16 @@ export function createCreateDashboardTool() {
     description: `Délègue la composition d'un dashboard à un agent spécialisé.
 Utilise ce tool quand l'utilisateur demande un dashboard, un cockpit,
 un tableau de bord visuel, ou d'afficher les indicateurs d'un chantier.
-Décris précisément ce que l'utilisateur veut visualiser.`,
+Fournis la description de ce que l'utilisateur veut visualiser ainsi que les identifiants résolus (territoire_codes, jalons, chantier_ids).`,
     inputSchema: createDashboardInputSchema,
-    execute: async ({ task }, { abortSignal }) => {
+    execute: async (
+      { task, territoire_codes, jalons, chantier_ids },
+      { abortSignal },
+    ) => {
       const result = await generateText({
         model: withOptionalDevTools(albertProvider.chat("openweight-large")),
         system: buildDashboardSystemPrompt(),
-        prompt: task,
+        prompt: buildSubagentPrompt(task, territoire_codes, jalons, chantier_ids),
         output: Output.object({ schema: composeDashboardInputSchema }),
         abortSignal,
       });
@@ -44,6 +144,13 @@ Décris précisément ce que l'utilisateur veut visualiser.`,
       if (!result.output) {
         throw new Error("Le subagent n'a pas pu composer de dashboard.");
       }
+
+      validateDashboardIdentifiers(
+        result.output,
+        territoire_codes,
+        jalons,
+        chantier_ids,
+      );
 
       return {
         titre: result.output.titre,

--- a/src/server/albert/tools/createDashboard.ts
+++ b/src/server/albert/tools/createDashboard.ts
@@ -1,6 +1,9 @@
-import { generateText, stepCountIs, tool, type ToolSet } from "ai";
+import { generateText, Output, stepCountIs, tool, type ToolSet } from "ai";
 import { z } from "zod";
-import type { ComposeDashboardOutput } from "@/server/albert/tools/composeDashboard";
+import {
+  composeDashboardInputSchema,
+  type ComposeDashboardOutput,
+} from "@/server/albert/tools/composeDashboard";
 import { buildDashboardSystemPrompt } from "@/server/albert/subagents/dashboardSystemPrompt";
 import { Albert } from "@/server/albert/Albert";
 
@@ -17,30 +20,18 @@ export type CreateDashboardOutput = ComposeDashboardOutput;
 
 type CreateDashboardToolDeps = {
   subagentTools: ToolSet;
-  userId: string;
-  chatId: string;
 };
 
-function extractDashboardOutput(
-  steps: { toolCalls: Array<{ toolName: string; result?: unknown }> }[],
-): CreateDashboardOutput {
-  console.log(steps.flatMap((step) => step.toolCalls));
-  const composeDashboardCall = steps
-    .flatMap((step) => step.toolCalls)
-    .findLast((call) => call.toolName === "compose_dashboard");
-
-  if (!composeDashboardCall?.result) {
-    throw new Error("Le subagent n'a pas pu composer de dashboard.");
-  }
-
-  return composeDashboardCall.result as CreateDashboardOutput;
-}
+const OUTPUT_INSTRUCTIONS = `Le dashboard a été composé et sera affiché visuellement sous forme de widgets dans l'interface.
+Ne reproduis JAMAIS de valeurs chiffrées dans ta réponse textuelle (les chiffres sont résolus au rendu côté client).
+Tu peux ajouter une phrase courte d'introduction ("Voici le dashboard demandé.") mais pas de commentaire sur les chiffres.
+Si l'utilisateur demande à modifier le dashboard, rappelle create_dashboard avec une nouvelle description.`;
 
 export function createCreateDashboardTool({
   subagentTools,
-  userId,
-  chatId,
 }: CreateDashboardToolDeps) {
+  const albertProvider = Albert.createProvider();
+
   return tool({
     description: `Délègue la composition d'un dashboard à un agent spécialisé.
 Utilise ce tool quand l'utilisateur demande un dashboard, un cockpit,
@@ -48,28 +39,25 @@ un tableau de bord visuel, ou d'afficher les indicateurs d'un chantier.
 Décris précisément ce que l'utilisateur veut visualiser.`,
     inputSchema: createDashboardInputSchema,
     execute: async ({ task }, { abortSignal }) => {
-      try {
-        console.log("---------------");
-        console.log("Début de la génération...");
-        const result = await Albert.generateText({
-          systemPrompt: buildDashboardSystemPrompt(),
-          prompt: task,
-          tools: subagentTools,
-          abortSignal,
-          userId,
-          chatId,
-        });
+      const result = await generateText({
+        model: albertProvider.chat("openweight-large"),
+        system: buildDashboardSystemPrompt(),
+        prompt: task,
+        tools: subagentTools,
+        output: Output.object({ schema: composeDashboardInputSchema }),
+        stopWhen: stepCountIs(10),
+        abortSignal,
+      });
 
-        // console.log(result.);
-
-        return extractDashboardOutput(result.steps);
-      } catch (e) {
-        console.log("--------------------------------");
-        console.log(e);
-        console.log("--------------------------------");
-
-        throw e;
+      if (!result.output) {
+        throw new Error("Le subagent n'a pas pu composer de dashboard.");
       }
+
+      return {
+        titre: result.output.titre,
+        containers: result.output.containers,
+        _output_instructions: OUTPUT_INSTRUCTIONS,
+      };
     },
   });
 }

--- a/src/server/albert/tools/createDashboard.ts
+++ b/src/server/albert/tools/createDashboard.ts
@@ -1,4 +1,4 @@
-import { generateText, Output, stepCountIs, tool, type ToolSet } from "ai";
+import { generateText, Output, tool } from "ai";
 import { z } from "zod";
 import {
   composeDashboardInputSchema,
@@ -18,18 +18,12 @@ export const createDashboardInputSchema = z.object({
 
 export type CreateDashboardOutput = ComposeDashboardOutput;
 
-type CreateDashboardToolDeps = {
-  subagentTools: ToolSet;
-};
-
 const OUTPUT_INSTRUCTIONS = `Le dashboard a été composé et sera affiché visuellement sous forme de widgets dans l'interface.
 Ne reproduis JAMAIS de valeurs chiffrées dans ta réponse textuelle (les chiffres sont résolus au rendu côté client).
 Tu peux ajouter une phrase courte d'introduction ("Voici le dashboard demandé.") mais pas de commentaire sur les chiffres.
 Si l'utilisateur demande à modifier le dashboard, rappelle create_dashboard avec une nouvelle description.`;
 
-export function createCreateDashboardTool({
-  subagentTools,
-}: CreateDashboardToolDeps) {
+export function createCreateDashboardTool() {
   const albertProvider = Albert.createProvider();
 
   return tool({
@@ -43,9 +37,7 @@ Décris précisément ce que l'utilisateur veut visualiser.`,
         model: albertProvider.chat("openweight-large"),
         system: buildDashboardSystemPrompt(),
         prompt: task,
-        tools: subagentTools,
         output: Output.object({ schema: composeDashboardInputSchema }),
-        stopWhen: stepCountIs(10),
         abortSignal,
       });
 

--- a/src/server/albert/tools/createDashboard.ts
+++ b/src/server/albert/tools/createDashboard.ts
@@ -1,4 +1,4 @@
-import { generateText, Output, tool } from "ai";
+import { generateText, Output, stepCountIs, tool } from "ai";
 import { z } from "zod";
 import {
   composeDashboardInputSchema,
@@ -154,6 +154,7 @@ Fournis la description de ce que l'utilisateur veut visualiser ainsi que les ide
         model: withOptionalDevTools(albertProvider.chat("openweight-large")),
         system: buildDashboardSystemPrompt(),
         prompt: buildSubagentPrompt(task, territoire_codes, jalons, chantiers),
+        stopWhen: stepCountIs(5),
         output: Output.object({ schema: composeDashboardInputSchema }),
         abortSignal,
       });

--- a/src/server/albert/tools/createDashboard.ts
+++ b/src/server/albert/tools/createDashboard.ts
@@ -1,0 +1,75 @@
+import { generateText, stepCountIs, tool, type ToolSet } from "ai";
+import { z } from "zod";
+import type { ComposeDashboardOutput } from "@/server/albert/tools/composeDashboard";
+import { buildDashboardSystemPrompt } from "@/server/albert/subagents/dashboardSystemPrompt";
+import { Albert } from "@/server/albert/Albert";
+
+export const createDashboardInputSchema = z.object({
+  task: z
+    .string()
+    .describe(
+      "Description de ce que l'utilisateur veut visualiser, " +
+        "incluant le(s) territoire(s), le jalon, et le type d'analyse souhaitée.",
+    ),
+});
+
+export type CreateDashboardOutput = ComposeDashboardOutput;
+
+type CreateDashboardToolDeps = {
+  subagentTools: ToolSet;
+  userId: string;
+  chatId: string;
+};
+
+function extractDashboardOutput(
+  steps: { toolCalls: Array<{ toolName: string; result?: unknown }> }[],
+): CreateDashboardOutput {
+  console.log(steps.flatMap((step) => step.toolCalls));
+  const composeDashboardCall = steps
+    .flatMap((step) => step.toolCalls)
+    .findLast((call) => call.toolName === "compose_dashboard");
+
+  if (!composeDashboardCall?.result) {
+    throw new Error("Le subagent n'a pas pu composer de dashboard.");
+  }
+
+  return composeDashboardCall.result as CreateDashboardOutput;
+}
+
+export function createCreateDashboardTool({
+  subagentTools,
+  userId,
+  chatId,
+}: CreateDashboardToolDeps) {
+  return tool({
+    description: `Délègue la composition d'un dashboard à un agent spécialisé.
+Utilise ce tool quand l'utilisateur demande un dashboard, un cockpit,
+un tableau de bord visuel, ou d'afficher les indicateurs d'un chantier.
+Décris précisément ce que l'utilisateur veut visualiser.`,
+    inputSchema: createDashboardInputSchema,
+    execute: async ({ task }, { abortSignal }) => {
+      try {
+        console.log("---------------");
+        console.log("Début de la génération...");
+        const result = await Albert.generateText({
+          systemPrompt: buildDashboardSystemPrompt(),
+          prompt: task,
+          tools: subagentTools,
+          abortSignal,
+          userId,
+          chatId,
+        });
+
+        // console.log(result.);
+
+        return extractDashboardOutput(result.steps);
+      } catch (e) {
+        console.log("--------------------------------");
+        console.log(e);
+        console.log("--------------------------------");
+
+        throw e;
+      }
+    },
+  });
+}

--- a/src/server/albert/tools/createDashboard.ts
+++ b/src/server/albert/tools/createDashboard.ts
@@ -8,6 +8,25 @@ import {
 import { buildDashboardSystemPrompt } from "@/server/albert/subagents/dashboardSystemPrompt";
 import { Albert, withOptionalDevTools } from "@/server/albert/Albert";
 
+const chantierContextSchema = z.object({
+  id: z.string().describe("Identifiant du chantier (ex: CH-064)"),
+  nom: z.string().describe("Nom complet du chantier"),
+  statut: z
+    .enum(["en_retard", "en_difficulte"])
+    .optional()
+    .describe("Statut du chantier si connu (en_retard ou en_difficulte)"),
+  meteo: z
+    .string()
+    .optional()
+    .describe("Météo du chantier (SOLEIL, COUVERT, NUAGE, ORAGE)"),
+  commentaire: z
+    .string()
+    .optional()
+    .describe("Commentaire de synthèse du chantier"),
+});
+
+export type ChantierContext = z.infer<typeof chantierContextSchema>;
+
 export const createDashboardInputSchema = z.object({
   task: z
     .string()
@@ -26,11 +45,11 @@ export const createDashboardInputSchema = z.object({
     .describe(
       "Années des jalons pour le dashboard (ex: [2025, 2026]). Supporte le multi-jalon.",
     ),
-  chantier_ids: z
-    .array(z.string())
+  chantiers: z
+    .array(chantierContextSchema)
     .optional()
     .describe(
-      "Identifiants des chantiers ciblés (ex: ['CH-064']). Uniquement si l'utilisateur cible des chantiers précis.",
+      "Chantiers ciblés avec leur nom et statut. Uniquement si l'utilisateur cible des chantiers précis ou obtenus via un outil de données.",
     ),
 });
 
@@ -45,12 +64,12 @@ export function validateDashboardIdentifiers(
   output: ComposeDashboardInput,
   allowedTerritoires: string[],
   allowedJalons: number[],
-  allowedChantierIds: string[] | undefined,
+  allowedChantiers: ChantierContext[] | undefined,
 ): void {
   const territoireSet = new Set(allowedTerritoires);
   const jalonSet = new Set(allowedJalons);
-  const chantierSet = allowedChantierIds
-    ? new Set(allowedChantierIds)
+  const chantierIdSet = allowedChantiers
+    ? new Set(allowedChantiers.map((c) => c.id))
     : undefined;
 
   for (const container of output.containers) {
@@ -71,28 +90,28 @@ export function validateDashboardIdentifiers(
       }
 
       if ("chantier_id" in widget) {
-        if (!chantierSet) {
+        if (!chantierIdSet) {
           throw new Error(
             `Le subagent a utilisé un chantier_id (${widget.chantier_id}) alors qu'aucun n'a été fourni.`,
           );
         }
-        if (!chantierSet.has(widget.chantier_id)) {
+        if (!chantierIdSet.has(widget.chantier_id)) {
           throw new Error(
-            `Le subagent a utilisé un chantier_id non autorisé : ${widget.chantier_id}. Chantiers autorisés : ${allowedChantierIds!.join(", ")}`,
+            `Le subagent a utilisé un chantier_id non autorisé : ${widget.chantier_id}. Chantiers autorisés : ${[...chantierIdSet].join(", ")}`,
           );
         }
       }
 
       if ("chantier_ids" in widget && Array.isArray(widget.chantier_ids)) {
         for (const id of widget.chantier_ids) {
-          if (!chantierSet) {
+          if (!chantierIdSet) {
             throw new Error(
               `Le subagent a utilisé des chantier_ids (${id}) alors qu'aucun n'a été fourni.`,
             );
           }
-          if (!chantierSet.has(id)) {
+          if (!chantierIdSet.has(id)) {
             throw new Error(
-              `Le subagent a utilisé un chantier_id non autorisé : ${id}. Chantiers autorisés : ${allowedChantierIds!.join(", ")}`,
+              `Le subagent a utilisé un chantier_id non autorisé : ${id}. Chantiers autorisés : ${[...chantierIdSet].join(", ")}`,
             );
           }
         }
@@ -105,15 +124,13 @@ function buildSubagentPrompt(
   task: string,
   territoireCodes: string[],
   jalons: number[],
-  chantierIds: string[] | undefined,
+  chantiers: ChantierContext[] | undefined,
 ): string {
   const contextLines = [
     "<context>",
     `territoire_codes: ${JSON.stringify(territoireCodes)}`,
     `jalons: ${JSON.stringify(jalons)}`,
-    ...(chantierIds?.length
-      ? [`chantier_ids: ${JSON.stringify(chantierIds)}`]
-      : []),
+    ...(chantiers?.length ? [`chantiers: ${JSON.stringify(chantiers)}`] : []),
     "</context>",
   ];
 
@@ -127,16 +144,16 @@ export function createCreateDashboardTool() {
     description: `Délègue la composition d'un dashboard à un agent spécialisé.
 Utilise ce tool quand l'utilisateur demande un dashboard, un cockpit,
 un tableau de bord visuel, ou d'afficher les indicateurs d'un chantier.
-Fournis la description de ce que l'utilisateur veut visualiser ainsi que les identifiants résolus (territoire_codes, jalons, chantier_ids).`,
+Fournis la description de ce que l'utilisateur veut visualiser ainsi que les identifiants résolus (territoire_codes, jalons, chantiers).`,
     inputSchema: createDashboardInputSchema,
     execute: async (
-      { task, territoire_codes, jalons, chantier_ids },
+      { task, territoire_codes, jalons, chantiers },
       { abortSignal },
     ) => {
       const result = await generateText({
         model: withOptionalDevTools(albertProvider.chat("openweight-large")),
         system: buildDashboardSystemPrompt(),
-        prompt: buildSubagentPrompt(task, territoire_codes, jalons, chantier_ids),
+        prompt: buildSubagentPrompt(task, territoire_codes, jalons, chantiers),
         output: Output.object({ schema: composeDashboardInputSchema }),
         abortSignal,
       });
@@ -149,7 +166,7 @@ Fournis la description de ce que l'utilisateur veut visualiser ainsi que les ide
         result.output,
         territoire_codes,
         jalons,
-        chantier_ids,
+        chantiers,
       );
 
       return {

--- a/src/server/albert/tools/createDashboard.ts
+++ b/src/server/albert/tools/createDashboard.ts
@@ -5,7 +5,7 @@ import {
   type ComposeDashboardOutput,
 } from "@/server/albert/tools/composeDashboard";
 import { buildDashboardSystemPrompt } from "@/server/albert/subagents/dashboardSystemPrompt";
-import { Albert } from "@/server/albert/Albert";
+import { Albert, withOptionalDevTools } from "@/server/albert/Albert";
 
 export const createDashboardInputSchema = z.object({
   task: z
@@ -34,7 +34,7 @@ Décris précisément ce que l'utilisateur veut visualiser.`,
     inputSchema: createDashboardInputSchema,
     execute: async ({ task }, { abortSignal }) => {
       const result = await generateText({
-        model: albertProvider.chat("openweight-large"),
+        model: withOptionalDevTools(albertProvider.chat("openweight-large")),
         system: buildDashboardSystemPrompt(),
         prompt: task,
         output: Output.object({ schema: composeDashboardInputSchema }),

--- a/src/server/albert/tools/createDashboard.ts
+++ b/src/server/albert/tools/createDashboard.ts
@@ -1,4 +1,4 @@
-import { generateText, Output, stepCountIs, tool } from "ai";
+import { tool } from "ai";
 import { z } from "zod";
 import {
   composeDashboardInputSchema,
@@ -6,7 +6,7 @@ import {
   type ComposeDashboardOutput,
 } from "@/server/albert/tools/composeDashboard";
 import { buildDashboardSystemPrompt } from "@/server/albert/subagents/dashboardSystemPrompt";
-import { Albert, withOptionalDevTools } from "@/server/albert/Albert";
+import { Albert } from "@/server/albert/Albert";
 
 const chantierContextSchema = z.object({
   id: z.string().describe("Identifiant du chantier (ex: CH-064)"),
@@ -138,8 +138,6 @@ function buildSubagentPrompt(
 }
 
 export function createCreateDashboardTool() {
-  const albertProvider = Albert.createProvider();
-
   return tool({
     description: `Délègue la composition d'un dashboard à un agent spécialisé.
 Utilise ce tool quand l'utilisateur demande un dashboard, un cockpit,
@@ -150,29 +148,18 @@ Fournis la description de ce que l'utilisateur veut visualiser ainsi que les ide
       { task, territoire_codes, jalons, chantiers },
       { abortSignal },
     ) => {
-      const result = await generateText({
-        model: withOptionalDevTools(albertProvider.chat("openweight-large")),
-        system: buildDashboardSystemPrompt(),
+      const output = await Albert.generateStructuredOutput({
+        systemPrompt: buildDashboardSystemPrompt(),
         prompt: buildSubagentPrompt(task, territoire_codes, jalons, chantiers),
-        stopWhen: stepCountIs(5),
-        output: Output.object({ schema: composeDashboardInputSchema }),
+        schema: composeDashboardInputSchema,
         abortSignal,
       });
 
-      if (!result.output) {
-        throw new Error("Le subagent n'a pas pu composer de dashboard.");
-      }
-
-      validateDashboardIdentifiers(
-        result.output,
-        territoire_codes,
-        jalons,
-        chantiers,
-      );
+      validateDashboardIdentifiers(output, territoire_codes, jalons, chantiers);
 
       return {
-        titre: result.output.titre,
-        containers: result.output.containers,
+        titre: output.titre,
+        containers: output.containers,
         _output_instructions: OUTPUT_INSTRUCTIONS,
       };
     },

--- a/src/server/albert/tools/displayChoices.ts
+++ b/src/server/albert/tools/displayChoices.ts
@@ -1,0 +1,35 @@
+import { tool } from "ai";
+import { z } from "zod";
+
+export const displayChoicesInputSchema = z.object({
+  question: z
+    .string()
+    .describe("Question affichée en haut du panneau de choix"),
+  choices: z
+    .array(
+      z.object({
+        label: z.string().describe("Texte à afficher sur le bouton"),
+        value: z
+          .string()
+          .describe("Valeur à renvoyer lorsque le bouton est cliqué"),
+      }),
+    )
+    .describe("Liste des choix à proposer"),
+});
+
+export type DisplayChoice = z.infer<
+  typeof displayChoicesInputSchema
+>["choices"][number];
+
+export const displayChoicesTool = tool({
+  description:
+    "Affiche des choix dans un panneau pour l'utilisateur. Le paramètre 'question' est la question affichée en haut du panneau. Utilise cet outil quand tu veux proposer des options à l'utilisateur. IMPORTANT : écris toujours ton message textuel AVANT d'appeler cet outil. Ne l'appelle jamais sans avoir d'abord rédigé le texte d'accompagnement.",
+  inputSchema: displayChoicesInputSchema,
+  execute: async ({
+    question,
+    choices,
+  }): Promise<{ question: string; choices: DisplayChoice[] }> => ({
+    question,
+    choices,
+  }),
+});

--- a/src/server/albert/tools/exportRapport.ts
+++ b/src/server/albert/tools/exportRapport.ts
@@ -1,0 +1,38 @@
+import { tool } from "ai";
+import { randomUUID } from "crypto";
+import { genererRapportPDF } from "@/server/albert/pdf/genererRapportPDF";
+import { buildRapportMarkdown } from "@/server/albert/markdown/buildRapportMarkdown";
+import type { RapportFileStorage } from "@/server/albert/domain/RapportFileStorage";
+import {
+  exportRapportInputSchema,
+  type ExportRapportOutput,
+} from "@/server/albert/exportRapportSchema";
+
+export function createExportRapportTool({
+  rapportFileStorage,
+}: {
+  rapportFileStorage: RapportFileStorage;
+}) {
+  return ({ userId }: { userId: string }) => {
+    return tool({
+      description:
+        "Génère un rapport structuré synthétisant la discussion. Appelle cet outil quand l'utilisateur demande d'exporter ou télécharger un rapport. Le rapport doit contenir un titre, une date, un résumé et des sections structurées reprenant les données clés de la conversation.",
+      inputSchema: exportRapportInputSchema,
+      execute: async (input): Promise<ExportRapportOutput> => {
+        const shortId = randomUUID().slice(0, 8);
+        const ext = input.format === "pdf" ? "pdf" : "md";
+        const filename = `${input.nom_fichier}-${shortId}.${ext}`;
+
+        if (input.format === "pdf") {
+          const buffer = await genererRapportPDF(input);
+          const url = await rapportFileStorage.save(userId, filename, buffer);
+          return { url, format: "pdf" };
+        }
+
+        const markdown = buildRapportMarkdown(input);
+        const url = await rapportFileStorage.save(userId, filename, markdown);
+        return { url, format: "markdown" };
+      },
+    });
+  };
+}

--- a/src/server/albert/tools/getChantierIndicateurs.ts
+++ b/src/server/albert/tools/getChantierIndicateurs.ts
@@ -14,13 +14,6 @@ export const getChantierIndicateursInputSchema = z.object({
     .min(2022)
     .max(new Date().getFullYear())
     .describe("Année du jalon (ex: 2024, 2025)"),
-  afficher: z
-    .boolean()
-    .optional()
-    .default(true)
-    .describe(
-      "Si true (par défaut), les résultats seront affichés dans un tableau visuel dans l'interface. Mettre à false quand les données sont récupérées pour un traitement interne (ex: génération de rapport via export_rapport).",
-    ),
 });
 
 export type GetChantierIndicateursOutput = {
@@ -28,11 +21,8 @@ export type GetChantierIndicateursOutput = {
   _output_instructions: string;
 };
 
-const OUTPUT_INSTRUCTIONS_AFFICHER = `Les valeurs des indicateurs seront automatiquement affichées dans un tableau visuel dans l'interface.
-Ne reproduis JAMAIS les données des indicateurs (VI, VA, VC, TA) dans ta réponse textuelle, ni sous forme de tableau, ni sous forme de liste, ni dans le texte.
-Tu peux ajouter un bref commentaire factuel sur les résultats si pertinent, sans répéter les valeurs.`;
-
-const OUTPUT_INSTRUCTIONS_MASQUER = `Les données des indicateurs ont été récupérées pour un traitement interne. Elles ne seront pas affichées dans l'interface. Utilise-les pour la suite du traitement (ex: génération de rapport).`;
+const OUTPUT_INSTRUCTIONS = `Les données des indicateurs ont été récupérées. Utilise-les pour la suite du traitement (ex: génération de rapport, composition de dashboard).
+Pour afficher les indicateurs à l'utilisateur, utilise create_dashboard avec un widget_tableau_indicateurs_chantier.`;
 
 export function createGetChantierIndicateursTool({
   getChantierIndicateursQuery,
@@ -67,9 +57,7 @@ Utilise cet outil quand l'utilisateur demande :
 
         return {
           resultats: result,
-          _output_instructions: input.afficher
-            ? OUTPUT_INSTRUCTIONS_AFFICHER
-            : OUTPUT_INSTRUCTIONS_MASQUER,
+          _output_instructions: OUTPUT_INSTRUCTIONS,
         };
       },
     });

--- a/src/server/infrastructure/api/trpc/routes/albert.ts
+++ b/src/server/infrastructure/api/trpc/routes/albert.ts
@@ -4,93 +4,9 @@ import {
   créerRouteurTRPC,
   procédureProtégée,
 } from "@/server/infrastructure/api/trpc/trpc";
-import { Albert, displayChoicesTool } from "@/server/albert/Albert";
-import { buildChatSystemPrompt } from "@/server/albert/systemPrompt";
-import { detecterCapacities } from "@/server/albert/detecteurIntention";
 import { getContainer } from "@/server/dependances";
-import { RecupererVariableContenuUseCase } from "@/server/gestion-contenu/usecases/RecupererVariableContenuUseCase";
-import { NotFoundError } from "@/server/app/error-boundary/not-found-error";
-import { ProfilEnum } from "@/server/app/enum/profil.enum";
 
 export const albertRouter = créerRouteurTRPC({
-  chat: procédureProtégée
-    .input(
-      z.object({
-        chatId: z.string().min(1),
-        prompt: z.string().min(1),
-      }),
-    )
-    .mutation(async ({ input, ctx }) => {
-      const estAskAiActif = new RecupererVariableContenuUseCase().run({
-        nomVariableContenu: "NEXT_PUBLIC_FF_ASK_AI",
-      }) as boolean;
-
-      if (!estAskAiActif && ctx.session.profil !== ProfilEnum.DITP_ADMIN) {
-        throw new NotFoundError("Not found");
-      }
-
-      const territoiresAccessibles =
-        ctx.session.habilitations.lecture.territoires;
-
-      const container = getContainer("albert");
-      const createGetTauxAvancementTerritoireTool = container.resolve(
-        "createGetTauxAvancementTerritoireTool",
-      );
-      const createGetChantiersEnRetardTool = container.resolve(
-        "createGetChantiersEnRetardTool",
-      );
-      const createGetChantiersEnDifficulteTool = container.resolve(
-        "createGetChantiersEnDifficulteTool",
-      );
-      const createGetChantierIndicateursTool = container.resolve(
-        "createGetChantierIndicateursTool",
-      );
-      const createExportRapportTool = container.resolve(
-        "createExportRapportTool",
-      );
-
-      const capacities = detecterCapacities(input.prompt);
-
-      const systemPrompt = buildChatSystemPrompt({
-        territoiresAccessibles,
-        capacities,
-      });
-      const getTauxAvancementTerritoire = createGetTauxAvancementTerritoireTool(
-        {
-          habilitations: ctx.session.habilitations,
-        },
-      );
-      const getChantiersEnRetard = createGetChantiersEnRetardTool({
-        territoiresAccessibles,
-      });
-      const getChantiersEnDifficulte = createGetChantiersEnDifficulteTool({
-        territoiresAccessibles,
-      });
-      const getChantierIndicateurs = createGetChantierIndicateursTool({
-        territoiresAccessibles,
-      });
-      const exportRapport = createExportRapportTool({
-        userId: ctx.session.user.id,
-      });
-
-      const tools = {
-        get_taux_avancement_territoire: getTauxAvancementTerritoire,
-        get_chantiers_en_retard: getChantiersEnRetard,
-        get_chantiers_en_difficulte: getChantiersEnDifficulte,
-        get_chantier_indicateurs: getChantierIndicateurs,
-        display_choices: displayChoicesTool,
-        ...(capacities.exportRapport ? { export_rapport: exportRapport } : {}),
-      };
-
-      return Albert.generateText({
-        chatId: input.chatId,
-        prompt: input.prompt,
-        systemPrompt,
-        userId: ctx.session.user.id,
-        tools,
-      });
-    }),
-
   evaluer: procédureProtégée
     .input(
       z.discriminatedUnion("evaluation", [


### PR DESCRIPTION
## Summary

- Introduce a dashboard subagent pattern: the main Albert agent delegates dashboard composition to a specialized sub-call using AI SDK `Output.object()` for structured output
- The subagent is a pure layout composer (no data tools) — single LLM call, no tool loop, typed output validated by the existing `composeDashboardInputSchema`
- Remove `afficher` parameter from `get_chantier_indicateurs` — all visual display now goes through `create_dashboard`
- Simplify `compose_dashboard` tool description (~70 lines → 3 lines), move knowledge to dedicated subagent system prompt
- Add "indicateur"/"indicateurs" keywords to dashboard capability detection
- **New**: `widget_paragraph` — widget générique pour afficher du texte dans le dashboard (contenu: string[]), avec variant `warning` pour signaler les incohérences météo/statut
- **New**: Météo + commentaire de synthèse affichés sous chaque chantier dans le dashboard via `widget_paragraph`
- Enrichissement du contexte chantier avec `meteo`, `commentaire` et `statut` depuis les outils existants
- **Cleanup**: Remove dead `Albert.generateText` method
- **Cleanup**: Extract `createExportRapportTool` → `tools/exportRapport.ts`
- **Cleanup**: Extract `displayChoicesTool` → `tools/displayChoices.ts`
- **Cleanup**: Add `validateDashboardIdentifiers` post-generation guard against hallucinated identifiers
- **Cleanup**: PRD updated to match actual implementation (structured output, no ToolLoopAgent)

## Architecture

```
Parent Agent (Albert)                   Subagent (1 LLM call)
┌──────────────────────┐                ┌─────────────────────┐
│ understands intent    │                │ dashboard layout    │
│ fetches data if needed│── task str ──► │ system prompt       │
│ calls create_dashboard│               │ Output.object(schema)│
│                       │◄── JSON ───── │ no tools            │
└──────────────────────┘                └─────────────────────┘
```

## Key changes

- **New**: `src/server/albert/subagents/dashboardSystemPrompt.ts` — focused prompt with widget catalog, grid rules, composition patterns, examples
- **New**: `src/server/albert/tools/createDashboard.ts` — `create_dashboard` tool using `generateText` + `Output.object()`, enriched chantier context (meteo, commentaire, statut), `validateDashboardIdentifiers` post-validation
- **New**: `src/server/albert/tools/exportRapport.ts` — extracted from `Albert.ts`
- **New**: `src/server/albert/tools/displayChoices.ts` — extracted from `Albert.ts`
- **New**: `src/client/components/_commons/ChatUI/DashboardWidgets/DashboardWidgetParagraph.tsx` — generic paragraph widget with warning variant
- **Modified**: `Albert.ts` — cleaned up: removed dead `generateText`, extracted tools, only contains `Albert` class + `withOptionalDevTools`
- **Modified**: `composeDashboard.ts` — description trimmed, added `widget_paragraph` schema
- **Modified**: `composeDashboardLayout.ts` — added `widget_paragraph` type + default width
- **Modified**: `systemPrompt.ts` — dashboard rules replaced by `create_dashboard` section, chantier context includes meteo/commentaire
- **Modified**: `DashboardWidgetRegistry.tsx` — registers `widget_paragraph`
- **Modified**: `BoutonSyntheseTerritoire.tsx` — prompt updated to request météo + commentaire
- **Modified**: `route.ts` — wires `createCreateDashboardTool()` (no deps needed)

## Test plan

- [ ] Ask for a dashboard ("dashboard Bretagne") → renders correctly
- [ ] Ask for indicators ("indicateurs CH-064 sur Cantal") → triggers dashboard with `widget_tableau_indicateurs_chantier`
- [ ] Click "Tableau de bord du territoire" → each chantier section shows météo + commentaire in a `widget_paragraph`
- [ ] Chantier en retard with météo SOLEIL/COUVERT → widget_paragraph renders with yellow warning border
- [ ] Export rapport still works
- [ ] TypeScript compiles cleanly, lint passes, existing tests pass
- [ ] `detecterCapacities` tests pass for "indicateur"/"indicateurs" keywords
- [ ] `validateDashboardIdentifiers` tests pass (8 test cases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)