### PR TITLE
feat: paramètre force pour le cron rapports-coordinateurs

### DIFF
--- a/src/pages/api/admin/cron/rapports-coordinateurs.ts
+++ b/src/pages/api/admin/cron/rapports-coordinateurs.ts
@@ -15,6 +15,10 @@ const querySchema = z.object({
       const parsed = Date.parse(val);
       return Number.isNaN(parsed) ? new Date() : new Date(parsed);
     }),
+  force: z
+    .enum(["true", "false"])
+    .optional()
+    .transform((val) => val === "true"),
 });
 
 async function handler(req: NextApiRequest, res: NextApiResponse) {
@@ -22,9 +26,12 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
   const roomId = configuration().tchap.roomIdRapportCoordinateurs;
   const accessToken = configuration().tchap.accessToken;
 
+  const { date: maintenant, force } = querySchema.parse(req.query);
+
   if (
-    !configurationFeatureFlip().rapportCoordinateurs ||
-    configuration().scalingoEnvironment !== "PROD"
+    !force &&
+    (!configurationFeatureFlip().rapportCoordinateurs ||
+      configuration().scalingoEnvironment !== "PROD")
   ) {
     return res.status(200).json({
       skipped: true,
@@ -33,8 +40,6 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
         : "Environment is not PROD",
     });
   }
-
-  const { date: maintenant } = querySchema.parse(req.query);
 
   logger.info(
     {


### PR DESCRIPTION
## Summary
- Ajoute un query param `?force=true` au endpoint `/api/admin/cron/rapports-coordinateurs`
- Permet de bypasser les conditions de feature flip et d'environnement PROD
- Utile pour déclencher manuellement le cron en dehors de PROD (tests, debug)

## Test plan
- [ ] Appel sans `force` → comportement inchangé (skip si pas PROD ou feature flip désactivé)
- [ ] Appel avec `?force=true` → exécution même hors PROD
- [ ] Appel avec `?force=false` → même comportement que sans le param

🤖 Generated with [Claude Code](https://claude.com/claude-code)