### PR TITLE
fix: empêcher l'insertion de lien de valider le formulaire parent

### DIFF
--- a/src/client/components/_commons/EditeurRiche/ModaleInsertionUrl.tsx
+++ b/src/client/components/_commons/EditeurRiche/ModaleInsertionUrl.tsx
@@ -70,6 +70,7 @@ export const ModaleInsertionUrl = ({
 
   const valider = (event: FormEvent) => {
     event.preventDefault();
+    event.stopPropagation();
     setErreur("");
 
     if (mode === "email") {


### PR DESCRIPTION
## Problème

Cliquer sur « Insérer » dans la modale d'ajout de lien de l'éditeur riche déclenchait la soumission du formulaire de publication parent.

## Cause

`ModaleInsertionUrl` possède son propre `<form>`. Son bouton « Insérer » (`type="submit"`) déclenche un événement `submit` sur ce formulaire interne. Cet événement **remonte dans l'arbre React** (fiber tree) — même à travers un `Dialog.Portal` de Radix — jusqu'au `<form>` de la publication parent, qui se trouve ainsi soumis.

## Correction

Ajout de `event.stopPropagation()` dans le handler `onSubmit` du formulaire interne de `ModaleInsertionUrl`, en complément du `event.preventDefault()` déjà présent.

## Test

- Ouvrir un formulaire de publication (commentaire)
- Sélectionner du texte dans l'éditeur
- Cliquer sur le bouton « Lien » dans la barre d'outils
- Saisir une URL et cliquer « Insérer »
- Vérifier que le lien est inséré dans l'éditeur **sans** soumettre le formulaire parent

🤖 Generated with [Claude Code](https://claude.com/claude-code)