### PR TITLE
fix: conserver le jalon sélectionné lors du retour depuis une PPG

### DIFF
--- a/src/client/components/PageChantier/EnTête/EnTête.tsx
+++ b/src/client/components/PageChantier/EnTête/EnTête.tsx
@@ -47,7 +47,10 @@ const PageChantierEnTête: FunctionComponent<{
     )
     .filter(Boolean);
 
-  const queryParamString = getQueryParamString(getFiltresActifs());
+  const queryParamString = getQueryParamString({
+    ...getFiltresActifs(),
+    jalon,
+  });
   const hrefBoutonRetour = `/accueil/chantier/${territoireCode}${queryParamString.length > 0 ? `?${queryParamString}` : ""}`;
 
   const chantierEstArchive = chantier.statut === "ARCHIVE";


### PR DESCRIPTION
## Contexte

Ticket : [PIL-1453](https://ditp-pilotage.atlassian.net/browse/PIL-1453)

Lors d'un retour depuis une PPG vers la page d'accueil via le bouton "Retour", le jalon sélectionné (ex : 2026) était réinitialisé sur la valeur par défaut (2025).

## Cause

Le bouton "Retour" dans `EnTête.tsx` construit l'URL de retour à partir de `getFiltresActifs()` (store Zustand). Or, le jalon est géré uniquement via `useQueryState` (nuqs) dans `SelecteurJalon` et n'est jamais synchronisé dans le store — qui conserve donc la valeur initiale `"2025"`.

## Fix

On surcharge le jalon du store avec celui issu du contexte SSR de la page chantier (lui-même lu depuis l'URL au chargement de la page) :

```ts
const queryParamString = getQueryParamString({
  ...getFiltresActifs(),
  jalon,
});
```

Le `jalon` est déjà disponible dans le composant via `pageChantier.useServerSidePropsContext()`, et correspond bien au jalon actif lors de la navigation vers la PPG.

[PIL-1453]: https://data-ditp.atlassian.net/browse/PIL-1453?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ