### PR TITLE
feat: désactiver les boutons de soumission pendant les mutations PVA et import indicateur (PIL-1476)

### DIFF
--- a/src/client/components/PageImportIndicateur/PageImportIndicateurSectionImport/EtapePublierFichier.tsx
+++ b/src/client/components/PageImportIndicateur/PageImportIndicateurSectionImport/EtapePublierFichier.tsx
@@ -4,6 +4,7 @@ import { RapportContrat } from "@/server/app/contrats/RapportContrat";
 import Alerte from "@/components/_commons/Alerte/Alerte";
 import { wording } from "@/client/utils/i18n/i18n";
 import FormulairePublierImportIndicateur from "@/components/PageImportIndicateur/PageImportIndicateurSectionImport/FormulaireImportIndicateur/FormulairePublierImportIndicateur";
+import { usePublierIndicateur } from "@/hooks/usePublierIndicateur";
 
 const EtapePublierFichier: FunctionComponent<{
   estFichierPublie: boolean;
@@ -20,6 +21,12 @@ const EtapePublierFichier: FunctionComponent<{
   setEstFichierPublie,
   rapportImport,
 }) => {
+  const { publierLeFichier, isPending } = usePublierIndicateur(
+    chantierId,
+    indicateurId,
+    rapportId,
+    setEstFichierPublie,
+  );
   return (
     <div>
       {estFichierPublie ? (
@@ -54,10 +61,8 @@ const EtapePublierFichier: FunctionComponent<{
           {rapportImport?.listeMesuresIndicateurTemporaire.length ? (
             <>
               <FormulairePublierImportIndicateur
-                chantierId={chantierId}
-                indicateurId={indicateurId}
-                rapportId={rapportId}
-                setEstFichierPublie={setEstFichierPublie}
+                isPending={isPending}
+                publierLeFichier={publierLeFichier}
               />
               <table className="fr-table fr-my-3w fr-p-0 w-full">
                 <thead>
@@ -118,10 +123,8 @@ const EtapePublierFichier: FunctionComponent<{
                 </tbody>
               </table>
               <FormulairePublierImportIndicateur
-                chantierId={chantierId}
-                indicateurId={indicateurId}
-                rapportId={rapportId}
-                setEstFichierPublie={setEstFichierPublie}
+                isPending={isPending}
+                publierLeFichier={publierLeFichier}
               />
             </>
           ) : (

--- a/src/client/components/PageImportIndicateur/PageImportIndicateurSectionImport/FormulaireImportIndicateur/FormulairePublierImportIndicateur.tsx
+++ b/src/client/components/PageImportIndicateur/PageImportIndicateurSectionImport/FormulaireImportIndicateur/FormulairePublierImportIndicateur.tsx
@@ -13,7 +13,7 @@ interface FormulairePublierImportIndicateurProps {
 const FormulairePublierImportIndicateur: FunctionComponent<
   FormulairePublierImportIndicateurProps
 > = ({ chantierId, indicateurId, rapportId, setEstFichierPublie }) => {
-  const { publierLeFichier } = usePublierIndicateur(
+  const { publierLeFichier, isPending } = usePublierIndicateur(
     chantierId,
     indicateurId,
     rapportId,
@@ -27,9 +27,12 @@ const FormulairePublierImportIndicateur: FunctionComponent<
     >
       <SubmitBouton
         className="ml-8"
+        disabled={isPending}
         label={
-          wording.PAGE_IMPORT_MESURE_INDICATEUR.SECTION_ETAPE_IMPORT
-            .ETAPE_PUBLIER_FICHIER.LABEL_BOUTON_PROCHAINE_ETAPE
+          isPending
+            ? "Publication en cours..."
+            : wording.PAGE_IMPORT_MESURE_INDICATEUR.SECTION_ETAPE_IMPORT
+                .ETAPE_PUBLIER_FICHIER.LABEL_BOUTON_PROCHAINE_ETAPE
         }
       />
     </form>

--- a/src/client/components/PageImportIndicateur/PageImportIndicateurSectionImport/FormulaireImportIndicateur/FormulairePublierImportIndicateur.tsx
+++ b/src/client/components/PageImportIndicateur/PageImportIndicateurSectionImport/FormulaireImportIndicateur/FormulairePublierImportIndicateur.tsx
@@ -1,30 +1,17 @@
-import { Dispatch, FunctionComponent, SetStateAction } from "react";
+import { FunctionComponent, SubmitEventHandler } from "react";
 import { SubmitBouton } from "@/components/_commons/SubmitBouton/SubmitBouton";
-import { usePublierIndicateur } from "@/hooks/usePublierIndicateur";
 import { wording } from "@/client/utils/i18n/i18n";
 
 interface FormulairePublierImportIndicateurProps {
-  chantierId: string;
-  indicateurId: string;
-  rapportId: string;
-  setEstFichierPublie: Dispatch<SetStateAction<boolean>>;
+  isPending: boolean;
+  publierLeFichier: SubmitEventHandler<HTMLFormElement>;
 }
 
 const FormulairePublierImportIndicateur: FunctionComponent<
   FormulairePublierImportIndicateurProps
-> = ({ chantierId, indicateurId, rapportId, setEstFichierPublie }) => {
-  const { publierLeFichier, isPending } = usePublierIndicateur(
-    chantierId,
-    indicateurId,
-    rapportId,
-    setEstFichierPublie,
-  );
-
+> = ({ isPending, publierLeFichier }) => {
   return (
-    <form
-      className="flex justify-end"
-      onSubmit={publierLeFichier as React.FormEventHandler<HTMLFormElement>}
-    >
+    <form className="flex justify-end" onSubmit={publierLeFichier}>
       <SubmitBouton
         className="ml-8"
         disabled={isPending}

--- a/src/client/components/_commons/IndicateursChantier/Bloc/ModaleAccepterPropositionValeurAvancement/ModaleAccepterPropositionValeurAvancement.tsx
+++ b/src/client/components/_commons/IndicateursChantier/Bloc/ModaleAccepterPropositionValeurAvancement/ModaleAccepterPropositionValeurAvancement.tsx
@@ -38,6 +38,7 @@ export const ModaleAccepterPropositionValeurAvancement: FunctionComponent<
     setEtapePropositionValeurAvancement,
     etapeSuivanteEstDesactive: EtapeSuivanteEstDesactive,
     traiterDecision,
+    isPending,
   } = useModaleAccepterPropositionValeurAvancement({
     indicateur,
     detailIndicateur,
@@ -346,12 +347,18 @@ export const ModaleAccepterPropositionValeurAvancement: FunctionComponent<
                     >
                       Étape précédente
                     </button>
-                    <button className="fr-btn" type="submit">
-                      {decision === "refuser"
-                        ? "Valider la décision"
-                        : decision === "accepter-avec-modification"
-                          ? "Accepter avec modification"
-                          : "Accepter la proposition"}
+                    <button
+                      className="fr-btn"
+                      disabled={isPending}
+                      type="submit"
+                    >
+                      {isPending
+                        ? "Traitement en cours..."
+                        : decision === "refuser"
+                          ? "Valider la décision"
+                          : decision === "accepter-avec-modification"
+                            ? "Accepter avec modification"
+                            : "Accepter la proposition"}
                     </button>
                   </div>
                 </>

--- a/src/client/components/_commons/IndicateursChantier/Bloc/ModaleAccepterPropositionValeurAvancement/useModaleAccepterPropositionValeurAvancement.ts
+++ b/src/client/components/_commons/IndicateursChantier/Bloc/ModaleAccepterPropositionValeurAvancement/useModaleAccepterPropositionValeurAvancement.ts
@@ -173,11 +173,17 @@ export const useModaleAccepterPropositionValeurAvancement = ({
 
   const etapeSuivanteEstDesactive = !reactHookForm.formState.isValid;
 
+  const isPending =
+    mutationAccepterPropositonValeurAvancement.isPending ||
+    mutationRefuserPropositonValeurAvancement.isPending ||
+    mutationAccepterAvecModificationPropositonValeurAvancement.isPending;
+
   return {
     reactHookForm,
     traiterDecision,
     etapePropositionValeurAvancement,
     setEtapePropositionValeurAvancement,
     etapeSuivanteEstDesactive,
+    isPending,
   };
 };

--- a/src/client/components/_commons/IndicateursChantier/Bloc/ModaleAccuserReceptionPropositionValeurAvancement/ModaleAccuserReceptionPropositionValeurAvancement.tsx
+++ b/src/client/components/_commons/IndicateursChantier/Bloc/ModaleAccuserReceptionPropositionValeurAvancement/ModaleAccuserReceptionPropositionValeurAvancement.tsx
@@ -37,6 +37,7 @@ export const ModaleAccuserReceptionPropositionValeurAvancement: FunctionComponen
     setEtapeAccuserReception,
     etapeSuivanteEstDesactive,
     traiterAccuseReception,
+    isPending,
   } = useModaleAccuserReceptionPropositionValeurAvancement({
     indicateur,
     detailIndicateur,
@@ -224,8 +225,14 @@ export const ModaleAccuserReceptionPropositionValeurAvancement: FunctionComponen
                     >
                       Étape précédente
                     </button>
-                    <button className="fr-btn" type="submit">
-                      Confirmer l'envoi de l'accusé de réception
+                    <button
+                      className="fr-btn"
+                      disabled={isPending}
+                      type="submit"
+                    >
+                      {isPending
+                        ? "Envoi en cours..."
+                        : "Confirmer l'envoi de l'accusé de réception"}
                     </button>
                   </div>
                 </>

--- a/src/client/components/_commons/IndicateursChantier/Bloc/ModaleAccuserReceptionPropositionValeurAvancement/useModaleAccuserReceptionPropositionValeurAvancement.ts
+++ b/src/client/components/_commons/IndicateursChantier/Bloc/ModaleAccuserReceptionPropositionValeurAvancement/useModaleAccuserReceptionPropositionValeurAvancement.ts
@@ -83,11 +83,14 @@ export const useModaleAccuserReceptionPropositionValeurAvancement = ({
 
   const etapeSuivanteEstDesactive = !reactHookForm.formState.isValid;
 
+  const isPending = mutationAccuserReceptionPropositionValeurAvancement.isPending;
+
   return {
     reactHookForm,
     traiterAccuseReception,
     etapeAccuserReception,
     setEtapeAccuserReception,
     etapeSuivanteEstDesactive,
+    isPending,
   };
 };

--- a/src/client/components/_commons/IndicateursChantier/Bloc/ModaleAccuserReceptionPropositionValeurAvancement/useModaleAccuserReceptionPropositionValeurAvancement.ts
+++ b/src/client/components/_commons/IndicateursChantier/Bloc/ModaleAccuserReceptionPropositionValeurAvancement/useModaleAccuserReceptionPropositionValeurAvancement.ts
@@ -83,7 +83,8 @@ export const useModaleAccuserReceptionPropositionValeurAvancement = ({
 
   const etapeSuivanteEstDesactive = !reactHookForm.formState.isValid;
 
-  const isPending = mutationAccuserReceptionPropositionValeurAvancement.isPending;
+  const isPending =
+    mutationAccuserReceptionPropositionValeurAvancement.isPending;
 
   return {
     reactHookForm,

--- a/src/client/components/_commons/IndicateursChantier/Bloc/ModalePropositionValeurAvancementV2/ModalePropositionValeurAvancementV2.tsx
+++ b/src/client/components/_commons/IndicateursChantier/Bloc/ModalePropositionValeurAvancementV2/ModalePropositionValeurAvancementV2.tsx
@@ -31,6 +31,7 @@ export const ModalePropositionValeurAvancementV2: FunctionComponent<
     EtapeSuivanteEstDesactive,
     estUneModificationDeProposition,
     optionsMois,
+    isPending,
   } = useModalePropositionValeurAvancementV2();
 
   const refreshRouter = useRefreshRouter();
@@ -412,8 +413,14 @@ export const ModalePropositionValeurAvancementV2: FunctionComponent<
                     >
                       Étape précédente
                     </button>
-                    <button className="fr-btn" type="submit">
-                      Publier la proposition
+                    <button
+                      className="fr-btn"
+                      disabled={isPending}
+                      type="submit"
+                    >
+                      {isPending
+                        ? "Publication en cours..."
+                        : "Publier la proposition"}
                     </button>
                   </div>
                 </>

--- a/src/client/components/_commons/IndicateursChantier/Bloc/ModalePropositionValeurAvancementV2/useModalePropositionValeurAvancementV2.ts
+++ b/src/client/components/_commons/IndicateursChantier/Bloc/ModalePropositionValeurAvancementV2/useModalePropositionValeurAvancementV2.ts
@@ -257,6 +257,10 @@ const useModalePropositionValeurAvancementV2 = () => {
     ],
   );
 
+  const isPending =
+    mutationCreerPropositonValeurAvancement.isPending ||
+    mutationModifierPropositonValeurAvancement.isPending;
+
   return {
     reactHookForm,
     creerPropositonValeurAvancement,
@@ -265,6 +269,7 @@ const useModalePropositionValeurAvancementV2 = () => {
     EtapeSuivanteEstDesactive,
     estUneModificationDeProposition,
     optionsMois,
+    isPending,
   };
 };
 

--- a/src/client/components/_commons/IndicateursChantier/Bloc/ModaleSuppressionValeurAvancementV2/ModaleSuppressionValeurAvancementV2.tsx
+++ b/src/client/components/_commons/IndicateursChantier/Bloc/ModaleSuppressionValeurAvancementV2/ModaleSuppressionValeurAvancementV2.tsx
@@ -35,6 +35,7 @@ export const ModaleSuppressionValeurAvancementV2: FunctionComponent<
     etapePropositionValeurAvancement,
     setEtapePropositionValeurAvancement,
     etapeSuivanteEstDesactive,
+    isPending,
   } = useModaleSuppressionValeurAvancementV2({
     indicateur,
     detailIndicateur,
@@ -233,8 +234,14 @@ export const ModaleSuppressionValeurAvancementV2: FunctionComponent<
                     >
                       Étape précédente
                     </button>
-                    <button className="fr-btn" type="submit">
-                      Supprimer la proposition
+                    <button
+                      className="fr-btn"
+                      disabled={isPending}
+                      type="submit"
+                    >
+                      {isPending
+                        ? "Suppression en cours..."
+                        : "Supprimer la proposition"}
                     </button>
                   </div>
                 </>

--- a/src/client/components/_commons/IndicateursChantier/Bloc/ModaleSuppressionValeurAvancementV2/useModaleSuppressionValeurAvancementV2.ts
+++ b/src/client/components/_commons/IndicateursChantier/Bloc/ModaleSuppressionValeurAvancementV2/useModaleSuppressionValeurAvancementV2.ts
@@ -90,6 +90,7 @@ const useModaleSuppressionValeurAvancementV2 = ({
     etapePropositionValeurAvancement,
     setEtapePropositionValeurAvancement,
     etapeSuivanteEstDesactive: !reactHookForm.formState.isValid,
+    isPending: mutationSupprimerPropositionValeurAvancement.isPending,
   };
 };
 

--- a/src/hooks/usePublierIndicateur.ts
+++ b/src/hooks/usePublierIndicateur.ts
@@ -1,4 +1,4 @@
-import { Dispatch, FormEventHandler, SetStateAction } from "react";
+import { Dispatch, FormEventHandler, SetStateAction, useState } from "react";
 import { DetailValidationFichierContrat } from "@/server/app/contrats/DetailValidationFichierContrat.interface";
 
 type UploadFichierFormulaireElement = {
@@ -11,10 +11,13 @@ export const usePublierIndicateur = (
   rapportId: string,
   setEstFichierPublie: Dispatch<SetStateAction<boolean>>,
 ) => {
+  const [isPending, setIsPending] = useState(false);
+
   const publierLeFichier: FormEventHandler<
     UploadFichierFormulaireElement
   > = async (event) => {
     event.preventDefault();
+    setIsPending(true);
 
     await fetch(
       `/api/chantier/${chantierId}/indicateur/${indicateurId}?rapportId=${rapportId}`,
@@ -29,8 +32,11 @@ export const usePublierIndicateur = (
       .then((response) => {
         setEstFichierPublie(true);
         return response.json() as Promise<DetailValidationFichierContrat>;
+      })
+      .finally(() => {
+        setIsPending(false);
       });
   };
 
-  return { publierLeFichier };
+  return { publierLeFichier, isPending };
 };

--- a/src/hooks/usePublierIndicateur.ts
+++ b/src/hooks/usePublierIndicateur.ts
@@ -1,9 +1,5 @@
-import { Dispatch, FormEventHandler, SetStateAction, useState } from "react";
+import { Dispatch, SetStateAction, SubmitEventHandler, useState } from "react";
 import { DetailValidationFichierContrat } from "@/server/app/contrats/DetailValidationFichierContrat.interface";
-
-type UploadFichierFormulaireElement = {
-  "file-upload": HTMLInputElement;
-} & HTMLFormElement;
 
 export const usePublierIndicateur = (
   chantierId: string,
@@ -13,9 +9,9 @@ export const usePublierIndicateur = (
 ) => {
   const [isPending, setIsPending] = useState(false);
 
-  const publierLeFichier: FormEventHandler<
-    UploadFichierFormulaireElement
-  > = async (event) => {
+  const publierLeFichier: SubmitEventHandler<HTMLFormElement> = async (
+    event,
+  ) => {
     event.preventDefault();
     setIsPending(true);
 


### PR DESCRIPTION
## Summary

- Désactive les boutons de soumission (`disabled`) et affiche un texte de chargement pendant les mutations sur les 4 modales PVA (proposition, accepter, accuser réception, suppression)
- Désactive le bouton de publication pendant le `fetch` sur la page d'import indicateur
- Corrige le bug où seul le bouton cliqué était désactivé (il y en a deux dans `EtapePublierFichier`) en remontant `usePublierIndicateur` au niveau parent
- Remplace les types React dépréciés `FormEventHandler`/`FormEvent` par `SubmitEvent<HTMLFormElement>` (React 19)

## Test plan

- [ ] Vérifier que le bouton de chaque modale PVA se désactive et affiche le texte de chargement au clic
- [ ] Vérifier que les deux boutons "Publier" de la page import indicateur se désactivent simultanément au clic

🤖 Generated with [Claude Code](https://claude.com/claude-code)