### PR TITLE
fix: conserver le jalon sélectionné lors du retour depuis le rapport détaillé

### DIFF
--- a/src/client/components/PageRapportDétaillé/PageRapportDétaillé.tsx
+++ b/src/client/components/PageRapportDétaillé/PageRapportDétaillé.tsx
@@ -94,7 +94,10 @@ const PageRapportDétaillé: FunctionComponent<PageRapportDétailléProps> = ({
   const territoireSélectionné = récupérerDétailsSurUnTerritoire(territoireCode);
   const [afficherLesChantiers, setAfficherLesChantiers] = useState(false);
 
-  const queryParamString = getQueryParamString(getFiltresActifs());
+  const queryParamString = getQueryParamString({
+    ...getFiltresActifs(),
+    jalon,
+  });
 
   const hrefBoutonRetour = `/accueil/chantier/${territoireCode}${queryParamString.length > 0 ? `?${queryParamString}` : ""}`;
 


### PR DESCRIPTION
## Summary

- Même correctif que #2068 (PIL-1453) appliqué au bouton de retour du rapport détaillé
- Le `jalon` sélectionné est maintenant propagé dans les query params du lien « Revenir à l'accueil »

## Test plan

- [ ] Sélectionner un jalon autre que celui par défaut sur la page d'accueil
- [ ] Naviguer vers le rapport détaillé
- [ ] Cliquer sur « Revenir à l'accueil » et vérifier que le jalon est conservé

🤖 Generated with [Claude Code](https://claude.com/claude-code)