### PR TITLE
fix: passer la date du dimanche précédent au cron rapports-coordinateurs

### DIFF
--- a/cron.json
+++ b/cron.json
@@ -4,7 +4,7 @@
       "command": "0 6 * * 1 curl -X POST -H \"Authorization: Bearer $CRON_AUTH_SECRET\" \"$APP_URL/api/admin/cron/rapports-pva\""
     },
     {
-      "command": "0 9 * * 1 curl -X POST -H \"Authorization: Bearer $CRON_AUTH_SECRET\" \"$APP_URL/api/admin/cron/rapports-coordinateurs\""
+      "command": "0 9 * * 1 curl -X POST -H \"Authorization: Bearer $CRON_AUTH_SECRET\" \"$APP_URL/api/admin/cron/rapports-coordinateurs?date=$(date -d 'yesterday' +%Y-%m-%d)\""
     },
     {
       "command": "45 15 * * * curl -X POST -H \"Authorization: Bearer $CRON_AUTH_SECRET\" \"$APP_URL/api/admin/cron/desactivation-comptes\""

--- a/cron.json
+++ b/cron.json
@@ -4,7 +4,7 @@
       "command": "0 6 * * 1 curl -X POST -H \"Authorization: Bearer $CRON_AUTH_SECRET\" \"$APP_URL/api/admin/cron/rapports-pva\""
     },
     {
-      "command": "0 9 * * 1 curl -X POST -H \"Authorization: Bearer $CRON_AUTH_SECRET\" \"$APP_URL/api/admin/cron/rapports-coordinateurs?date=$(date -d 'yesterday' +%Y-%m-%d)\""
+      "command": "0 7 * * 1 curl -X POST -H \"Authorization: Bearer $CRON_AUTH_SECRET\" \"$APP_URL/api/admin/cron/rapports-coordinateurs?date=$(date -d 'yesterday' +%Y-%m-%d)\""
     },
     {
       "command": "45 15 * * * curl -X POST -H \"Authorization: Bearer $CRON_AUTH_SECRET\" \"$APP_URL/api/admin/cron/desactivation-comptes\""


### PR DESCRIPTION
## Summary

- Le cron `rapports-coordinateurs` s'exécute le lundi à 7h (au lieu de 9h) mais ne passait pas de date, ce qui laissait `calculerPeriodeDernierLundiNeufHeures` calculer une période lundi 9h01 → maintenant (quelques secondes seulement)
- Injection de `$(date -d 'yesterday' +%Y-%m-%d)` dans l'URL pour cibler le dimanche précédent comme `dateFin`, couvrant ainsi toute la semaine écoulée (lundi 9h01 → dimanche)

## Test plan

- [ ] Vérifier sur Scalingo que la variable est bien interpolée au moment de l'exécution
- [ ] Contrôler les logs du cron le prochain lundi pour confirmer la période couverte

🤖 Generated with [Claude Code](https://claude.com/claude-code)