### PR TITLE
feat: filtrer les jobs CI par paths modifiés (dorny/paths-filter)

### DIFF
--- a/.github/workflows/testAndLint.yml
+++ b/.github/workflows/testAndLint.yml
@@ -10,8 +10,29 @@ env:
   NODE_VERSION: 24.9.0
 
 jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      pilote-ppg: ${{ steps.filter.outputs.pilote-ppg }}
+      pilote-ppg-data-management: ${{ steps.filter.outputs.pilote-ppg-data-management }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            pilote-ppg:
+              - 'apps/pilote-ppg/**'
+              - 'package.json'
+              - 'pnpm-lock.yaml'
+            pilote-ppg-data-management:
+              - 'apps/pilote-ppg-data-management/**'
+
   test:
     name: Run tests
+    needs: changes
+    if: needs.changes.outputs['pilote-ppg'] == 'true'
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -43,6 +64,8 @@ jobs:
 
   lint:
     name: Run linters for code
+    needs: changes
+    if: needs.changes.outputs['pilote-ppg'] == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -57,6 +80,8 @@ jobs:
 
   lint-sql:
     name: Run SQL linter on dbt models
+    needs: changes
+    if: needs.changes.outputs['pilote-ppg-data-management'] == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Ajoute un job `changes` en amont dans `testAndLint.yml` via `dorny/paths-filter` pour ne déclencher les jobs que quand les fichiers pertinents sont modifiés.

- **pilote-ppg** : `apps/pilote-ppg/**`, `package.json`, `pnpm-lock.yaml` → déclenche `test` + `lint`
- **pilote-ppg-data-management** : `apps/pilote-ppg-data-management/**` → déclenche `lint-sql`

Si aucun fichier pertinent n'a changé, les jobs sont marqués "skipped" (pas "pending").

## Test plan

- [ ] PR qui touche uniquement `apps/pilote-ppg-data-management/` → seul `lint-sql` tourne
- [ ] PR qui touche uniquement `apps/pilote-ppg/` → seul `test` + `lint` tournent
- [ ] PR qui touche les deux → tout tourne
- [ ] PR qui ne touche ni l'un ni l'autre (ex: README racine) → rien ne tourne