### PR TITLE
fix: tooltip nom territoire tronqué + suppression date météo (PIL-1451)

### DIFF
--- a/apps/pilote-ppg/src/client/components/_commons/Widget/TerritoireLabel.tsx
+++ b/apps/pilote-ppg/src/client/components/_commons/Widget/TerritoireLabel.tsx
@@ -8,7 +8,11 @@ export const TerritoireLabel = ({
   onSupprimer?: () => void;
 }) => (
   <div className="flex items-center gap-1">
-    <span className="text-right flex-1 truncate" style={{ color: couleur }}>
+    <span
+      className="text-right flex-1 truncate"
+      title={nom}
+      style={{ color: couleur }}
+    >
       {nom}
     </span>
     <div className="w-4 shrink-0 flex justify-center">

--- a/apps/pilote-ppg/src/client/components/_commons/Widget/WidgetCartographieMeteo/RepartitionNiveauxDeConfiance.tsx
+++ b/apps/pilote-ppg/src/client/components/_commons/Widget/WidgetCartographieMeteo/RepartitionNiveauxDeConfiance.tsx
@@ -51,11 +51,6 @@ export const RepartitionNiveauxDeConfiance = ({
 
         {territoiresTries.map((territoire) => {
           const meteo = territoire.meteo;
-          const dateMaj = territoire.dateDeMajQualitative
-            ? new Date(territoire.dateDeMajQualitative).toLocaleDateString(
-                "fr-FR",
-              )
-            : "—";
           const estInitial = territoire.territoireCode === territoireCode;
           const couleur = getCouleurTerritoireParCode(
             territoire.territoireCode,
@@ -88,9 +83,12 @@ export const RepartitionNiveauxDeConfiance = ({
                 </div>
               </div>
               <div
-                className={clsxm("py-2 flex items-center flex-col border-b", {
-                  "flex-row gap-4": !isModeP,
-                })}
+                className={clsxm(
+                  "py-2 flex items-center justify-center flex-col border-b",
+                  {
+                    "flex-row gap-4": !isModeP,
+                  },
+                )}
               >
                 <div className="flex items-center gap-2">
                   <MeteoPicto meteo={meteo} size="sm" />
@@ -100,9 +98,6 @@ export const RepartitionNiveauxDeConfiance = ({
                       : libellesMeteos[meteo]}
                   </span>
                 </div>
-                <span className="text-[10px] !text-dsfr-grey-625">
-                  ({dateMaj})
-                </span>
               </div>
             </Fragment>
           );


### PR DESCRIPTION
## Résumé

- Ajout de `title={nom}` sur le label territoire tronqué pour afficher le nom complet au survol
- Suppression de la date de mise à jour météo dans `RepartitionNiveauxDeConfiance`

## Plan de test

- [ ] Vérifier qu'au survol d'un nom territoire tronqué, le tooltip affiche le nom complet
- [ ] Vérifier que la date de météo n'apparaît plus dans la répartition niveaux de confiance

🤖 Generated with [Claude Code](https://claude.com/claude-code)