### PR TITLE
fix: corriger URL schema Validata + stack trace dans les logs (PIL-1475)

### DIFF
--- a/apps/pilote-ppg/src/config.ts
+++ b/apps/pilote-ppg/src/config.ts
@@ -455,7 +455,7 @@ const config = convict({
   schemaValidataUrl: {
     format: String,
     default:
-      "https://raw.githubusercontent.com/DITP-pilotage/pilote-2/dev/public/schema/",
+      "https://raw.githubusercontent.com/DITP-pilotage/pilote-2/dev/apps/pilote-ppg/public/schema/",
     env: "NEXT_PUBLIC_SCHEMA_VALIDATA_URL",
   },
   e2e: {

--- a/apps/pilote-ppg/src/server/import-indicateur/infrastructure/handlers/ImportDonneeIndicateurAPIHandler.ts
+++ b/apps/pilote-ppg/src/server/import-indicateur/infrastructure/handlers/ImportDonneeIndicateurAPIHandler.ts
@@ -14,6 +14,7 @@ import { PublierFichierIndicateurImporteUseCase } from "@/server/import-indicate
 import { VerifierFichierIndicateurImporteUseCase } from "@/server/import-indicateur/usecases/VerifierFichierIndicateurImporteUseCase";
 import { isENOENTError } from "@/server/utils/errors";
 import logger from "@/server/infrastructure/Logger";
+import { configuration } from "@/config";
 
 function convertirEnTableauPourCSV(
   donnees: ImportDonneeIndicateurAPIContrat[],
@@ -27,8 +28,6 @@ function convertirEnTableauPourCSV(
     donnee.valeur,
   ]);
 }
-const baseSchemaUrl =
-  "https://raw.githubusercontent.com/DITP-pilotage/pilote-2/main/public/schema/";
 
 export class ImportDonneeIndicateurAPIHandler {
   private publierFichierIndicateurImporteUseCase: PublierFichierIndicateurImporteUseCase;
@@ -165,7 +164,7 @@ export class ImportDonneeIndicateurAPIHandler {
     const report = await this.verifierFichierIndicateurImporteUseCase.execute({
       cheminCompletDuFichier,
       nomDuFichier,
-      baseSchemaUrl,
+      baseSchemaUrl: configuration().schemaValidataUrl,
       indicateurId,
       utilisateurAuteurDeLimportEmail,
       isAdmin,

--- a/apps/pilote-ppg/src/server/infrastructure/Logger.ts
+++ b/apps/pilote-ppg/src/server/infrastructure/Logger.ts
@@ -71,7 +71,9 @@ function persisterEnBase(
     const contexte = extraireContexte(obj);
     const stackTrace =
       level === "ERROR" || level === "WARN"
-        ? (obj.errorStack as string) ?? (obj.stack as string) ?? captureStackTrace()
+        ? ((obj.errorStack as string) ??
+          (obj.stack as string) ??
+          captureStackTrace())
         : null;
 
     const contexteAvecStack: Prisma.InputJsonObject | undefined =

--- a/apps/pilote-ppg/src/server/infrastructure/Logger.ts
+++ b/apps/pilote-ppg/src/server/infrastructure/Logger.ts
@@ -68,12 +68,19 @@ function persisterEnBase(
     const level = mapPinoLevelToEnum(levelNumber);
     if (!level) return;
 
-    const contexte = extraireContexte(obj) ?? {};
-    if (level === "ERROR" || level === "WARN") {
-      const errorStack =
-        (obj.errorStack as string) ?? (obj.stack as string) ?? null;
-      contexte.stack_trace = errorStack || captureStackTrace();
-    }
+    const contexte = extraireContexte(obj);
+    const stackTrace =
+      level === "ERROR" || level === "WARN"
+        ? (obj.errorStack as string) ?? (obj.stack as string) ?? captureStackTrace()
+        : null;
+
+    const contexteAvecStack: Prisma.InputJsonObject | undefined =
+      contexte || stackTrace
+        ? ({
+            ...(contexte ?? {}),
+            ...(stackTrace ? { stack_trace: stackTrace } : {}),
+          } as Prisma.InputJsonObject)
+        : undefined;
 
     db.application_log
       .create({
@@ -81,10 +88,7 @@ function persisterEnBase(
           level: level as "ERROR" | "WARN" | "INFO" | "DEBUG",
           categorie: (obj.categorie as string) ?? "systeme",
           message: msg,
-          contexte:
-            Object.keys(contexte).length > 0
-              ? (contexte as Prisma.InputJsonObject)
-              : undefined,
+          contexte: contexteAvecStack,
           source: (obj.source as string) ?? null,
           duree_ms: (obj.duree_ms as number) ?? null,
         },

--- a/apps/pilote-ppg/src/server/infrastructure/Logger.ts
+++ b/apps/pilote-ppg/src/server/infrastructure/Logger.ts
@@ -45,6 +45,17 @@ function getPrismaInstance() {
   return prismaPilote.getInstance();
 }
 
+function captureStackTrace(): string {
+  const stack = new Error().stack;
+  if (!stack) return "";
+  return stack
+    .split("\n")
+    .slice(4)
+    .filter((line) => !line.includes("node_modules"))
+    .slice(0, 10)
+    .join("\n");
+}
+
 function persisterEnBase(
   levelNumber: number,
   obj: Record<string, unknown>,
@@ -57,13 +68,23 @@ function persisterEnBase(
     const level = mapPinoLevelToEnum(levelNumber);
     if (!level) return;
 
+    const contexte = extraireContexte(obj) ?? {};
+    if (level === "ERROR" || level === "WARN") {
+      const errorStack =
+        (obj.errorStack as string) ?? (obj.stack as string) ?? null;
+      contexte.stack_trace = errorStack || captureStackTrace();
+    }
+
     db.application_log
       .create({
         data: {
           level: level as "ERROR" | "WARN" | "INFO" | "DEBUG",
           categorie: (obj.categorie as string) ?? "systeme",
           message: msg,
-          contexte: extraireContexte(obj) ?? undefined,
+          contexte:
+            Object.keys(contexte).length > 0
+              ? (contexte as Prisma.InputJsonObject)
+              : undefined,
           source: (obj.source as string) ?? null,
           duree_ms: (obj.duree_ms as number) ?? null,
         },


### PR DESCRIPTION
## Summary

- Corrige l'URL des schemas Validata cassée par la migration workspaces (`public/schema/` → `apps/pilote-ppg/public/schema/`)
- Remplace le `baseSchemaUrl` hardcodé par `configuration().schemaValidataUrl` (variable d'env `NEXT_PUBLIC_SCHEMA_VALIDATA_URL`)
- Ajoute la stack trace automatique dans le contexte persisté en base pour les logs `ERROR` et `WARN`

## Test plan

- [ ] Importer un fichier indicateur → Validata valide correctement (plus d'erreur "JSON non valide")
- [ ] Vérifier en base `application_log` qu'un log ERROR contient `stack_trace` dans le contexte

🤖 Generated with [Claude Code](https://claude.com/claude-code)