### PR TITLE
fix: restaurer les schémas Validata à la racine du repo (PIL-1475)

### DIFF
--- a/public/schema/README.md
+++ b/public/schema/README.md
@@ -1,0 +1,8 @@
+# Schémas Validata
+
+Ces fichiers de schéma JSON sont référencés directement par URL depuis Validata (liens bruts GitHub).
+
+Le passage en pnpm workspaces (déplacement de l'app dans `apps/pilote-ppg/`) a cassé ces liens.
+Ce dossier a été restauré à la racine du repo pour rétablir les URLs existantes.
+
+Il pourra être supprimé à la prochaine mise en production, une fois les URLs mises à jour côté Validata.

--- a/public/schema/restrict-0-100.json
+++ b/public/schema/restrict-0-100.json
@@ -1,0 +1,100 @@
+{
+  "$schema": "https://specs.frictionlessdata.io/schemas/table-schema.json",
+  "name": "restrict-0-100",
+  "title": "Indicateur Pilote - Saisie pourcentage",
+  "description": "Spécification d'un fichier d'import d'indicateur Pilote - Saisie pourcentage",
+  "keywords": [
+    "pilote",
+    "ditp"
+  ],
+  "countryCode": "FR",
+  "homepage": "https://github.com/DITP-pilotage/poc-imports",
+  "path": "",
+  "licenses": [
+    {
+      "title": "-",
+      "name": "-",
+      "path": "-"
+    }
+  ],
+  "resources": [],
+  "sources": [
+  ],
+  "created": "2023-06-21",
+  "lastModified": "2023-06-21",
+  "version": "0.0.1",
+  "contributors": [
+    {
+      "title": "Colin Dugeai",
+      "email": "colin.dugeai@modernisation.gouv.fr",
+      "organisation": "DITP",
+      "role": "author"
+    }
+  ],
+  "fields": [
+    {
+      "name": "identifiant_indic",
+      "description": "Identifiant de l'indicateur. Au format 'IND-XXX'",
+      "example": "IND-001",
+      "type": "string",
+      "constraints": {
+        "required": true,
+        "pattern": "^IND-([0-9]{3,4})$"
+      }
+    },
+    {
+      "name": "zone_id",
+      "description": "La zone renseignée n'est pas dans le référentiel.",
+      "example": "D46",
+      "type": "string",
+      "constraints": {
+        "required": true,
+        "pattern": "^(D([02][1-9]|2[AB]|[1345678][0-9]|9[012345]|97[12346])|(R(0[12346]|11|2[478]|32|44|5[23]|7[56]|84|9[34]))|FRANCE|France)$"
+      }
+    },
+    {
+      "name": "date_valeur",
+      "description": "Date à laquelle a été mesurée l'indicateur. Au format AAAA-MM-JJ ou JJ/MM/AAAA",
+      "example": "2023-01-31",
+      "type": "string",
+      "constraints": {
+        "required": true,
+        "pattern": "^(20[0-9]{2}-(0?[0-9]|1[012])-([0-2]?[0-9]|3[01]))|(([0-2]?[0-9]|3[01])\/(0?[0-9]|1[012])\/(20)?[0-9]{2})|(0?[0-9]|1[012])-([0-2]?[0-9]|3[01])-([0-9]{2})$"
+      }
+    },
+    {
+      "name": "type_valeur",
+      "description": "Type de la donnée importée. vi/va/vc",
+      "example": "vi",
+      "type": "string",
+      "constraints": {
+        "required": true,
+        "enum": [
+          "vi",
+          "va",
+          "vc",
+          "VI",
+          "VA",
+          "VC"
+        ]
+      }
+    },
+    {
+      "name": "valeur",
+      "description": "Valeur de l'indicateur",
+      "example": "12.23",
+      "type": "number",
+      "constraints": {
+        "required": false,
+        "minimum": 0,
+        "maximum": 100
+      }
+    }
+  ],
+  "primaryKey": [
+    "identifiant_indic",
+    "zone_id",
+    "date_valeur",
+    "type_valeur"
+  ]
+}

--- a/public/schema/restrict-dept.json
+++ b/public/schema/restrict-dept.json
@@ -1,0 +1,98 @@
+{
+  "$schema": "https://specs.frictionlessdata.io/schemas/table-schema.json",
+  "name": "restrict-dept",
+  "title": "Indicateur Pilote - Saisie départementale",
+  "description": "Spécification d'un fichier d'import d'indicateur Pilote - Saisie départementale",
+  "keywords": [
+    "pilote",
+    "ditp"
+  ],
+  "countryCode": "FR",
+  "homepage": "https://github.com/DITP-pilotage/poc-imports",
+  "path": "",
+  "licenses": [
+    {
+      "title": "-",
+      "name": "-",
+      "path": "-"
+    }
+  ],
+  "resources": [],
+  "sources": [
+  ],
+  "created": "2023-06-21",
+  "lastModified": "2023-06-21",
+  "version": "0.0.1",
+  "contributors": [
+    {
+      "title": "Colin Dugeai",
+      "email": "colin.dugeai@modernisation.gouv.fr",
+      "organisation": "DITP",
+      "role": "author"
+    }
+  ],
+  "fields": [
+    {
+      "name": "identifiant_indic",
+      "description": "Identifiant de l'indicateur. Au format 'IND-XXX'",
+      "example": "IND-001",
+      "type": "string",
+      "constraints": {
+        "required": true,
+        "pattern": "^IND-([0-9]{3,4})$"
+      }
+    },
+    {
+      "name": "zone_id",
+      "description": "La zone renseignée n'est pas dans le référentiel. L'indicateur ne peut être renseigné qu'à la maille départementale.",
+      "example": "D46",
+      "type": "string",
+      "constraints": {
+        "required": true,
+        "pattern": "^D([02][1-9]|2[AB]|[1345678][0-9]|9[012345]|97[12346])$"
+      }
+    },
+    {
+      "name": "date_valeur",
+      "description": "Date à laquelle a été mesurée l'indicateur. Au format AAAA-MM-JJ ou JJ/MM/AAAA",
+      "example": "2023-01-31",
+      "type": "string",
+      "constraints": {
+        "required": true,
+        "pattern": "^(20[0-9]{2}-(0?[0-9]|1[012])-([0-2]?[0-9]|3[01]))|(([0-2]?[0-9]|3[01])\/(0?[0-9]|1[012])\/(20)?[0-9]{2})|(0?[0-9]|1[012])-([0-2]?[0-9]|3[01])-([0-9]{2})$"
+      }
+    },
+    {
+      "name": "type_valeur",
+      "description": "Type de la donnée importée. vi/va/vc",
+      "example": "vi",
+      "type": "string",
+      "constraints": {
+        "required": true,
+        "enum": [
+          "vi",
+          "va",
+          "vc",
+          "VI",
+          "VA",
+          "VC"
+        ]
+      }
+    },
+    {
+      "name": "valeur",
+      "description": "Valeur de l'indicateur",
+      "example": "12.23",
+      "type": "number",
+      "constraints": {
+        "required": false
+      }
+    }
+  ],
+  "primaryKey": [
+    "identifiant_indic",
+    "zone_id",
+    "date_valeur",
+    "type_valeur"
+  ]
+}

--- a/public/schema/restrict-reg.json
+++ b/public/schema/restrict-reg.json
@@ -1,0 +1,98 @@
+{
+  "$schema": "https://specs.frictionlessdata.io/schemas/table-schema.json",
+  "name": "restrict-reg",
+  "title": "Indicateur Pilote - Saisie régionale",
+  "description": "Spécification d'un fichier d'import d'indicateur Pilote - Saisie régionale",
+  "keywords": [
+    "pilote",
+    "ditp"
+  ],
+  "countryCode": "FR",
+  "homepage": "https://github.com/DITP-pilotage/poc-imports",
+  "path": "",
+  "licenses": [
+    {
+      "title": "-",
+      "name": "-",
+      "path": "-"
+    }
+  ],
+  "resources": [],
+  "sources": [
+  ],
+  "created": "2023-06-21",
+  "lastModified": "2023-06-21",
+  "version": "0.0.1",
+  "contributors": [
+    {
+      "title": "Colin Dugeai",
+      "email": "colin.dugeai@modernisation.gouv.fr",
+      "organisation": "DITP",
+      "role": "author"
+    }
+  ],
+  "fields": [
+    {
+      "name": "identifiant_indic",
+      "description": "Identifiant de l'indicateur. Au format 'IND-XXX'",
+      "example": "IND-001",
+      "type": "string",
+      "constraints": {
+        "required": true,
+        "pattern": "^IND-([0-9]{3,4})$"
+      }
+    },
+    {
+      "name": "zone_id",
+      "description": "La zone renseignée n'est pas dans le référentiel. L'indicateur ne peut être renseigné qu'à la maille régionale.",
+      "example": "R84",
+      "type": "string",
+      "constraints": {
+        "required": true,
+        "pattern": "^R(0[12346]|11|2[478]|32|44|5[23]|7[56]|84|9[34])$"
+      }
+    },
+    {
+      "name": "date_valeur",
+      "description": "Date à laquelle a été mesurée l'indicateur. Au format AAAA-MM-JJ ou JJ/MM/AAAA",
+      "example": "2023-01-31",
+      "type": "string",
+      "constraints": {
+        "required": true,
+        "pattern": "^(20[0-9]{2}-(0?[0-9]|1[012])-([0-2]?[0-9]|3[01]))|(([0-2]?[0-9]|3[01])\/(0?[0-9]|1[012])\/(20)?[0-9]{2})|(0?[0-9]|1[012])-([0-2]?[0-9]|3[01])-([0-9]{2})$"
+      }
+    },
+    {
+      "name": "type_valeur",
+      "description": "Type de la donnée importée. vi/va/vc",
+      "example": "vi",
+      "type": "string",
+      "constraints": {
+        "required": true,
+        "enum": [
+          "vi",
+          "va",
+          "vc",
+          "VI",
+          "VA",
+          "VC"
+        ]
+      }
+    },
+    {
+      "name": "valeur",
+      "description": "Valeur de l'indicateur",
+      "example": "12.23",
+      "type": "number",
+      "constraints": {
+        "required": false
+      }
+    }
+  ],
+  "primaryKey": [
+    "identifiant_indic",
+    "zone_id",
+    "date_valeur",
+    "type_valeur"
+  ]
+}

--- a/public/schema/sans-contraintes.json
+++ b/public/schema/sans-contraintes.json
@@ -1,0 +1,120 @@
+{
+  "$schema": "https://specs.frictionlessdata.io/schemas/table-schema.json",
+  "name": "sans-contrainte",
+  "title": "Indicateur Pilote sans contraintes",
+  "description": "Spécification d'un fichier d'import d'indicateur Pilote sans contraintes",
+  "keywords": [
+    "pilote",
+    "ditp"
+  ],
+  "countryCode": "FR",
+  "homepage": "https://github.com/DITP-pilotage/poc-imports",
+  "path": "https://raw.githubusercontent.com/DITP-pilotage/poc-imports/master/schemas/prod/sans-contraintes.json",
+  "licenses": [
+    {
+      "title": "-",
+      "name": "-",
+      "path": "-"
+    }
+  ],
+  "resources": [
+    {
+      "title": "Fichier valide (CSV)",
+      "name": "exemple-valide-csv",
+      "path": "https://raw.githubusercontent.com/DITP-pilotage/poc-imports/master/schemas/prod/example/sans-contraintes-ok.csv"
+    },
+    {
+      "title": "Fichier invalide (CSV)",
+      "name": "exemple-invalide-csv",
+      "path": "https://raw.githubusercontent.com/DITP-pilotage/poc-imports/master/schemas/prod/example/sans-contraintes-ko.csv"
+    },
+    {
+      "title": "Ressource valide (XLSX)",
+      "name": "exemple-valide-xlsx",
+      "path": "https://raw.githubusercontent.com/DITP-pilotage/poc-imports/master/schemas/prod/example/sans-contraintes-ok.xlsx"
+    }
+  ],
+  "sources": [
+  ],
+  "created": "2023-02-17",
+  "lastModified": "2023-02-17",
+  "version": "0.0.1",
+  "contributors": [
+    {
+      "title": "Colin Dugeai",
+      "email": "colin.dugeai@modernisation.gouv.fr",
+      "organisation": "DITP",
+      "role": "author"
+    },
+    {
+      "title": "Geoffrey Aldebert",
+      "email": "geoffrey.aldebert@data.gouv.fr",
+      "organisation": "Etalab",
+      "role": "contributor"
+    }
+  ],
+  "fields": [
+    {
+      "name": "identifiant_indic",
+      "description": "Identifiant de l'indicateur. Au format 'IND-XXX'",
+      "example": "IND-001",
+      "type": "string",
+      "constraints": {
+        "required": true,
+        "pattern": "^IND-([0-9]{3,4})$"
+      }
+    },
+    {
+      "name": "zone_id",
+      "description": "La zone renseignée n'est pas dans le référentiel.",
+      "example": "D46",
+      "type": "string",
+      "constraints": {
+        "required": true,
+        "pattern": "^(D([02][1-9]|2[AB]|[1345678][0-9]|9[012345]|97[12346])|(R(0[12346]|11|2[478]|32|44|5[23]|7[56]|84|9[34]))|FRANCE|France)$"
+      }
+    },
+    {
+      "name": "date_valeur",
+      "description": "Date à laquelle a été mesurée l'indicateur. Au format AAAA-MM-JJ ou JJ/MM/AAAA",
+      "example": "2023-01-31",
+      "type": "string",
+      "constraints": {
+        "required": true,
+        "pattern": "^(20[0-9]{2}-(0?[0-9]|1[012])-([0-2]?[0-9]|3[01]))|(([0-2]?[0-9]|3[01])\/(0?[0-9]|1[012])\/(20)?[0-9]{2})|(0?[0-9]|1[012])-([0-2]?[0-9]|3[01])-([0-9]{2})$"
+      }
+    },
+    {
+      "name": "type_valeur",
+      "description": "Type de la donnée importée. vi/va/vc",
+      "example": "vi",
+      "type": "string",
+      "constraints": {
+        "required": true,
+        "enum": [
+          "vi",
+          "va",
+          "vc",
+          "VI",
+          "VA",
+          "VC"
+        ]
+      }
+    },
+    {
+      "name": "valeur",
+      "description": "Valeur de l'indicateur",
+      "example": "12.23",
+      "type": "number",
+      "constraints": {
+        "required": false
+      }
+    }
+  ],
+  "primaryKey": [
+    "identifiant_indic",
+    "zone_id",
+    "date_valeur",
+    "type_valeur"
+  ]
+}


### PR DESCRIPTION
## Summary
- Restaure les 4 fichiers JSON de schéma Validata à la racine (`public/schema/`) pour rétablir les liens directs GitHub cassés par la migration pnpm workspaces
- Ajoute un README expliquant pourquoi ce dossier existe et quand il pourra être supprimé (prochaine MEP)

## Test plan
- [ ] Vérifier que les URLs brutes GitHub des schémas sont à nouveau accessibles
- [ ] Vérifier que Validata peut charger les schémas via ces URLs