### PR TITLE
chore: remonter cron.json à la racine avec garde APP_PACKAGE

### DIFF
--- a/.slugignore
+++ b/.slugignore
@@ -1,7 +1,6 @@
 .cache
 apps/pilote-ppg/CLAUDE.md
 apps/pilote-ppg/copy-assets.js
-apps/pilote-ppg/cron.json
 apps/pilote-ppg/doc
 apps/pilote-ppg/docker
 apps/pilote-ppg/docker-compose.prod.yml

--- a/apps/pilote-ppg/src/server/infrastructure/Logger.ts
+++ b/apps/pilote-ppg/src/server/infrastructure/Logger.ts
@@ -1,6 +1,7 @@
 import pino, { type LogFn } from "pino";
 import { type Prisma } from "@prisma/client";
 import { PrismaPilote } from "@/server/db/PrismaPilote";
+import { configuration } from "@/config";
 
 const CHAMPS_STANDARD_PINO = new Set([
   "level",
@@ -56,11 +57,16 @@ function captureStackTrace(): string {
     .join("\n");
 }
 
+const dbLogMinLevel =
+  pino.levels.values[configuration().logLevel.toLowerCase()] ?? 40;
+
 function persisterEnBase(
   levelNumber: number,
   obj: Record<string, unknown>,
   msg: string,
 ): void {
+  if (levelNumber < dbLogMinLevel) return;
+
   try {
     const db = getPrismaInstance();
     if (!db?.application_log) return;

--- a/apps/pilote-ppg/src/server/infrastructure/api/cron/__tests__/onlyCron.unit.test.ts
+++ b/apps/pilote-ppg/src/server/infrastructure/api/cron/__tests__/onlyCron.unit.test.ts
@@ -6,6 +6,7 @@ import {
 
 vi.mock("@/config", () => ({
   configuration: vi.fn(() => ({
+    logLevel: "warn",
     cron: {
       authSecret: "valid-secret",
     },

--- a/cron.json
+++ b/cron.json
@@ -1,0 +1,22 @@
+{
+  "jobs": [
+    {
+      "command": "0 6 * * 1 test \"$APP_PACKAGE\" = \"@pilote/ppg\" && curl -X POST -H \"Authorization: Bearer $CRON_AUTH_SECRET\" \"$APP_URL/api/admin/cron/rapports-pva\""
+    },
+    {
+      "command": "0 7 * * 1 test \"$APP_PACKAGE\" = \"@pilote/ppg\" && curl -X POST -H \"Authorization: Bearer $CRON_AUTH_SECRET\" \"$APP_URL/api/admin/cron/rapports-coordinateurs?date=$(date -d 'yesterday' +%Y-%m-%d)\""
+    },
+    {
+      "command": "45 15 * * * test \"$APP_PACKAGE\" = \"@pilote/ppg\" && curl -X POST -H \"Authorization: Bearer $CRON_AUTH_SECRET\" \"$APP_URL/api/admin/cron/desactivation-comptes\""
+    },
+    {
+      "command": "30 11 * * 1 test \"$APP_PACKAGE\" = \"@pilote/ppg\" && curl -X POST -H \"Authorization: Bearer $CRON_AUTH_SECRET\" \"$APP_URL/api/admin/cron/rapport-service-autre\""
+    },
+    {
+      "command": "0 3 * * * test \"$APP_PACKAGE\" = \"@pilote/ppg\" && curl -X POST -H \"Authorization: Bearer $CRON_AUTH_SECRET\" \"$APP_URL/api/admin/cron/nettoyage-rapports\""
+    },
+    {
+      "command": "0 8 * * * test \"$APP_PACKAGE\" = \"@pilote/ppg\" && curl -X POST -H \"Authorization: Bearer $CRON_AUTH_SECRET\" \"$APP_URL/api/admin/cron/purge-logs\""
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Déplace `cron.json` de `apps/pilote-ppg/` vers la racine du monorepo pour que Scalingo le détecte correctement
- Chaque job est conditionné par `test "$APP_PACKAGE" = "@pilote/ppg"` — sans `APP_PACKAGE` défini, aucun cron ne se déclenche
- Inclut le filtre `dbLogMinLevel` dans `Logger.ts` (non mergé en dev depuis la PR purge-logs)
- Met à jour `.slugignore` en conséquence

## Test plan
- [ ] Vérifier que Scalingo détecte le `cron.json` à la racine
- [ ] Vérifier que les crons se déclenchent avec `APP_PACKAGE=@pilote/ppg`
- [ ] Vérifier qu'aucun cron ne se déclenche sans `APP_PACKAGE`