### PR TITLE
fix: corriger URL schema Validata dans le dotenv E2E (PIL-1475)

### DIFF
--- a/apps/pilote-ppg/.env.e2e
+++ b/apps/pilote-ppg/.env.e2e
@@ -91,7 +91,7 @@ INDICATEUR_ID_ACCESSIBLE_PAR_UTILISATEUR_EQUIPE_DIR_PROJET=e2e-indicateur-id
 NEXT_PUBLIC_DATE_BASCULE_AFFICHAGE_VALEURS_ANNEE_PRECEDENTE=2000-03-31
 
 # Schema Validata
-NEXT_PUBLIC_SCHEMA_VALIDATA_URL=https://raw.githubusercontent.com/DITP-pilotage/pilote-2/dev/public/schema/
+NEXT_PUBLIC_SCHEMA_VALIDATA_URL=https://raw.githubusercontent.com/DITP-pilotage/pilote-2/dev/apps/pilote-ppg/public/schema/
 
 # E2E Testing
 E2E_USERNAME=ditp.admin@example.com


### PR DESCRIPTION
## Summary
- Corrige l'URL du schéma Validata dans `.env.e2e` pour pointer vers `apps/pilote-ppg/public/schema/` après la migration pnpm workspaces

## Test plan
- [ ] Vérifier que les tests E2E d'import passent avec la nouvelle URL