### PR TITLE
chore: fusionner les crons nettoyage-rapports et purge-logs

### DIFF
--- a/cron.json
+++ b/cron.json
@@ -13,10 +13,7 @@
       "command": "30 11 * * 1 test \"$APP_PACKAGE\" = \"@pilote/ppg\" && curl -X POST -H \"Authorization: Bearer $CRON_AUTH_SECRET\" \"$APP_URL/api/admin/cron/rapport-service-autre\""
     },
     {
-      "command": "0 3 * * * test \"$APP_PACKAGE\" = \"@pilote/ppg\" && curl -X POST -H \"Authorization: Bearer $CRON_AUTH_SECRET\" \"$APP_URL/api/admin/cron/nettoyage-rapports\""
-    },
-    {
-      "command": "0 8 * * * test \"$APP_PACKAGE\" = \"@pilote/ppg\" && curl -X POST -H \"Authorization: Bearer $CRON_AUTH_SECRET\" \"$APP_URL/api/admin/cron/purge-logs\""
+      "command": "0 3 * * * test \"$APP_PACKAGE\" = \"@pilote/ppg\" && curl -X POST -H \"Authorization: Bearer $CRON_AUTH_SECRET\" \"$APP_URL/api/admin/cron/nettoyage-rapports\" && curl -X POST -H \"Authorization: Bearer $CRON_AUTH_SECRET\" \"$APP_URL/api/admin/cron/purge-logs\""
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Fusionne les jobs cron `nettoyage-rapports` et `purge-logs` en un seul job quotidien à 3h
- Réduit le nombre de jobs de 6 à 5 (limite Scalingo)
- Les deux opérations de ménage sont chaînées avec `&&` (purge-logs ne s'exécute que si nettoyage-rapports réussit)

## Test plan
- [ ] Vérifier que le cron à 3h exécute bien nettoyage-rapports puis purge-logs
- [ ] Vérifier que les 4 autres jobs ne sont pas impactés