### PR TITLE
fix: corriger l'export image sur Firefox dans ExportableWidget

### DIFF
--- a/apps/pilote-ppg/src/client/components/_commons/Widget/useExportImage.ts
+++ b/apps/pilote-ppg/src/client/components/_commons/Widget/useExportImage.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { toBlob, toPng } from "html-to-image";
 import { flushSync } from "react-dom";
 import { toast } from "sonner";
@@ -7,19 +7,20 @@ const filtreExport = (node: Node) =>
   !(node instanceof Element) ||
   node.getAttribute("data-html-to-image-ignore") === null;
 
-// Firefox crashes when html-to-image accesses `.font` on non-CSSFontFaceRule rules
-const isFirefox = navigator.userAgent.includes("Firefox");
-
-const optionsExport = {
-  pixelRatio: 2,
-  backgroundColor: "#ffffff",
-  filter: filtreExport,
-  skipFonts: isFirefox,
-};
-
 export const useExportImage = (nomFichier: string) => {
   const ref = useRef<HTMLDivElement>(null);
   const [modeExport, setModeExport] = useState(false);
+
+  // Firefox crashes when html-to-image accesses `.font` on non-CSSFontFaceRule rules
+  const optionsExport = useMemo(
+    () => ({
+      pixelRatio: 2,
+      backgroundColor: "#ffffff",
+      filter: filtreExport,
+      skipFonts: navigator.userAgent.includes("Firefox"),
+    }),
+    [],
+  );
 
   const capturerImage = useCallback(
     async <T>(
@@ -56,7 +57,7 @@ export const useExportImage = (nomFichier: string) => {
     } catch {
       toast.error("Erreur lors de l'export de l'image");
     }
-  }, [capturerImage, nomFichier]);
+  }, [capturerImage, nomFichier, optionsExport]);
 
   const copierDansLePressePapiers = useCallback(async () => {
     try {
@@ -73,7 +74,7 @@ export const useExportImage = (nomFichier: string) => {
     } catch {
       toast.error("Erreur lors de la copie dans le presse-papiers");
     }
-  }, [capturerImage]);
+  }, [capturerImage, optionsExport]);
 
   return { ref, modeExport, enregistrerCommeImage, copierDansLePressePapiers };
 };

--- a/apps/pilote-ppg/src/client/components/_commons/Widget/useExportImage.ts
+++ b/apps/pilote-ppg/src/client/components/_commons/Widget/useExportImage.ts
@@ -7,10 +7,14 @@ const filtreExport = (node: Node) =>
   !(node instanceof Element) ||
   node.getAttribute("data-html-to-image-ignore") === null;
 
+// Firefox crashes when html-to-image accesses `.font` on non-CSSFontFaceRule rules
+const isFirefox = navigator.userAgent.includes("Firefox");
+
 const optionsExport = {
   pixelRatio: 2,
   backgroundColor: "#ffffff",
   filter: filtreExport,
+  skipFonts: isFirefox,
 };
 
 export const useExportImage = (nomFichier: string) => {


### PR DESCRIPTION
## Summary

- `html-to-image` itère sur toutes les règles CSS et accède à `.font` sans vérifier le type de règle — Firefox lève un `TypeError` sur les règles qui n'exposent pas cette propriété (`@namespace`, `@charset`, etc.)
- Fix : détection Firefox via `navigator.userAgent` + activation de `skipFonts: true` uniquement sur ce navigateur
- Chrome conserve le comportement existant avec les polices embarquées ; Firefox exporte avec la police de fallback système

## Test plan

- [ ] Tester le bouton "Enregistrer comme image" sur Firefox → téléchargement déclenché sans erreur
- [ ] Tester le bouton "Copier dans le presse-papiers" sur Firefox → toast de succès
- [ ] Vérifier que les deux fonctions fonctionnent toujours correctement sur Chrome/Safari

🤖 Generated with [Claude Code](https://claude.com/claude-code)