### PR TITLE
fix: stabiliser les tests E2E flaky (networkidle + timeouts Validata)

### DIFF
--- a/apps/pilote-ppg/tests/components/header.component.ts
+++ b/apps/pilote-ppg/tests/components/header.component.ts
@@ -40,7 +40,7 @@ export class HeaderComponent {
       // puis redirige. On attend que la navigation déclenchée par signOut
       // soit terminée avant de vérifier l'état des cookies — sinon notre
       // goto de fallback racerait avec la navigation en cours (ERR_ABORTED).
-      await this.page.waitForLoadState("networkidle");
+      await this.page.waitForLoadState("load");
 
       // Dans next-auth v5 beta, le cookie de session (authjs.session-token)
       // peut persister après la redirection à cause d'une race avec une

--- a/apps/pilote-ppg/tests/pages/page-mise-a-jour-donnees.ts
+++ b/apps/pilote-ppg/tests/pages/page-mise-a-jour-donnees.ts
@@ -61,13 +61,13 @@ export class PageMiseAJourDonnees extends BasePage {
   async expectFileValid(): Promise<void> {
     await expect(
       this.page.getByText(/Bravo, le fichier est conforme !/),
-    ).toBeVisible();
+    ).toBeVisible({ timeout: 30_000 });
   }
 
   async expectFileInvalid(): Promise<void> {
     await expect(
       this.page.getByText(/Le fichier ne peut pas être importé/),
-    ).toBeVisible();
+    ).toBeVisible({ timeout: 30_000 });
   }
 
   async expectImportSuccess(indicateurId: string): Promise<void> {
@@ -75,6 +75,6 @@ export class PageMiseAJourDonnees extends BasePage {
       this.page.getByText(
         `Les données ont été importées avec succès pour l'indicateur ${indicateurId}`,
       ),
-    ).toBeVisible();
+    ).toBeVisible({ timeout: 30_000 });
   }
 }


### PR DESCRIPTION
## Summary
- Remplace `waitForLoadState("networkidle")` par `"load"` dans `header.component.ts` — le `networkidle` ne se résout jamais sur la CI (probable polling next-auth session refresh), ce qui fait fail tous les tests qui appellent `switchUser`/`logout`
- Augmente les timeouts des assertions de validation d'import de 5s à 30s dans `page-mise-a-jour-donnees.ts` — le POST vers Validata (API externe) peut être lent sur la CI

## Test plan
- [x] 6/6 tests passés en local (import-donnee + proposition-valeur-avancement)
- [ ] Vérifier que la CI passe au vert