### PR TITLE
fix: forcer https sur le lien d'archive des newsletters

### DIFF
--- a/apps/pilote-ppg/src/client/components/PageActualites/PageNewsletterDetail.tsx
+++ b/apps/pilote-ppg/src/client/components/PageActualites/PageNewsletterDetail.tsx
@@ -35,7 +35,7 @@ export const PageNewsletterDetail = ({
       <iframe
         sandbox="allow-same-origin allow-popups allow-popups-to-escape-sandbox"
         className="w-full flex-1 border-0"
-        src={newsletter.lienArchive}
+        src={newsletter.lienArchive.replace(/^http:\/\//i, "https://")}
         title={newsletter.sujet}
       />
     </main>


### PR DESCRIPTION
## Summary

- Remplace `http://` par `https://` sur le `src` de l'iframe affichant l'archive newsletter
- Les URL déjà en `https` ou avec d'autres protocoles ne sont pas modifiées

## Test plan

- [ ] Vérifier qu'une newsletter avec un `lienArchive` en `http://` s'affiche correctement en `https`
- [ ] Vérifier qu'une newsletter avec un `lienArchive` déjà en `https://` n'est pas altérée

🤖 Generated with [Claude Code](https://claude.com/claude-code)