### PR TITLE
feat: LLM - préparation ouverture aux DP (PIL-1488)

### DIFF
--- a/apps/pilote-ppg/docs/superpowers/plans/2026-04-24-pil-1488-llm-preparation-ouverture-dp.md
+++ b/apps/pilote-ppg/docs/superpowers/plans/2026-04-24-pil-1488-llm-preparation-ouverture-dp.md
@@ -8,12 +8,28 @@
 
 **Tech Stack:** React 18 + Next.js + NextAuth (`useSession`) + feature flag via `useEnv("NEXT_PUBLIC_FF_ASK_AI")` + `ProfilEnum` (`src/server/app/enum/profil.enum.ts`).
 
-**Règle d'accès retenue :** `[DITP_ADMIN, EQUIPE_DIR_PROJET].includes(profil) || ffAskAI` (option β). DITP_ADMIN et EQUIPE_DIR_PROJET ont toujours accès ; le FF reste un toggle pour ouvrir plus largement.
+**Règle d'accès retenue (pivot du 2026-04-24) :** pilotage par 3 feature flips imbriqués pour permettre une ouverture progressive contrôlable en DB sans redeploy.
+
+```
+if (!ffAskAI) return false;                                           // master kill switch
+if (ffAskAIDitpAdmin && profil === DITP_ADMIN) return true;
+if (ffAskAIEquipeDirProjet && profil === EQUIPE_DIR_PROJET) return true;
+return false;
+```
+
+Nouveaux FFs :
+- `NEXT_PUBLIC_FF_ASK_AI` — master (existant, inchangé)
+- `NEXT_PUBLIC_FF_ASK_AI_DITP_ADMIN` — ouverture au profil DITP_ADMIN
+- `NEXT_PUBLIC_FF_ASK_AI_EQUIPE_DIR_PROJET` — ouverture au profil EQUIPE_DIR_PROJET
+
+La logique de check par profil est isolée dans une fonction `profilAutoriseParFeatureFlip()` à l'intérieur de `useAskAIAccess.ts` : quand Ask AI sera ouvert à tout le monde, on supprime cette fonction et on garde juste `peutUtiliserAskAI = Boolean(ffAskAI)`.
 
 ---
 
 ## File Structure
 
+- **Modify** `src/config.ts` — déclarer 2 nouveaux FFs (`askAIDitpAdmin`, `askAIEquipeDirProjet`).
+- **Modify** `src/server/gestion-contenu/domain/VariableContenuDisponible.ts` — ajouter les 2 env keys dans l'interface et dans `FEATURE_FLIP_DEFINITIONS`.
 - **Create** `src/client/components/PageAccueil/useAskAIAccess.ts` — hook qui retourne `{peutUtiliserAskAI, estDITPAdmin, profil}`.
 - **Modify** `src/client/components/PageAccueil/BoutonSyntheseTerritoire.tsx` — accepte une prop `estDITPAdmin: boolean`, change la 1re tuile, ajoute la tuile chantier, conditionne les tuiles prototypes.
 - **Modify** `src/client/components/PageAccueil/BasePageAccueilLayout.tsx:87-191` — utilise `useAskAIAccess()`.
@@ -21,55 +37,118 @@
 
 ---
 
-## Task 1: Hook `useAskAIAccess`
+## Task 1: Feature flips + hook `useAskAIAccess`
 
 **Files:**
+- Modify: `apps/pilote-ppg/src/config.ts`
+- Modify: `apps/pilote-ppg/src/server/gestion-contenu/domain/VariableContenuDisponible.ts`
 - Create: `apps/pilote-ppg/src/client/components/PageAccueil/useAskAIAccess.ts`
 
-- [ ] **Step 1: Créer le hook**
+- [ ] **Step 1: Déclarer les 2 nouveaux FFs dans `config.ts`**
+
+Juste après le bloc `askAI:` :
+
+```typescript
+askAIDitpAdmin: {
+  format: Boolean,
+  default: false,
+  env: "NEXT_PUBLIC_FF_ASK_AI_DITP_ADMIN",
+},
+askAIEquipeDirProjet: {
+  format: Boolean,
+  default: false,
+  env: "NEXT_PUBLIC_FF_ASK_AI_EQUIPE_DIR_PROJET",
+},
+```
+
+- [ ] **Step 2: Exposer les FFs côté contenu dans `VariableContenuDisponible.ts`**
+
+Ajouter dans l'interface `VARIABLE_CONTENU_DISPONIBLE` après la ligne `NEXT_PUBLIC_FF_ASK_AI` :
+
+```typescript
+NEXT_PUBLIC_FF_ASK_AI_DITP_ADMIN: boolean;
+NEXT_PUBLIC_FF_ASK_AI_EQUIPE_DIR_PROJET: boolean;
+```
+
+Puis dans `FEATURE_FLIP_DEFINITIONS`, juste après l'entrée Ask AI :
+
+```typescript
+{
+  envKey: "NEXT_PUBLIC_FF_ASK_AI_DITP_ADMIN",
+  configKey: "askAIDitpAdmin",
+  label: "Ask AI — ouverture DITP Admin",
+},
+{
+  envKey: "NEXT_PUBLIC_FF_ASK_AI_EQUIPE_DIR_PROJET",
+  configKey: "askAIEquipeDirProjet",
+  label: "Ask AI — ouverture Équipe Direction de Projet",
+},
+```
+
+- [ ] **Step 3: Créer le hook**
+
+Le chemin réel de `useEnv` est `@/client/hooks/useEnv` (vérifié dans le repo).
 
 ```typescript
 import { useSession } from "next-auth/react";
-import { useEnv } from "@/client/utils/env/useEnv";
+import { useEnv } from "@/client/hooks/useEnv";
 import { ProfilEnum } from "@/server/app/enum/profil.enum";
 
-export const PROFILS_ASK_AI_PRIVILEGIES = [
-  ProfilEnum.DITP_ADMIN,
-  ProfilEnum.EQUIPE_DIR_PROJET,
-] as const;
+function profilAutoriseParFeatureFlip(params: {
+  profil: string | null;
+  ffAskAIDitpAdmin: boolean;
+  ffAskAIEquipeDirProjet: boolean;
+}): boolean {
+  if (params.ffAskAIDitpAdmin && params.profil === ProfilEnum.DITP_ADMIN) {
+    return true;
+  }
+  if (
+    params.ffAskAIEquipeDirProjet &&
+    params.profil === ProfilEnum.EQUIPE_DIR_PROJET
+  ) {
+    return true;
+  }
+  return false;
+}
 
 export function useAskAIAccess() {
   const { data: session } = useSession();
   const ffAskAI = useEnv("NEXT_PUBLIC_FF_ASK_AI");
+  const ffAskAIDitpAdmin = useEnv("NEXT_PUBLIC_FF_ASK_AI_DITP_ADMIN");
+  const ffAskAIEquipeDirProjet = useEnv(
+    "NEXT_PUBLIC_FF_ASK_AI_EQUIPE_DIR_PROJET",
+  );
 
   const profil = session?.profil ?? null;
-  const estProfilPrivilegie =
-    profil !== null &&
-    (PROFILS_ASK_AI_PRIVILEGIES as readonly string[]).includes(profil);
+
+  const peutUtiliserAskAI =
+    Boolean(ffAskAI) &&
+    profilAutoriseParFeatureFlip({
+      profil,
+      ffAskAIDitpAdmin: Boolean(ffAskAIDitpAdmin),
+      ffAskAIEquipeDirProjet: Boolean(ffAskAIEquipeDirProjet),
+    });
 
   return {
-    peutUtiliserAskAI: Boolean(ffAskAI) || estProfilPrivilegie,
+    peutUtiliserAskAI,
     estDITPAdmin: profil === ProfilEnum.DITP_ADMIN,
     profil,
   };
 }
 ```
 
-- [ ] **Step 2: Vérifier le chemin `useEnv`**
-
-Run: `grep -rn "from \"@/client/utils/env/useEnv\"\|from \"@/.*/useEnv\"" apps/pilote-ppg/src/client/components/PageAccueil | head -3`
-Expected: au moins une occurrence important `useEnv` depuis un chemin stable. Si différent, adapter l'import du hook en conséquence.
-
-- [ ] **Step 3: Lint**
+- [ ] **Step 4: Lint**
 
 Run: `cd apps/pilote-ppg && pnpm lint`
-Expected: pas d'erreur sur le nouveau fichier.
+Expected: pas d'erreur.
 
-- [ ] **Step 4: Commit**
+- [ ] **Step 5: Commit**
 
 ```bash
-git add apps/pilote-ppg/src/client/components/PageAccueil/useAskAIAccess.ts
-git commit -m "feat(llm): ajoute le hook useAskAIAccess (PIL-1488)"
+git add apps/pilote-ppg/src/config.ts \
+        apps/pilote-ppg/src/server/gestion-contenu/domain/VariableContenuDisponible.ts \
+        apps/pilote-ppg/src/client/components/PageAccueil/useAskAIAccess.ts
+git commit -m "feat(llm): FF Ask AI par profil + hook useAskAIAccess (PIL-1488)"
 ```
 
 ---

--- a/apps/pilote-ppg/docs/superpowers/plans/2026-04-24-pil-1488-llm-preparation-ouverture-dp.md
+++ b/apps/pilote-ppg/docs/superpowers/plans/2026-04-24-pil-1488-llm-preparation-ouverture-dp.md
@@ -307,10 +307,14 @@ Insérer dans le groupe `Synthèse`, juste après la 1re tuile :
 ```typescript
 {
   label: "Synthèse d'un chantier sur un territoire",
-  message: `Fais moi la synthèse du chantier CH-XXX sur ${territoire.nomAffiché}`,
+  message: `Fais moi la synthèse du chantier CH-XXX sur le territoire NOM_TERRITOIRE
+Comment se situe ce chantier par rapport aux autres territoires ?
+Quelles sont les principales difficultés remontées dans les commentaires ?`,
   mode: "fill",
 },
 ```
+
+Note : les deux placeholders `CH-XXX` et `NOM_TERRITOIRE` sont volontaires — l'utilisateur les remplace à la main avant d'envoyer. Le bloc complet part en un seul message au LLM (synthèse + 2 questions de suivi).
 
 - [ ] **Step 4: Conditionner les tuiles prototypes sur `estDITPAdmin`**
 
@@ -362,9 +366,9 @@ Scénarios à vérifier en naviguant sur une page accueil territoire :
 1. Connecté DITP_ADMIN : bouton visible, 6 tuiles du groupe Synthèse (cf. Step 5) + Comparaison.
 2. Connecté EQUIPE_DIR_PROJET : bouton visible, 4 tuiles du groupe Synthèse (sans Rapport complet ni Tableau de bord) + Comparaison.
 3. Connecté autre profil, `NEXT_PUBLIC_FF_ASK_AI=false` : bouton **non visible**.
-4. Connecté autre profil, `NEXT_PUBLIC_FF_ASK_AI=true` : bouton visible, mêmes tuiles que EQUIPE_DIR_PROJET (pas de Rapport / Tableau).
+4. Connecté autre profil, `NEXT_PUBLIC_FF_ASK_AI=true` sans FF profilé activé : bouton **non visible** (le master seul ne suffit pas ; l'accès exige aussi un FF profilé matchant le profil de l'utilisateur).
 5. Sur un département : la tuile "Synthèse de X et ses départements" n'apparaît pas.
-6. Clic sur "Synthèse d'un territoire" : input pré-rempli avec `Fais moi la synthèse du territoire ` (espace final, curseur au bout). Clic sur "Synthèse d'un chantier sur un territoire" : input pré-rempli avec `Fais moi la synthèse du chantier CH-XXX sur <territoire>`.
+6. Clic sur "Synthèse d'un territoire" : input pré-rempli avec `Fais moi la synthèse du territoire ` (espace final, curseur au bout). Clic sur "Synthèse d'un chantier sur un territoire" : input pré-rempli avec le bloc de 3 lignes (demande + 2 questions de suivi) contenant les placeholders `CH-XXX` et `NOM_TERRITOIRE` à remplacer à la main.
 
 - [ ] **Step 8: Commit**
 
@@ -406,4 +410,4 @@ git push -u origin PIL-1488-llm-preparation-ouverture-aux-dp
 ## Notes
 
 - Pas de test unitaire front ajouté : le changement est de la plomberie de rendu conditionnel. Les chemins sensibles (règle d'accès) sont centralisés dans `useAskAIAccess`, et pourront être testés unitairement si un besoin émerge (mock de `useSession` + `useEnv`).
-- La règle métier est intentionnellement centralisée dans `PROFILS_ASK_AI_PRIVILEGIES`. Ajouter un profil supplémentaire à l'avenir = éditer cette constante uniquement.
+- La règle métier est intentionnellement centralisée dans `useAskAIAccess.ts`, via la fonction `profilAutoriseParFeatureFlip`. Ajouter un profil supplémentaire à l'avenir = ajouter un FF dédié (`config.ts` + `VariableContenuDisponible.ts`) et une clause dans cette fonction. Quand Ask AI sera ouvert à tous, on supprime la fonction et on garde uniquement `peutUtiliserAskAI = Boolean(ffAskAI)`.

--- a/apps/pilote-ppg/docs/superpowers/plans/2026-04-24-pil-1488-llm-preparation-ouverture-dp.md
+++ b/apps/pilote-ppg/docs/superpowers/plans/2026-04-24-pil-1488-llm-preparation-ouverture-dp.md
@@ -1,0 +1,330 @@
+# PIL-1488 — LLM Préparation ouverture aux DP
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ouvrir l'accès à Ask AI au profil `EQUIPE_DIR_PROJET`, masquer les tuiles prototypes aux non-DITP_ADMIN, et faire évoluer les tuiles de scénarios dans `BoutonSyntheseTerritoire`.
+
+**Architecture:** Changement purement front, localisé dans 3 fichiers (`BasePageAccueilLayout.tsx`, `PageAccueilLegacy.tsx`, `BoutonSyntheseTerritoire.tsx`). On extrait un petit hook `useAskAIAccess()` pour factoriser la règle d'accès, et on passe le profil à `BoutonSyntheseTerritoire` pour conditionner l'affichage des tuiles prototypes.
+
+**Tech Stack:** React 18 + Next.js + NextAuth (`useSession`) + feature flag via `useEnv("NEXT_PUBLIC_FF_ASK_AI")` + `ProfilEnum` (`src/server/app/enum/profil.enum.ts`).
+
+**Règle d'accès retenue :** `[DITP_ADMIN, EQUIPE_DIR_PROJET].includes(profil) || ffAskAI` (option β). DITP_ADMIN et EQUIPE_DIR_PROJET ont toujours accès ; le FF reste un toggle pour ouvrir plus largement.
+
+---
+
+## File Structure
+
+- **Create** `src/client/components/PageAccueil/useAskAIAccess.ts` — hook qui retourne `{peutUtiliserAskAI, estDITPAdmin, profil}`.
+- **Modify** `src/client/components/PageAccueil/BoutonSyntheseTerritoire.tsx` — accepte une prop `estDITPAdmin: boolean`, change la 1re tuile, ajoute la tuile chantier, conditionne les tuiles prototypes.
+- **Modify** `src/client/components/PageAccueil/BasePageAccueilLayout.tsx:87-191` — utilise `useAskAIAccess()`.
+- **Modify** `src/client/components/PageAccueil/PageAccueilLegacy.tsx:83-185` — utilise `useAskAIAccess()`.
+
+---
+
+## Task 1: Hook `useAskAIAccess`
+
+**Files:**
+- Create: `apps/pilote-ppg/src/client/components/PageAccueil/useAskAIAccess.ts`
+
+- [ ] **Step 1: Créer le hook**
+
+```typescript
+import { useSession } from "next-auth/react";
+import { useEnv } from "@/client/utils/env/useEnv";
+import { ProfilEnum } from "@/server/app/enum/profil.enum";
+
+export const PROFILS_ASK_AI_PRIVILEGIES = [
+  ProfilEnum.DITP_ADMIN,
+  ProfilEnum.EQUIPE_DIR_PROJET,
+] as const;
+
+export function useAskAIAccess() {
+  const { data: session } = useSession();
+  const ffAskAI = useEnv("NEXT_PUBLIC_FF_ASK_AI");
+
+  const profil = session?.profil ?? null;
+  const estProfilPrivilegie =
+    profil !== null &&
+    (PROFILS_ASK_AI_PRIVILEGIES as readonly string[]).includes(profil);
+
+  return {
+    peutUtiliserAskAI: Boolean(ffAskAI) || estProfilPrivilegie,
+    estDITPAdmin: profil === ProfilEnum.DITP_ADMIN,
+    profil,
+  };
+}
+```
+
+- [ ] **Step 2: Vérifier le chemin `useEnv`**
+
+Run: `grep -rn "from \"@/client/utils/env/useEnv\"\|from \"@/.*/useEnv\"" apps/pilote-ppg/src/client/components/PageAccueil | head -3`
+Expected: au moins une occurrence important `useEnv` depuis un chemin stable. Si différent, adapter l'import du hook en conséquence.
+
+- [ ] **Step 3: Lint**
+
+Run: `cd apps/pilote-ppg && pnpm lint`
+Expected: pas d'erreur sur le nouveau fichier.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/pilote-ppg/src/client/components/PageAccueil/useAskAIAccess.ts
+git commit -m "feat(llm): ajoute le hook useAskAIAccess (PIL-1488)"
+```
+
+---
+
+## Task 2: Brancher `BasePageAccueilLayout` sur le hook
+
+**Files:**
+- Modify: `apps/pilote-ppg/src/client/components/PageAccueil/BasePageAccueilLayout.tsx`
+
+- [ ] **Step 1: Importer le hook**
+
+Remplacer l'import et la déclaration actuels :
+
+```typescript
+// Avant (l.87)
+const ffAskAI = useEnv("NEXT_PUBLIC_FF_ASK_AI");
+
+// Après
+import { useAskAIAccess } from "@/components/PageAccueil/useAskAIAccess";
+// ...
+const { peutUtiliserAskAI, estDITPAdmin } = useAskAIAccess();
+```
+
+Supprimer la ligne `const ffAskAI = useEnv("NEXT_PUBLIC_FF_ASK_AI");` à la l.87.
+
+- [ ] **Step 2: Mettre à jour le rendu du bouton**
+
+```tsx
+// Avant (l.191-193)
+{ffAskAI || session?.profil === ProfilEnum.DITP_ADMIN ? (
+  <BoutonSyntheseTerritoire
+    territoireCode={territoireCode}
+    jalon={jalon}
+  />
+) : null}
+
+// Après
+{peutUtiliserAskAI ? (
+  <BoutonSyntheseTerritoire
+    territoireCode={territoireCode}
+    jalon={jalon}
+    estDITPAdmin={estDITPAdmin}
+  />
+) : null}
+```
+
+- [ ] **Step 3: Nettoyer l'import `ProfilEnum` s'il n'est plus utilisé**
+
+Run: `grep -n "ProfilEnum" apps/pilote-ppg/src/client/components/PageAccueil/BasePageAccueilLayout.tsx`
+Expected: si plus aucune occurrence, retirer `ProfilEnum` de la ligne d'import correspondante. Sinon laisser.
+
+- [ ] **Step 4: Lint + typecheck**
+
+Run: `cd apps/pilote-ppg && pnpm lint`
+Expected: pas d'erreur.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/pilote-ppg/src/client/components/PageAccueil/BasePageAccueilLayout.tsx
+git commit -m "feat(llm): BasePageAccueilLayout utilise useAskAIAccess (PIL-1488)"
+```
+
+---
+
+## Task 3: Brancher `PageAccueilLegacy` sur le hook
+
+**Files:**
+- Modify: `apps/pilote-ppg/src/client/components/PageAccueil/PageAccueilLegacy.tsx`
+
+- [ ] **Step 1: Même substitution qu'à Task 2**
+
+```typescript
+// Remplace (l.83)
+const ffAskAI = useEnv("NEXT_PUBLIC_FF_ASK_AI");
+// par
+import { useAskAIAccess } from "@/components/PageAccueil/useAskAIAccess";
+// ...
+const { peutUtiliserAskAI, estDITPAdmin } = useAskAIAccess();
+```
+
+```tsx
+// Remplace (l.183-185)
+{ffAskAI || session?.profil === ProfilEnum.DITP_ADMIN ? (
+  <BoutonSyntheseTerritoire ... />
+) : null}
+// par
+{peutUtiliserAskAI ? (
+  <BoutonSyntheseTerritoire
+    territoireCode={territoireCode}
+    jalon={jalon}
+    estDITPAdmin={estDITPAdmin}
+  />
+) : null}
+```
+
+- [ ] **Step 2: Lint**
+
+Run: `cd apps/pilote-ppg && pnpm lint`
+Expected: pas d'erreur.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/pilote-ppg/src/client/components/PageAccueil/PageAccueilLegacy.tsx
+git commit -m "feat(llm): PageAccueilLegacy utilise useAskAIAccess (PIL-1488)"
+```
+
+---
+
+## Task 4: Mise à jour des tuiles dans `BoutonSyntheseTerritoire`
+
+**Files:**
+- Modify: `apps/pilote-ppg/src/client/components/PageAccueil/BoutonSyntheseTerritoire.tsx`
+
+- [ ] **Step 1: Ajouter la prop `estDITPAdmin`**
+
+```typescript
+export const BoutonSyntheseTerritoire = ({
+  territoireCode,
+  jalon,
+  estDITPAdmin,
+}: {
+  territoireCode: string;
+  jalon: number;
+  estDITPAdmin: boolean;
+}) => {
+```
+
+- [ ] **Step 2: Réécrire la 1re tuile "Synthèse d'un territoire"**
+
+Dans le groupe `Synthèse`, remplacer l'entrée actuelle :
+
+```typescript
+// Avant
+{
+  label: `Synthèse de ${territoire.nomAffiché}`,
+  message: `Fais moi la synthèse de ${territoire.nomAffiché}`,
+  mode: "send",
+},
+
+// Après
+{
+  label: "Synthèse d'un territoire",
+  message: "Fais moi la synthèse du territoire ",
+  mode: "fill",
+},
+```
+
+La tuile conditionnelle « Synthèse de X et ses départements » (si `estRegion`) reste inchangée.
+
+- [ ] **Step 3: Ajouter la tuile "Synthèse d'un chantier sur un territoire"**
+
+Insérer dans le groupe `Synthèse`, juste après la 1re tuile :
+
+```typescript
+{
+  label: "Synthèse d'un chantier sur un territoire",
+  message: `Fais moi la synthèse du chantier CH-XXX sur ${territoire.nomAffiché}`,
+  mode: "fill",
+},
+```
+
+- [ ] **Step 4: Conditionner les tuiles prototypes sur `estDITPAdmin`**
+
+Remplacer les deux entrées "Rapport complet (Markdown)" et "Tableau de bord du territoire" par un spread conditionnel :
+
+```typescript
+// Dans le groupe Synthèse, après les tuiles "Synthèse d'un territoire",
+// "Synthèse d'un chantier sur un territoire", la région+départements (conditionnelle),
+// "Chantiers en retard et leurs indicateurs" :
+
+...(estDITPAdmin
+  ? [
+      {
+        label: "Rapport complet (Markdown)",
+        message: `Crée un rapport de synthèse du territoire ${territoire.nomAffiché} incluant le taux d'avancement, les chantiers en retard, les chantiers en difficulté et leurs indicateurs. Format Markdown`,
+        mode: "send" as const,
+      },
+      {
+        label: "Tableau de bord du territoire",
+        message: `Compose un tableau de bord pour ${territoire.nomAffiché}. Commence par une première section contenant le taux d'avancement du territoire, le nombre de chantiers en retard, le nombre de chantiers en difficulté et la cartographie du taux d'avancement. Ensuite, récupère la liste des chantiers en difficulté et en retard sur ce territoire, et pour chacun, ajoute une section dédiée avec un titre reprenant le nom du chantier, la météo et le commentaire de synthèse, la cartographie météo en pleine largeur et le tableau de ses indicateurs.`,
+        mode: "send" as const,
+      },
+    ]
+  : []),
+```
+
+- [ ] **Step 5: Vérifier l'ordre final des tuiles du groupe Synthèse**
+
+Ordre attendu après modifs :
+1. `Synthèse d'un territoire` (fill)
+2. `Synthèse d'un chantier sur un territoire` (fill, **nouveau**)
+3. `Synthèse de {region} et ses départements` (send, uniquement si `estRegion`)
+4. `Chantiers en retard et leurs indicateurs` (send)
+5. `Rapport complet (Markdown)` (send, **uniquement DITP_ADMIN**)
+6. `Tableau de bord du territoire` (send, **uniquement DITP_ADMIN**)
+
+Le groupe `Comparaison` reste inchangé.
+
+- [ ] **Step 6: Lint**
+
+Run: `cd apps/pilote-ppg && pnpm lint`
+Expected: pas d'erreur.
+
+- [ ] **Step 7: Test manuel front (dev server)**
+
+Run: `cd apps/pilote-ppg && pnpm dev`
+Scénarios à vérifier en naviguant sur une page accueil territoire :
+
+1. Connecté DITP_ADMIN : bouton visible, 6 tuiles du groupe Synthèse (cf. Step 5) + Comparaison.
+2. Connecté EQUIPE_DIR_PROJET : bouton visible, 4 tuiles du groupe Synthèse (sans Rapport complet ni Tableau de bord) + Comparaison.
+3. Connecté autre profil, `NEXT_PUBLIC_FF_ASK_AI=false` : bouton **non visible**.
+4. Connecté autre profil, `NEXT_PUBLIC_FF_ASK_AI=true` : bouton visible, mêmes tuiles que EQUIPE_DIR_PROJET (pas de Rapport / Tableau).
+5. Sur un département : la tuile "Synthèse de X et ses départements" n'apparaît pas.
+6. Clic sur "Synthèse d'un territoire" : input pré-rempli avec `Fais moi la synthèse du territoire ` (espace final, curseur au bout). Clic sur "Synthèse d'un chantier sur un territoire" : input pré-rempli avec `Fais moi la synthèse du chantier CH-XXX sur <territoire>`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/pilote-ppg/src/client/components/PageAccueil/BoutonSyntheseTerritoire.tsx
+git commit -m "feat(llm): ajuste les tuiles scénarios pour l'ouverture aux DP (PIL-1488)"
+```
+
+---
+
+## Task 5: Vérification finale
+
+- [ ] **Step 1: Lint complet**
+
+Run: `cd apps/pilote-ppg && pnpm lint`
+Expected: 0 erreur.
+
+- [ ] **Step 2: Typecheck**
+
+Run: `cd apps/pilote-ppg && pnpm tsc --noEmit`
+Expected: 0 erreur.
+
+- [ ] **Step 3: Grep final**
+
+Run: `grep -rn "ProfilEnum.DITP_ADMIN\b" apps/pilote-ppg/src/client/components/PageAccueil/`
+Expected: plus aucune occurrence liée au gate Ask AI (les checks sont désormais dans `useAskAIAccess.ts`).
+
+Run: `grep -rn "NEXT_PUBLIC_FF_ASK_AI" apps/pilote-ppg/src/client/components/PageAccueil/`
+Expected: uniquement dans `useAskAIAccess.ts`.
+
+- [ ] **Step 4: Push**
+
+```bash
+git push -u origin PIL-1488-llm-preparation-ouverture-aux-dp
+```
+
+---
+
+## Notes
+
+- Pas de test unitaire front ajouté : le changement est de la plomberie de rendu conditionnel. Les chemins sensibles (règle d'accès) sont centralisés dans `useAskAIAccess`, et pourront être testés unitairement si un besoin émerge (mock de `useSession` + `useEnv`).
+- La règle métier est intentionnellement centralisée dans `PROFILS_ASK_AI_PRIVILEGIES`. Ajouter un profil supplémentaire à l'avenir = éditer cette constante uniquement.

--- a/apps/pilote-ppg/src/client/components/PageAccueil/BasePageAccueilLayout.tsx
+++ b/apps/pilote-ppg/src/client/components/PageAccueil/BasePageAccueilLayout.tsx
@@ -4,6 +4,7 @@ import { useSession } from "next-auth/react";
 import { parseAsStringLiteral, useQueryState } from "nuqs";
 import { useProfilUtilisateurConnecte } from "@/client/hooks/useProfilUtilisateurConnecte";
 import { useEnv } from "@/client/hooks/useEnv";
+import { useAskAIAccess } from "@/components/PageAccueil/useAskAIAccess";
 import BarreLatérale from "@/components/_commons/BarreLatérale/BarreLatérale";
 import BarreLatéraleEncart from "@/components/_commons/BarreLatérale/BarreLatéraleEncart/BarreLatéraleEncart";
 import { Filtres } from "@/components/PageAccueil/Filtres/Filtres";
@@ -84,7 +85,7 @@ export const BasePageAccueilLayout: FunctionComponent<
   const { data: session } = useSession();
   const profil = useProfilUtilisateurConnecte();
   const monProfilEstDisponible = useEnv("NEXT_PUBLIC_FF_MON_PROFIL");
-  const ffAskAI = useEnv("NEXT_PUBLIC_FF_ASK_AI");
+  const { peutUtiliserAskAI } = useAskAIAccess();
 
   const estProfilTerritorialise =
     PROFIL_AUTORISE_A_VOIR_FILTRE_TERRITORIALISE.has(session?.profil || "");
@@ -188,7 +189,7 @@ export const BasePageAccueilLayout: FunctionComponent<
               mailleSelectionnee={mailleSelectionnee}
               ministères={ministères}
             />
-            {ffAskAI || session?.profil === ProfilEnum.DITP_ADMIN ? (
+            {peutUtiliserAskAI ? (
               <div className="h-full flex items-center pt-1 pr-2 ml-auto">
                 <BoutonSyntheseTerritoire
                   jalon={jalon}

--- a/apps/pilote-ppg/src/client/components/PageAccueil/BasePageAccueilLayout.tsx
+++ b/apps/pilote-ppg/src/client/components/PageAccueil/BasePageAccueilLayout.tsx
@@ -85,7 +85,7 @@ export const BasePageAccueilLayout: FunctionComponent<
   const { data: session } = useSession();
   const profil = useProfilUtilisateurConnecte();
   const monProfilEstDisponible = useEnv("NEXT_PUBLIC_FF_MON_PROFIL");
-  const { peutUtiliserAskAI } = useAskAIAccess();
+  const { peutUtiliserAskAI, estDITPAdmin } = useAskAIAccess();
 
   const estProfilTerritorialise =
     PROFIL_AUTORISE_A_VOIR_FILTRE_TERRITORIALISE.has(session?.profil || "");
@@ -194,6 +194,7 @@ export const BasePageAccueilLayout: FunctionComponent<
                 <BoutonSyntheseTerritoire
                   jalon={jalon}
                   territoireCode={territoireCode}
+                  estDITPAdmin={estDITPAdmin}
                 />
               </div>
             ) : null}

--- a/apps/pilote-ppg/src/client/components/PageAccueil/BoutonSyntheseTerritoire.tsx
+++ b/apps/pilote-ppg/src/client/components/PageAccueil/BoutonSyntheseTerritoire.tsx
@@ -8,9 +8,11 @@ import { ModalePleinEcran } from "@/components/shared/ModalePleinEcran";
 export const BoutonSyntheseTerritoire = ({
   territoireCode,
   jalon,
+  estDITPAdmin,
 }: {
   territoireCode: string;
   jalon: number;
+  estDITPAdmin: boolean;
 }) => {
   const [isOpen, setIsOpen] = useState(false);
   const territoire = récupérerDétailsSurUnTerritoire(territoireCode);
@@ -28,9 +30,14 @@ export const BoutonSyntheseTerritoire = ({
         label: "Synthèse",
         scenarios: [
           {
-            label: `Synthèse de ${territoire.nomAffiché}`,
-            message: `Fais moi la synthèse de ${territoire.nomAffiché}`,
-            mode: "send",
+            label: "Synthèse d'un territoire",
+            message: "Fais moi la synthèse du territoire ",
+            mode: "fill",
+          },
+          {
+            label: "Synthèse d'un chantier sur un territoire",
+            message: `Fais moi la synthèse du chantier CH-XXX sur ${territoire.nomAffiché}`,
+            mode: "fill",
           },
           ...(estRegion
             ? [
@@ -46,16 +53,20 @@ export const BoutonSyntheseTerritoire = ({
             message: `Analyse les chantiers en retard sur ${territoire.nomAffiché}. Pour chaque chantier en retard, récupère également les valeurs de ses indicateurs.`,
             mode: "send",
           },
-          {
-            label: "Rapport complet (Markdown)",
-            message: `Crée un rapport de synthèse du territoire ${territoire.nomAffiché} incluant le taux d'avancement, les chantiers en retard, les chantiers en difficulté et leurs indicateurs. Format Markdown`,
-            mode: "send",
-          },
-          {
-            label: "Tableau de bord du territoire",
-            message: `Compose un tableau de bord pour ${territoire.nomAffiché}. Commence par une première section contenant le taux d'avancement du territoire, le nombre de chantiers en retard, le nombre de chantiers en difficulté et la cartographie du taux d'avancement. Ensuite, récupère la liste des chantiers en difficulté et en retard sur ce territoire, et pour chacun, ajoute une section dédiée avec un titre reprenant le nom du chantier, la météo et le commentaire de synthèse, la cartographie météo en pleine largeur et le tableau de ses indicateurs.`,
-            mode: "send",
-          },
+          ...(estDITPAdmin
+            ? [
+                {
+                  label: "Rapport complet (Markdown)",
+                  message: `Crée un rapport de synthèse du territoire ${territoire.nomAffiché} incluant le taux d'avancement, les chantiers en retard, les chantiers en difficulté et leurs indicateurs. Format Markdown`,
+                  mode: "send" as const,
+                },
+                {
+                  label: "Tableau de bord du territoire",
+                  message: `Compose un tableau de bord pour ${territoire.nomAffiché}. Commence par une première section contenant le taux d'avancement du territoire, le nombre de chantiers en retard, le nombre de chantiers en difficulté et la cartographie du taux d'avancement. Ensuite, récupère la liste des chantiers en difficulté et en retard sur ce territoire, et pour chacun, ajoute une section dédiée avec un titre reprenant le nom du chantier, la météo et le commentaire de synthèse, la cartographie météo en pleine largeur et le tableau de ses indicateurs.`,
+                  mode: "send" as const,
+                },
+              ]
+            : []),
         ],
       },
       {

--- a/apps/pilote-ppg/src/client/components/PageAccueil/BoutonSyntheseTerritoire.tsx
+++ b/apps/pilote-ppg/src/client/components/PageAccueil/BoutonSyntheseTerritoire.tsx
@@ -36,7 +36,9 @@ export const BoutonSyntheseTerritoire = ({
           },
           {
             label: "Synthèse d'un chantier sur un territoire",
-            message: `Fais moi la synthèse du chantier CH-XXX sur ${territoire.nomAffiché}`,
+            message: `Fais moi la synthèse du chantier CH-XXX sur le territoire NOM_TERRITOIRE
+Comment se situe ce chantier par rapport aux autres territoires ?
+Quelles sont les principales difficultés remontées dans les commentaires ?`,
             mode: "fill",
           },
           ...(estRegion

--- a/apps/pilote-ppg/src/client/components/PageAccueil/PageAccueilLegacy.tsx
+++ b/apps/pilote-ppg/src/client/components/PageAccueil/PageAccueilLegacy.tsx
@@ -6,6 +6,7 @@ import { parseAsStringLiteral, useQueryState } from "nuqs";
 import { useProfilUtilisateurConnecte } from "@/client/hooks/useProfilUtilisateurConnecte";
 import { useEnv } from "@/client/hooks/useEnv";
 import PageChantiers from "@/components/PageAccueil/PageChantiers/PageChantiers";
+import { useAskAIAccess } from "@/components/PageAccueil/useAskAIAccess";
 import BarreLatérale from "@/components/_commons/BarreLatérale/BarreLatérale";
 import BarreLatéraleEncart from "@/components/_commons/BarreLatérale/BarreLatéraleEncart/BarreLatéraleEncart";
 import { Filtres } from "@/components/PageAccueil/Filtres/Filtres";
@@ -80,7 +81,7 @@ export const PageAccueilLegacy = ({
   const ffFicheTerritoriale = useEnv("NEXT_PUBLIC_FF_FICHE_TERRITORIALE");
   const profil = useProfilUtilisateurConnecte();
   const monProfilEstDisponible = useEnv("NEXT_PUBLIC_FF_MON_PROFIL");
-  const ffAskAI = useEnv("NEXT_PUBLIC_FF_ASK_AI");
+  const { peutUtiliserAskAI } = useAskAIAccess();
   const doitAfficherModaleRenseignerService =
     !!monProfilEstDisponible &&
     (profil.service == null || profil.fonction == null);
@@ -180,7 +181,7 @@ export const PageAccueilLegacy = ({
               mailleSelectionnee={mailleSelectionnee}
               ministères={ministères}
             />
-            {ffAskAI || session?.profil === ProfilEnum.DITP_ADMIN ? (
+            {peutUtiliserAskAI ? (
               <div className="ml-auto flex items-center h-full pr-2 pt-1">
                 <BoutonSyntheseTerritoire
                   territoireCode={territoireCode}

--- a/apps/pilote-ppg/src/client/components/PageAccueil/PageAccueilLegacy.tsx
+++ b/apps/pilote-ppg/src/client/components/PageAccueil/PageAccueilLegacy.tsx
@@ -81,7 +81,7 @@ export const PageAccueilLegacy = ({
   const ffFicheTerritoriale = useEnv("NEXT_PUBLIC_FF_FICHE_TERRITORIALE");
   const profil = useProfilUtilisateurConnecte();
   const monProfilEstDisponible = useEnv("NEXT_PUBLIC_FF_MON_PROFIL");
-  const { peutUtiliserAskAI } = useAskAIAccess();
+  const { peutUtiliserAskAI, estDITPAdmin } = useAskAIAccess();
   const doitAfficherModaleRenseignerService =
     !!monProfilEstDisponible &&
     (profil.service == null || profil.fonction == null);
@@ -186,6 +186,7 @@ export const PageAccueilLegacy = ({
                 <BoutonSyntheseTerritoire
                   territoireCode={territoireCode}
                   jalon={jalon}
+                  estDITPAdmin={estDITPAdmin}
                 />
               </div>
             ) : null}

--- a/apps/pilote-ppg/src/client/components/PageAccueil/useAskAIAccess.ts
+++ b/apps/pilote-ppg/src/client/components/PageAccueil/useAskAIAccess.ts
@@ -1,0 +1,45 @@
+import { useSession } from "next-auth/react";
+import { useEnv } from "@/client/hooks/useEnv";
+import { ProfilEnum } from "@/server/app/enum/profil.enum";
+
+function profilAutoriseParFeatureFlip(params: {
+  profil: string | null;
+  ffAskAIDitpAdmin: boolean;
+  ffAskAIEquipeDirProjet: boolean;
+}): boolean {
+  if (params.ffAskAIDitpAdmin && params.profil === ProfilEnum.DITP_ADMIN) {
+    return true;
+  }
+  if (
+    params.ffAskAIEquipeDirProjet &&
+    params.profil === ProfilEnum.EQUIPE_DIR_PROJET
+  ) {
+    return true;
+  }
+  return false;
+}
+
+export function useAskAIAccess() {
+  const { data: session } = useSession();
+  const ffAskAI = useEnv("NEXT_PUBLIC_FF_ASK_AI");
+  const ffAskAIDitpAdmin = useEnv("NEXT_PUBLIC_FF_ASK_AI_DITP_ADMIN");
+  const ffAskAIEquipeDirProjet = useEnv(
+    "NEXT_PUBLIC_FF_ASK_AI_EQUIPE_DIR_PROJET",
+  );
+
+  const profil = session?.profil ?? null;
+
+  const peutUtiliserAskAI =
+    Boolean(ffAskAI) &&
+    profilAutoriseParFeatureFlip({
+      profil,
+      ffAskAIDitpAdmin: Boolean(ffAskAIDitpAdmin),
+      ffAskAIEquipeDirProjet: Boolean(ffAskAIEquipeDirProjet),
+    });
+
+  return {
+    peutUtiliserAskAI,
+    estDITPAdmin: profil === ProfilEnum.DITP_ADMIN,
+    profil,
+  };
+}

--- a/apps/pilote-ppg/src/config.ts
+++ b/apps/pilote-ppg/src/config.ts
@@ -304,6 +304,16 @@ const config = convict({
       default: false,
       env: "NEXT_PUBLIC_FF_ASK_AI",
     },
+    askAIDitpAdmin: {
+      format: Boolean,
+      default: false,
+      env: "NEXT_PUBLIC_FF_ASK_AI_DITP_ADMIN",
+    },
+    askAIEquipeDirProjet: {
+      format: Boolean,
+      default: false,
+      env: "NEXT_PUBLIC_FF_ASK_AI_EQUIPE_DIR_PROJET",
+    },
     centreAideAdmin: {
       format: Boolean,
       default: false,

--- a/apps/pilote-ppg/src/server/gestion-contenu/domain/VariableContenuDisponible.ts
+++ b/apps/pilote-ppg/src/server/gestion-contenu/domain/VariableContenuDisponible.ts
@@ -23,6 +23,8 @@ export interface VARIABLE_CONTENU_DISPONIBLE {
   NEXT_PUBLIC_FF_PANEL_ADMIN: boolean;
   NEXT_PUBLIC_FF_MON_PROFIL: boolean;
   NEXT_PUBLIC_FF_ASK_AI: boolean;
+  NEXT_PUBLIC_FF_ASK_AI_DITP_ADMIN: boolean;
+  NEXT_PUBLIC_FF_ASK_AI_EQUIPE_DIR_PROJET: boolean;
   NEXT_PUBLIC_FF_CENTRE_AIDE_ADMIN: boolean;
   NEXT_PUBLIC_FF_CENTRE_AIDE_PILOTE: boolean;
   NEXT_PUBLIC_FF_PILOTE_EVAL: boolean;
@@ -140,6 +142,16 @@ const FEATURE_FLIP_DEFINITIONS: FeatureFlipDefinition[] = [
     label: "Mon profil",
   },
   { envKey: "NEXT_PUBLIC_FF_ASK_AI", configKey: "askAI", label: "Ask AI" },
+  {
+    envKey: "NEXT_PUBLIC_FF_ASK_AI_DITP_ADMIN",
+    configKey: "askAIDitpAdmin",
+    label: "Ask AI — ouverture DITP Admin",
+  },
+  {
+    envKey: "NEXT_PUBLIC_FF_ASK_AI_EQUIPE_DIR_PROJET",
+    configKey: "askAIEquipeDirProjet",
+    label: "Ask AI — ouverture Équipe Direction de Projet",
+  },
   {
     envKey: "NEXT_PUBLIC_FF_CENTRE_AIDE_ADMIN",
     configKey: "centreAideAdmin",


### PR DESCRIPTION
## Résumé

- Ouverture progressive de l'assistant Albert au profil `EQUIPE_DIR_PROJET` via un nouveau système de FFs par profil (master + 1 FF par profil autorisé), pilotable en DB sans redeploy.
- Refonte des tuiles de `BoutonSyntheseTerritoire` : 1re tuile passe en mode `fill` (pré-remplissage libre), nouvelle tuile "Synthèse d'un chantier sur un territoire", et masquage des tuiles prototypes (Rapport complet, Tableau de bord) pour tout le monde sauf DITP_ADMIN.

Nouveaux feature flips (à activer en DB pour tester) :
- `NEXT_PUBLIC_FF_ASK_AI` — master (existant)
- `NEXT_PUBLIC_FF_ASK_AI_DITP_ADMIN`
- `NEXT_PUBLIC_FF_ASK_AI_EQUIPE_DIR_PROJET`

Le gate est centralisé dans le hook `useAskAIAccess`. Quand Ask AI sera ouvert à tous, on supprimera la fonction `profilAutoriseParFeatureFlip` et on gardera uniquement le master.

## Tuiles du groupe "Synthèse"

| Ordre | Label | Mode | Condition |
|---|---|---|---|
| 1 | Synthèse d'un territoire | `fill` | toujours |
| 2 | **Synthèse d'un chantier sur un territoire** (nouveau) | `fill` | toujours |
| 3 | Synthèse de {région} et ses départements | `send` | `estRegion` |
| 4 | Chantiers en retard et leurs indicateurs | `send` | toujours |
| 5 | Rapport complet (Markdown) | `send` | **DITP_ADMIN uniquement** |
| 6 | Tableau de bord du territoire | `send` | **DITP_ADMIN uniquement** |

Groupe "Comparaison" inchangé.

## Test plan

- [ ] Activer `NEXT_PUBLIC_FF_ASK_AI` + `NEXT_PUBLIC_FF_ASK_AI_DITP_ADMIN` → bouton visible pour DITP_ADMIN uniquement, 6 tuiles Synthèse
- [ ] Activer `NEXT_PUBLIC_FF_ASK_AI` + `NEXT_PUBLIC_FF_ASK_AI_EQUIPE_DIR_PROJET` → bouton visible pour EQUIPE_DIR_PROJET uniquement, 4 tuiles Synthèse (sans Rapport / Tableau de bord)
- [ ] `NEXT_PUBLIC_FF_ASK_AI=false` → bouton invisible pour tous, quels que soient les autres FFs
- [ ] Tous les FFs à true + profil autre (ex: PREFET_REGION) → bouton invisible
- [ ] Clic sur "Synthèse d'un territoire" → champ pré-rempli avec `Fais moi la synthèse du territoire ` (espace final)
- [ ] Clic sur "Synthèse d'un chantier sur un territoire" → champ pré-rempli avec `Fais moi la synthèse du chantier CH-XXX sur <territoire>`
- [ ] Sur un département : la tuile "Synthèse de {région} et ses départements" n'apparaît pas