### PR TITLE
feat: fil d'Ariane sur la page détail newsletter (PIL-1160)

### DIFF
--- a/apps/pilote-ppg/src/client/components/PageActualites/PageNewsletterDetail.tsx
+++ b/apps/pilote-ppg/src/client/components/PageActualites/PageNewsletterDetail.tsx
@@ -1,6 +1,6 @@
-import Link from "next/link";
 import { Newsletter } from "@/server/actualites/domain/Newsletter";
 import { PiloteDateFormatter } from "@/utils/PiloteDateFormatter";
+import FilAriane from "@/components/_commons/FilAriane/FilAriane";
 
 type PageNewsletterDetailProps = {
   newsletter: Newsletter;
@@ -11,14 +11,12 @@ export const PageNewsletterDetail = ({
 }: PageNewsletterDetailProps) => {
   return (
     <main className="flex flex-col" style={{ height: "calc(100vh - 56px)" }}>
-      <div className="border-b border-gray-200 bg-white px-8 py-5">
+      <div className="border-b border-gray-200 bg-white px-8 pb-5 pt-2">
         <div className="mx-auto max-w-6xl">
-          <Link
-            className="inline-flex items-center gap-1 text-xs font-medium text-blue-700 hover:underline"
-            href="/actualites"
-          >
-            ← Actualités
-          </Link>
+          <FilAriane
+            chemin={[{ nom: "Actualités", lien: "/actualites" }]}
+            libelléPageCourante={newsletter.sujet}
+          />
           <div className="mt-4 border-l-4 border-l-blue-700 pl-4">
             <p className="mb-1 text-sm text-gray-400">
               Publié le{" "}
@@ -26,7 +24,7 @@ export const PageNewsletterDetail = ({
                 new Date(newsletter.dateEnvoi),
               )}
             </p>
-            <h1 className="text-xl font-bold leading-snug text-blue-900">
+            <h1 className="text-xl font-bold leading-snug text-blue-900 mb-0">
               {newsletter.sujet}
             </h1>
           </div>

--- a/apps/pilote-ppg/src/client/components/_commons/MiseEnPage/Navigation/NavigationPilote.tsx
+++ b/apps/pilote-ppg/src/client/components/_commons/MiseEnPage/Navigation/NavigationPilote.tsx
@@ -113,14 +113,6 @@ export const NavigationPilote = () => {
           target: "_self",
         },
         {
-          nom: "Actualités",
-          lien: "/actualites",
-          matcher: "/actualites",
-          accessible: ffPageActualites,
-          prefetch: false,
-          target: "_self",
-        },
-        {
           nom: "Centre d'aide",
           lien: "/centre-aide-pilote-2/centre-aide",
           matcher: "/centre-aide-pilote-2/centre-aide",
@@ -145,6 +137,14 @@ export const NavigationPilote = () => {
             estAdministrateurOuPilotage(session!),
           prefetch: false,
           target: "_blank",
+        },
+        {
+          nom: "Actualités",
+          lien: "/actualites",
+          matcher: "/actualites",
+          accessible: ffPageActualites,
+          prefetch: false,
+          target: "_self",
         },
       ]}
     />


### PR DESCRIPTION
## Summary

- Remplace le bouton « ← Actualités » par le composant `FilAriane` sur `PageNewsletterDetail`
- Le fil d'Ariane affiche : **Accueil > Actualités > {sujet de la newsletter}**
- Déplace l'entrée « Actualités » en fin de menu dans `NavigationPilote`

## Test plan

- [ ] Ouvrir une newsletter depuis `/actualites`
- [ ] Vérifier que le fil d'Ariane affiche bien `Accueil > Actualités > {titre}`
- [ ] Vérifier que le lien « Actualités » dans le fil d'Ariane redirige vers `/actualites`
- [ ] Vérifier que le menu de navigation affiche toujours « Actualités »

🤖 Generated with [Claude Code](https://claude.com/claude-code)