### PR TITLE
fix: simplifier scripts daily jordan et corriger chemin data-management

### DIFF
--- a/apps/pilote-ppg/scripts/daily/jordan.sh
+++ b/apps/pilote-ppg/scripts/daily/jordan.sh
@@ -4,20 +4,10 @@
 #   - run a dbt command (for example)
 #   - exec descente de prod
 #   - run PROD datajobs
-# 
-# Warn: only with docker commands
-# You can dupplicate this file and modify it to fit your local env (example: use docker only for data operations)
 
 
 echo ">> Reset db"
 pnpm database:init
 
 bash scripts/ddp_dump.sh
-bash scripts/ddp_restore.sh
-bash scripts/anonymisation_utilisateurs.sh
-# ou ddp via docker avec: "docker compose run --rm ddp bash docker/entrypoint.ddp.sh"
-#   pré-requis: mettre des clés ssh dans pilote-2/docker (voir pilote-2/docker/.gitignore) 
-#       pour que le tunnel vers la db soit fait dans le container (Colin)
-echo ">> Run dj prod"
-cd data_management
-FULL_DJ=false docker compose run --rm -e FULL_DJ pilote_datajobs
+bash scripts/daily/jordan_only_restore.sh

--- a/apps/pilote-ppg/scripts/daily/jordan_only_restore.sh
+++ b/apps/pilote-ppg/scripts/daily/jordan_only_restore.sh
@@ -1,9 +1,5 @@
-
 bash scripts/ddp_restore.sh
 bash scripts/anonymisation_utilisateurs.sh
-# ou ddp via docker avec: "docker compose run --rm ddp bash docker/entrypoint.ddp.sh"
-#   pré-requis: mettre des clés ssh dans pilote-2/docker (voir pilote-2/docker/.gitignore) 
-#       pour que le tunnel vers la db soit fait dans le container (Colin)
 echo ">> Run dj prod"
-cd data_management
+cd ../pilote-ppg-data-management
 FULL_DJ=false docker compose run --rm -e FULL_DJ pilote_datajobs


### PR DESCRIPTION
## Summary
- Simplifie `scripts/daily/jordan.sh` en déléguant la restauration à `jordan_only_restore.sh`
- Corrige le chemin vers `pilote-ppg-data-management` dans `jordan_only_restore.sh`
- Nettoie les commentaires obsolètes

## Test plan
- [ ] Lancer `bash scripts/daily/jordan.sh` en local et vérifier le déroulement complet