### PR TITLE
feature: setup portless pour servir l'app en HTTPS local

### DIFF
--- a/apps/pilote-ppg/package.json
+++ b/apps/pilote-ppg/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@pilote/ppg",
+  "portless": "pilote-ppg",
   "version": "0.1.0",
   "private": true,
   "packageManager": "pnpm@10.28.2",
@@ -7,7 +8,7 @@
     "node": "24.9.0"
   },
   "scripts": {
-    "dev": "next dev | pino-pretty",
+    "dev": "portless run next dev | pino-pretty",
     "build": "prisma generate && bash scripts/clone_centre_aide.sh && next build && pnpm exec pagefind --site .next/server/app --output-path public/_pagefind && node copy-assets.js && prisma migrate deploy && prisma db seed",
     "build:dev": "prisma generate && next build && pnpm exec pagefind --site .next/server/app --output-path public/_pagefind && node copy-assets.js && prisma migrate deploy && prisma db seed",
     "start": "node --max-old-space-size=${MAX_OLD_SPACE_SIZE:-768} .next/standalone/apps/pilote-ppg/server.js",
@@ -197,6 +198,7 @@
     "pagefind": "^1.5.2",
     "pino-pretty": "^10.0.0",
     "playwright-core": "1.59.1",
+    "portless": "^0.11.1",
     "prettier": "^3.6.2",
     "prisma": "6.2.1",
     "proj4": "^2.9.0",

--- a/apps/pilote-ppg/src/proxy.ts
+++ b/apps/pilote-ppg/src/proxy.ts
@@ -120,7 +120,7 @@ export async function proxy(request: NextRequest) {
     const token = await getToken({
       req: request,
       secret: process.env.NEXTAUTH_SECRET,
-      secureCookie: !isDev,
+      secureCookie: true,
     });
 
     if (!token) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -422,6 +422,9 @@ importers:
       playwright-core:
         specifier: 1.59.1
         version: 1.59.1
+      portless:
+        specifier: ^0.11.1
+        version: 0.11.1
       prettier:
         specifier: ^3.6.2
         version: 3.8.3
@@ -6374,6 +6377,12 @@ packages:
 
   points-on-path@0.2.1:
     resolution: {integrity: sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==}
+
+  portless@0.11.1:
+    resolution: {integrity: sha512-A/U6sBo/aC+MDoLjVTzAUeB18KTzJQs7z+MnuyyCjJTOZoCh9xZzOjSqUPA+aWS0uS3UytWPrNLA5AO96TzuKQ==}
+    engines: {node: '>=20'}
+    os: [darwin, linux, win32]
+    hasBin: true
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -14843,6 +14852,8 @@ snapshots:
     dependencies:
       path-data-parser: 0.1.0
       points-on-curve: 0.2.0
+
+  portless@0.11.1: {}
 
   possible-typed-array-names@1.1.0: {}
 


### PR DESCRIPTION
## Summary
- Ajout de `portless` (devDep) et wrap du script `dev` : `portless run next dev`. L'app est servie sur `https://pilote-ppg.localhost` au lieu de `http://localhost:3000`.
- Champ `portless: "pilote-ppg"` dans `package.json` pour fixer le hostname.
- Fix du middleware `proxy.ts` : `secureCookie: true` au lieu de `!isDev`. En dev derrière le reverse-proxy HTTPS, Auth.js écrit le cookie en `__Secure-authjs.session-token` ; sans ce fix, le middleware cherchait `authjs.session-token` (non sécurisé) → boucle `ERR_TOO_MANY_REDIRECTS` au login.

## Test plan
- [ ] `pnpm dev` puis ouvrir `https://pilote-ppg.localhost` et se connecter — la session doit s'établir sans boucle de redirection.
- [ ] Vérifier qu'en prod (HTTPS classique) le comportement est inchangé.
- [ ] Confirmer avec l'équipe que le setup dev `http://localhost:3000` n'est plus utilisé (sinon `secureCookie: true` le casserait).

🤖 Generated with [Claude Code](https://claude.com/claude-code)