### PR TITLE
fix: fuite mémoire pino-pretty et bug _tag du formatter tRPC

### DIFF
--- a/apps/pilote-ppg/package.json
+++ b/apps/pilote-ppg/package.json
@@ -8,7 +8,7 @@
     "node": "24.9.0"
   },
   "scripts": {
-    "dev": "portless run next dev | pino-pretty",
+    "dev": "portless run next dev",
     "build": "prisma generate && bash scripts/clone_centre_aide.sh && next build && pnpm exec pagefind --site .next/server/app --output-path public/_pagefind && node copy-assets.js && prisma migrate deploy && prisma db seed",
     "build:dev": "prisma generate && next build && pnpm exec pagefind --site .next/server/app --output-path public/_pagefind && node copy-assets.js && prisma migrate deploy && prisma db seed",
     "start": "node --max-old-space-size=${MAX_OLD_SPACE_SIZE:-768} .next/standalone/apps/pilote-ppg/server.js",

--- a/apps/pilote-ppg/src/pages/chantier/[id]/[territoireCode].tsx
+++ b/apps/pilote-ppg/src/pages/chantier/[id]/[territoireCode].tsx
@@ -6,7 +6,7 @@ import PageChantierLegacy from "@/components/PageChantier/PageChantierLegacy";
 import { PageChantier } from "@/components/PageChantier/PageChantier";
 import { useEnv } from "@/client/hooks/useEnv";
 import { auth } from "@/server/infrastructure/api/auth/[...nextauth]";
-import { NonAutorisé } from "@/server/utils/errors";
+import { PiloteError } from "@/server/app/error-boundary/pilote-error";
 import { ProfilEnum } from "@/server/app/enum/profil.enum";
 import ChoixTerritoire from "@/components/PageChantier/ChoixTerritoire/ChoixTerritoire";
 import calculerChantierAvancements from "@/client/utils/chantier/avancement/calculerChantierAvancementsNew";
@@ -276,7 +276,7 @@ export const getServerSideProps = async (
       },
     };
   } catch (error) {
-    if (error instanceof NonAutorisé) {
+    if (error instanceof PiloteError && error.status === 403) {
       return { notFound: true };
     } else {
       throw error;

--- a/apps/pilote-ppg/src/server/app/error-boundary/pilote-error.ts
+++ b/apps/pilote-ppg/src/server/app/error-boundary/pilote-error.ts
@@ -23,7 +23,11 @@ export class PiloteError extends Error {
   }
 
   static isPiloteError(error: unknown): error is PiloteError {
-    return (error as PiloteError)._tag === "PiloteError";
+    return (
+      error !== null &&
+      typeof error === "object" &&
+      (error as PiloteError)._tag === "PiloteError"
+    );
   }
 
   get message() {

--- a/apps/pilote-ppg/src/server/infrastructure/Logger.ts
+++ b/apps/pilote-ppg/src/server/infrastructure/Logger.ts
@@ -120,6 +120,12 @@ class AppLogger implements StructuredLogger {
   constructor() {
     this._logger = pino({
       level: "info",
+      ...(process.env.NODE_ENV !== "production" && {
+        transport: {
+          target: "pino-pretty",
+          options: { colorize: true, translateTime: "SYS:HH:MM:ss.l" },
+        },
+      }),
       hooks: {
         logMethod(inputArgs: Parameters<LogFn>, method: LogFn, level: number) {
           const [first, second] = inputArgs;

--- a/apps/pilote-ppg/src/server/infrastructure/api/auth/[...nextauth].tsx
+++ b/apps/pilote-ppg/src/server/infrastructure/api/auth/[...nextauth].tsx
@@ -21,10 +21,7 @@ function _assertResponseOk(
   errorMessage: string,
 ): void {
   if (response.status < 200 || response.status >= 300) {
-    logger.error(
-      { status: response.status, data: response.data },
-      errorMessage,
-    );
+    logger.warn({ status: response.status, data: response.data }, errorMessage);
     throw new Error(errorMessage);
   }
 }
@@ -180,7 +177,7 @@ async function refreshAccessToken(
       return result;
     } catch (error) {
       const errorMessage = "Bad in refresh_token";
-      logger.error(
+      logger.warn(
         {
           categorie: "auth",
           source: "nextauth.refreshAccessToken",
@@ -341,7 +338,7 @@ export const authConfig: NextAuthConfig = {
         toPiloteJWTPayload(token),
       );
       if (refreshedToken.error === "RefreshAccessTokenError") {
-        logger.error(
+        logger.warn(
           { categorie: "auth", source: "nextauth.jwt" },
           "Failed to refresh access token, invalidating session",
         );

--- a/apps/pilote-ppg/src/server/infrastructure/api/trpc/trpc.ts
+++ b/apps/pilote-ppg/src/server/infrastructure/api/trpc/trpc.ts
@@ -3,7 +3,6 @@ import superjson from "superjson";
 import { ZodError } from "zod";
 import { type CreateNextContextOptions } from "@trpc/server/adapters/next";
 import { auth } from "@/server/infrastructure/api/auth/[...nextauth]";
-import { NonAutorisé } from "@/server/utils/errors";
 import { PiloteError } from "@/server/app/error-boundary/pilote-error";
 import { CreateContextOptions } from "./trpc.interface";
 
@@ -31,26 +30,16 @@ const trpc = initTRPC.context<typeof créerContextTRPC>().create({
   errorFormatter({ shape, error }) {
     const formattedData = { ...shape.data };
     delete formattedData.stack;
-    const isInternalServerError =
-      !NonAutorisé.isNonAutorisé(error.cause) &&
-      !PiloteError.isPiloteError(error.cause);
+    const piloteCause = PiloteError.isPiloteError(error.cause)
+      ? error.cause
+      : null;
     return {
       ...shape,
-      message: isInternalServerError
-        ? "Une erreur est survenue"
-        : shape.message,
+      message: piloteCause ? shape.message : "Une erreur est survenue",
       data: {
         ...formattedData,
-        httpStatus: isInternalServerError
-          ? 500
-          : PiloteError.isPiloteError(error.cause)
-            ? error.cause.status
-            : 403,
-        code: isInternalServerError
-          ? "INTERNAL_SERVER_ERROR"
-          : PiloteError.isPiloteError(error.cause)
-            ? error.cause.type
-            : "UNAUTHORIZED",
+        httpStatus: piloteCause?.status ?? formattedData.httpStatus,
+        code: piloteCause?.type ?? formattedData.code,
         zodError:
           error.cause instanceof ZodError ? error.cause.flatten() : null,
       },

--- a/apps/pilote-ppg/src/server/utils/errors.ts
+++ b/apps/pilote-ppg/src/server/utils/errors.ts
@@ -1,32 +1,25 @@
 import { z } from "zod";
+import { ForbiddenError } from "@/server/app/error-boundary/forbidden-error";
 
-export class NonAutorisé extends Error {
-  private readonly _tag = "NonAutorisé";
-
-  static isNonAutorisé(error: unknown): error is NonAutorisé {
-    return (error as NonAutorisé)._tag === "NonAutorisé";
-  }
-}
-
-export class TerritoireNonAutoriséErreur extends NonAutorisé {
+export class TerritoireNonAutoriséErreur extends ForbiddenError {
   constructor() {
     super("Territoire non autorisé");
   }
 }
 
-export class ChantierNonAutoriséErreur extends NonAutorisé {
+export class ChantierNonAutoriséErreur extends ForbiddenError {
   constructor() {
     super("Chantier non autorisé");
   }
 }
 
-export class MailleNonAutoriséeErreur extends NonAutorisé {
+export class MailleNonAutoriséeErreur extends ForbiddenError {
   constructor() {
     super("Maille non autorisée");
   }
 }
 
-export class ChantiersNonAutorisésCreationModificationUtilisateurErreur extends NonAutorisé {
+export class ChantiersNonAutorisésCreationModificationUtilisateurErreur extends ForbiddenError {
   constructor() {
     super(
       "Au moins un des chantiers n'est pas autorisé pour la création ou modification de l'utilisateur",
@@ -34,7 +27,7 @@ export class ChantiersNonAutorisésCreationModificationUtilisateurErreur extends
   }
 }
 
-export class TerritoiresNonAutorisésCreationModificationUtilisateurErreur extends NonAutorisé {
+export class TerritoiresNonAutorisésCreationModificationUtilisateurErreur extends ForbiddenError {
   constructor() {
     super(
       "Au moins un des territoires n'est pas autorisé pour la création ou modification de l'utilisateur",
@@ -42,7 +35,7 @@ export class TerritoiresNonAutorisésCreationModificationUtilisateurErreur exten
   }
 }
 
-export class ChantiersNonAutorisésSuppressionUtilisateurErreur extends NonAutorisé {
+export class ChantiersNonAutorisésSuppressionUtilisateurErreur extends ForbiddenError {
   constructor() {
     super(
       "Au moins un des chantiers n'est pas autorisé pour la supression de l'utilisateur",
@@ -50,7 +43,7 @@ export class ChantiersNonAutorisésSuppressionUtilisateurErreur extends NonAutor
   }
 }
 
-export class TerritoiresNonAutorisésSuppressionUtilisateurErreur extends NonAutorisé {
+export class TerritoiresNonAutorisésSuppressionUtilisateurErreur extends ForbiddenError {
   constructor() {
     super(
       "Au moins un des territoires n'est pas autorisé pour la suppression de l'utilisateur",
@@ -58,7 +51,7 @@ export class TerritoiresNonAutorisésSuppressionUtilisateurErreur extends NonAut
   }
 }
 
-export class ProfilNonAutorisésSuppressionUtilisateurErreur extends NonAutorisé {
+export class ProfilNonAutorisésSuppressionUtilisateurErreur extends ForbiddenError {
   constructor() {
     super("Le profil n'est pas autorisé pour la suppression de l'utilisateur");
   }


### PR DESCRIPTION
## Summary

- déplace `pino-pretty` en transport pino (worker thread) au lieu d'un pipe shell `next dev | pino-pretty` qui faisait fuir la mémoire en dev (heap saturée à 8 GB → OOM)
- supprime la classe `NonAutorisé` : ses 8 sous-classes héritent désormais de `ForbiddenError` (donc `PiloteError`, status 403). Une seule hiérarchie d'erreurs côté serveur
- rend `PiloteError.isPiloteError` null-safe pour corriger `Cannot read properties of undefined (reading '_tag')` quand un `TRPCError` est levé sans `cause` (ex. middleware UNAUTHORIZED)
- simplifie le `errorFormatter` tRPC : si la cause est une `PiloteError`, on utilise son `status`/`type` ; sinon on respecte le `httpStatus`/`code` natif que tRPC place dans `shape.data` (le middleware UNAUTHORIZED renvoie maintenant un vrai 401 au lieu de 403)
- repasse en `warn` les logs de refresh token (échec normal d'expiration de session, pas une erreur applicative)

## Test plan

- [ ] `pnpm dev` tourne plusieurs heures sans OOM
- [ ] les logs en dev sortent bien formatés (pino-pretty via transport)
- [ ] une session expirée → refresh KO → log en `warn`, pas `error`
- [ ] un appel tRPC non authentifié renvoie 401 `UNAUTHORIZED` (et non plus une 500 `_tag`)
- [ ] un appel sur un chantier/territoire non autorisé renvoie 403 `ForbiddenError`
- [ ] la page `/chantier/[id]/[territoireCode]` continue à renvoyer un `notFound` quand l'utilisateur n'a pas accès