### PR TITLE
feat: FF export CSV widgets + retrait colonne date météo

### DIFF
--- a/apps/pilote-ppg/src/client/components/_commons/Widget/ExportableWidget.tsx
+++ b/apps/pilote-ppg/src/client/components/_commons/Widget/ExportableWidget.tsx
@@ -2,6 +2,7 @@ import { ReactNode } from "react";
 import { Icone } from "@/components/_commons/Icone";
 import { Download1Icon } from "@/components/_commons/Icones/Download1Icon";
 import { ClipboardIcon } from "@/components/_commons/Icones/ClipboardIcon";
+import { useEnv } from "@/client/hooks/useEnv";
 import { ModeExportContext } from "./ModeExportContext";
 import { useExportImage } from "./useExportImage";
 
@@ -14,6 +15,7 @@ export const ExportableWidget = ({
   boutonExportCsv?: ReactNode;
   children: ReactNode;
 }) => {
+  const ffExportWidgets = useEnv("NEXT_PUBLIC_FF_EXPORT_CSV_WIDGETS");
   const { ref, modeExport, enregistrerCommeImage, copierDansLePressePapiers } =
     useExportImage(nomFichier);
 
@@ -39,7 +41,7 @@ export const ExportableWidget = ({
         >
           <Icone className="w-4 h-4" icone={ClipboardIcon} />
         </button>
-        {boutonExportCsv}
+        {ffExportWidgets && boutonExportCsv}
       </div>
     </div>
   );

--- a/apps/pilote-ppg/src/client/components/_commons/Widget/WidgetCartographieMeteo/BoutonExportCsvMeteo.tsx
+++ b/apps/pilote-ppg/src/client/components/_commons/Widget/WidgetCartographieMeteo/BoutonExportCsvMeteo.tsx
@@ -1,6 +1,5 @@
 import { BoutonExportCsv } from "@/components/_commons/Widget/BoutonExportCsv";
 import { getLabelTerritoire } from "@/client/constants/territoires";
-import { PiloteDateFormatter } from "@/utils/PiloteDateFormatter";
 import { useExportCsv } from "@/client/hooks/useExportCsv";
 import { filtrerLesTerritoires } from "@/client/utils/csv";
 import { libellesMeteos } from "@/server/domain/météo/Météo.interface";
@@ -29,17 +28,12 @@ export const BoutonExportCsvMeteo = ({
       });
 
       return [
-        ["Territoire", "Niveau de confiance", "Date de publication"],
+        ["Territoire", "Niveau de confiance"],
         ...filtrerLesTerritoires(donnees, territoiresPourExport).map(
           (territoire) => [
             getLabelTerritoire(territoire.territoireCode),
             territoire.meteo !== null
               ? (libellesMeteos[territoire.meteo] ?? "Non renseignée")
-              : "Non renseignée",
-            territoire.dateDeMajQualitative !== null
-              ? PiloteDateFormatter.isoDateFranceMetropolitaine(
-                  territoire.dateDeMajQualitative,
-                )
               : "Non renseignée",
           ],
         ),

--- a/apps/pilote-ppg/src/config.ts
+++ b/apps/pilote-ppg/src/config.ts
@@ -365,6 +365,11 @@ const config = convict({
       default: false,
       env: "NEXT_PUBLIC_FF_PAGE_ACTUALITES",
     },
+    exportCsvWidgets: {
+      format: Boolean,
+      default: false,
+      env: "NEXT_PUBLIC_FF_EXPORT_CSV_WIDGETS",
+    },
   },
   analytics: {
     doc: "Matomo Analytics",

--- a/apps/pilote-ppg/src/server/gestion-contenu/domain/VariableContenuDisponible.ts
+++ b/apps/pilote-ppg/src/server/gestion-contenu/domain/VariableContenuDisponible.ts
@@ -43,6 +43,7 @@ export interface VARIABLE_CONTENU_DISPONIBLE {
   NEXT_PUBLIC_FF_REFONTE_PAGE_CHANTIER: boolean;
   NEXT_PUBLIC_FF_REORGANISATION_PAGE_ACCUEIL: boolean;
   NEXT_PUBLIC_FF_PAGE_ACTUALITES: boolean;
+  NEXT_PUBLIC_FF_EXPORT_CSV_WIDGETS: boolean;
 }
 
 type FeatureFlipConfig = ReturnType<typeof configuration>["featureFlip"];
@@ -241,6 +242,11 @@ const FEATURE_FLIP_DEFINITIONS: FeatureFlipDefinition[] = [
     envKey: "NEXT_PUBLIC_FF_PAGE_ACTUALITES",
     configKey: "pageActualites",
     label: "Page actualités (newsletters Brevo)",
+  },
+  {
+    envKey: "NEXT_PUBLIC_FF_EXPORT_CSV_WIDGETS",
+    configKey: "exportCsvWidgets",
+    label: "Export csv des widgets",
   },
 ];
 


### PR DESCRIPTION
## Summary

- Ajout du feature flag `NEXT_PUBLIC_FF_EXPORT_WIDGETS` (default `false`) pour conditionner l'affichage du bouton d'export CSV dans `ExportableWidget`
- Suppression de la colonne « Date de publication » de l'export CSV du widget Niveaux de confiance (météo)

## Test plan

- [ ] Vérifier que le bouton export CSV n'apparaît pas dans les widgets avec `NEXT_PUBLIC_FF_EXPORT_CSV_WIDGETS=false` (défaut)
- [ ] Vérifier que le bouton export CSV apparaît avec `NEXT_PUBLIC_FF_EXPORT_CSV_WIDGETS=true`
- [ ] Vérifier que les boutons export image et presse-papiers restent toujours visibles quel que soit le FF
- [ ] Exporter le CSV météo (niveaux de confiance) et vérifier que la colonne « Date de publication » est absente

🤖 Generated with [Claude Code](https://claude.com/claude-code)