### PR TITLE
chore: binding portless explicite pour le script dev

### DIFF
--- a/apps/pilote-ppg/package.json
+++ b/apps/pilote-ppg/package.json
@@ -8,7 +8,7 @@
     "node": "24.9.0"
   },
   "scripts": {
-    "dev": "portless run next dev",
+    "dev": "portless ${PORTLESS_NAME:-}pilote-ppg next dev",
     "build": "prisma generate && bash scripts/clone_centre_aide.sh && next build && pnpm exec pagefind --site .next/server/app --output-path public/_pagefind && node copy-assets.js && prisma migrate deploy && prisma db seed",
     "build:dev": "prisma generate && next build && pnpm exec pagefind --site .next/server/app --output-path public/_pagefind && node copy-assets.js && prisma migrate deploy && prisma db seed",
     "start": "node --max-old-space-size=${MAX_OLD_SPACE_SIZE:-768} .next/standalone/apps/pilote-ppg/server.js",


### PR DESCRIPTION
## Summary

- remplace `portless run next dev` par `portless ${PORTLESS_NAME:-}pilote-ppg next dev` pour fixer le binding portless sur l'app PPG (et permettre un override via `PORTLESS_NAME`)

## Test plan

- [ ] `pnpm dev` démarre derrière portless avec le bon binding
- [ ] override avec `PORTLESS_NAME=foo- pnpm dev` cible le binding attendu