### PR TITLE
fix: bypass portless dans le script test:e2e:server

### DIFF
--- a/apps/pilote-ppg/package.json
+++ b/apps/pilote-ppg/package.json
@@ -27,7 +27,7 @@
     "test:e2e": "pnpm exec playwright test --workers=1",
     "test:e2e:seed": "./tests/seed/seed.sh",
     "test:e2e:ui": "pnpm exec playwright test --ui",
-    "test:e2e:server": "dotenv -e .env.e2e pnpm dev",
+    "test:e2e:server": "dotenv -e .env.e2e next dev",
     "test:e2e:database:init": "dotenv -e .env.e2e -- pnpm database:init-force",
     "test:server:unit": "vitest run --project server-unit",
     "test:server:integration": "vitest run --project server-integration",


### PR DESCRIPTION
## Problème

Les tests e2e échouaient en CI car le script `test:e2e:server` appelait `pnpm dev`, qui lance `portless ... next dev`. Or, portless nécessite un proxy en cours d'exécution (ou les droits sudo) qui ne sont pas disponibles dans l'environnement GitHub Actions.

```
[WebServer] portless
[WebServer] Proxy is not running and no TTY is available for sudo.
```

## Solution

Le fichier `.env.e2e` utilise déjà `BASE_URL=http://localhost:3030` et `PORT=3030` — aucun domaine personnalisé n'est nécessaire pour les tests e2e. On remplace donc l'appel à `pnpm dev` (qui passe par portless) par un appel direct à `next dev`, qui respecte la variable `PORT`.

## Changement

```diff
- "test:e2e:server": "dotenv -e .env.e2e pnpm dev",
+ "test:e2e:server": "dotenv -e .env.e2e next dev",
```

> Note : portless reste utilisé pour le développement local via `pnpm dev`.