### PR TITLE
fix(PIL-1500): jalon par défaut dérivé de getAnneeDateDeBascule

### DIFF
--- a/apps/pilote-ppg/src/client/stores/useFiltresStoreNew/useFiltresStoreNew.ts
+++ b/apps/pilote-ppg/src/client/stores/useFiltresStoreNew/useFiltresStoreNew.ts
@@ -1,4 +1,6 @@
 import { create } from "zustand";
+import { configuration } from "@/config";
+import { getAnneeDateDeBascule } from "@/components/_commons/IndicateursChantier/Bloc/ValeurEtDate/getAnneeDateDeBascule";
 
 export interface FiltreAccueil {
   territoireCode: string;
@@ -39,7 +41,10 @@ const etatInitial = {
   territorialisation: [] as string[],
   q: "",
   statut: "PUBLIE",
-  jalon: "2025",
+  jalon: getAnneeDateDeBascule(
+    new Date(),
+    configuration().dateBasculeAffichageValeursAnneePrecedente,
+  ).toString(),
   groupeParMinistere: false,
   estBarometre: false,
   estTerritorialise: false,

--- a/apps/pilote-ppg/src/client/utils/getQueryParamString.ts
+++ b/apps/pilote-ppg/src/client/utils/getQueryParamString.ts
@@ -5,6 +5,7 @@ import {
   parseAsBoolean,
 } from "nuqs";
 import { FiltreAccueil } from "@/stores/useFiltresStoreNew/useFiltresStoreNew";
+import { buildJalons } from "@/client/utils/jalons";
 
 const listeKeyPositiveBooleanExclusion = new Set(["brouillon"]);
 
@@ -46,7 +47,7 @@ export const useGetFullQueryParamString = (): string => {
       "BROUILLON_ET_PUBLIE",
       "ARCHIVE",
     ]),
-    jalon: parseAsStringLiteral(["2024", "2025"]),
+    jalon: parseAsStringLiteral(buildJalons().map(String)),
   });
 
   const [filtresAlertes] = useQueryStates({


### PR DESCRIPTION
## Contexte

Ticket : [PIL-1500](https://data-ditp.atlassian.net/browse/PIL-1500)

Depuis la bascule de date 2026, l'onglet "Accueil" de la navigation construit un href avec `jalon=2025` codé en dur, par exemple :

```
/accueil/chantier/NAT-FR?statut=PUBLIE&jalon=2025
```

alors que le jalon courant calculé par `getAnneeDateDeBascule` est `2026`.

## Cause

Deux endroits faisaient l'hypothèse `jalon === "2025"` :

- `apps/pilote-ppg/src/client/stores/useFiltresStoreNew/useFiltresStoreNew.ts` : valeur initiale `jalon: "2025"` codée en dur dans `etatInitial`. Reprise par `NavigationPilote.tsx` pour le href de l'onglet Accueil.
- `apps/pilote-ppg/src/client/utils/getQueryParamString.ts` : `parseAsStringLiteral(["2024", "2025"])` rejetait silencieusement `?jalon=2026` lu depuis l'URL.

## Correction

- **Store** : `jalon` initial dérivé dynamiquement de `getAnneeDateDeBascule(new Date(), configuration().dateBasculeAffichageValeursAnneePrecedente).toString()` (pattern déjà utilisé côté client dans `recupererJalon.ts` et `useSelecteurJalon.ts`).
- **Parser nuqs** : `parseAsStringLiteral(buildJalons().map(String))` pour rester aligné avec la liste dynamique des jalons (`buildJalons()` génère `["2022", ..., currentYear]`).

## Test plan

- [ ] Se connecter sans query param et vérifier que l'onglet Accueil pointe vers `?statut=PUBLIE&jalon=2026`
- [ ] Naviguer avec une URL `?jalon=2026` et vérifier que le filtre est bien appliqué (et conservé après navigation vers le rapport détaillé)
- [ ] Vérifier qu'aucune régression n'apparait sur les filtres existants de la page Accueil (statut, périmètres, etc.)

[PIL-1500]: https://data-ditp.atlassian.net/browse/PIL-1500?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ