### PR TITLE
feat(mb-api): logger composable avec sinks pino + database

### DIFF
--- a/apps/mb-api/prisma/migrations/20260505150336_add_application_log/migration.sql
+++ b/apps/mb-api/prisma/migrations/20260505150336_add_application_log/migration.sql
@@ -1,0 +1,26 @@
+-- CreateEnum
+CREATE TYPE "application_log_level_enum" AS ENUM ('ERROR', 'WARN', 'INFO', 'DEBUG');
+
+-- CreateTable
+CREATE TABLE "application_log" (
+    "id" BIGSERIAL NOT NULL,
+    "level" "application_log_level_enum" NOT NULL,
+    "categorie" TEXT NOT NULL DEFAULT 'systeme',
+    "message" TEXT NOT NULL,
+    "contexte" JSONB,
+    "source" TEXT,
+    "duree_ms" INTEGER,
+    "request_id" TEXT,
+    "date" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "application_log_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "application_log_date_idx" ON "application_log"("date");
+
+-- CreateIndex
+CREATE INDEX "application_log_level_date_idx" ON "application_log"("level", "date");
+
+-- CreateIndex
+CREATE INDEX "application_log_request_id_idx" ON "application_log"("request_id");

--- a/apps/mb-api/prisma/schema.prisma
+++ b/apps/mb-api/prisma/schema.prisma
@@ -33,3 +33,29 @@ model Indicateur {
 
   @@map("indicateur")
 }
+
+enum ApplicationLogLevel {
+  ERROR
+  WARN
+  INFO
+  DEBUG
+
+  @@map("application_log_level_enum")
+}
+
+model ApplicationLog {
+  id        BigInt              @id @default(autoincrement())
+  level     ApplicationLogLevel
+  categorie String              @default("systeme")
+  message   String
+  contexte  Json?
+  source    String?
+  dureeMs   Int?                @map("duree_ms")
+  requestId String?             @map("request_id")
+  date      DateTime            @default(now())
+
+  @@index([date])
+  @@index([level, date])
+  @@index([requestId])
+  @@map("application_log")
+}

--- a/apps/mb-api/src/env.ts
+++ b/apps/mb-api/src/env.ts
@@ -22,6 +22,9 @@ const envSchema = z.object({
   LOG_LEVEL: z
     .enum(['fatal', 'error', 'warn', 'info', 'debug', 'trace', 'silent'])
     .default('info'),
+  LOG_TO_DATABASE: z.stringbool().default(false),
 })
+
+export type Env = z.infer<typeof envSchema>
 
 export const env = envSchema.parse(process.env)

--- a/apps/mb-api/src/framework/errors/errorHandler.ts
+++ b/apps/mb-api/src/framework/errors/errorHandler.ts
@@ -4,6 +4,7 @@ import { ZodError } from 'zod'
 
 import { AppError } from '@/framework/errors/AppError'
 import type { ErrorKind } from '@/framework/errors/kinds'
+import { logger } from '@/framework/logger/logger'
 import { Prisma } from '@/generated/prisma/client'
 
 const KIND_TO_STATUS: Record<ErrorKind, 400 | 401 | 403 | 404 | 409 | 500 | 501> = {
@@ -25,8 +26,11 @@ export const registerErrorHandler = (app: OpenAPIHono): void => {
 
     if (error instanceof AppError) {
       const status = mapAppErrorToHttpStatus(error)
-      const logFn = status >= 500 ? console.error : console.warn
-      logFn(`[${method} ${url}] ${error.code}: ${error.message}`)
+      const logFn = status >= 500 ? logger.error.bind(logger) : logger.warn.bind(logger)
+      logFn(
+        { method, url, code: error.code, status, details: error.details },
+        error.message,
+      )
       return context.json(
         {
           code: error.code,
@@ -38,7 +42,7 @@ export const registerErrorHandler = (app: OpenAPIHono): void => {
     }
 
     if (error instanceof HTTPException) {
-      console.warn(`[${method} ${url}] HTTPException ${error.status}: ${error.message}`)
+      logger.warn({ method, url, status: error.status }, error.message)
       return context.json(
         {
           code:
@@ -54,7 +58,7 @@ export const registerErrorHandler = (app: OpenAPIHono): void => {
     }
 
     if (error instanceof ZodError) {
-      console.warn(`[${method} ${url}] Validation error`, error.issues)
+      logger.warn({ method, url, issues: error.issues }, 'Validation error')
       return context.json(
         {
           code: 'VALIDATION_ERROR',
@@ -69,7 +73,7 @@ export const registerErrorHandler = (app: OpenAPIHono): void => {
       error instanceof Prisma.PrismaClientKnownRequestError &&
       error.code === 'P2025'
     ) {
-      console.warn(`[${method} ${url}] Prisma not found: ${error.message}`)
+      logger.warn({ method, url, prismaCode: error.code }, error.message)
       return context.json(
         {
           code: 'ENTITY_NOT_FOUND',
@@ -79,10 +83,7 @@ export const registerErrorHandler = (app: OpenAPIHono): void => {
       )
     }
 
-    console.error(
-      `[${method} ${url}] Unhandled error: ${error.message}`,
-      error.stack,
-    )
+    logger.error({ method, url, err: error }, 'Unhandled error')
     return context.json(
       {
         code: 'INTERNAL_SERVER_ERROR',

--- a/apps/mb-api/src/framework/logger/build-logger.ts
+++ b/apps/mb-api/src/framework/logger/build-logger.ts
@@ -1,0 +1,11 @@
+import { type Env } from '@/env'
+import { CompositeLogger } from '@/framework/logger/composite-logger'
+import { type LogSink } from '@/framework/logger/log-sink'
+import { DatabaseSink } from '@/framework/logger/sinks/database.sink'
+import { PinoStdoutSink } from '@/framework/logger/sinks/pino-stdout.sink'
+
+export const buildLogger = (env: Env): CompositeLogger => {
+  const sinks: LogSink[] = [new PinoStdoutSink(env)]
+  if (env.LOG_TO_DATABASE) sinks.push(new DatabaseSink())
+  return new CompositeLogger(sinks)
+}

--- a/apps/mb-api/src/framework/logger/composite-logger.test.ts
+++ b/apps/mb-api/src/framework/logger/composite-logger.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { CompositeLogger } from '@/framework/logger/composite-logger'
+import { type LogEntry, type LogSink } from '@/framework/logger/log-sink'
+
+const buildSink = () => {
+  const write = vi.fn<(entry: LogEntry) => void>()
+  const sink: LogSink = { write }
+  return { sink, write }
+}
+
+describe('CompositeLogger', () => {
+  it('dispatches each level call to every sink with the corresponding entry', () => {
+    const a = buildSink()
+    const b = buildSink()
+    const logger = new CompositeLogger([a.sink, b.sink])
+
+    logger.debug({ k: 'd' }, 'debug message')
+    logger.info({ k: 'i' }, 'info message')
+    logger.warn({ k: 'w' }, 'warn message')
+    logger.error({ k: 'e' }, 'error message')
+
+    for (const write of [a.write, b.write]) {
+      expect(write).toHaveBeenCalledTimes(4)
+      expect(write.mock.calls[0]?.[0]).toMatchObject({ level: 'debug', message: 'debug message', context: { k: 'd' } })
+      expect(write.mock.calls[1]?.[0]).toMatchObject({ level: 'info', message: 'info message', context: { k: 'i' } })
+      expect(write.mock.calls[2]?.[0]).toMatchObject({ level: 'warn', message: 'warn message', context: { k: 'w' } })
+      expect(write.mock.calls[3]?.[0]).toMatchObject({ level: 'error', message: 'error message', context: { k: 'e' } })
+    }
+  })
+
+  it('attaches a Date timestamp to every entry', () => {
+    const { sink, write } = buildSink()
+    const logger = new CompositeLogger([sink])
+
+    logger.info({}, 'tick')
+
+    const entry = write.mock.calls[0]?.[0]
+    expect(entry?.timestamp).toBeInstanceOf(Date)
+  })
+
+  it('preserves the order of sinks', () => {
+    const calls: string[] = []
+    const a: LogSink = { write: () => calls.push('a') }
+    const b: LogSink = { write: () => calls.push('b') }
+    const c: LogSink = { write: () => calls.push('c') }
+
+    new CompositeLogger([a, b, c]).info({}, 'msg')
+
+    expect(calls).toEqual(['a', 'b', 'c'])
+  })
+
+  it('does not throw when no sink is configured', () => {
+    const logger = new CompositeLogger([])
+    expect(() => logger.info({}, 'msg')).not.toThrow()
+  })
+})

--- a/apps/mb-api/src/framework/logger/composite-logger.ts
+++ b/apps/mb-api/src/framework/logger/composite-logger.ts
@@ -1,0 +1,27 @@
+import { type LogEntry, type LogLevel, type LogSink } from './log-sink'
+import { type Logger } from './logger'
+
+export class CompositeLogger implements Logger {
+  constructor(private readonly sinks: ReadonlyArray<LogSink>) {}
+
+  debug(context: Record<string, unknown>, message: string): void {
+    this.emit('debug', context, message)
+  }
+
+  info(context: Record<string, unknown>, message: string): void {
+    this.emit('info', context, message)
+  }
+
+  warn(context: Record<string, unknown>, message: string): void {
+    this.emit('warn', context, message)
+  }
+
+  error(context: Record<string, unknown>, message: string): void {
+    this.emit('error', context, message)
+  }
+
+  private emit(level: LogLevel, context: Record<string, unknown>, message: string): void {
+    const entry: LogEntry = { level, timestamp: new Date(), message, context }
+    for (const sink of this.sinks) sink.write(entry)
+  }
+}

--- a/apps/mb-api/src/framework/logger/log-sink.ts
+++ b/apps/mb-api/src/framework/logger/log-sink.ts
@@ -1,0 +1,12 @@
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error'
+
+export type LogEntry = {
+  readonly level: LogLevel
+  readonly timestamp: Date
+  readonly message: string
+  readonly context: Record<string, unknown>
+}
+
+export interface LogSink {
+  write(entry: LogEntry): void
+}

--- a/apps/mb-api/src/framework/logger/logger.ts
+++ b/apps/mb-api/src/framework/logger/logger.ts
@@ -1,22 +1,11 @@
-import { pino } from 'pino'
-
 import { env } from '@/env'
+import { buildLogger } from '@/framework/logger/build-logger'
 
-const isDev = process.env.NODE_ENV !== 'production'
+export interface Logger {
+  debug(context: Record<string, unknown>, message: string): void
+  info(context: Record<string, unknown>, message: string): void
+  warn(context: Record<string, unknown>, message: string): void
+  error(context: Record<string, unknown>, message: string): void
+}
 
-export const logger = pino({
-  level: env.LOG_LEVEL,
-  base: { app: 'mb-api' },
-  redact: {
-    paths: ['req.headers.authorization', 'req.headers.cookie', 'token', '*.token', '*.refreshToken'],
-    censor: '[REDACTED]',
-  },
-  ...(isDev
-    ? {
-        transport: {
-          target: 'pino-pretty',
-          options: { colorize: true, translateTime: 'SYS:HH:MM:ss.l' },
-        },
-      }
-    : {}),
-})
+export const logger: Logger = buildLogger(env)

--- a/apps/mb-api/src/framework/logger/sinks/database.sink.ts
+++ b/apps/mb-api/src/framework/logger/sinks/database.sink.ts
@@ -1,0 +1,40 @@
+import { prisma } from '@/framework/persistence/prisma'
+import { type LogEntry, type LogLevel, type LogSink } from '@/framework/logger/log-sink'
+import { ApplicationLogLevel } from '@/generated/prisma/enums'
+
+const LEVEL_MAP: Record<LogLevel, ApplicationLogLevel> = {
+  debug: ApplicationLogLevel.DEBUG,
+  info: ApplicationLogLevel.INFO,
+  warn: ApplicationLogLevel.WARN,
+  error: ApplicationLogLevel.ERROR,
+}
+
+type StructuredContext = {
+  requestId?: string
+  source?: string
+  dureeMs?: number
+}
+
+export class DatabaseSink implements LogSink {
+  write(entry: LogEntry): void {
+    const { requestId, source, dureeMs, ...rest } = entry.context as StructuredContext &
+      Record<string, unknown>
+
+    void prisma.applicationLog
+      .create({
+        data: {
+          level: LEVEL_MAP[entry.level],
+          message: entry.message,
+          date: entry.timestamp,
+          ...(Object.keys(rest).length > 0 ? { contexte: rest as object } : {}),
+          ...(source !== undefined ? { source } : {}),
+          ...(dureeMs !== undefined ? { dureeMs } : {}),
+          ...(requestId !== undefined ? { requestId } : {}),
+        },
+      })
+      .catch(() => {
+        // best-effort : un crash de la DB ne doit pas couler une requête.
+        // l'autre sink (stdout) a déjà reçu l'entry.
+      })
+  }
+}

--- a/apps/mb-api/src/framework/logger/sinks/pino-stdout.sink.ts
+++ b/apps/mb-api/src/framework/logger/sinks/pino-stdout.sink.ts
@@ -1,0 +1,33 @@
+import { pino, type Logger as PinoLogger } from 'pino'
+
+import { type Env } from '@/env'
+import { type LogEntry, type LogSink } from '@/framework/logger/log-sink'
+
+const isDev = process.env['NODE_ENV'] !== 'production'
+
+export class PinoStdoutSink implements LogSink {
+  private readonly pino: PinoLogger
+
+  constructor(env: Env) {
+    this.pino = pino({
+      level: env.LOG_LEVEL,
+      base: { app: 'mb-api' },
+      redact: {
+        paths: ['req.headers.authorization', 'req.headers.cookie', 'token', '*.token', '*.refreshToken'],
+        censor: '[REDACTED]',
+      },
+      ...(isDev
+        ? {
+            transport: {
+              target: 'pino-pretty',
+              options: { colorize: true, translateTime: 'SYS:HH:MM:ss.l' },
+            },
+          }
+        : {}),
+    })
+  }
+
+  write(entry: LogEntry): void {
+    this.pino[entry.level](entry.context, entry.message)
+  }
+}

--- a/apps/mb-api/src/index.ts
+++ b/apps/mb-api/src/index.ts
@@ -1,9 +1,10 @@
 import { serve } from '@hono/node-server'
 
 import { env } from '@/env'
+import { logger } from '@/framework/logger/logger'
 
 import { app } from './app'
 
 serve({ fetch: app.fetch, port: env.PORT }, (info) => {
-  console.log(`mb-api listening on http://localhost:${info.port}`)
+  logger.info({ port: info.port }, 'mb-api listening')
 })


### PR DESCRIPTION
## Summary
- Port `Logger` + `CompositeLogger` qui dispatch vers N sinks (`PinoStdoutSink` JSON/pretty + `DatabaseSink` best-effort vers `application_log`), conformément à `apps/mb-api/docs/architecture/init-design.md` §6.5 et `init-plan.md` tâche 13
- Factory `buildLogger(env)` qui compose les sinks selon `LOG_TO_DATABASE` (nouveau env var, default `false`) ; singleton exporté depuis `framework/logger/logger.ts` (pas de DI)
- Tous les `console.*` de `src/index.ts` et `src/framework/errors/errorHandler.ts` migrés vers le logger structuré (redaction préservée, `LOG_LEVEL` respecté)
- Schéma Prisma : modèle `ApplicationLog` + enum `ApplicationLogLevel` + migration `20260505150336_add_application_log`

## Test plan
- [x] `pnpm -F @pilote/mb-api typecheck`
- [x] `pnpm -F @pilote/mb-api lint`
- [ ] `pnpm -F @pilote/mb-api test` — bloqué localement par drift préexistant de la DB test (à reset)
- [ ] `pnpm -F @pilote/mb-api dev` puis :
  - vérifier la ligne `mb-api listening` formatée pretty avec `port`
  - 404 sur route inexistante → log `warn` structuré
  - relancer avec `LOG_TO_DATABASE=true` → vérifier insertion dans `application_log`
  - header `Authorization: Bearer xxx` → valeur `[REDACTED]` dans la sortie
- [ ] Couper la DB pendant `LOG_TO_DATABASE=true` → l'app ne crash pas (best-effort)

🤖 Generated with [Claude Code](https://claude.com/claude-code)