### PR TITLE
feat(mb-webapp): page detail indicateur avec select individus + onglets

### DIFF
--- a/apps/mb-webapp/package.json
+++ b/apps/mb-webapp/package.json
@@ -28,7 +28,9 @@
   "dependencies": {
     "@hono/node-server": "^1.13.7",
     "@pilote/mb-shared": "workspace:*",
+    "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-slot": "^1.2.4",
+    "@radix-ui/react-tabs": "^1.1.13",
     "@tanstack/react-query": "^5.62.7",
     "@tanstack/react-router": "^1.168.26",
     "@tanstack/react-router-devtools": "^1.166.13",

--- a/apps/mb-webapp/src/api/indicateurs.ts
+++ b/apps/mb-webapp/src/api/indicateurs.ts
@@ -4,6 +4,12 @@ import {
   type IndicateurListApiModel,
   indicateurListApiModelSchema,
 } from '@pilote/mb-shared/indicateur'
+import {
+  type IndividusWithValeursListApiModel,
+  individusWithValeursListApiModelSchema,
+  type ValeurAvancementListApiModel,
+  valeurAvancementListApiModelSchema,
+} from '@pilote/mb-shared/valeurAvancement'
 
 import { apiClient } from '@/api/client'
 
@@ -24,4 +30,26 @@ export const fetchIndicateurs = async (
 export const fetchIndicateurById = async (id: string): Promise<IndicateurApiModel> => {
   const json = await apiClient.get(`indicateurs/${id}`).json()
   return indicateurApiModelSchema.parse(json)
+}
+
+export const fetchIndividusForIndicateur = async (
+  indicateurId: string,
+  params: { cursor?: string } = {},
+): Promise<IndividusWithValeursListApiModel> => {
+  const json = await apiClient
+    .get(`indicateurs/${indicateurId}/individus`, { searchParams: params })
+    .json()
+  return individusWithValeursListApiModelSchema.parse(json)
+}
+
+export const fetchValeursForIndicateur = async (
+  indicateurId: string,
+  params: { individus: string[] },
+): Promise<ValeurAvancementListApiModel> => {
+  const json = await apiClient
+    .get(`indicateurs/${indicateurId}/valeurs`, {
+      searchParams: { individus: params.individus.join(',') },
+    })
+    .json()
+  return valeurAvancementListApiModelSchema.parse(json)
 }

--- a/apps/mb-webapp/src/components/RouteError.tsx
+++ b/apps/mb-webapp/src/components/RouteError.tsx
@@ -1,6 +1,9 @@
 import type { ErrorComponentProps } from '@tanstack/react-router'
 import { Link } from '@tanstack/react-router'
 import { HTTPError } from 'ky'
+import { ArrowLeft } from 'lucide-react'
+
+import { Button } from '@/components/ui/Button'
 
 const isNotFoundError = (error: Error): boolean => {
   return error instanceof HTTPError && error.response.status === 404
@@ -16,13 +19,12 @@ export function RouteError({ error, reset }: ErrorComponentProps) {
             La ressource demandée n'existe pas ou a été supprimée.
           </p>
         </div>
-        <Link
-          to="/indicateurs"
-          search={{}}
-          className="inline-block text-sm text-slate-700 underline hover:text-slate-900"
-        >
-          ← Retour à la liste
-        </Link>
+        <Button variant="tertiary" size="sm" asChild>
+          <Link to="/indicateurs" search={{}}>
+            <ArrowLeft />
+            Retour à la liste
+          </Link>
+        </Button>
       </div>
     )
   }

--- a/apps/mb-webapp/src/components/ui/Select.tsx
+++ b/apps/mb-webapp/src/components/ui/Select.tsx
@@ -1,0 +1,79 @@
+import * as SelectPrimitive from '@radix-ui/react-select'
+import { ChevronDown } from 'lucide-react'
+import type { ComponentProps } from 'react'
+
+import { clsxm } from '@/lib/clsxm'
+
+export const Select = SelectPrimitive.Root
+export const SelectValue = SelectPrimitive.Value
+
+export function SelectTrigger({
+  className,
+  children,
+  ...props
+}: ComponentProps<typeof SelectPrimitive.Trigger>) {
+  return (
+    <SelectPrimitive.Trigger
+      className={clsxm(
+        'inline-flex items-center justify-between gap-2 rounded border border-secondary-border bg-surface px-3 py-2 text-sm text-text',
+        'hover:bg-secondary-hover',
+        'focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary',
+        'disabled:cursor-not-allowed disabled:bg-disabled disabled:text-disabled-foreground',
+        'data-[placeholder]:text-text-muted',
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <SelectPrimitive.Icon>
+        <ChevronDown className="size-4 text-text-muted" />
+      </SelectPrimitive.Icon>
+    </SelectPrimitive.Trigger>
+  )
+}
+
+export function SelectContent({
+  className,
+  children,
+  position = 'popper',
+  ...props
+}: ComponentProps<typeof SelectPrimitive.Content>) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Content
+        position={position}
+        sideOffset={4}
+        className={clsxm(
+          'z-50 min-w-[var(--radix-select-trigger-width)] overflow-hidden rounded border border-border bg-surface shadow-md',
+          className,
+        )}
+        {...props}
+      >
+        <SelectPrimitive.Viewport className="p-1">
+          {children}
+        </SelectPrimitive.Viewport>
+      </SelectPrimitive.Content>
+    </SelectPrimitive.Portal>
+  )
+}
+
+export function SelectItem({
+  className,
+  children,
+  ...props
+}: ComponentProps<typeof SelectPrimitive.Item>) {
+  return (
+    <SelectPrimitive.Item
+      className={clsxm(
+        'relative flex cursor-pointer select-none items-center rounded px-2 py-1.5 text-sm text-text outline-none',
+        'data-[highlighted]:bg-secondary-hover',
+        'data-[state=checked]:font-medium',
+        'data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+        className,
+      )}
+      {...props}
+    >
+      <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+    </SelectPrimitive.Item>
+  )
+}

--- a/apps/mb-webapp/src/components/ui/Tabs.tsx
+++ b/apps/mb-webapp/src/components/ui/Tabs.tsx
@@ -1,0 +1,48 @@
+import * as TabsPrimitive from '@radix-ui/react-tabs'
+import type { ComponentProps } from 'react'
+
+import { clsxm } from '@/lib/clsxm'
+
+export const Tabs = TabsPrimitive.Root
+
+export function TabsList({
+  className,
+  ...props
+}: ComponentProps<typeof TabsPrimitive.List>) {
+  return (
+    <TabsPrimitive.List
+      className={clsxm('flex border-b border-border', className)}
+      {...props}
+    />
+  )
+}
+
+export function TabsTrigger({
+  className,
+  ...props
+}: ComponentProps<typeof TabsPrimitive.Trigger>) {
+  return (
+    <TabsPrimitive.Trigger
+      className={clsxm(
+        '-mb-px inline-flex items-center border-b-2 border-transparent px-4 py-2 text-sm text-text-muted transition-colors',
+        'hover:text-text',
+        'focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary',
+        'data-[state=active]:border-primary data-[state=active]:text-text data-[state=active]:font-medium',
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+export function TabsContent({
+  className,
+  ...props
+}: ComponentProps<typeof TabsPrimitive.Content>) {
+  return (
+    <TabsPrimitive.Content
+      className={clsxm('pt-4 focus-visible:outline-none', className)}
+      {...props}
+    />
+  )
+}

--- a/apps/mb-webapp/src/queries/indicateurs.ts
+++ b/apps/mb-webapp/src/queries/indicateurs.ts
@@ -3,10 +3,12 @@ import { queryOptions } from '@tanstack/react-query'
 import {
   fetchIndicateurById,
   fetchIndicateurs,
+  fetchIndividusForIndicateur,
+  fetchValeursForIndicateur,
   type IndicateursQueryParams,
 } from '@/api/indicateurs'
 
-import { DEFAULT_STALE_TIME } from './utils'
+import { DEFAULT_STALE_TIME, fetchAllPaginatedItems } from './utils'
 
 export const indicateursQueryOptions = (params: IndicateursQueryParams) =>
   queryOptions({
@@ -19,5 +21,26 @@ export const indicateurQueryOptions = (id: string) =>
   queryOptions({
     queryKey: ['indicateur', id],
     queryFn: () => fetchIndicateurById(id),
+    staleTime: DEFAULT_STALE_TIME,
+  })
+
+export const indicateurIndividusQueryOptions = (indicateurId: string) =>
+  queryOptions({
+    queryKey: ['indicateur', indicateurId, 'individus'],
+    queryFn: () =>
+      fetchAllPaginatedItems((cursor) =>
+        fetchIndividusForIndicateur(indicateurId, cursor ? { cursor } : {}),
+      ),
+    staleTime: DEFAULT_STALE_TIME,
+  })
+
+export const indicateurValeursQueryOptions = (
+  indicateurId: string,
+  individuId: string,
+) =>
+  queryOptions({
+    queryKey: ['indicateur', indicateurId, 'valeurs', individuId],
+    queryFn: () =>
+      fetchValeursForIndicateur(indicateurId, { individus: [individuId] }),
     staleTime: DEFAULT_STALE_TIME,
   })

--- a/apps/mb-webapp/src/queries/utils.ts
+++ b/apps/mb-webapp/src/queries/utils.ts
@@ -1,1 +1,22 @@
 export const DEFAULT_STALE_TIME = 5 * 60 * 1000
+
+type PaginatedPage<T> = {
+  items: T[]
+  pagination: { hasMore: boolean; cursor: string | null }
+}
+
+export const fetchAllPaginatedItems = async <T>(
+  fetchPage: (cursor: string | undefined) => Promise<PaginatedPage<T>>,
+): Promise<T[]> => {
+  const items: T[] = []
+  let cursor: string | undefined
+  do {
+    const page = await fetchPage(cursor)
+    items.push(...page.items)
+    cursor =
+      page.pagination.hasMore && page.pagination.cursor
+        ? page.pagination.cursor
+        : undefined
+  } while (cursor)
+  return items
+}

--- a/apps/mb-webapp/src/routes/_authenticated/indicateurs/$id.tsx
+++ b/apps/mb-webapp/src/routes/_authenticated/indicateurs/$id.tsx
@@ -52,21 +52,23 @@ export const Route = createFileRoute('/_authenticated/indicateurs/$id')({
       context.queryClient.fetchQuery(indicateurIndividusQueryOptions(params.id)),
     ])
 
-    if (individus.length > 0) {
-      const isValid =
-        deps.individu !== undefined &&
-        individus.some((i) => i.individu.id === deps.individu)
-      if (!isValid) {
-        throw redirect({
-          to: '/indicateurs/$id',
-          params,
-          search: { individu: individus[0]!.individu.id },
-          replace: true,
-        })
-      }
+    if (individus.length === 0) return { indicateur, individus }
+
+    if (!deps.individu || !individus.some((i) => i.individu.id === deps.individu)) {
+      throw redirect({
+        to: '/indicateurs/$id',
+        params,
+        search: { individu: individus[0]!.individu.id },
+        replace: true,
+      })
     }
 
-    return [indicateur, individus] as const
+    // Préfetch des valeurs : useSuspenseQuery dans le composant tape le cache.
+    await context.queryClient.fetchQuery(
+      indicateurValeursQueryOptions(params.id, deps.individu),
+    )
+
+    return { indicateur, individus }
   },
   pendingComponent: () => <RouteLoading message="Chargement de l'indicateur…" />,
   errorComponent: RouteError,

--- a/apps/mb-webapp/src/routes/_authenticated/indicateurs/$id.tsx
+++ b/apps/mb-webapp/src/routes/_authenticated/indicateurs/$id.tsx
@@ -78,16 +78,17 @@ function IndicateurDetailComponent() {
 
   return (
     <div className="space-y-6">
-      <Link
-        to="/indicateurs"
-        search={{}}
-        className="text-sm text-secondary-foreground underline hover:text-text"
-      >
-        ← Retour à la liste
-      </Link>
+      <div>
+        <Link
+          to="/indicateurs"
+          search={{}}
+          className="text-sm text-secondary-foreground underline hover:text-text"
+        >
+          ← Retour à la liste
+        </Link>
+      </div>
 
       <header>
-        <span className="text-xs uppercase tracking-wide text-text-muted">{indicateur.id}</span>
         <h1 className="text-3xl font-semibold text-text">{indicateur.nom}</h1>
       </header>
 

--- a/apps/mb-webapp/src/routes/_authenticated/indicateurs/$id.tsx
+++ b/apps/mb-webapp/src/routes/_authenticated/indicateurs/$id.tsx
@@ -1,7 +1,13 @@
 import { indicateurPublicIdSchema } from '@pilote/mb-shared/indicateur'
 import { individuPublicIdSchema } from '@pilote/mb-shared/individu'
 import { useSuspenseQuery } from '@tanstack/react-query'
-import { createFileRoute, Link, useNavigate } from '@tanstack/react-router'
+import {
+  createFileRoute,
+  Link,
+  redirect,
+  useNavigate,
+} from '@tanstack/react-router'
+import { startTransition } from 'react'
 import { z } from 'zod'
 
 import { RouteError } from '@/components/RouteError'
@@ -39,11 +45,29 @@ export const Route = createFileRoute('/_authenticated/indicateurs/$id')({
     stringify: ({ id }) => ({ id }),
   },
   validateSearch: searchSchema,
-  loader: ({ context, params }) =>
-    Promise.all([
+  loaderDeps: ({ search }) => ({ individu: search.individu }),
+  loader: async ({ context, params, deps }) => {
+    const [indicateur, individus] = await Promise.all([
       context.queryClient.fetchQuery(indicateurQueryOptions(params.id)),
       context.queryClient.fetchQuery(indicateurIndividusQueryOptions(params.id)),
-    ]),
+    ])
+
+    if (individus.length > 0) {
+      const isValid =
+        deps.individu !== undefined &&
+        individus.some((i) => i.individu.id === deps.individu)
+      if (!isValid) {
+        throw redirect({
+          to: '/indicateurs/$id',
+          params,
+          search: { individu: individus[0]!.individu.id },
+          replace: true,
+        })
+      }
+    }
+
+    return [indicateur, individus] as const
+  },
   pendingComponent: () => <RouteLoading message="Chargement de l'indicateur…" />,
   errorComponent: RouteError,
   component: IndicateurDetailComponent,
@@ -59,10 +83,10 @@ function IndicateurDetailComponent() {
     indicateurIndividusQueryOptions(id),
   )
 
-  const selectedIndividu =
-    (search.individu && individus.find((i) => i.individu.id === search.individu)) ||
-    individus[0] ||
-    undefined
+  // Le loader garantit que `search.individu` est défini et valide dès lors que la liste n'est pas vide.
+  const selectedIndividu = search.individu
+    ? individus.find((i) => i.individu.id === search.individu)
+    : undefined
 
   return (
     <div className="space-y-6">
@@ -94,8 +118,10 @@ function IndicateurDetailComponent() {
             <Select
               value={selectedIndividu.individu.id}
               onValueChange={(value) => {
-                void navigate({
-                  search: (prev) => ({ ...prev, individu: value }),
+                startTransition(() => {
+                  void navigate({
+                    search: (prev) => ({ ...prev, individu: value }),
+                  })
                 })
               }}
             >

--- a/apps/mb-webapp/src/routes/_authenticated/indicateurs/$id.tsx
+++ b/apps/mb-webapp/src/routes/_authenticated/indicateurs/$id.tsx
@@ -1,13 +1,8 @@
 import { indicateurPublicIdSchema } from '@pilote/mb-shared/indicateur'
 import { individuPublicIdSchema } from '@pilote/mb-shared/individu'
 import { useSuspenseQuery } from '@tanstack/react-query'
-import {
-  createFileRoute,
-  Link,
-  redirect,
-  useNavigate,
-} from '@tanstack/react-router'
-import { startTransition, Suspense } from 'react'
+import { createFileRoute, Link, redirect, useNavigate } from '@tanstack/react-router'
+import { startTransition } from 'react'
 import { z } from 'zod'
 
 import { RouteError } from '@/components/RouteError'
@@ -19,12 +14,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/Select'
-import {
-  Tabs,
-  TabsContent,
-  TabsList,
-  TabsTrigger,
-} from '@/components/ui/Tabs'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/Tabs'
 import {
   indicateurIndividusQueryOptions,
   indicateurQueryOptions,
@@ -64,9 +54,7 @@ export const Route = createFileRoute('/_authenticated/indicateurs/$id')({
     }
 
     // Préfetch des valeurs : useSuspenseQuery dans le composant tape le cache.
-    await context.queryClient.fetchQuery(
-      indicateurValeursQueryOptions(params.id, deps.individu),
-    )
+    await context.queryClient.fetchQuery(indicateurValeursQueryOptions(params.id, deps.individu))
 
     return { indicateur, individus }
   },
@@ -81,9 +69,7 @@ function IndicateurDetailComponent() {
   const navigate = useNavigate({ from: Route.fullPath })
 
   const { data: indicateur } = useSuspenseQuery(indicateurQueryOptions(id))
-  const { data: individus } = useSuspenseQuery(
-    indicateurIndividusQueryOptions(id),
-  )
+  const { data: individus } = useSuspenseQuery(indicateurIndividusQueryOptions(id))
 
   // Le loader garantit que `search.individu` est défini et valide dès lors que la liste n'est pas vide.
   const selectedIndividu = search.individu
@@ -101,9 +87,7 @@ function IndicateurDetailComponent() {
       </Link>
 
       <header>
-        <span className="text-xs uppercase tracking-wide text-text-muted">
-          {indicateur.id}
-        </span>
+        <span className="text-xs uppercase tracking-wide text-text-muted">{indicateur.id}</span>
         <h1 className="text-3xl font-semibold text-text">{indicateur.nom}</h1>
       </header>
 
@@ -147,18 +131,7 @@ function IndicateurDetailComponent() {
             </TabsList>
 
             <TabsContent value="valeurs">
-              <Suspense
-                fallback={
-                  <p className="rounded border border-border bg-surface p-6 text-sm text-text-muted">
-                    Chargement des valeurs…
-                  </p>
-                }
-              >
-                <ValeursTable
-                  indicateurId={id}
-                  individuId={selectedIndividu.individu.id}
-                />
-              </Suspense>
+              <ValeursTable indicateurId={id} individuId={selectedIndividu.individu.id} />
             </TabsContent>
 
             <TabsContent value="metadonnees">
@@ -171,20 +144,10 @@ function IndicateurDetailComponent() {
   )
 }
 
-function ValeursTable({
-  indicateurId,
-  individuId,
-}: {
-  indicateurId: string
-  individuId: string
-}) {
-  const { data } = useSuspenseQuery(
-    indicateurValeursQueryOptions(indicateurId, individuId),
-  )
+function ValeursTable({ indicateurId, individuId }: { indicateurId: string; individuId: string }) {
+  const { data } = useSuspenseQuery(indicateurValeursQueryOptions(indicateurId, individuId))
 
-  const rows = [...data.items].sort((a, b) =>
-    a.date < b.date ? 1 : a.date > b.date ? -1 : 0,
-  )
+  const rows = [...data.items].sort((a, b) => (a.date < b.date ? 1 : a.date > b.date ? -1 : 0))
 
   if (rows.length === 0) {
     return (
@@ -234,14 +197,10 @@ function MetadonneesPanel({
       <dd className="text-text">{indicateur.nom}</dd>
 
       <dt className="text-text-muted">Créé le</dt>
-      <dd className="text-text">
-        {new Date(indicateur.createdAt).toLocaleString('fr-FR')}
-      </dd>
+      <dd className="text-text">{new Date(indicateur.createdAt).toLocaleString('fr-FR')}</dd>
 
       <dt className="text-text-muted">Mis à jour le</dt>
-      <dd className="text-text">
-        {new Date(indicateur.updatedAt).toLocaleString('fr-FR')}
-      </dd>
+      <dd className="text-text">{new Date(indicateur.updatedAt).toLocaleString('fr-FR')}</dd>
     </dl>
   )
 }

--- a/apps/mb-webapp/src/routes/_authenticated/indicateurs/$id.tsx
+++ b/apps/mb-webapp/src/routes/_authenticated/indicateurs/$id.tsx
@@ -7,7 +7,7 @@ import {
   redirect,
   useNavigate,
 } from '@tanstack/react-router'
-import { startTransition } from 'react'
+import { startTransition, Suspense } from 'react'
 import { z } from 'zod'
 
 import { RouteError } from '@/components/RouteError'
@@ -145,10 +145,18 @@ function IndicateurDetailComponent() {
             </TabsList>
 
             <TabsContent value="valeurs">
-              <ValeursTable
-                indicateurId={id}
-                individuId={selectedIndividu.individu.id}
-              />
+              <Suspense
+                fallback={
+                  <p className="rounded border border-border bg-surface p-6 text-sm text-text-muted">
+                    Chargement des valeurs…
+                  </p>
+                }
+              >
+                <ValeursTable
+                  indicateurId={id}
+                  individuId={selectedIndividu.individu.id}
+                />
+              </Suspense>
             </TabsContent>
 
             <TabsContent value="metadonnees">

--- a/apps/mb-webapp/src/routes/_authenticated/indicateurs/$id.tsx
+++ b/apps/mb-webapp/src/routes/_authenticated/indicateurs/$id.tsx
@@ -2,11 +2,13 @@ import { indicateurPublicIdSchema } from '@pilote/mb-shared/indicateur'
 import { individuPublicIdSchema } from '@pilote/mb-shared/individu'
 import { useSuspenseQuery } from '@tanstack/react-query'
 import { createFileRoute, Link, redirect, useNavigate } from '@tanstack/react-router'
+import { ArrowLeft } from 'lucide-react'
 import { startTransition } from 'react'
 import { z } from 'zod'
 
 import { RouteError } from '@/components/RouteError'
 import { RouteLoading } from '@/components/RouteLoading'
+import { Button } from '@/components/ui/Button'
 import {
   Select,
   SelectContent,
@@ -79,13 +81,12 @@ function IndicateurDetailComponent() {
   return (
     <div className="space-y-6">
       <div>
-        <Link
-          to="/indicateurs"
-          search={{}}
-          className="text-sm text-secondary-foreground underline hover:text-text"
-        >
-          ← Retour à la liste
-        </Link>
+        <Button variant="tertiary" size="sm" asChild>
+          <Link to="/indicateurs" search={{}}>
+            <ArrowLeft />
+            Retour à la liste
+          </Link>
+        </Button>
       </div>
 
       <header>

--- a/apps/mb-webapp/src/routes/_authenticated/indicateurs/$id.tsx
+++ b/apps/mb-webapp/src/routes/_authenticated/indicateurs/$id.tsx
@@ -1,14 +1,36 @@
 import { indicateurPublicIdSchema } from '@pilote/mb-shared/indicateur'
+import { individuPublicIdSchema } from '@pilote/mb-shared/individu'
 import { useSuspenseQuery } from '@tanstack/react-query'
-import { createFileRoute, Link } from '@tanstack/react-router'
+import { createFileRoute, Link, useNavigate } from '@tanstack/react-router'
 import { z } from 'zod'
 
 import { RouteError } from '@/components/RouteError'
 import { RouteLoading } from '@/components/RouteLoading'
-import { indicateurQueryOptions } from '@/queries/indicateurs'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/Select'
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from '@/components/ui/Tabs'
+import {
+  indicateurIndividusQueryOptions,
+  indicateurQueryOptions,
+  indicateurValeursQueryOptions,
+} from '@/queries/indicateurs'
 
 const paramsSchema = z.object({
   id: indicateurPublicIdSchema,
+})
+
+const searchSchema = z.object({
+  individu: individuPublicIdSchema.optional(),
 })
 
 export const Route = createFileRoute('/_authenticated/indicateurs/$id')({
@@ -16,8 +38,12 @@ export const Route = createFileRoute('/_authenticated/indicateurs/$id')({
     parse: (raw) => paramsSchema.parse(raw),
     stringify: ({ id }) => ({ id }),
   },
+  validateSearch: searchSchema,
   loader: ({ context, params }) =>
-    context.queryClient.fetchQuery(indicateurQueryOptions(params.id)),
+    Promise.all([
+      context.queryClient.fetchQuery(indicateurQueryOptions(params.id)),
+      context.queryClient.fetchQuery(indicateurIndividusQueryOptions(params.id)),
+    ]),
   pendingComponent: () => <RouteLoading message="Chargement de l'indicateur…" />,
   errorComponent: RouteError,
   component: IndicateurDetailComponent,
@@ -25,40 +51,161 @@ export const Route = createFileRoute('/_authenticated/indicateurs/$id')({
 
 function IndicateurDetailComponent() {
   const { id } = Route.useParams()
-  const { data } = useSuspenseQuery(indicateurQueryOptions(id))
+  const search = Route.useSearch()
+  const navigate = useNavigate({ from: Route.fullPath })
+
+  const { data: indicateur } = useSuspenseQuery(indicateurQueryOptions(id))
+  const { data: individus } = useSuspenseQuery(
+    indicateurIndividusQueryOptions(id),
+  )
+
+  const selectedIndividu =
+    (search.individu && individus.find((i) => i.individu.id === search.individu)) ||
+    individus[0] ||
+    undefined
 
   return (
     <div className="space-y-6">
       <Link
         to="/indicateurs"
         search={{}}
-        className="text-sm text-slate-700 underline hover:text-slate-900"
+        className="text-sm text-secondary-foreground underline hover:text-text"
       >
         ← Retour à la liste
       </Link>
 
       <header>
-        <span className="text-xs uppercase tracking-wide text-slate-500">
-          {data.id}
+        <span className="text-xs uppercase tracking-wide text-text-muted">
+          {indicateur.id}
         </span>
-        <h1 className="text-3xl font-semibold">{data.nom}</h1>
+        <h1 className="text-3xl font-semibold text-text">{indicateur.nom}</h1>
       </header>
 
-      <section className="rounded border border-slate-200 bg-white p-6 text-sm text-slate-600">
-        <p>Créé le {new Date(data.createdAt).toLocaleString('fr-FR')}</p>
-        <p>Mis à jour le {new Date(data.updatedAt).toLocaleString('fr-FR')}</p>
-      </section>
+      {selectedIndividu === undefined ? (
+        <p className="rounded border border-border bg-surface p-6 text-sm text-text-muted">
+          Aucun individu n'a de valeur pour cet indicateur.
+        </p>
+      ) : (
+        <>
+          <div className="flex items-center gap-3">
+            <label className="text-sm text-text-muted" htmlFor="individu-select">
+              Individu
+            </label>
+            <Select
+              value={selectedIndividu.individu.id}
+              onValueChange={(value) => {
+                void navigate({
+                  search: (prev) => ({ ...prev, individu: value }),
+                })
+              }}
+            >
+              <SelectTrigger id="individu-select" className="min-w-[16rem]">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {individus.map(({ individu }) => (
+                  <SelectItem key={individu.id} value={individu.id}>
+                    {individu.nom}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
 
-      <section className="rounded border border-slate-200 bg-slate-100 p-4 text-sm">
-        <p className="font-medium">Diagnostic TanStack Router</p>
-        <ul className="mt-2 list-inside list-disc text-slate-700">
-          <li>
-            ✓ Route param <code>id</code> = <strong>{id}</strong>
-          </li>
-          <li>✓ Loader détail exécuté</li>
-          <li>✓ useSuspenseQuery (cache partagé avec liste)</li>
-        </ul>
-      </section>
+          <Tabs defaultValue="valeurs">
+            <TabsList>
+              <TabsTrigger value="valeurs">Valeurs</TabsTrigger>
+              <TabsTrigger value="metadonnees">Métadonnées</TabsTrigger>
+            </TabsList>
+
+            <TabsContent value="valeurs">
+              <ValeursTable
+                indicateurId={id}
+                individuId={selectedIndividu.individu.id}
+              />
+            </TabsContent>
+
+            <TabsContent value="metadonnees">
+              <MetadonneesPanel indicateur={indicateur} />
+            </TabsContent>
+          </Tabs>
+        </>
+      )}
     </div>
+  )
+}
+
+function ValeursTable({
+  indicateurId,
+  individuId,
+}: {
+  indicateurId: string
+  individuId: string
+}) {
+  const { data } = useSuspenseQuery(
+    indicateurValeursQueryOptions(indicateurId, individuId),
+  )
+
+  const rows = [...data.items].sort((a, b) =>
+    a.date < b.date ? 1 : a.date > b.date ? -1 : 0,
+  )
+
+  if (rows.length === 0) {
+    return (
+      <p className="rounded border border-border bg-surface p-6 text-sm text-text-muted">
+        Aucune valeur pour cet individu.
+      </p>
+    )
+  }
+
+  return (
+    <div className="overflow-hidden rounded border border-border bg-surface">
+      <table className="w-full text-sm">
+        <thead className="bg-secondary-hover text-text">
+          <tr>
+            <th className="px-4 py-2 text-left font-medium">Date</th>
+            <th className="px-4 py-2 text-right font-medium">Valeur</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-border">
+          {rows.map((row) => (
+            <tr key={row.date}>
+              <td className="px-4 py-2 text-text">
+                {new Date(row.date).toLocaleDateString('fr-FR')}
+              </td>
+              <td className="px-4 py-2 text-right text-text">
+                {row.valeur.toLocaleString('fr-FR')}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+function MetadonneesPanel({
+  indicateur,
+}: {
+  indicateur: { id: string; nom: string; createdAt: string; updatedAt: string }
+}) {
+  return (
+    <dl className="grid grid-cols-[max-content_1fr] gap-x-6 gap-y-2 rounded border border-border bg-surface p-6 text-sm">
+      <dt className="text-text-muted">ID</dt>
+      <dd className="text-text">{indicateur.id}</dd>
+
+      <dt className="text-text-muted">Nom</dt>
+      <dd className="text-text">{indicateur.nom}</dd>
+
+      <dt className="text-text-muted">Créé le</dt>
+      <dd className="text-text">
+        {new Date(indicateur.createdAt).toLocaleString('fr-FR')}
+      </dd>
+
+      <dt className="text-text-muted">Mis à jour le</dt>
+      <dd className="text-text">
+        {new Date(indicateur.updatedAt).toLocaleString('fr-FR')}
+      </dd>
+    </dl>
   )
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,9 +110,15 @@ importers:
       '@pilote/mb-shared':
         specifier: workspace:*
         version: link:../../packages/mb-shared
+      '@radix-ui/react-select':
+        specifier: ^2.2.6
+        version: 2.2.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@radix-ui/react-slot':
         specifier: ^1.2.4
         version: 1.2.4(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-tabs':
+        specifier: ^1.1.13
+        version: 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@tanstack/react-query':
         specifier: ^5.62.7
         version: 5.99.0(react@19.2.5)


### PR DESCRIPTION
## Summary

Branche la page `/indicateurs/$id` sur les endpoints `/indicateurs/:id/individus` et `/indicateurs/:id/valeurs` :

- **Select Radix** pour choisir l'individu lié à l'indicateur (label = nom de l'individu)
- **Sélection initiale via search param** `?individu=...` — si absent ou invalide, le loader fait un `redirect({ replace: true })` vers le premier individu, l'URL est canonique dès l'arrivée
- **Onglet Valeurs** (Radix Tabs) — tableau Date / Valeur, tri date desc, format FR
- **Onglet Métadonnées** — ID, Nom, Créé le, Mis à jour le
- `startTransition` + `<Suspense>` locale autour du tableau pour éviter le flash sur changement d'individu (React 19 pattern)

## Architecture

- **Helper générique `fetchAllPaginatedItems`** dans `queries/utils.ts` — boucle sur le `cursor` jusqu'à `hasMore=false`. Couche `api/` reste unitaire (1 page = 1 appel HTTP), la boucle multi-pages est dans le `queryFn`.
- **Composants UI partagés** `Select.tsx` et `Tabs.tsx` (Radix wrappers + `clsxm`), pattern identique à `Button.tsx`.
- Tokens sémantiques Tailwind (`bg-surface`, `text-text`, `border-border`, …), continuité du design minimaliste.

## Endpoints consommés

- `GET /indicateurs/:id` — `IndicateurApiModel`
- `GET /indicateurs/:id/individus?cursor?` — paginé, agrégé via `fetchAllPaginatedItems`
- `GET /indicateurs/:id/valeurs?individus=…` — toutes les valeurs pour l'individu sélectionné

## Hors scope

- Sélection multiple d'individus
- Filtres `dateDebut` / `dateFin`
- Filtre par référentiel
- Recherche dans le select
- Graphique des valeurs

## Test plan

- [ ] La page liste les indicateurs → cliquer un indicateur → atterrit sur `/indicateurs/IND-XX?individu=DEPT-YY` (premier individu auto-sélectionné, URL canonique)
- [ ] Changer l'individu via le select met à jour l'URL et le tableau, sans flash visuel ("Chargement de l'indicateur…" ne doit pas apparaître)
- [ ] Recharger la page sur une URL avec `?individu=DEPT-ZZ` valide → cet individu est sélectionné
- [ ] URL avec un individu inexistant → redirect (replace) vers le premier individu valide
- [ ] Onglet Valeurs : tableau Date / Valeur, tri desc, format FR (date `JJ/MM/AAAA`, valeur séparateurs FR)
- [ ] Onglet Métadonnées : ID, Nom, Créé le, Mis à jour le
- [ ] Indicateur sans aucun individu lié → message "Aucun individu n'a de valeur pour cet indicateur."
- [ ] Individu avec zéro valeur → message "Aucune valeur pour cet individu."