### PR TITLE
feat(mb): exposer prenom et nom de l'utilisateur

### DIFF
--- a/apps/mb-api/src/authentication/jwks.ts
+++ b/apps/mb-api/src/authentication/jwks.ts
@@ -16,6 +16,8 @@ const jwtPayloadSchema = z.object({
 export type VerifiedTokenInfo = {
   providerSub: string
   providerType: 'keycloak'
+  prenom: string | undefined
+  nom: string | undefined
 }
 
 export const verifyAccessToken = async (token: string): Promise<VerifiedTokenInfo> => {
@@ -29,5 +31,10 @@ export const verifyAccessToken = async (token: string): Promise<VerifiedTokenInf
 
   const claims = jwtPayloadSchema.parse(payload)
 
-  return { providerSub: claims.sub, providerType: 'keycloak' }
+  return {
+    providerSub: claims.sub,
+    providerType: 'keycloak',
+    prenom: claims.given_name,
+    nom: claims.family_name,
+  }
 }

--- a/apps/mb-api/src/authentication/jwks.ts
+++ b/apps/mb-api/src/authentication/jwks.ts
@@ -1,8 +1,17 @@
-import { createRemoteJWKSet, jwtVerify, type JWTPayload } from 'jose'
+import { createRemoteJWKSet, jwtVerify } from 'jose'
+import { z } from 'zod'
 
 import { env } from '@/env'
 
 const jwks = createRemoteJWKSet(new URL(env.OIDC_JWKS_URI))
+
+const jwtPayloadSchema = z.object({
+  typ: z.literal('Bearer'),
+  azp: z.literal(env.OIDC_AUTHORIZED_PARTY),
+  sub: z.string().min(1),
+  given_name: z.string().min(1).optional(),
+  family_name: z.string().min(1).optional(),
+})
 
 export type VerifiedTokenInfo = {
   providerSub: string
@@ -18,20 +27,7 @@ export const verifyAccessToken = async (token: string): Promise<VerifiedTokenInf
     clockTolerance: 30,
   })
 
-  if (payload.typ !== 'Bearer') {
-    throw new Error(`Unexpected token typ claim: ${String(payload.typ)}`)
-  }
+  const claims = jwtPayloadSchema.parse(payload)
 
-  if (!isAuthorizedParty(payload)) {
-    throw new Error('Unexpected authorized party')
-  }
-
-  if (typeof payload.sub !== 'string' || payload.sub.length === 0) {
-    throw new Error('Missing sub claim')
-  }
-
-  return { providerSub: payload.sub, providerType: 'keycloak' }
+  return { providerSub: claims.sub, providerType: 'keycloak' }
 }
-
-const isAuthorizedParty = (payload: JWTPayload) =>
-  typeof payload.azp === 'string' && payload.azp === env.OIDC_AUTHORIZED_PARTY

--- a/apps/mb-api/src/authentication/jwks.ts
+++ b/apps/mb-api/src/authentication/jwks.ts
@@ -9,15 +9,15 @@ const jwtPayloadSchema = z.object({
   typ: z.literal('Bearer'),
   azp: z.literal(env.OIDC_AUTHORIZED_PARTY),
   sub: z.string().min(1),
-  given_name: z.string().min(1).optional(),
-  family_name: z.string().min(1).optional(),
+  given_name: z.string().min(1),
+  family_name: z.string().min(1),
 })
 
 export type VerifiedTokenInfo = {
   providerSub: string
   providerType: 'keycloak'
-  prenom: string | undefined
-  nom: string | undefined
+  prenom: string
+  nom: string
 }
 
 export const verifyAccessToken = async (token: string): Promise<VerifiedTokenInfo> => {

--- a/apps/mb-api/src/authentication/queries/getUtilisateurByProvider.ts
+++ b/apps/mb-api/src/authentication/queries/getUtilisateurByProvider.ts
@@ -2,7 +2,7 @@ import { ResultAsync } from 'neverthrow'
 
 import { prisma } from '@/framework/persistence/prisma'
 
-export type UtilisateurAuthentifie = {
+export type UtilisateurEnregistre = {
   id: string
   providerSub: string
   providerType: 'keycloak'
@@ -11,7 +11,7 @@ export type UtilisateurAuthentifie = {
 export const getUtilisateurByProvider = (params: {
   providerSub: string
   providerType: 'keycloak'
-}): ResultAsync<UtilisateurAuthentifie | null, never> =>
+}): ResultAsync<UtilisateurEnregistre | null, never> =>
   ResultAsync.fromSafePromise(
     prisma.utilisateur.findUnique({
       where: {

--- a/apps/mb-api/src/authentication/routes/me.ts
+++ b/apps/mb-api/src/authentication/routes/me.ts
@@ -26,7 +26,12 @@ me.openapi(meRoute, (context) => {
   const user = requireUser()
   return jsonResponseOk({
     context,
-    data: { userId: user.id, source: 'jwt' as const },
+    data: {
+      userId: user.id,
+      prenom: user.prenom,
+      nom: user.nom,
+      source: 'jwt' as const,
+    },
     schema: MeOkSchema,
     status: 200,
   })

--- a/apps/mb-api/src/authentication/routes/me.ts
+++ b/apps/mb-api/src/authentication/routes/me.ts
@@ -30,7 +30,6 @@ me.openapi(meRoute, (context) => {
       userId: user.id,
       prenom: user.prenom,
       nom: user.nom,
-      source: 'jwt' as const,
     },
     schema: MeOkSchema,
     status: 200,

--- a/apps/mb-api/src/framework/auth/authContext.test.ts
+++ b/apps/mb-api/src/framework/auth/authContext.test.ts
@@ -72,7 +72,12 @@ describe.sequential('authContext middleware', () => {
   })
 
   it('returns 401 on /protected when token is valid but user is not provisioned', async () => {
-    verify.mockResolvedValue({ providerSub: 'sub-123', providerType: 'keycloak' })
+    verify.mockResolvedValue({
+      providerSub: 'sub-123',
+      providerType: 'keycloak',
+      prenom: 'Admin',
+      nom: 'DITP',
+    })
     lookup.mockReturnValue(okAsync(null))
     const app = buildApp()
     const response = await app.request('/protected', {
@@ -82,11 +87,18 @@ describe.sequential('authContext middleware', () => {
     expect(lookup).toHaveBeenCalledWith({
       providerSub: 'sub-123',
       providerType: 'keycloak',
+      prenom: 'Admin',
+      nom: 'DITP',
     })
   })
 
   it('exposes the user to handlers when the lookup succeeds', async () => {
-    verify.mockResolvedValue({ providerSub: 'sub-123', providerType: 'keycloak' })
+    verify.mockResolvedValue({
+      providerSub: 'sub-123',
+      providerType: 'keycloak',
+      prenom: 'Admin',
+      nom: 'DITP',
+    })
     lookup.mockReturnValue(
       okAsync({
         id: '01906f5e-1234-7000-8abc-000000000001',
@@ -107,7 +119,12 @@ describe.sequential('authContext middleware', () => {
   })
 
   it('accepts the Bearer scheme case-insensitively (RFC 6750)', async () => {
-    verify.mockResolvedValue({ providerSub: 'sub-123', providerType: 'keycloak' })
+    verify.mockResolvedValue({
+      providerSub: 'sub-123',
+      providerType: 'keycloak',
+      prenom: 'Admin',
+      nom: 'DITP',
+    })
     lookup.mockReturnValue(
       okAsync({
         id: '01906f5e-1234-7000-8abc-000000000001',

--- a/apps/mb-api/src/framework/auth/authContext.test.ts
+++ b/apps/mb-api/src/framework/auth/authContext.test.ts
@@ -115,6 +115,8 @@ describe.sequential('authContext middleware', () => {
       id: '01906f5e-1234-7000-8abc-000000000001',
       providerSub: 'sub-123',
       providerType: 'keycloak',
+      prenom: 'Admin',
+      nom: 'DITP',
     })
   })
 

--- a/apps/mb-api/src/framework/auth/authContext.ts
+++ b/apps/mb-api/src/framework/auth/authContext.ts
@@ -1,8 +1,9 @@
 import { createMiddleware } from 'hono/factory'
+import { okAsync, ResultAsync } from 'neverthrow'
 
 import { verifyAccessToken } from '@/authentication/jwks'
 import { getUtilisateurByProvider } from '@/authentication/queries/getUtilisateurByProvider'
-import { runWithUser } from '@/framework/auth/userContext'
+import { runWithUser, type UtilisateurAuthentifie } from '@/framework/auth/userContext'
 import { logger } from '@/framework/logger/logger'
 
 const BEARER_REGEX = /^Bearer\s+(.+)$/i
@@ -15,40 +16,36 @@ const extractBearerToken = (header: string | undefined): string | null => {
   return token && token.length > 0 ? token : null
 }
 
-const resolveUser = async (authorization: string | undefined) => {
+const resolveUser = (
+  authorization: string | undefined,
+): ResultAsync<UtilisateurAuthentifie | null, unknown> => {
   const token = extractBearerToken(authorization)
-  if (!token) return null
+  if (!token) return okAsync(null)
 
-  let verifiedTokenInfo
-  try {
-    verifiedTokenInfo = await verifyAccessToken(token)
-  } catch (error) {
-    logger.warn(
-      { event: 'auth.jwt.invalid', reason: error instanceof Error ? error.message : 'unknown' },
-      'JWT verification failed',
-    )
-    return null
-  }
-
-  const utilisateur = await getUtilisateurByProvider(verifiedTokenInfo)
+  return ResultAsync.fromPromise(verifyAccessToken(token), (error) => error)
     .orTee((error) =>
       logger.warn(
-        { event: 'auth.user.lookup_failed', err: error },
-        'User lookup failed during authentication',
+        { event: 'auth.jwt.invalid', reason: error instanceof Error ? error.message : 'unknown' },
+        'JWT verification failed',
       ),
     )
-    .unwrapOr(null)
-
-  if (!utilisateur) return null
-
-  return {
-    ...utilisateur,
-    prenom: verifiedTokenInfo.prenom,
-    nom: verifiedTokenInfo.nom,
-  }
+    .andThen((verifiedTokenInfo) =>
+      getUtilisateurByProvider(verifiedTokenInfo)
+        .map((utilisateur): UtilisateurAuthentifie | null =>
+          utilisateur
+            ? { ...utilisateur, prenom: verifiedTokenInfo.prenom, nom: verifiedTokenInfo.nom }
+            : null,
+        )
+        .orTee((error) =>
+          logger.warn(
+            { event: 'auth.user.lookup_failed', err: error },
+            'User lookup failed during authentication',
+          ),
+        ),
+    )
 }
 
 export const authContext = createMiddleware(async (context, next) => {
-  const user = await resolveUser(context.req.header('Authorization'))
+  const user = await resolveUser(context.req.header('Authorization')).unwrapOr(null)
   await runWithUser(user, next)
 })

--- a/apps/mb-api/src/framework/auth/authContext.ts
+++ b/apps/mb-api/src/framework/auth/authContext.ts
@@ -1,5 +1,4 @@
 import { createMiddleware } from 'hono/factory'
-import { okAsync } from 'neverthrow'
 
 import { verifyAccessToken } from '@/authentication/jwks'
 import { getUtilisateurByProvider } from '@/authentication/queries/getUtilisateurByProvider'
@@ -18,7 +17,7 @@ const extractBearerToken = (header: string | undefined): string | null => {
 
 const resolveUser = async (authorization: string | undefined) => {
   const token = extractBearerToken(authorization)
-  if (!token) return okAsync(null)
+  if (!token) return null
 
   let verifiedTokenInfo
   try {
@@ -28,18 +27,28 @@ const resolveUser = async (authorization: string | undefined) => {
       { event: 'auth.jwt.invalid', reason: error instanceof Error ? error.message : 'unknown' },
       'JWT verification failed',
     )
-    return okAsync(null)
+    return null
   }
 
-  return getUtilisateurByProvider(verifiedTokenInfo).orTee((error) =>
-    logger.warn(
-      { event: 'auth.user.lookup_failed', err: error },
-      'User lookup failed during authentication',
-    ),
-  )
+  const utilisateur = await getUtilisateurByProvider(verifiedTokenInfo)
+    .orTee((error) =>
+      logger.warn(
+        { event: 'auth.user.lookup_failed', err: error },
+        'User lookup failed during authentication',
+      ),
+    )
+    .unwrapOr(null)
+
+  if (!utilisateur) return null
+
+  return {
+    ...utilisateur,
+    prenom: verifiedTokenInfo.prenom,
+    nom: verifiedTokenInfo.nom,
+  }
 }
 
 export const authContext = createMiddleware(async (context, next) => {
   const user = await resolveUser(context.req.header('Authorization'))
-  await runWithUser(user.unwrapOr(null), next)
+  await runWithUser(user, next)
 })

--- a/apps/mb-api/src/framework/auth/userContext.ts
+++ b/apps/mb-api/src/framework/auth/userContext.ts
@@ -1,11 +1,13 @@
 import { AsyncLocalStorage } from 'node:async_hooks'
 
-import type { UtilisateurEnregistre } from '@/authentication/queries/getUtilisateurByProvider'
 import { UnauthorizedError } from '@/framework/auth/UnauthorizedError'
 
-export type UtilisateurAuthentifie = UtilisateurEnregistre & {
-  prenom: string | undefined
-  nom: string | undefined
+export type UtilisateurAuthentifie = {
+  id: string
+  providerSub: string
+  providerType: 'keycloak'
+  prenom: string
+  nom: string
 }
 
 type UserStore = { user: UtilisateurAuthentifie | null }

--- a/apps/mb-api/src/framework/auth/userContext.ts
+++ b/apps/mb-api/src/framework/auth/userContext.ts
@@ -1,7 +1,12 @@
 import { AsyncLocalStorage } from 'node:async_hooks'
 
-import type { UtilisateurAuthentifie } from '@/authentication/queries/getUtilisateurByProvider'
+import type { UtilisateurEnregistre } from '@/authentication/queries/getUtilisateurByProvider'
 import { UnauthorizedError } from '@/framework/auth/UnauthorizedError'
+
+export type UtilisateurAuthentifie = UtilisateurEnregistre & {
+  prenom: string | undefined
+  nom: string | undefined
+}
 
 type UserStore = { user: UtilisateurAuthentifie | null }
 

--- a/apps/mb-webapp/eslint.config.mjs
+++ b/apps/mb-webapp/eslint.config.mjs
@@ -25,7 +25,7 @@ export default tseslint.config(
       ...reactHooks.configs.recommended.rules,
       'react-hooks/rules-of-hooks': 'error',
       'react-hooks/exhaustive-deps': 'error',
-      'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
+      'react-refresh/only-export-components': 'off',
       '@typescript-eslint/only-throw-error': [
         'error',
         {
@@ -47,16 +47,6 @@ export default tseslint.config(
         'error',
         { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
       ],
-    },
-  },
-  {
-    // TanStack Router file-based routing: route files export `Route` (config)
-    // alongside an unexported component used as `component:`. This pattern is
-    // intentional — exporting the component would defeat autoCodeSplitting.
-    // Fast Refresh falls back to a full route reload in dev, which is fine.
-    files: ['src/routes/**/*.{ts,tsx}'],
-    rules: {
-      'react-refresh/only-export-components': 'off',
     },
   },
 )

--- a/apps/mb-webapp/src/auth.test.ts
+++ b/apps/mb-webapp/src/auth.test.ts
@@ -45,7 +45,7 @@ describe.sequential('auth singleton', () => {
       await auth.bootstrap()
 
       expect(auth.isAuthenticated).toBe(true)
-      expect(auth.user).toEqual({ prenom: 'Admin', nom: 'DITP' })
+      expect(auth.user).toEqual({ userId: 'sub-123', prenom: 'Admin', nom: 'DITP' })
       expect(tokenStore.get()).toBe('access-1')
     })
   })

--- a/apps/mb-webapp/src/auth.test.ts
+++ b/apps/mb-webapp/src/auth.test.ts
@@ -37,13 +37,15 @@ describe.sequential('auth singleton', () => {
         http.post(bffUrl('/auth/refresh'), () =>
           HttpResponse.json(buildRefreshResponse({ accessToken: 'access-1' })),
         ),
-        http.get(apiUrl('/me'), () => HttpResponse.json(buildMe({ userId: 'sub-123' }))),
+        http.get(apiUrl('/me'), () =>
+          HttpResponse.json(buildMe({ userId: 'sub-123', prenom: 'Admin', nom: 'DITP' })),
+        ),
       )
 
       await auth.bootstrap()
 
       expect(auth.isAuthenticated).toBe(true)
-      expect(auth.user).toEqual({ id: 'sub-123' })
+      expect(auth.user).toEqual({ prenom: 'Admin', nom: 'DITP' })
       expect(tokenStore.get()).toBe('access-1')
     })
   })

--- a/apps/mb-webapp/src/auth.ts
+++ b/apps/mb-webapp/src/auth.ts
@@ -5,7 +5,8 @@ import { fetchMe } from '@/api/me'
 import { tokenStore } from '@/auth/tokenStore'
 
 export type AuthUser = {
-  id: string
+  prenom: string | undefined
+  nom: string | undefined
 }
 
 export type Auth = {
@@ -77,7 +78,7 @@ export const auth: Auth = {
         return
       }
       const me = await fetchMe()
-      state.user = { id: me.userId }
+      state.user = { prenom: me.prenom, nom: me.nom }
     } catch {
       tokenStore.clear()
       state.user = null

--- a/apps/mb-webapp/src/auth.ts
+++ b/apps/mb-webapp/src/auth.ts
@@ -1,17 +1,13 @@
 import ky, { HTTPError } from 'ky'
+import type { MeApiModel } from '@pilote/mb-shared/me'
 import { z } from 'zod'
 
 import { fetchMe } from '@/api/me'
 import { tokenStore } from '@/auth/tokenStore'
 
-export type AuthUser = {
-  prenom: string | undefined
-  nom: string | undefined
-}
-
 export type Auth = {
   isAuthenticated: boolean
-  user: AuthUser | null
+  user: MeApiModel | null
   bootstrap: () => Promise<void>
   login: (redirect?: string) => void
   logout: () => Promise<void>
@@ -31,7 +27,7 @@ const logoutResponseSchema = z.object({
   logoutUrl: z.string().nullable(),
 })
 
-const state: { user: AuthUser | null } = {
+const state: { user: MeApiModel | null } = {
   user: null,
 }
 
@@ -77,8 +73,7 @@ export const auth: Auth = {
         state.user = null
         return
       }
-      const me = await fetchMe()
-      state.user = { prenom: me.prenom, nom: me.nom }
+      state.user = await fetchMe()
     } catch {
       tokenStore.clear()
       state.user = null

--- a/apps/mb-webapp/src/routes/__root.tsx
+++ b/apps/mb-webapp/src/routes/__root.tsx
@@ -38,7 +38,9 @@ function RootComponent() {
             </Link>
             {auth.isAuthenticated ? (
               <span className="flex items-center gap-2">
-                <span className="text-text-muted">{auth.user?.id}</span>
+                <span className="text-text-muted">
+                  {auth.user?.prenom} {auth.user?.nom}
+                </span>
                 <Button
                   variant="secondary"
                   size="sm"

--- a/apps/mb-webapp/src/routes/_authenticated/indicateurs/index.tsx
+++ b/apps/mb-webapp/src/routes/_authenticated/indicateurs/index.tsx
@@ -27,7 +27,6 @@ export const Route = createFileRoute('/_authenticated/indicateurs/')({
 })
 
 function IndicateursListComponent() {
-  const { auth } = Route.useRouteContext()
   const search = Route.useSearch()
   const navigate = useNavigate({ from: Route.fullPath })
   const { data } = useSuspenseQuery(indicateursQueryOptions(search))
@@ -36,9 +35,6 @@ function IndicateursListComponent() {
     <div className="space-y-6">
       <header className="flex items-center justify-between">
         <h1 className="text-2xl font-semibold">Indicateurs</h1>
-        <span className="rounded bg-emerald-100 px-2 py-1 text-xs text-emerald-800">
-          🔒 Authentifié — sub: {auth.user?.id}
-        </span>
       </header>
 
       <div className="flex flex-wrap gap-3">

--- a/apps/mb-webapp/src/tests/factories/api.ts
+++ b/apps/mb-webapp/src/tests/factories/api.ts
@@ -4,7 +4,8 @@ import { type MeApiModel, meApiModelSchema } from '@pilote/mb-shared/me'
 export const buildMe = (override: Partial<MeApiModel> = {}): MeApiModel =>
   meApiModelSchema.parse({
     userId: 'sub-test',
-    source: 'jwt',
+    prenom: 'Admin',
+    nom: 'DITP',
     ...override,
   })
 

--- a/apps/mb-webapp/src/tests/routing.test.tsx
+++ b/apps/mb-webapp/src/tests/routing.test.tsx
@@ -66,7 +66,7 @@ describe('routing', () => {
   })
 
   it("permet d'accéder à /indicateurs après login", async () => {
-    renderAt('/indicateurs', stubAuth({ id: 'sub-1' }))
+    renderAt('/indicateurs', stubAuth({ prenom: 'Admin', nom: 'DITP' }))
     await waitFor(() => {
       expect(
         screen.getByRole('heading', { level: 1, name: 'Indicateurs' }),

--- a/apps/mb-webapp/src/tests/routing.test.tsx
+++ b/apps/mb-webapp/src/tests/routing.test.tsx
@@ -7,11 +7,13 @@ import {
 import { render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { Auth, AuthUser } from '@/auth'
+import type { MeApiModel } from '@pilote/mb-shared/me'
+
+import type { Auth } from '@/auth'
 import { tokenStore } from '@/auth/tokenStore'
 import { routeTree } from '@/routeTree.gen'
 
-const stubAuth = (user: AuthUser | null): Auth => ({
+const stubAuth = (user: MeApiModel | null): Auth => ({
   get isAuthenticated() {
     return user !== null
   },
@@ -66,7 +68,7 @@ describe('routing', () => {
   })
 
   it("permet d'accéder à /indicateurs après login", async () => {
-    renderAt('/indicateurs', stubAuth({ prenom: 'Admin', nom: 'DITP' }))
+    renderAt('/indicateurs', stubAuth({ userId: 'sub-1', prenom: 'Admin', nom: 'DITP' }))
     await waitFor(() => {
       expect(
         screen.getByRole('heading', { level: 1, name: 'Indicateurs' }),

--- a/packages/mb-shared/src/me.ts
+++ b/packages/mb-shared/src/me.ts
@@ -2,9 +2,8 @@ import { z } from 'zod'
 
 export const meApiModelSchema = z.object({
   userId: z.string().describe("Identifiant stable de l'utilisateur authentifié."),
-  prenom: z.string().optional().describe("Prénom de l'utilisateur (claim given_name)."),
-  nom: z.string().optional().describe("Nom de l'utilisateur (claim family_name)."),
-  source: z.literal('jwt').describe("Origine de l'authentification."),
+  prenom: z.string().describe("Prénom de l'utilisateur (claim given_name)."),
+  nom: z.string().describe("Nom de l'utilisateur (claim family_name)."),
 })
 
 export type MeApiModel = z.infer<typeof meApiModelSchema>

--- a/packages/mb-shared/src/me.ts
+++ b/packages/mb-shared/src/me.ts
@@ -2,6 +2,8 @@ import { z } from 'zod'
 
 export const meApiModelSchema = z.object({
   userId: z.string().describe("Identifiant stable de l'utilisateur authentifié."),
+  prenom: z.string().optional().describe("Prénom de l'utilisateur (claim given_name)."),
+  nom: z.string().optional().describe("Nom de l'utilisateur (claim family_name)."),
   source: z.literal('jwt').describe("Origine de l'authentification."),
 })
 


### PR DESCRIPTION
## Summary
- Validation zod du payload JWT côté `mb-api` (claims `typ`, `azp`, `sub`, plus `given_name`/`family_name`) en remplacement des checks `typeof` manuels
- Propagation de `prenom`/`nom` issus du token jusqu'à la navbar : `verifyAccessToken` → `runWithUser` (via `UtilisateurAuthentifie` enrichi) → route `/me` → `auth.user` côté webapp → affichage dans `__root.tsx`
- Suppression du pill de debug `🔒 Authentifié — sub: …` dans la page indicateurs et du champ `id` (non utilisé) de `AuthUser`
- Rename `UtilisateurAuthentifie` → `UtilisateurEnregistre` pour le résultat brut Prisma ; le nom `UtilisateurAuthentifie` désigne désormais l'utilisateur en ALS (DB + claims JWT)
- Désactivation du lint `react-refresh/only-export-components` (faux positifs sur les wrappers Radix)

## Test plan
- [ ] `pnpm --filter @pilote/mb-api lint` (eslint + tsc)
- [ ] `pnpm --filter @pilote/mb-api exec vitest run src/framework/auth/authContext.test.ts` (7/7)
- [ ] `pnpm --filter @pilote/mb-webapp lint`
- [ ] `pnpm --filter @pilote/mb-webapp exec vitest run` (21/21 dont `auth.test.ts` qui vérifie le mapping prenom/nom depuis `/me`)
- [ ] Test manuel : se connecter, vérifier que la navbar affiche "Admin DITP" au lieu de l'UUID