### PR TITLE
fix(mb-api): appliquer migrations et seed prisma au build

### DIFF
--- a/apps/mb-api/package.json
+++ b/apps/mb-api/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "dev": "portless run vite",
     "deploy:prepare": "bash deploy-prepare.sh",
-    "build": "prisma generate && vite build",
+    "build": "prisma generate && prisma migrate deploy && prisma db seed && vite build",
     "deploy:bundle": "bash deploy-bundle.sh",
     "start": "node dist/index.js",
     "test": "vitest run",


### PR DESCRIPTION
## Summary
- Ajoute `prisma migrate deploy && prisma db seed` à l'étape `build` de `@pilote/mb-api` pour que les migrations et le seed soient appliqués lors du déploiement (en plus du `prisma generate`).

## Test plan
- [ ] Vérifier que la pipeline de déploiement applique bien les migrations en attente sur la base cible
- [ ] Vérifier que le seed s'exécute après les migrations