### PR TITLE
feat(mb-api): authentification par API key

### DIFF
--- a/apps/mb-api/.env.example
+++ b/apps/mb-api/.env.example
@@ -4,4 +4,5 @@ OIDC_ISSUER_URL=https://fca.integ01.dev-agentconnect.fr/api/v2
 OIDC_USERINFO_URL=https://fca.integ01.dev-agentconnect.fr/api/v2/userinfo
 OIDC_JWKS_URI=https://fca.integ01.dev-agentconnect.fr/api/v2/jwks
 OIDC_AUDIENCE=4ce2e36ceeb69c4a9ede20b52bad46470bc95bfaf5fdf0afedd9815e336d52da
+API_KEY_HMAC_SECRET=change-me-with-a-32-bytes-secret-or-more
 LOG_LEVEL=info

--- a/apps/mb-api/.env.test
+++ b/apps/mb-api/.env.test
@@ -4,4 +4,5 @@ OIDC_ISSUER_URL=https://example.com/api/v2
 OIDC_USERINFO_URL=https://example.com/api/v2/userinfo
 OIDC_JWKS_URI=https://example.com/api/v2/jwks
 OIDC_AUDIENCE=test-audience
+API_KEY_HMAC_SECRET=test-only-secret-must-be-32-bytes-min
 LOG_LEVEL=silent

--- a/apps/mb-api/eslint.config.mjs
+++ b/apps/mb-api/eslint.config.mjs
@@ -8,7 +8,7 @@ export default tseslint.config(
   js.configs.recommended,
   ...tseslint.configs.recommendedTypeChecked,
   {
-    files: ['src/**/*.ts'],
+    files: ['src/**/*.ts', 'scripts/**/*.ts'],
     languageOptions: {
       parserOptions: {
         project: './tsconfig.json',

--- a/apps/mb-api/package.json
+++ b/apps/mb-api/package.json
@@ -18,13 +18,14 @@
     "start": "node dist/index.js",
     "test": "vitest run",
     "test:watch": "vitest",
-    "lint": "eslint src && tsc --noEmit",
-    "lint:fix": "eslint src --fix",
+    "lint": "eslint src scripts && tsc --noEmit",
+    "lint:fix": "eslint src scripts --fix",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "prisma:generate": "prisma generate",
     "database:init": "prisma migrate reset --force",
-    "database:migration": "prisma migrate dev"
+    "database:migration": "prisma migrate dev",
+    "api-key:generate": "tsx scripts/generate-api-key.ts"
   },
   "prisma": {
     "schema": "prisma/schema.prisma"

--- a/apps/mb-api/prisma/migrations/20260507150000_add_api_key/migration.sql
+++ b/apps/mb-api/prisma/migrations/20260507150000_add_api_key/migration.sql
@@ -1,0 +1,19 @@
+-- CreateTable
+CREATE TABLE "api_key" (
+    "id" UUID NOT NULL,
+    "label" TEXT NOT NULL,
+    "key_hash" TEXT NOT NULL,
+    "prefix" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "expires_at" TIMESTAMP(3),
+    "revoked_at" TIMESTAMP(3),
+    "last_used_at" TIMESTAMP(3),
+
+    CONSTRAINT "api_key_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "api_key_key_hash_key" ON "api_key"("key_hash");
+
+-- CreateIndex
+CREATE INDEX "api_key_prefix_idx" ON "api_key"("prefix");

--- a/apps/mb-api/prisma/schema.prisma
+++ b/apps/mb-api/prisma/schema.prisma
@@ -19,6 +19,20 @@ model Utilisateur {
   @@map("utilisateur")
 }
 
+model ApiKey {
+  id         String    @id @db.Uuid
+  label      String
+  keyHash    String    @unique @map("key_hash")
+  prefix     String    @map("prefix")
+  createdAt  DateTime  @default(now()) @map("created_at")
+  expiresAt  DateTime? @map("expires_at")
+  revokedAt  DateTime? @map("revoked_at")
+  lastUsedAt DateTime? @map("last_used_at")
+
+  @@index([prefix])
+  @@map("api_key")
+}
+
 model Indicateur {
   id        String   @id @db.Uuid
   publicId  String   @unique @map("public_id")

--- a/apps/mb-api/scripts/generate-api-key.ts
+++ b/apps/mb-api/scripts/generate-api-key.ts
@@ -1,0 +1,81 @@
+import { parseArgs } from 'node:util'
+
+import { buildApiKey } from '@/framework/auth/apiKey'
+import { prisma } from '@/framework/persistence/prisma'
+
+const printUsage = () => {
+  process.stderr.write(
+    [
+      'Usage: tsx scripts/generate-api-key.ts --label=<label> [--expires-at=YYYY-MM-DD]',
+      '',
+      "  --label       Description courte de l'API key (obligatoire)",
+      "  --expires-at  Date d'expiration ISO (optionnel ; sans cette option, la clé n'expire pas)",
+      '',
+    ].join('\n'),
+  )
+}
+
+const parseExpiresAt = (raw: string | undefined): Date | null => {
+  if (!raw) return null
+  const parsed = new Date(raw)
+  if (Number.isNaN(parsed.getTime())) {
+    process.stderr.write(`Date d'expiration invalide : ${raw}\n`)
+    process.exit(2)
+  }
+  return parsed
+}
+
+const main = async (): Promise<void> => {
+  const { values } = parseArgs({
+    options: {
+      label: { type: 'string' },
+      'expires-at': { type: 'string' },
+      help: { type: 'boolean', short: 'h' },
+    },
+    strict: true,
+  })
+
+  if (values.help || !values.label) {
+    printUsage()
+    process.exit(values.help ? 0 : 1)
+  }
+
+  const expiresAt = parseExpiresAt(values['expires-at'])
+  const generated = buildApiKey()
+
+  await prisma.apiKey.create({
+    data: {
+      id: generated.id,
+      label: values.label,
+      keyHash: generated.keyHash,
+      prefix: generated.prefix,
+      expiresAt,
+    },
+  })
+
+  process.stdout.write(
+    [
+      '',
+      'API key générée avec succès.',
+      `  id        : ${generated.id}`,
+      `  label     : ${values.label}`,
+      `  prefix    : ${generated.prefix}`,
+      `  expiresAt : ${expiresAt ? expiresAt.toISOString() : 'jamais'}`,
+      '',
+      "  Clé en clair (à conserver maintenant, elle n'est pas re-affichable) :",
+      `  ${generated.rawKey}`,
+      '',
+    ].join('\n'),
+  )
+}
+
+main()
+  .catch((error: unknown) => {
+    process.stderr.write(
+      `Échec de la génération : ${error instanceof Error ? error.message : String(error)}\n`,
+    )
+    process.exitCode = 1
+  })
+  .finally(() => {
+    void prisma.$disconnect()
+  })

--- a/apps/mb-api/scripts/generate-api-key.ts
+++ b/apps/mb-api/scripts/generate-api-key.ts
@@ -1,15 +1,18 @@
 import { parseArgs } from 'node:util'
 
 import { buildApiKey } from '@/framework/auth/apiKey'
-import { prisma } from '@/framework/persistence/prisma'
 
 const printUsage = () => {
   process.stderr.write(
     [
-      'Usage: tsx scripts/generate-api-key.ts --label=<label> [--expires-at=YYYY-MM-DD]',
+      'Usage: tsx scripts/generate-api-key.ts --secret=<hmac-secret> [--label=<label>] [--expires-at=YYYY-MM-DD]',
       '',
-      "  --label       Description courte de l'API key (obligatoire)",
-      "  --expires-at  Date d'expiration ISO (optionnel ; sans cette option, la clé n'expire pas)",
+      "  --secret      Secret HMAC à utiliser pour calculer le hash (obligatoire ; sinon lu depuis API_KEY_HMAC_SECRET).",
+      "  --label       Étiquette à utiliser dans la commande SQL d'insertion (optionnel ; défaut: 'à renseigner').",
+      "  --expires-at  Date d'expiration ISO (optionnel ; sans cette option, la clé n'expire pas).",
+      '',
+      'Le script ne touche pas la base : il imprime la clé en clair (à transmettre au client) et',
+      "le SQL d'insertion (à exécuter manuellement) sur stdout.",
       '',
     ].join('\n'),
   )
@@ -25,57 +28,59 @@ const parseExpiresAt = (raw: string | undefined): Date | null => {
   return parsed
 }
 
-const main = async (): Promise<void> => {
+const sqlString = (value: string): string => `'${value.replace(/'/g, "''")}'`
+
+const main = (): void => {
   const { values } = parseArgs({
     options: {
+      secret: { type: 'string' },
       label: { type: 'string' },
       'expires-at': { type: 'string' },
       help: { type: 'boolean', short: 'h' },
     },
     strict: true,
+    allowPositionals: true,
   })
 
-  if (values.help || !values.label) {
+  if (values.help) {
     printUsage()
-    process.exit(values.help ? 0 : 1)
+    process.exit(0)
   }
 
-  const expiresAt = parseExpiresAt(values['expires-at'])
-  const generated = buildApiKey()
+  const secret = values.secret ?? process.env['API_KEY_HMAC_SECRET']
+  if (!secret || secret.length < 32) {
+    process.stderr.write(
+      "Secret HMAC manquant ou trop court (32 chars min). Passez --secret=… ou définissez API_KEY_HMAC_SECRET.\n",
+    )
+    process.exit(2)
+  }
 
-  await prisma.apiKey.create({
-    data: {
-      id: generated.id,
-      label: values.label,
-      keyHash: generated.keyHash,
-      prefix: generated.prefix,
-      expiresAt,
-    },
-  })
+  const label = values.label ?? 'à renseigner'
+  const expiresAt = parseExpiresAt(values['expires-at'])
+  const generated = buildApiKey(secret)
+
+  const sqlInsert =
+    `INSERT INTO api_key (id, label, key_hash, prefix, expires_at) VALUES (` +
+    `${sqlString(generated.id)}, ${sqlString(label)}, ${sqlString(generated.keyHash)}, ${sqlString(generated.prefix)}, ` +
+    `${expiresAt ? sqlString(expiresAt.toISOString()) : 'NULL'});`
 
   process.stdout.write(
     [
       '',
-      'API key générée avec succès.',
-      `  id        : ${generated.id}`,
-      `  label     : ${values.label}`,
-      `  prefix    : ${generated.prefix}`,
-      `  expiresAt : ${expiresAt ? expiresAt.toISOString() : 'jamais'}`,
+      '== API key générée ==',
+      `id        : ${generated.id}`,
+      `label     : ${label}`,
+      `prefix    : ${generated.prefix}`,
+      `expiresAt : ${expiresAt ? expiresAt.toISOString() : 'jamais'}`,
       '',
-      "  Clé en clair (à conserver maintenant, elle n'est pas re-affichable) :",
+      "Clé en clair (à conserver maintenant, elle n'est pas re-affichable) :",
       `  ${generated.rawKey}`,
+      '',
+      "SQL d'insertion :",
+      `  ${sqlInsert}`,
       '',
     ].join('\n'),
   )
 }
 
 main()
-  .catch((error: unknown) => {
-    process.stderr.write(
-      `Échec de la génération : ${error instanceof Error ? error.message : String(error)}\n`,
-    )
-    process.exitCode = 1
-  })
-  .finally(() => {
-    void prisma.$disconnect()
-  })

--- a/apps/mb-api/src/app.ts
+++ b/apps/mb-api/src/app.ts
@@ -5,6 +5,7 @@ import { cors } from 'hono/cors'
 import { me } from '@/authentication/routes/me'
 import { env } from '@/env'
 import { authContext } from '@/framework/auth/authContext'
+import { requireAuthentication } from '@/framework/auth/requireAuthentication'
 import { registerErrorHandler } from '@/framework/errors/errorHandler'
 import { databaseContext } from '@/framework/persistence/databaseContext'
 import { health } from '@/healthcheck/routes/health'
@@ -20,27 +21,31 @@ app.use('*', cors({ origin: env.CORS_ORIGINS, credentials: false }))
 app.use('*', databaseContext)
 app.use('*', authContext)
 
+app.openAPIRegistry.registerComponent('securitySchemes', 'bearer', {
+  type: 'http',
+  scheme: 'bearer',
+  description:
+    "Accepte un access token JWT (utilisateur OIDC) ou une API key au format `pilote_live_<secret>`.",
+})
+
+// Routes publiques (avant le guard d'authentification)
 app.get('/', (context) => context.json({ hello: 'world' }))
 app.route('/', health)
+app.doc('/openapi.json', {
+  openapi: '3.0.0',
+  info: { title: 'Pilote API', version: '0.1.0' },
+  security: [{ bearer: [] }],
+})
+app.get('/docs', swaggerUI({ url: '/openapi.json' }))
+
+// Routes protégées : nécessitent un principal authentifié
+app.use('*', requireAuthentication)
+
 app.route('/', sharedMessage)
 app.route('/', indicateurRoutes)
 app.route('/', valeurAvancementRoutes)
 app.route('/', referentielRoutes)
 app.route('/', individuRoutes)
 app.route('/', me)
-
-app.doc('/openapi.json', {
-  openapi: '3.0.0',
-  info: { title: 'Pilote API', version: '0.1.0' },
-})
-
-app.openAPIRegistry.registerComponent('securitySchemes', 'bearer', {
-  type: 'http',
-  scheme: 'bearer',
-  description:
-    "Accepte un access token JWT (utilisateur OIDC) ou une API key au format `mb_live_<secret>`.",
-})
-
-app.get('/docs', swaggerUI({ url: '/openapi.json' }))
 
 registerErrorHandler(app)

--- a/apps/mb-api/src/app.ts
+++ b/apps/mb-api/src/app.ts
@@ -37,7 +37,8 @@ app.doc('/openapi.json', {
 app.openAPIRegistry.registerComponent('securitySchemes', 'bearer', {
   type: 'http',
   scheme: 'bearer',
-  bearerFormat: 'JWT',
+  description:
+    "Accepte un access token JWT (utilisateur OIDC) ou une API key au format `mb_live_<secret>`.",
 })
 
 app.get('/docs', swaggerUI({ url: '/openapi.json' }))

--- a/apps/mb-api/src/app.ts
+++ b/apps/mb-api/src/app.ts
@@ -5,7 +5,6 @@ import { cors } from 'hono/cors'
 import { me } from '@/authentication/routes/me'
 import { env } from '@/env'
 import { authContext } from '@/framework/auth/authContext'
-import { requireAuthentication } from '@/framework/auth/requireAuthentication'
 import { registerErrorHandler } from '@/framework/errors/errorHandler'
 import { databaseContext } from '@/framework/persistence/databaseContext'
 import { health } from '@/healthcheck/routes/health'
@@ -28,24 +27,21 @@ app.openAPIRegistry.registerComponent('securitySchemes', 'bearer', {
     "Accepte un access token JWT (utilisateur OIDC) ou une API key au format `pilote_live_<secret>`.",
 })
 
-// Routes publiques (avant le guard d'authentification)
 app.get('/', (context) => context.json({ hello: 'world' }))
 app.route('/', health)
-app.doc('/openapi.json', {
-  openapi: '3.0.0',
-  info: { title: 'Pilote API', version: '0.1.0' },
-  security: [{ bearer: [] }],
-})
-app.get('/docs', swaggerUI({ url: '/openapi.json' }))
-
-// Routes protégées : nécessitent un principal authentifié
-app.use('*', requireAuthentication)
-
 app.route('/', sharedMessage)
 app.route('/', indicateurRoutes)
 app.route('/', valeurAvancementRoutes)
 app.route('/', referentielRoutes)
 app.route('/', individuRoutes)
 app.route('/', me)
+
+app.doc('/openapi.json', {
+  openapi: '3.0.0',
+  info: { title: 'Pilote API', version: '0.1.0' },
+  security: [{ bearer: [] }],
+})
+
+app.get('/docs', swaggerUI({ url: '/openapi.json' }))
 
 registerErrorHandler(app)

--- a/apps/mb-api/src/authentication/routes/me.ts
+++ b/apps/mb-api/src/authentication/routes/me.ts
@@ -12,6 +12,7 @@ const meRoute = createRoute({
   path: '/me',
   tags: ['Authentication'],
   summary: "Renvoyer l'utilisateur authentifié",
+  middleware: [requireAuthentication],
   responses: {
     200: {
       content: { 'application/json': { schema: MeOkSchema } },
@@ -21,8 +22,6 @@ const meRoute = createRoute({
 })
 
 export const me = new OpenAPIHono()
-
-me.use('*', requireAuthentication)
 
 me.openapi(meRoute, (context) => {
   const user = requireUser()

--- a/apps/mb-api/src/authentication/routes/me.ts
+++ b/apps/mb-api/src/authentication/routes/me.ts
@@ -1,6 +1,7 @@
 import { createRoute, OpenAPIHono } from '@hono/zod-openapi'
 import { meApiModelSchema } from '@pilote/mb-shared/me'
 
+import { requireAuthentication } from '@/framework/auth/requireAuthentication'
 import { requireUser } from '@/framework/auth/userContext'
 import { jsonResponseOk } from '@/framework/openapi/jsonResponse'
 
@@ -20,6 +21,8 @@ const meRoute = createRoute({
 })
 
 export const me = new OpenAPIHono()
+
+me.use('*', requireAuthentication)
 
 me.openapi(meRoute, (context) => {
   const user = requireUser()

--- a/apps/mb-api/src/authentication/routes/me.ts
+++ b/apps/mb-api/src/authentication/routes/me.ts
@@ -11,7 +11,6 @@ const meRoute = createRoute({
   path: '/me',
   tags: ['Authentication'],
   summary: "Renvoyer l'utilisateur authentifié",
-  security: [{ bearer: [] }],
   responses: {
     200: {
       content: { 'application/json': { schema: MeOkSchema } },

--- a/apps/mb-api/src/env.ts
+++ b/apps/mb-api/src/env.ts
@@ -19,6 +19,7 @@ const envSchema = z.object({
   OIDC_USERINFO_URL: z.url(),
   OIDC_JWKS_URI: z.url(),
   OIDC_AUDIENCE: z.string().min(1),
+  API_KEY_HMAC_SECRET: z.string().min(32),
   LOG_LEVEL: z
     .enum(['fatal', 'error', 'warn', 'info', 'debug', 'trace', 'silent'])
     .default('info'),

--- a/apps/mb-api/src/framework/auth/apiKey.test.ts
+++ b/apps/mb-api/src/framework/auth/apiKey.test.ts
@@ -6,44 +6,46 @@ const TEST_SECRET = 'unit-test-secret-must-be-32-bytes-min'
 
 describe.concurrent('apiKey', () => {
   describe('looksLikeApiKey', () => {
-    it('returns true when the token starts with the public prefix', () => {
-      expect(looksLikeApiKey('mb_live_abc')).toBe(true)
+    it('renvoie true quand le token commence par le préfixe public', () => {
+      expect(looksLikeApiKey('pilote_live_abc')).toBe(true)
     })
 
-    it('returns false for a JWT-shaped token', () => {
+    it("renvoie false pour un token de format JWT", () => {
       expect(looksLikeApiKey('eyJhbGciOiJSUzI1NiJ9.payload.signature')).toBe(false)
     })
   })
 
   describe('hashApiKey', () => {
-    it('is deterministic and produces a 64-char hex digest', () => {
-      const first = hashApiKey('mb_live_some_value', TEST_SECRET)
-      const second = hashApiKey('mb_live_some_value', TEST_SECRET)
+    it('est déterministe et produit un digest hex de 64 caractères', () => {
+      const first = hashApiKey('pilote_live_some_value', TEST_SECRET)
+      const second = hashApiKey('pilote_live_some_value', TEST_SECRET)
       expect(first).toBe(second)
       expect(first).toMatch(/^[a-f0-9]{64}$/)
     })
 
-    it('produces different hashes for different inputs', () => {
-      expect(hashApiKey('mb_live_a', TEST_SECRET)).not.toBe(hashApiKey('mb_live_b', TEST_SECRET))
+    it('produit des hashs différents pour des entrées différentes', () => {
+      expect(hashApiKey('pilote_live_a', TEST_SECRET)).not.toBe(
+        hashApiKey('pilote_live_b', TEST_SECRET),
+      )
     })
 
-    it('produces different hashes for different secrets', () => {
-      const a = hashApiKey('mb_live_same', TEST_SECRET)
-      const b = hashApiKey('mb_live_same', 'another-secret-must-be-32-bytes-min')
+    it('produit des hashs différents pour des secrets différents', () => {
+      const a = hashApiKey('pilote_live_same', TEST_SECRET)
+      const b = hashApiKey('pilote_live_same', 'another-secret-must-be-32-bytes-min')
       expect(a).not.toBe(b)
     })
   })
 
   describe('buildApiKey', () => {
-    it('builds a key with the public prefix and a matching hash', () => {
+    it('construit une clé avec le préfixe public et un hash cohérent', () => {
       const generated = buildApiKey(TEST_SECRET)
       expect(generated.rawKey.startsWith(API_KEY_PREFIX)).toBe(true)
       expect(generated.keyHash).toBe(hashApiKey(generated.rawKey, TEST_SECRET))
-      expect(generated.prefix).toHaveLength(16)
-      expect(generated.prefix).toBe(generated.rawKey.slice(0, 16))
+      expect(generated.prefix).toHaveLength(API_KEY_PREFIX.length + 8)
+      expect(generated.prefix).toBe(generated.rawKey.slice(0, API_KEY_PREFIX.length + 8))
     })
 
-    it('produces unique keys on each call', () => {
+    it('produit des clés uniques à chaque appel', () => {
       const a = buildApiKey(TEST_SECRET)
       const b = buildApiKey(TEST_SECRET)
       expect(a.rawKey).not.toBe(b.rawKey)

--- a/apps/mb-api/src/framework/auth/apiKey.test.ts
+++ b/apps/mb-api/src/framework/auth/apiKey.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from 'vitest'
 
-import { API_KEY_PREFIX, buildApiKey, hashApiKey, looksLikeApiKey, verifyApiKey } from '@/framework/auth/apiKey'
-import { fixtures } from '@/test/fixtures'
-import { integrationTest } from '@/test/integrationTest'
+import { API_KEY_PREFIX, buildApiKey, hashApiKey, looksLikeApiKey } from '@/framework/auth/apiKey'
 
-describe.concurrent('apiKey module', () => {
+const TEST_SECRET = 'unit-test-secret-must-be-32-bytes-min'
+
+describe.concurrent('apiKey', () => {
   describe('looksLikeApiKey', () => {
     it('returns true when the token starts with the public prefix', () => {
       expect(looksLikeApiKey('mb_live_abc')).toBe(true)
@@ -17,84 +17,37 @@ describe.concurrent('apiKey module', () => {
 
   describe('hashApiKey', () => {
     it('is deterministic and produces a 64-char hex digest', () => {
-      const first = hashApiKey('mb_live_some_value')
-      const second = hashApiKey('mb_live_some_value')
+      const first = hashApiKey('mb_live_some_value', TEST_SECRET)
+      const second = hashApiKey('mb_live_some_value', TEST_SECRET)
       expect(first).toBe(second)
       expect(first).toMatch(/^[a-f0-9]{64}$/)
     })
 
     it('produces different hashes for different inputs', () => {
-      expect(hashApiKey('mb_live_a')).not.toBe(hashApiKey('mb_live_b'))
+      expect(hashApiKey('mb_live_a', TEST_SECRET)).not.toBe(hashApiKey('mb_live_b', TEST_SECRET))
+    })
+
+    it('produces different hashes for different secrets', () => {
+      const a = hashApiKey('mb_live_same', TEST_SECRET)
+      const b = hashApiKey('mb_live_same', 'another-secret-must-be-32-bytes-min')
+      expect(a).not.toBe(b)
     })
   })
 
   describe('buildApiKey', () => {
     it('builds a key with the public prefix and a matching hash', () => {
-      const generated = buildApiKey()
+      const generated = buildApiKey(TEST_SECRET)
       expect(generated.rawKey.startsWith(API_KEY_PREFIX)).toBe(true)
-      expect(generated.keyHash).toBe(hashApiKey(generated.rawKey))
+      expect(generated.keyHash).toBe(hashApiKey(generated.rawKey, TEST_SECRET))
       expect(generated.prefix).toHaveLength(16)
       expect(generated.prefix).toBe(generated.rawKey.slice(0, 16))
     })
 
     it('produces unique keys on each call', () => {
-      const a = buildApiKey()
-      const b = buildApiKey()
+      const a = buildApiKey(TEST_SECRET)
+      const b = buildApiKey(TEST_SECRET)
       expect(a.rawKey).not.toBe(b.rawKey)
       expect(a.id).not.toBe(b.id)
     })
-  })
-
-  describe('verifyApiKey', () => {
-    it(
-      'returns the api key principal when the key exists and is active',
-      integrationTest(async () => {
-        const row = await fixtures.apiKey({
-          rawKey: 'mb_live_active_key_for_test_value',
-          label: 'partenaire X',
-        })
-
-        const result = await verifyApiKey('mb_live_active_key_for_test_value')
-
-        expect(result.isOk()).toBe(true)
-        expect(result._unsafeUnwrap()).toEqual({ id: row.id, label: 'partenaire X' })
-      }),
-    )
-
-    it(
-      "returns null when the key is unknown",
-      integrationTest(async () => {
-        const result = await verifyApiKey('mb_live_unknown_key_value_xx')
-        expect(result._unsafeUnwrap()).toBeNull()
-      }),
-    )
-
-    it(
-      'returns null when the key is revoked',
-      integrationTest(async () => {
-        await fixtures.apiKey({
-          rawKey: 'mb_live_revoked_key_for_test_value',
-          revokedAt: new Date('2026-01-01'),
-        })
-
-        const result = await verifyApiKey('mb_live_revoked_key_for_test_value')
-
-        expect(result._unsafeUnwrap()).toBeNull()
-      }),
-    )
-
-    it(
-      'returns null when the key has expired',
-      integrationTest(async () => {
-        await fixtures.apiKey({
-          rawKey: 'mb_live_expired_key_for_test_value',
-          expiresAt: new Date('2020-01-01'),
-        })
-
-        const result = await verifyApiKey('mb_live_expired_key_for_test_value')
-
-        expect(result._unsafeUnwrap()).toBeNull()
-      }),
-    )
   })
 })

--- a/apps/mb-api/src/framework/auth/apiKey.test.ts
+++ b/apps/mb-api/src/framework/auth/apiKey.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest'
+
+import { API_KEY_PREFIX, buildApiKey, hashApiKey, looksLikeApiKey, verifyApiKey } from '@/framework/auth/apiKey'
+import { fixtures } from '@/test/fixtures'
+import { integrationTest } from '@/test/integrationTest'
+
+describe.concurrent('apiKey module', () => {
+  describe('looksLikeApiKey', () => {
+    it('returns true when the token starts with the public prefix', () => {
+      expect(looksLikeApiKey('mb_live_abc')).toBe(true)
+    })
+
+    it('returns false for a JWT-shaped token', () => {
+      expect(looksLikeApiKey('eyJhbGciOiJSUzI1NiJ9.payload.signature')).toBe(false)
+    })
+  })
+
+  describe('hashApiKey', () => {
+    it('is deterministic and produces a 64-char hex digest', () => {
+      const first = hashApiKey('mb_live_some_value')
+      const second = hashApiKey('mb_live_some_value')
+      expect(first).toBe(second)
+      expect(first).toMatch(/^[a-f0-9]{64}$/)
+    })
+
+    it('produces different hashes for different inputs', () => {
+      expect(hashApiKey('mb_live_a')).not.toBe(hashApiKey('mb_live_b'))
+    })
+  })
+
+  describe('buildApiKey', () => {
+    it('builds a key with the public prefix and a matching hash', () => {
+      const generated = buildApiKey()
+      expect(generated.rawKey.startsWith(API_KEY_PREFIX)).toBe(true)
+      expect(generated.keyHash).toBe(hashApiKey(generated.rawKey))
+      expect(generated.prefix).toHaveLength(16)
+      expect(generated.prefix).toBe(generated.rawKey.slice(0, 16))
+    })
+
+    it('produces unique keys on each call', () => {
+      const a = buildApiKey()
+      const b = buildApiKey()
+      expect(a.rawKey).not.toBe(b.rawKey)
+      expect(a.id).not.toBe(b.id)
+    })
+  })
+
+  describe('verifyApiKey', () => {
+    it(
+      'returns the api key principal when the key exists and is active',
+      integrationTest(async () => {
+        const row = await fixtures.apiKey({
+          rawKey: 'mb_live_active_key_for_test_value',
+          label: 'partenaire X',
+        })
+
+        const result = await verifyApiKey('mb_live_active_key_for_test_value')
+
+        expect(result.isOk()).toBe(true)
+        expect(result._unsafeUnwrap()).toEqual({ id: row.id, label: 'partenaire X' })
+      }),
+    )
+
+    it(
+      "returns null when the key is unknown",
+      integrationTest(async () => {
+        const result = await verifyApiKey('mb_live_unknown_key_value_xx')
+        expect(result._unsafeUnwrap()).toBeNull()
+      }),
+    )
+
+    it(
+      'returns null when the key is revoked',
+      integrationTest(async () => {
+        await fixtures.apiKey({
+          rawKey: 'mb_live_revoked_key_for_test_value',
+          revokedAt: new Date('2026-01-01'),
+        })
+
+        const result = await verifyApiKey('mb_live_revoked_key_for_test_value')
+
+        expect(result._unsafeUnwrap()).toBeNull()
+      }),
+    )
+
+    it(
+      'returns null when the key has expired',
+      integrationTest(async () => {
+        await fixtures.apiKey({
+          rawKey: 'mb_live_expired_key_for_test_value',
+          expiresAt: new Date('2020-01-01'),
+        })
+
+        const result = await verifyApiKey('mb_live_expired_key_for_test_value')
+
+        expect(result._unsafeUnwrap()).toBeNull()
+      }),
+    )
+  })
+})

--- a/apps/mb-api/src/framework/auth/apiKey.ts
+++ b/apps/mb-api/src/framework/auth/apiKey.ts
@@ -1,0 +1,80 @@
+import { createHmac, randomBytes } from 'node:crypto'
+
+import { ResultAsync } from 'neverthrow'
+import { uuidv7 } from 'uuidv7'
+
+import { env } from '@/env'
+import type { ApiKeyAuthentifiee } from '@/framework/auth/userContext'
+import { logger } from '@/framework/logger/logger'
+import { db } from '@/framework/persistence/dbStore'
+
+export const API_KEY_PREFIX = 'mb_live_'
+
+const PREFIX_VISIBLE_LENGTH = 16
+
+export const looksLikeApiKey = (token: string): boolean => token.startsWith(API_KEY_PREFIX)
+
+export const hashApiKey = (rawKey: string): string =>
+  createHmac('sha256', env.API_KEY_HMAC_SECRET).update(rawKey).digest('hex')
+
+export type GeneratedApiKey = {
+  id: string
+  rawKey: string
+  keyHash: string
+  prefix: string
+}
+
+export const buildApiKey = (): GeneratedApiKey => {
+  const randomPart = randomBytes(32).toString('base64url')
+  const rawKey = `${API_KEY_PREFIX}${randomPart}`
+  return {
+    id: uuidv7(),
+    rawKey,
+    keyHash: hashApiKey(rawKey),
+    prefix: rawKey.slice(0, PREFIX_VISIBLE_LENGTH),
+  }
+}
+
+export const verifyApiKey = (
+  rawKey: string,
+): ResultAsync<ApiKeyAuthentifiee | null, never> =>
+  ResultAsync.fromSafePromise(resolveApiKey(rawKey))
+
+const resolveApiKey = async (rawKey: string): Promise<ApiKeyAuthentifiee | null> => {
+  const keyHash = hashApiKey(rawKey)
+  const row = await db().apiKey.findUnique({
+    where: { keyHash },
+    select: { id: true, label: true, revokedAt: true, expiresAt: true },
+  })
+  if (!row) return null
+
+  if (row.revokedAt) {
+    logger.warn(
+      { event: 'auth.api_key.revoked', apiKeyId: row.id },
+      'Revoked API key used',
+    )
+    return null
+  }
+
+  if (row.expiresAt && row.expiresAt.getTime() <= Date.now()) {
+    logger.warn(
+      { event: 'auth.api_key.expired', apiKeyId: row.id },
+      'Expired API key used',
+    )
+    return null
+  }
+
+  void db()
+    .apiKey.update({
+      where: { id: row.id },
+      data: { lastUsedAt: new Date() },
+    })
+    .catch((error: unknown) => {
+      logger.warn(
+        { event: 'auth.api_key.last_used_update_failed', err: error },
+        'Failed to update API key lastUsedAt',
+      )
+    })
+
+  return { id: row.id, label: row.label }
+}

--- a/apps/mb-api/src/framework/auth/apiKey.ts
+++ b/apps/mb-api/src/framework/auth/apiKey.ts
@@ -2,9 +2,9 @@ import { createHmac, randomBytes } from 'node:crypto'
 
 import { uuidv7 } from 'uuidv7'
 
-export const API_KEY_PREFIX = 'mb_live_'
+export const API_KEY_PREFIX = 'pilote_live_'
 
-const PREFIX_VISIBLE_LENGTH = 16
+const PREFIX_VISIBLE_LENGTH = API_KEY_PREFIX.length + 8
 
 export const looksLikeApiKey = (token: string): boolean => token.startsWith(API_KEY_PREFIX)
 

--- a/apps/mb-api/src/framework/auth/apiKey.ts
+++ b/apps/mb-api/src/framework/auth/apiKey.ts
@@ -1,12 +1,6 @@
 import { createHmac, randomBytes } from 'node:crypto'
 
-import { ResultAsync } from 'neverthrow'
 import { uuidv7 } from 'uuidv7'
-
-import { env } from '@/env'
-import type { ApiKeyAuthentifiee } from '@/framework/auth/userContext'
-import { logger } from '@/framework/logger/logger'
-import { db } from '@/framework/persistence/dbStore'
 
 export const API_KEY_PREFIX = 'mb_live_'
 
@@ -14,8 +8,8 @@ const PREFIX_VISIBLE_LENGTH = 16
 
 export const looksLikeApiKey = (token: string): boolean => token.startsWith(API_KEY_PREFIX)
 
-export const hashApiKey = (rawKey: string): string =>
-  createHmac('sha256', env.API_KEY_HMAC_SECRET).update(rawKey).digest('hex')
+export const hashApiKey = (rawKey: string, secret: string): string =>
+  createHmac('sha256', secret).update(rawKey).digest('hex')
 
 export type GeneratedApiKey = {
   id: string
@@ -24,57 +18,13 @@ export type GeneratedApiKey = {
   prefix: string
 }
 
-export const buildApiKey = (): GeneratedApiKey => {
+export const buildApiKey = (secret: string): GeneratedApiKey => {
   const randomPart = randomBytes(32).toString('base64url')
   const rawKey = `${API_KEY_PREFIX}${randomPart}`
   return {
     id: uuidv7(),
     rawKey,
-    keyHash: hashApiKey(rawKey),
+    keyHash: hashApiKey(rawKey, secret),
     prefix: rawKey.slice(0, PREFIX_VISIBLE_LENGTH),
   }
-}
-
-export const verifyApiKey = (
-  rawKey: string,
-): ResultAsync<ApiKeyAuthentifiee | null, never> =>
-  ResultAsync.fromSafePromise(resolveApiKey(rawKey))
-
-const resolveApiKey = async (rawKey: string): Promise<ApiKeyAuthentifiee | null> => {
-  const keyHash = hashApiKey(rawKey)
-  const row = await db().apiKey.findUnique({
-    where: { keyHash },
-    select: { id: true, label: true, revokedAt: true, expiresAt: true },
-  })
-  if (!row) return null
-
-  if (row.revokedAt) {
-    logger.warn(
-      { event: 'auth.api_key.revoked', apiKeyId: row.id },
-      'Revoked API key used',
-    )
-    return null
-  }
-
-  if (row.expiresAt && row.expiresAt.getTime() <= Date.now()) {
-    logger.warn(
-      { event: 'auth.api_key.expired', apiKeyId: row.id },
-      'Expired API key used',
-    )
-    return null
-  }
-
-  void db()
-    .apiKey.update({
-      where: { id: row.id },
-      data: { lastUsedAt: new Date() },
-    })
-    .catch((error: unknown) => {
-      logger.warn(
-        { event: 'auth.api_key.last_used_update_failed', err: error },
-        'Failed to update API key lastUsedAt',
-      )
-    })
-
-  return { id: row.id, label: row.label }
 }

--- a/apps/mb-api/src/framework/auth/authContext.test.ts
+++ b/apps/mb-api/src/framework/auth/authContext.test.ts
@@ -55,14 +55,14 @@ const buildApp = () => {
   return app
 }
 
-describe.sequential('authContext middleware', () => {
+describe.sequential('middleware authContext', () => {
   beforeEach(() => {
     verifyJwt.mockReset()
     lookup.mockReset()
     verifyKey.mockReset()
   })
 
-  it('initializes the ALS with null when no Authorization header is present', async () => {
+  it("initialise l'ALS à null en l'absence de header Authorization", async () => {
     const app = buildApp()
     const response = await app.request('/anonymous')
     expect(response.status).toBe(200)
@@ -71,7 +71,7 @@ describe.sequential('authContext middleware', () => {
     expect(verifyKey).not.toHaveBeenCalled()
   })
 
-  it('initializes the ALS with null when the scheme is not Bearer', async () => {
+  it("initialise l'ALS à null quand le scheme n'est pas Bearer", async () => {
     const app = buildApp()
     const response = await app.request('/anonymous', {
       headers: { Authorization: 'Basic abc' },
@@ -82,7 +82,7 @@ describe.sequential('authContext middleware', () => {
     expect(verifyKey).not.toHaveBeenCalled()
   })
 
-  it('initializes the ALS with null when the JWT verification fails', async () => {
+  it("initialise l'ALS à null quand la vérification du JWT échoue", async () => {
     verifyJwt.mockRejectedValue(new Error('boom'))
     const app = buildApp()
     const response = await app.request('/anonymous', {
@@ -94,7 +94,7 @@ describe.sequential('authContext middleware', () => {
     expect(lookup).not.toHaveBeenCalled()
   })
 
-  it('returns 401 on /protected-user when token is valid but user is not provisioned', async () => {
+  it("renvoie 401 sur /protected-user quand le token est valide mais l'utilisateur n'est pas provisionné", async () => {
     verifyJwt.mockResolvedValue({
       providerSub: 'sub-123',
       email: 'agent@example.com',
@@ -115,7 +115,7 @@ describe.sequential('authContext middleware', () => {
     })
   })
 
-  it('exposes the user to handlers when the lookup succeeds', async () => {
+  it("expose l'utilisateur aux handlers quand le lookup réussit", async () => {
     verifyJwt.mockResolvedValue({
       providerSub: 'sub-123',
       email: 'agent@example.com',
@@ -141,7 +141,7 @@ describe.sequential('authContext middleware', () => {
     })
   })
 
-  it('accepts the Bearer scheme case-insensitively (RFC 6750)', async () => {
+  it('accepte le scheme Bearer de manière insensible à la casse (RFC 6750)', async () => {
     verifyJwt.mockResolvedValue({
       providerSub: 'sub-123',
       email: 'agent@example.com',
@@ -162,51 +162,51 @@ describe.sequential('authContext middleware', () => {
     expect(verifyJwt).toHaveBeenCalledWith('good.token')
   })
 
-  it('makes requireUser() throw UnauthorizedError on anonymous requests to protected handlers', async () => {
+  it('fait throw UnauthorizedError sur requireUser() pour une requête anonyme', async () => {
     const app = buildApp()
     const response = await app.request('/protected-user')
     expect(response.status).toBe(401)
   })
 
-  it('routes mb_live_ tokens to the API key verifier', async () => {
+  it("route les tokens préfixés pilote_live_ vers le vérificateur d'API key", async () => {
     verifyKey.mockReturnValue(okAsync({ id: 'api-key-id-1', label: 'partner-x' }))
     const app = buildApp()
     const response = await app.request('/protected-principal', {
-      headers: { Authorization: 'Bearer mb_live_abc123' },
+      headers: { Authorization: 'Bearer pilote_live_abc123' },
     })
     expect(response.status).toBe(200)
     expect(await response.json()).toEqual({
       kind: 'apiKey',
       apiKey: { id: 'api-key-id-1', label: 'partner-x' },
     })
-    expect(verifyKey).toHaveBeenCalledWith('mb_live_abc123', expect.any(String))
+    expect(verifyKey).toHaveBeenCalledWith('pilote_live_abc123', expect.any(String))
     expect(verifyJwt).not.toHaveBeenCalled()
   })
 
-  it('returns null principal when the API key is unknown or revoked', async () => {
+  it("renvoie un principal null quand l'API key est inconnue ou révoquée", async () => {
     verifyKey.mockReturnValue(okAsync(null))
     const app = buildApp()
     const response = await app.request('/anonymous', {
-      headers: { Authorization: 'Bearer mb_live_unknown' },
+      headers: { Authorization: 'Bearer pilote_live_unknown' },
     })
     expect(response.status).toBe(200)
     expect(await response.json()).toEqual({ user: null, principal: null })
   })
 
-  it('makes requireUser() throw UnauthorizedError when the principal is an API key', async () => {
+  it('fait throw UnauthorizedError sur requireUser() quand le principal est une API key', async () => {
     verifyKey.mockReturnValue(okAsync({ id: 'api-key-id-1', label: 'partner-x' }))
     const app = buildApp()
     const response = await app.request('/protected-user', {
-      headers: { Authorization: 'Bearer mb_live_abc123' },
+      headers: { Authorization: 'Bearer pilote_live_abc123' },
     })
     expect(response.status).toBe(401)
   })
 
-  it('makes requirePrincipal() succeed for an API key principal', async () => {
+  it('fait passer requirePrincipal() avec un principal API key', async () => {
     verifyKey.mockReturnValue(okAsync({ id: 'api-key-id-1', label: 'partner-x' }))
     const app = buildApp()
     const response = await app.request('/protected-principal', {
-      headers: { Authorization: 'Bearer mb_live_abc123' },
+      headers: { Authorization: 'Bearer pilote_live_abc123' },
     })
     expect(response.status).toBe(200)
   })

--- a/apps/mb-api/src/framework/auth/authContext.test.ts
+++ b/apps/mb-api/src/framework/auth/authContext.test.ts
@@ -17,17 +17,13 @@ vi.mock('@/authentication/jwks', () => ({
 vi.mock('@/authentication/queries/getUtilisateurByProvider', () => ({
   getUtilisateurByProvider: vi.fn(),
 }))
-vi.mock('@/framework/auth/apiKey', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@/framework/auth/apiKey')>()
-  return {
-    ...actual,
-    verifyApiKey: vi.fn(),
-  }
-})
+vi.mock('@/framework/auth/verifyApiKey', () => ({
+  verifyApiKey: vi.fn(),
+}))
 
 const { verifyAccessToken } = await import('@/authentication/jwks')
 const { getUtilisateurByProvider } = await import('@/authentication/queries/getUtilisateurByProvider')
-const { verifyApiKey } = await import('@/framework/auth/apiKey')
+const { verifyApiKey } = await import('@/framework/auth/verifyApiKey')
 const verifyJwt = vi.mocked(verifyAccessToken)
 const lookup = vi.mocked(getUtilisateurByProvider)
 const verifyKey = vi.mocked(verifyApiKey)
@@ -183,7 +179,7 @@ describe.sequential('authContext middleware', () => {
       kind: 'apiKey',
       apiKey: { id: 'api-key-id-1', label: 'partner-x' },
     })
-    expect(verifyKey).toHaveBeenCalledWith('mb_live_abc123')
+    expect(verifyKey).toHaveBeenCalledWith('mb_live_abc123', expect.any(String))
     expect(verifyJwt).not.toHaveBeenCalled()
   })
 

--- a/apps/mb-api/src/framework/auth/authContext.test.ts
+++ b/apps/mb-api/src/framework/auth/authContext.test.ts
@@ -4,7 +4,12 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { authContext } from '@/framework/auth/authContext'
 import { UnauthorizedError } from '@/framework/auth/UnauthorizedError'
-import { getCurrentUser, requireUser } from '@/framework/auth/userContext'
+import {
+  getCurrentPrincipal,
+  getCurrentUser,
+  requirePrincipal,
+  requireUser,
+} from '@/framework/auth/userContext'
 
 vi.mock('@/authentication/jwks', () => ({
   verifyAccessToken: vi.fn(),
@@ -12,20 +17,40 @@ vi.mock('@/authentication/jwks', () => ({
 vi.mock('@/authentication/queries/getUtilisateurByProvider', () => ({
   getUtilisateurByProvider: vi.fn(),
 }))
+vi.mock('@/framework/auth/apiKey', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/framework/auth/apiKey')>()
+  return {
+    ...actual,
+    verifyApiKey: vi.fn(),
+  }
+})
 
 const { verifyAccessToken } = await import('@/authentication/jwks')
 const { getUtilisateurByProvider } = await import('@/authentication/queries/getUtilisateurByProvider')
-const verify = vi.mocked(verifyAccessToken)
+const { verifyApiKey } = await import('@/framework/auth/apiKey')
+const verifyJwt = vi.mocked(verifyAccessToken)
 const lookup = vi.mocked(getUtilisateurByProvider)
+const verifyKey = vi.mocked(verifyApiKey)
 
 const buildApp = () => {
   const app = new Hono()
   app.use('*', authContext)
-  app.get('/anonymous', (context) => context.json({ user: getCurrentUser() ?? null }))
-  app.get('/protected', (context) => {
+  app.get('/anonymous', (context) =>
+    context.json({ user: getCurrentUser() ?? null, principal: getCurrentPrincipal() ?? null }),
+  )
+  app.get('/protected-user', (context) => {
     try {
       const user = requireUser()
       return context.json(user)
+    } catch (error) {
+      if (error instanceof UnauthorizedError) return context.json({ error: 'unauthorized' }, 401)
+      throw error
+    }
+  })
+  app.get('/protected-principal', (context) => {
+    try {
+      const principal = requirePrincipal()
+      return context.json(principal)
     } catch (error) {
       if (error instanceof UnauthorizedError) return context.json({ error: 'unauthorized' }, 401)
       throw error
@@ -36,17 +61,18 @@ const buildApp = () => {
 
 describe.sequential('authContext middleware', () => {
   beforeEach(() => {
-    verify.mockReset()
+    verifyJwt.mockReset()
     lookup.mockReset()
+    verifyKey.mockReset()
   })
 
   it('initializes the ALS with null when no Authorization header is present', async () => {
     const app = buildApp()
     const response = await app.request('/anonymous')
     expect(response.status).toBe(200)
-    expect(await response.json()).toEqual({ user: null })
-    expect(verify).not.toHaveBeenCalled()
-    expect(lookup).not.toHaveBeenCalled()
+    expect(await response.json()).toEqual({ user: null, principal: null })
+    expect(verifyJwt).not.toHaveBeenCalled()
+    expect(verifyKey).not.toHaveBeenCalled()
   })
 
   it('initializes the ALS with null when the scheme is not Bearer', async () => {
@@ -55,24 +81,25 @@ describe.sequential('authContext middleware', () => {
       headers: { Authorization: 'Basic abc' },
     })
     expect(response.status).toBe(200)
-    expect(await response.json()).toEqual({ user: null })
-    expect(verify).not.toHaveBeenCalled()
+    expect(await response.json()).toEqual({ user: null, principal: null })
+    expect(verifyJwt).not.toHaveBeenCalled()
+    expect(verifyKey).not.toHaveBeenCalled()
   })
 
   it('initializes the ALS with null when the JWT verification fails', async () => {
-    verify.mockRejectedValue(new Error('boom'))
+    verifyJwt.mockRejectedValue(new Error('boom'))
     const app = buildApp()
     const response = await app.request('/anonymous', {
       headers: { Authorization: 'Bearer some.token.value' },
     })
     expect(response.status).toBe(200)
-    expect(await response.json()).toEqual({ user: null })
-    expect(verify).toHaveBeenCalledOnce()
+    expect(await response.json()).toEqual({ user: null, principal: null })
+    expect(verifyJwt).toHaveBeenCalledOnce()
     expect(lookup).not.toHaveBeenCalled()
   })
 
-  it('returns 401 on /protected when token is valid but user is not provisioned', async () => {
-    verify.mockResolvedValue({
+  it('returns 401 on /protected-user when token is valid but user is not provisioned', async () => {
+    verifyJwt.mockResolvedValue({
       providerSub: 'sub-123',
       email: 'agent@example.com',
       prenom: 'Admin',
@@ -80,7 +107,7 @@ describe.sequential('authContext middleware', () => {
     })
     lookup.mockReturnValue(okAsync(null))
     const app = buildApp()
-    const response = await app.request('/protected', {
+    const response = await app.request('/protected-user', {
       headers: { Authorization: 'Bearer good.token' },
     })
     expect(response.status).toBe(401)
@@ -93,7 +120,7 @@ describe.sequential('authContext middleware', () => {
   })
 
   it('exposes the user to handlers when the lookup succeeds', async () => {
-    verify.mockResolvedValue({
+    verifyJwt.mockResolvedValue({
       providerSub: 'sub-123',
       email: 'agent@example.com',
       prenom: 'Admin',
@@ -106,7 +133,7 @@ describe.sequential('authContext middleware', () => {
       }),
     )
     const app = buildApp()
-    const response = await app.request('/protected', {
+    const response = await app.request('/protected-user', {
       headers: { Authorization: 'Bearer good.token' },
     })
     expect(response.status).toBe(200)
@@ -119,7 +146,7 @@ describe.sequential('authContext middleware', () => {
   })
 
   it('accepts the Bearer scheme case-insensitively (RFC 6750)', async () => {
-    verify.mockResolvedValue({
+    verifyJwt.mockResolvedValue({
       providerSub: 'sub-123',
       email: 'agent@example.com',
       prenom: 'Admin',
@@ -132,16 +159,59 @@ describe.sequential('authContext middleware', () => {
       }),
     )
     const app = buildApp()
-    const response = await app.request('/protected', {
+    const response = await app.request('/protected-user', {
       headers: { Authorization: 'bearer good.token' },
     })
     expect(response.status).toBe(200)
-    expect(verify).toHaveBeenCalledWith('good.token')
+    expect(verifyJwt).toHaveBeenCalledWith('good.token')
   })
 
   it('makes requireUser() throw UnauthorizedError on anonymous requests to protected handlers', async () => {
     const app = buildApp()
-    const response = await app.request('/protected')
+    const response = await app.request('/protected-user')
     expect(response.status).toBe(401)
+  })
+
+  it('routes mb_live_ tokens to the API key verifier', async () => {
+    verifyKey.mockReturnValue(okAsync({ id: 'api-key-id-1', label: 'partner-x' }))
+    const app = buildApp()
+    const response = await app.request('/protected-principal', {
+      headers: { Authorization: 'Bearer mb_live_abc123' },
+    })
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({
+      kind: 'apiKey',
+      apiKey: { id: 'api-key-id-1', label: 'partner-x' },
+    })
+    expect(verifyKey).toHaveBeenCalledWith('mb_live_abc123')
+    expect(verifyJwt).not.toHaveBeenCalled()
+  })
+
+  it('returns null principal when the API key is unknown or revoked', async () => {
+    verifyKey.mockReturnValue(okAsync(null))
+    const app = buildApp()
+    const response = await app.request('/anonymous', {
+      headers: { Authorization: 'Bearer mb_live_unknown' },
+    })
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({ user: null, principal: null })
+  })
+
+  it('makes requireUser() throw UnauthorizedError when the principal is an API key', async () => {
+    verifyKey.mockReturnValue(okAsync({ id: 'api-key-id-1', label: 'partner-x' }))
+    const app = buildApp()
+    const response = await app.request('/protected-user', {
+      headers: { Authorization: 'Bearer mb_live_abc123' },
+    })
+    expect(response.status).toBe(401)
+  })
+
+  it('makes requirePrincipal() succeed for an API key principal', async () => {
+    verifyKey.mockReturnValue(okAsync({ id: 'api-key-id-1', label: 'partner-x' }))
+    const app = buildApp()
+    const response = await app.request('/protected-principal', {
+      headers: { Authorization: 'Bearer mb_live_abc123' },
+    })
+    expect(response.status).toBe(200)
   })
 })

--- a/apps/mb-api/src/framework/auth/authContext.ts
+++ b/apps/mb-api/src/framework/auth/authContext.ts
@@ -3,8 +3,10 @@ import { okAsync, ResultAsync } from 'neverthrow'
 
 import { verifyAccessToken } from '@/authentication/jwks'
 import { getUtilisateurByProvider } from '@/authentication/queries/getUtilisateurByProvider'
-import { looksLikeApiKey, verifyApiKey } from '@/framework/auth/apiKey'
+import { env } from '@/env'
+import { looksLikeApiKey } from '@/framework/auth/apiKey'
 import { type Principal, runWithPrincipal } from '@/framework/auth/userContext'
+import { verifyApiKey } from '@/framework/auth/verifyApiKey'
 import { logger } from '@/framework/logger/logger'
 
 const BEARER_REGEX = /^Bearer\s+(.+)$/i
@@ -48,7 +50,7 @@ const resolveJwtPrincipal = (token: string): ResultAsync<Principal | null, unkno
     )
 
 const resolveApiKeyPrincipal = (token: string): ResultAsync<Principal | null, never> =>
-  verifyApiKey(token).map((apiKey): Principal | null =>
+  verifyApiKey(token, env.API_KEY_HMAC_SECRET).map((apiKey): Principal | null =>
     apiKey ? { kind: 'apiKey', apiKey } : null,
   )
 

--- a/apps/mb-api/src/framework/auth/authContext.ts
+++ b/apps/mb-api/src/framework/auth/authContext.ts
@@ -1,8 +1,11 @@
 import { createMiddleware } from 'hono/factory'
 import { okAsync, ResultAsync } from 'neverthrow'
 
-import { verifyAccessToken } from '@/authentication/jwks'
-import { getUtilisateurByProvider } from '@/authentication/queries/getUtilisateurByProvider'
+import { type VerifiedTokenInfo, verifyAccessToken } from '@/authentication/jwks'
+import {
+  getUtilisateurByProvider,
+  type UtilisateurEnregistre,
+} from '@/authentication/queries/getUtilisateurByProvider'
 import { env } from '@/env'
 import { looksLikeApiKey } from '@/framework/auth/apiKey'
 import { type Principal, runWithPrincipal } from '@/framework/auth/userContext'
@@ -19,6 +22,14 @@ const extractBearerToken = (header: string | undefined): string | null => {
   return token && token.length > 0 ? token : null
 }
 
+const buildUserPrincipal = (
+  utilisateur: UtilisateurEnregistre,
+  tokenInfo: VerifiedTokenInfo,
+): Principal => ({
+  kind: 'user',
+  user: { ...utilisateur, prenom: tokenInfo.prenom, nom: tokenInfo.nom },
+})
+
 const resolveJwtPrincipal = (token: string): ResultAsync<Principal | null, unknown> =>
   ResultAsync.fromPromise(verifyAccessToken(token), (error) => error)
     .orTee((error) =>
@@ -27,19 +38,10 @@ const resolveJwtPrincipal = (token: string): ResultAsync<Principal | null, unkno
         'JWT verification failed',
       ),
     )
-    .andThen((verifiedTokenInfo) =>
-      getUtilisateurByProvider(verifiedTokenInfo)
+    .andThen((tokenInfo) =>
+      getUtilisateurByProvider(tokenInfo)
         .map((utilisateur): Principal | null =>
-          utilisateur
-            ? {
-                kind: 'user',
-                user: {
-                  ...utilisateur,
-                  prenom: verifiedTokenInfo.prenom,
-                  nom: verifiedTokenInfo.nom,
-                },
-              }
-            : null,
+          utilisateur ? buildUserPrincipal(utilisateur, tokenInfo) : null,
         )
         .orTee((error) =>
           logger.warn(

--- a/apps/mb-api/src/framework/auth/authContext.ts
+++ b/apps/mb-api/src/framework/auth/authContext.ts
@@ -3,7 +3,8 @@ import { okAsync, ResultAsync } from 'neverthrow'
 
 import { verifyAccessToken } from '@/authentication/jwks'
 import { getUtilisateurByProvider } from '@/authentication/queries/getUtilisateurByProvider'
-import { runWithUser, type UtilisateurAuthentifie } from '@/framework/auth/userContext'
+import { looksLikeApiKey, verifyApiKey } from '@/framework/auth/apiKey'
+import { type Principal, runWithPrincipal } from '@/framework/auth/userContext'
 import { logger } from '@/framework/logger/logger'
 
 const BEARER_REGEX = /^Bearer\s+(.+)$/i
@@ -16,13 +17,8 @@ const extractBearerToken = (header: string | undefined): string | null => {
   return token && token.length > 0 ? token : null
 }
 
-const resolveUser = (
-  authorization: string | undefined,
-): ResultAsync<UtilisateurAuthentifie | null, unknown> => {
-  const token = extractBearerToken(authorization)
-  if (!token) return okAsync(null)
-
-  return ResultAsync.fromPromise(verifyAccessToken(token), (error) => error)
+const resolveJwtPrincipal = (token: string): ResultAsync<Principal | null, unknown> =>
+  ResultAsync.fromPromise(verifyAccessToken(token), (error) => error)
     .orTee((error) =>
       logger.warn(
         { event: 'auth.jwt.invalid', reason: error instanceof Error ? error.message : 'unknown' },
@@ -31,9 +27,16 @@ const resolveUser = (
     )
     .andThen((verifiedTokenInfo) =>
       getUtilisateurByProvider(verifiedTokenInfo)
-        .map((utilisateur): UtilisateurAuthentifie | null =>
+        .map((utilisateur): Principal | null =>
           utilisateur
-            ? { ...utilisateur, prenom: verifiedTokenInfo.prenom, nom: verifiedTokenInfo.nom }
+            ? {
+                kind: 'user',
+                user: {
+                  ...utilisateur,
+                  prenom: verifiedTokenInfo.prenom,
+                  nom: verifiedTokenInfo.nom,
+                },
+              }
             : null,
         )
         .orTee((error) =>
@@ -43,9 +46,22 @@ const resolveUser = (
           ),
         ),
     )
+
+const resolveApiKeyPrincipal = (token: string): ResultAsync<Principal | null, never> =>
+  verifyApiKey(token).map((apiKey): Principal | null =>
+    apiKey ? { kind: 'apiKey', apiKey } : null,
+  )
+
+const resolvePrincipal = (
+  authorization: string | undefined,
+): ResultAsync<Principal | null, unknown> => {
+  const token = extractBearerToken(authorization)
+  if (!token) return okAsync(null)
+  if (looksLikeApiKey(token)) return resolveApiKeyPrincipal(token)
+  return resolveJwtPrincipal(token)
 }
 
 export const authContext = createMiddleware(async (context, next) => {
-  const user = await resolveUser(context.req.header('Authorization')).unwrapOr(null)
-  await runWithUser(user, next)
+  const principal = await resolvePrincipal(context.req.header('Authorization')).unwrapOr(null)
+  await runWithPrincipal(principal, next)
 })

--- a/apps/mb-api/src/framework/auth/requireAuthentication.test.ts
+++ b/apps/mb-api/src/framework/auth/requireAuthentication.test.ts
@@ -1,0 +1,53 @@
+import { Hono } from 'hono'
+import { describe, expect, it } from 'vitest'
+
+import { UnauthorizedError } from '@/framework/auth/UnauthorizedError'
+import { requireAuthentication } from '@/framework/auth/requireAuthentication'
+import {
+  type Principal,
+  runWithPrincipal,
+} from '@/framework/auth/userContext'
+
+const buildApp = (principal: Principal | null) => {
+  const app = new Hono()
+  app.use('*', async (_, next) => runWithPrincipal(principal, next))
+  app.use('*', requireAuthentication)
+  app.onError((error, context) => {
+    if (error instanceof UnauthorizedError) return context.json({ error: 'unauthorized' }, 401)
+    throw error
+  })
+  app.get('/protected', (context) => context.json({ ok: true }))
+  return app
+}
+
+describe.concurrent('middleware requireAuthentication', () => {
+  it('renvoie 401 quand aucun principal est présent dans le contexte', async () => {
+    const app = buildApp(null)
+    const response = await app.request('/protected')
+    expect(response.status).toBe(401)
+  })
+
+  it('laisse passer la requête quand un principal user est présent', async () => {
+    const app = buildApp({
+      kind: 'user',
+      user: {
+        id: '01906f5e-1234-7000-8abc-000000000001',
+        email: 'agent@example.com',
+        prenom: 'Admin',
+        nom: 'DITP',
+      },
+    })
+    const response = await app.request('/protected')
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({ ok: true })
+  })
+
+  it('laisse passer la requête quand un principal API key est présent', async () => {
+    const app = buildApp({
+      kind: 'apiKey',
+      apiKey: { id: 'api-key-id-1', label: 'partner-x' },
+    })
+    const response = await app.request('/protected')
+    expect(response.status).toBe(200)
+  })
+})

--- a/apps/mb-api/src/framework/auth/requireAuthentication.ts
+++ b/apps/mb-api/src/framework/auth/requireAuthentication.ts
@@ -1,0 +1,8 @@
+import { createMiddleware } from 'hono/factory'
+
+import { requirePrincipal } from '@/framework/auth/userContext'
+
+export const requireAuthentication = createMiddleware(async (_context, next) => {
+  requirePrincipal()
+  await next()
+})

--- a/apps/mb-api/src/framework/auth/userContext.ts
+++ b/apps/mb-api/src/framework/auth/userContext.ts
@@ -9,15 +9,35 @@ export type UtilisateurAuthentifie = {
   nom: string
 }
 
-type UserStore = { user: UtilisateurAuthentifie | null }
+export type ApiKeyAuthentifiee = {
+  id: string
+  label: string
+}
 
-const storage = new AsyncLocalStorage<UserStore>()
+export type Principal =
+  | { kind: 'user'; user: UtilisateurAuthentifie }
+  | { kind: 'apiKey'; apiKey: ApiKeyAuthentifiee }
 
-export const runWithUser = <T>(user: UtilisateurAuthentifie | null, fn: () => T): T =>
-  storage.run({ user }, fn)
+type Store = { principal: Principal | null }
 
-export const getCurrentUser = (): UtilisateurAuthentifie | null =>
-  storage.getStore()?.user ?? null
+const storage = new AsyncLocalStorage<Store>()
+
+export const runWithPrincipal = <T>(principal: Principal | null, fn: () => T): T =>
+  storage.run({ principal }, fn)
+
+export const getCurrentPrincipal = (): Principal | null =>
+  storage.getStore()?.principal ?? null
+
+export const requirePrincipal = (): Principal => {
+  const principal = getCurrentPrincipal()
+  if (!principal) throw new UnauthorizedError('Authentification requise')
+  return principal
+}
+
+export const getCurrentUser = (): UtilisateurAuthentifie | null => {
+  const principal = getCurrentPrincipal()
+  return principal?.kind === 'user' ? principal.user : null
+}
 
 export const requireUser = (): UtilisateurAuthentifie => {
   const user = getCurrentUser()

--- a/apps/mb-api/src/framework/auth/verifyApiKey.test.ts
+++ b/apps/mb-api/src/framework/auth/verifyApiKey.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest'
+
+import { env } from '@/env'
+import { verifyApiKey } from '@/framework/auth/verifyApiKey'
+import { fixtures } from '@/test/fixtures'
+import { integrationTest } from '@/test/integrationTest'
+
+describe.concurrent('verifyApiKey', () => {
+  it(
+    'returns the api key principal when the key exists and is active',
+    integrationTest(async () => {
+      const row = await fixtures.apiKey({
+        rawKey: 'mb_live_active_key_for_test_value',
+        label: 'partenaire X',
+      })
+
+      const result = await verifyApiKey(
+        'mb_live_active_key_for_test_value',
+        env.API_KEY_HMAC_SECRET,
+      )
+
+      expect(result.isOk()).toBe(true)
+      expect(result._unsafeUnwrap()).toEqual({ id: row.id, label: 'partenaire X' })
+    }),
+  )
+
+  it(
+    'returns null when the key is unknown',
+    integrationTest(async () => {
+      const result = await verifyApiKey(
+        'mb_live_unknown_key_value_xx',
+        env.API_KEY_HMAC_SECRET,
+      )
+      expect(result._unsafeUnwrap()).toBeNull()
+    }),
+  )
+
+  it(
+    'returns null when the key is revoked',
+    integrationTest(async () => {
+      await fixtures.apiKey({
+        rawKey: 'mb_live_revoked_key_for_test_value',
+        revokedAt: new Date('2026-01-01'),
+      })
+
+      const result = await verifyApiKey(
+        'mb_live_revoked_key_for_test_value',
+        env.API_KEY_HMAC_SECRET,
+      )
+
+      expect(result._unsafeUnwrap()).toBeNull()
+    }),
+  )
+
+  it(
+    'returns null when the key has expired',
+    integrationTest(async () => {
+      await fixtures.apiKey({
+        rawKey: 'mb_live_expired_key_for_test_value',
+        expiresAt: new Date('2020-01-01'),
+      })
+
+      const result = await verifyApiKey(
+        'mb_live_expired_key_for_test_value',
+        env.API_KEY_HMAC_SECRET,
+      )
+
+      expect(result._unsafeUnwrap()).toBeNull()
+    }),
+  )
+})

--- a/apps/mb-api/src/framework/auth/verifyApiKey.test.ts
+++ b/apps/mb-api/src/framework/auth/verifyApiKey.test.ts
@@ -7,15 +7,15 @@ import { integrationTest } from '@/test/integrationTest'
 
 describe.concurrent('verifyApiKey', () => {
   it(
-    'returns the api key principal when the key exists and is active',
+    'renvoie le principal API key quand la clé existe et est active',
     integrationTest(async () => {
       const row = await fixtures.apiKey({
-        rawKey: 'mb_live_active_key_for_test_value',
+        rawKey: 'pilote_live_active_key_for_test_value',
         label: 'partenaire X',
       })
 
       const result = await verifyApiKey(
-        'mb_live_active_key_for_test_value',
+        'pilote_live_active_key_for_test_value',
         env.API_KEY_HMAC_SECRET,
       )
 
@@ -25,10 +25,10 @@ describe.concurrent('verifyApiKey', () => {
   )
 
   it(
-    'returns null when the key is unknown',
+    'renvoie null quand la clé est inconnue',
     integrationTest(async () => {
       const result = await verifyApiKey(
-        'mb_live_unknown_key_value_xx',
+        'pilote_live_unknown_key_value_xx',
         env.API_KEY_HMAC_SECRET,
       )
       expect(result._unsafeUnwrap()).toBeNull()
@@ -36,15 +36,15 @@ describe.concurrent('verifyApiKey', () => {
   )
 
   it(
-    'returns null when the key is revoked',
+    'renvoie null quand la clé a été révoquée',
     integrationTest(async () => {
       await fixtures.apiKey({
-        rawKey: 'mb_live_revoked_key_for_test_value',
+        rawKey: 'pilote_live_revoked_key_for_test_value',
         revokedAt: new Date('2026-01-01'),
       })
 
       const result = await verifyApiKey(
-        'mb_live_revoked_key_for_test_value',
+        'pilote_live_revoked_key_for_test_value',
         env.API_KEY_HMAC_SECRET,
       )
 
@@ -53,15 +53,15 @@ describe.concurrent('verifyApiKey', () => {
   )
 
   it(
-    'returns null when the key has expired',
+    'renvoie null quand la clé a expiré',
     integrationTest(async () => {
       await fixtures.apiKey({
-        rawKey: 'mb_live_expired_key_for_test_value',
+        rawKey: 'pilote_live_expired_key_for_test_value',
         expiresAt: new Date('2020-01-01'),
       })
 
       const result = await verifyApiKey(
-        'mb_live_expired_key_for_test_value',
+        'pilote_live_expired_key_for_test_value',
         env.API_KEY_HMAC_SECRET,
       )
 

--- a/apps/mb-api/src/framework/auth/verifyApiKey.ts
+++ b/apps/mb-api/src/framework/auth/verifyApiKey.ts
@@ -16,10 +16,7 @@ const resolveApiKey = async (
   secret: string,
 ): Promise<ApiKeyAuthentifiee | null> => {
   const keyHash = hashApiKey(rawKey, secret)
-  const row = await db().apiKey.findUnique({
-    where: { keyHash },
-    select: { id: true, label: true, revokedAt: true, expiresAt: true },
-  })
+  const row = await db().apiKey.findUnique({ where: { keyHash } })
   if (!row) return null
 
   if (row.revokedAt) {
@@ -38,17 +35,17 @@ const resolveApiKey = async (
     return null
   }
 
-  void db()
-    .apiKey.update({
+  try {
+    await db().apiKey.update({
       where: { id: row.id },
       data: { lastUsedAt: new Date() },
     })
-    .catch((error: unknown) => {
-      logger.warn(
-        { event: 'auth.api_key.last_used_update_failed', err: error },
-        'Failed to update API key lastUsedAt',
-      )
-    })
+  } catch (error: unknown) {
+    logger.warn(
+      { event: 'auth.api_key.last_used_update_failed', err: error },
+      'Failed to update API key lastUsedAt',
+    )
+  }
 
   return { id: row.id, label: row.label }
 }

--- a/apps/mb-api/src/framework/auth/verifyApiKey.ts
+++ b/apps/mb-api/src/framework/auth/verifyApiKey.ts
@@ -1,0 +1,54 @@
+import { ResultAsync } from 'neverthrow'
+
+import { hashApiKey } from '@/framework/auth/apiKey'
+import type { ApiKeyAuthentifiee } from '@/framework/auth/userContext'
+import { logger } from '@/framework/logger/logger'
+import { db } from '@/framework/persistence/dbStore'
+
+export const verifyApiKey = (
+  rawKey: string,
+  secret: string,
+): ResultAsync<ApiKeyAuthentifiee | null, never> =>
+  ResultAsync.fromSafePromise(resolveApiKey(rawKey, secret))
+
+const resolveApiKey = async (
+  rawKey: string,
+  secret: string,
+): Promise<ApiKeyAuthentifiee | null> => {
+  const keyHash = hashApiKey(rawKey, secret)
+  const row = await db().apiKey.findUnique({
+    where: { keyHash },
+    select: { id: true, label: true, revokedAt: true, expiresAt: true },
+  })
+  if (!row) return null
+
+  if (row.revokedAt) {
+    logger.warn(
+      { event: 'auth.api_key.revoked', apiKeyId: row.id },
+      'Revoked API key used',
+    )
+    return null
+  }
+
+  if (row.expiresAt && row.expiresAt.getTime() <= Date.now()) {
+    logger.warn(
+      { event: 'auth.api_key.expired', apiKeyId: row.id },
+      'Expired API key used',
+    )
+    return null
+  }
+
+  void db()
+    .apiKey.update({
+      where: { id: row.id },
+      data: { lastUsedAt: new Date() },
+    })
+    .catch((error: unknown) => {
+      logger.warn(
+        { event: 'auth.api_key.last_used_update_failed', err: error },
+        'Failed to update API key lastUsedAt',
+      )
+    })
+
+  return { id: row.id, label: row.label }
+}

--- a/apps/mb-api/src/healthcheck/routes/health.ts
+++ b/apps/mb-api/src/healthcheck/routes/health.ts
@@ -22,6 +22,7 @@ const healthRoute = createRoute({
   path: '/health',
   tags: ['Healthcheck'],
   summary: 'Vérifier la santé du service',
+  security: [],
   responses: {
     200: {
       content: { 'application/json': { schema: HealthOkSchema } },

--- a/apps/mb-api/src/indicateur/routes.ts
+++ b/apps/mb-api/src/indicateur/routes.ts
@@ -27,6 +27,7 @@ const getIndicateursRoute = createRoute({
   summary: 'Lister les indicateurs',
   description:
     "Retourne la liste paginée des indicateurs avec un filtre de recherche par nom. La pagination est cursor-based : passez `cursor` (renvoyé dans la réponse précédente) pour obtenir la page suivante. `hasMore` indique s'il reste des pages.",
+  middleware: [requireAuthentication],
   request: { query: listIndicateursQuerySchema },
   responses: {
     200: {
@@ -53,6 +54,7 @@ const getIndicateurByIdRoute = createRoute({
   summary: 'Récupérer un indicateur par identifiant public',
   description:
     'Retourne un indicateur identifié par son identifiant public (format `IND-XXX`). Renvoie 404 (`ENTITY_NOT_FOUND`) si aucun indicateur ne correspond.',
+  middleware: [requireAuthentication],
   request: { params: detailParamsSchema },
   responses: {
     200: {
@@ -69,8 +71,6 @@ const getIndicateurByIdRoute = createRoute({
 // --- App registration --------------------------------------------------------
 
 export const indicateurRoutes = new OpenAPIHono()
-
-indicateurRoutes.use('*', requireAuthentication)
 
 indicateurRoutes.openapi(getIndicateursRoute, async (context) => {
   const { recherche, cursor, pageSize } = context.req.valid('query')

--- a/apps/mb-api/src/indicateur/routes.ts
+++ b/apps/mb-api/src/indicateur/routes.ts
@@ -7,6 +7,7 @@ import {
 } from '@pilote/mb-shared/indicateur'
 import { createPaginatedApiListSchema } from '@pilote/mb-shared/pagination'
 
+import { requireAuthentication } from '@/framework/auth/requireAuthentication'
 import { never } from '@/framework/errors/never'
 import { jsonResponseOk } from '@/framework/openapi/jsonResponse'
 import { getIndicateurByPublicId } from '@/indicateur/queries/getIndicateurByPublicId'
@@ -68,6 +69,8 @@ const getIndicateurByIdRoute = createRoute({
 // --- App registration --------------------------------------------------------
 
 export const indicateurRoutes = new OpenAPIHono()
+
+indicateurRoutes.use('*', requireAuthentication)
 
 indicateurRoutes.openapi(getIndicateursRoute, async (context) => {
   const { recherche, cursor, pageSize } = context.req.valid('query')

--- a/apps/mb-api/src/individu/routes.ts
+++ b/apps/mb-api/src/individu/routes.ts
@@ -19,6 +19,7 @@ const getIndividuByIdRoute = createRoute({
   summary: 'Récupérer un individu par identifiant public',
   description:
     "Retourne un individu identifié par son identifiant public (ex. `DEPT-84`, `REG-93`, `FR`). Le payload inclut les référentiels auxquels l'individu appartient.",
+  middleware: [requireAuthentication],
   request: { params: detailParamsSchema },
   responses: {
     200: {
@@ -29,8 +30,6 @@ const getIndividuByIdRoute = createRoute({
 })
 
 export const individuRoutes = new OpenAPIHono()
-
-individuRoutes.use('*', requireAuthentication)
 
 individuRoutes.openapi(getIndividuByIdRoute, async (context) => {
   const { id } = context.req.valid('param')

--- a/apps/mb-api/src/individu/routes.ts
+++ b/apps/mb-api/src/individu/routes.ts
@@ -1,6 +1,7 @@
 import { createRoute, OpenAPIHono, z } from '@hono/zod-openapi'
 import { individuApiModelSchema, individuPublicIdSchema } from '@pilote/mb-shared/individu'
 
+import { requireAuthentication } from '@/framework/auth/requireAuthentication'
 import { never } from '@/framework/errors/never'
 import { jsonResponseOk } from '@/framework/openapi/jsonResponse'
 import { getIndividuByPublicId } from '@/individu/queries/getIndividuByPublicId'
@@ -28,6 +29,8 @@ const getIndividuByIdRoute = createRoute({
 })
 
 export const individuRoutes = new OpenAPIHono()
+
+individuRoutes.use('*', requireAuthentication)
 
 individuRoutes.openapi(getIndividuByIdRoute, async (context) => {
   const { id } = context.req.valid('param')

--- a/apps/mb-api/src/referentiel/routes.ts
+++ b/apps/mb-api/src/referentiel/routes.ts
@@ -11,6 +11,7 @@ import {
   referentielPublicIdSchema,
 } from '@pilote/mb-shared/referentiel'
 
+import { requireAuthentication } from '@/framework/auth/requireAuthentication'
 import { never } from '@/framework/errors/never'
 import { jsonResponseOk } from '@/framework/openapi/jsonResponse'
 import { getReferentielByPublicId } from '@/referentiel/queries/getReferentielByPublicId'
@@ -93,6 +94,8 @@ const getIndividusForReferentielRoute = createRoute({
 // --- App registration --------------------------------------------------------
 
 export const referentielRoutes = new OpenAPIHono()
+
+referentielRoutes.use('*', requireAuthentication)
 
 referentielRoutes.openapi(getReferentielsRoute, async (context) => {
   const { recherche, cursor, pageSize } = context.req.valid('query')

--- a/apps/mb-api/src/referentiel/routes.ts
+++ b/apps/mb-api/src/referentiel/routes.ts
@@ -36,6 +36,7 @@ const getReferentielsRoute = createRoute({
   summary: 'Lister les référentiels',
   description:
     "Retourne la liste paginée des référentiels avec un filtre de recherche par nom. La pagination est cursor-based : passez `cursor` (renvoyé dans la réponse précédente) pour obtenir la page suivante. Chaque item inclut `nombreIndividus` (population du référentiel).",
+  middleware: [requireAuthentication],
   request: { query: listReferentielsQuerySchema },
   responses: {
     200: {
@@ -61,6 +62,7 @@ const getReferentielByIdRoute = createRoute({
   tags: ['Referentiel'],
   summary: 'Récupérer un référentiel par identifiant public',
   description: 'Retourne un référentiel identifié par son identifiant public (format `REF-<SLUG>`).',
+  middleware: [requireAuthentication],
   request: { params: detailParamsSchema },
   responses: {
     200: {
@@ -79,6 +81,7 @@ const getIndividusForReferentielRoute = createRoute({
   summary: "Lister les individus d'un référentiel",
   description:
     "Retourne la liste paginée des individus appartenant à la population du référentiel donné. Filtre optionnel `recherche` sur le nom. Pagination cursor-based.",
+  middleware: [requireAuthentication],
   request: {
     params: detailParamsSchema,
     query: listIndividusForReferentielQuerySchema,
@@ -94,8 +97,6 @@ const getIndividusForReferentielRoute = createRoute({
 // --- App registration --------------------------------------------------------
 
 export const referentielRoutes = new OpenAPIHono()
-
-referentielRoutes.use('*', requireAuthentication)
 
 referentielRoutes.openapi(getReferentielsRoute, async (context) => {
   const { recherche, cursor, pageSize } = context.req.valid('query')

--- a/apps/mb-api/src/shared/routes/sharedMessage.ts
+++ b/apps/mb-api/src/shared/routes/sharedMessage.ts
@@ -1,6 +1,7 @@
 import { createRoute, OpenAPIHono } from '@hono/zod-openapi'
 import { SHARED_GREETING, type SharedMessage, sharedMessageSchema } from '@pilote/mb-shared'
 
+import { requireAuthentication } from '@/framework/auth/requireAuthentication'
 import { jsonResponseOk } from '@/framework/openapi/jsonResponse'
 
 const SharedMessageSchema = sharedMessageSchema.openapi('SharedMessage')
@@ -19,6 +20,8 @@ const sharedMessageRoute = createRoute({
 })
 
 export const sharedMessage = new OpenAPIHono()
+
+sharedMessage.use('*', requireAuthentication)
 
 sharedMessage.openapi(sharedMessageRoute, (context) => {
   const data: SharedMessage = { greeting: SHARED_GREETING }

--- a/apps/mb-api/src/shared/routes/sharedMessage.ts
+++ b/apps/mb-api/src/shared/routes/sharedMessage.ts
@@ -11,6 +11,7 @@ const sharedMessageRoute = createRoute({
   path: '/shared-message',
   tags: ['Shared'],
   summary: 'Retourner la constante partagée',
+  middleware: [requireAuthentication],
   responses: {
     200: {
       content: { 'application/json': { schema: SharedMessageSchema } },
@@ -20,8 +21,6 @@ const sharedMessageRoute = createRoute({
 })
 
 export const sharedMessage = new OpenAPIHono()
-
-sharedMessage.use('*', requireAuthentication)
 
 sharedMessage.openapi(sharedMessageRoute, (context) => {
   const data: SharedMessage = { greeting: SHARED_GREETING }

--- a/apps/mb-api/src/test/fixtures.ts
+++ b/apps/mb-api/src/test/fixtures.ts
@@ -272,8 +272,8 @@ type ApiKeyOverrides = Partial<{
 
 const DEFAULT_API_KEY = {
   label: 'API key de test',
-  rawKey: 'mb_live_test_default_key_value_xx',
-  prefix: 'mb_live_test_def',
+  rawKey: 'pilote_live_test_default_key_value_xx',
+  prefix: 'pilote_live_test_def',
 } as const
 
 const upsertApiKey = async (o: ApiKeyOverrides = {}) => {

--- a/apps/mb-api/src/test/fixtures.ts
+++ b/apps/mb-api/src/test/fixtures.ts
@@ -1,7 +1,9 @@
 import { uuidv7 } from 'uuidv7'
 
+import { hashApiKey } from '@/framework/auth/apiKey'
 import { db } from '@/framework/persistence/dbStore'
 import {
+  type ApiKeyModel,
   type IndicateurModel,
   type IndividuModel,
   type ReferentielIndividuModel,
@@ -255,6 +257,64 @@ async function valeurAvancement(
   return results
 }
 
+// --- ApiKey ------------------------------------------------------------------
+
+type ApiKeyOverrides = Partial<{
+  id: string
+  label: string
+  rawKey: string
+  prefix: string
+  expiresAt: Date | null
+  revokedAt: Date | null
+  lastUsedAt: Date | null
+}>
+
+const DEFAULT_API_KEY = {
+  label: 'API key de test',
+  rawKey: 'mb_live_test_default_key_value_xx',
+  prefix: 'mb_live_test_def',
+} as const
+
+const upsertApiKey = async (o: ApiKeyOverrides = {}) => {
+  const rawKey = o.rawKey ?? DEFAULT_API_KEY.rawKey
+  const keyHash = hashApiKey(rawKey)
+  const create = {
+    id: o.id ?? uuidv7(),
+    label: o.label ?? DEFAULT_API_KEY.label,
+    keyHash,
+    prefix: o.prefix ?? DEFAULT_API_KEY.prefix,
+    expiresAt: o.expiresAt ?? null,
+    revokedAt: o.revokedAt ?? null,
+    lastUsedAt: o.lastUsedAt ?? null,
+  }
+  const { id: _id, rawKey: _raw, ...update } = o
+  if (Object.keys(update).length === 0) {
+    const existing = await db().apiKey.findUnique({ where: { keyHash } })
+    if (existing) return existing
+  }
+  return db().apiKey.upsert({
+    where: { keyHash },
+    update,
+    create,
+  })
+}
+
+function apiKey(): Promise<ApiKeyModel>
+function apiKey(override: ApiKeyOverrides): Promise<ApiKeyModel>
+function apiKey(
+  o1: ApiKeyOverrides,
+  o2: ApiKeyOverrides,
+  ...rest: ApiKeyOverrides[]
+): Promise<ApiKeyModel[]>
+async function apiKey(
+  ...overrides: ApiKeyOverrides[]
+): Promise<ApiKeyModel | ApiKeyModel[]> {
+  if (overrides.length <= 1) return upsertApiKey(overrides[0])
+  const results: ApiKeyModel[] = []
+  for (const o of overrides) results.push(await upsertApiKey(o))
+  return results
+}
+
 export const fixtures = {
   indicateur,
   referentiel,
@@ -262,4 +322,5 @@ export const fixtures = {
   referentielIndividu,
   relation,
   valeurAvancement,
+  apiKey,
 }

--- a/apps/mb-api/src/test/fixtures.ts
+++ b/apps/mb-api/src/test/fixtures.ts
@@ -1,5 +1,6 @@
 import { uuidv7 } from 'uuidv7'
 
+import { env } from '@/env'
 import { hashApiKey } from '@/framework/auth/apiKey'
 import { db } from '@/framework/persistence/dbStore'
 import {
@@ -277,7 +278,7 @@ const DEFAULT_API_KEY = {
 
 const upsertApiKey = async (o: ApiKeyOverrides = {}) => {
   const rawKey = o.rawKey ?? DEFAULT_API_KEY.rawKey
-  const keyHash = hashApiKey(rawKey)
+  const keyHash = hashApiKey(rawKey, env.API_KEY_HMAC_SECRET)
   const create = {
     id: o.id ?? uuidv7(),
     label: o.label ?? DEFAULT_API_KEY.label,

--- a/apps/mb-api/src/valeurAvancement/routes.ts
+++ b/apps/mb-api/src/valeurAvancement/routes.ts
@@ -9,6 +9,7 @@ import {
   valeurAvancementListApiModelSchema,
 } from '@pilote/mb-shared/valeurAvancement'
 
+import { requireAuthentication } from '@/framework/auth/requireAuthentication'
 import { never } from '@/framework/errors/never'
 import { jsonResponseOk } from '@/framework/openapi/jsonResponse'
 import { listIndividusWithValeurs } from '@/valeurAvancement/queries/listIndividusWithValeurs'
@@ -79,6 +80,8 @@ const getIndividusWithValeursRoute = createRoute({
 // --- App registration --------------------------------------------------------
 
 export const valeurAvancementRoutes = new OpenAPIHono()
+
+valeurAvancementRoutes.use('*', requireAuthentication)
 
 valeurAvancementRoutes.openapi(getValeursForIndicateurRoute, async (context) => {
   const { id } = context.req.valid('param')

--- a/apps/mb-api/src/valeurAvancement/routes.ts
+++ b/apps/mb-api/src/valeurAvancement/routes.ts
@@ -36,6 +36,7 @@ const getValeursForIndicateurRoute = createRoute({
   summary: 'Lister les valeurs pour un indicateur sur des individus',
   description:
     "Retourne les valeurs saisies pour l'indicateur sur la liste d'individus fournie. Le paramètre `individus` est obligatoire (1..N identifiants séparés par une virgule, ex. `DEPT-84,DEPT-13`). Filtres optionnels `dateDebut`/`dateFin` (ISO `YYYY-MM-DD`, inclusifs). La réponse n'est pas paginée — le volume est borné par la liste d'individus.",
+  middleware: [requireAuthentication],
   request: {
     params: indicateurParamsSchema,
     query: listValeursForIndicateurQuerySchema,
@@ -61,6 +62,7 @@ const getIndividusWithValeursRoute = createRoute({
   summary: "Lister les individus disposant de valeurs pour un indicateur",
   description:
     "Retourne la liste paginée des individus ayant au moins une valeur pour l'indicateur. Filtre optionnel `referentiel` pour ne conserver que les individus appartenant à la population d'un référentiel donné. Chaque item inclut la dernière valeur et le nombre total de valeurs.",
+  middleware: [requireAuthentication],
   request: {
     params: indicateurParamsSchema,
     query: listIndividusWithValeursQuerySchema,
@@ -80,8 +82,6 @@ const getIndividusWithValeursRoute = createRoute({
 // --- App registration --------------------------------------------------------
 
 export const valeurAvancementRoutes = new OpenAPIHono()
-
-valeurAvancementRoutes.use('*', requireAuthentication)
 
 valeurAvancementRoutes.openapi(getValeursForIndicateurRoute, async (context) => {
   const { id } = context.req.valid('param')

--- a/apps/mb-api/tsconfig.json
+++ b/apps/mb-api/tsconfig.json
@@ -27,6 +27,6 @@
       "@/env": ["./src/env"]
     }
   },
-  "include": ["src/**/*", "vite.config.ts", "vitest.config.ts", "prisma.config.ts", "eslint.config.mjs"],
+  "include": ["src/**/*", "scripts/**/*", "vite.config.ts", "vitest.config.ts", "prisma.config.ts", "eslint.config.mjs"],
   "exclude": ["dist", "node_modules"]
 }


### PR DESCRIPTION
## Summary
- Ajoute l'authentification par API key en parallèle du JWT OIDC : table `api_key` (hash HMAC-SHA256 + préfixe public + cycle de vie), middleware qui dispatche selon le préfixe `mb_live_` (sinon JWT), ALS étendue en `Principal = { kind: 'user' | 'apiKey' }`.
- Script `pnpm api-key:generate -- --label="..." [--expires-at=YYYY-MM-DD]` : insère le hash en DB et print la clé en clair sur stdout (jamais ré-exposée). Le secret HMAC est en env (`API_KEY_HMAC_SECRET`, min 32 chars) — il pepper les hashs et sert de kill-switch global.
- Swagger : le scheme `bearer` accepte JWT ou `mb_live_<secret>` (mêmes routes, même header). `/me` reste user-only.

## Notes
- Construit sur #2123 (mb-proconnect) — les changements `authContext` réutilisent le `VerifiedTokenInfo` enrichi (prenom/nom).
- HMAC déterministe → lookup O(1) par `key_hash` ; `bcrypt`/`argon2` aurait imposé un scan des clés.
- Préfixe en clair stocké en DB (16 chars, ex `mb_live_AbCdEf12`) → identifier une clé dans les logs/UI sans exposer le secret.
- `lastUsedAt` mis à jour fire-and-forget à chaque requête.
- Pas de scopes pour l'instant (volontairement hors scope, à ajouter plus tard).

## Test plan
- [ ] `pnpm --filter @pilote/mb-api lint` ✅
- [ ] `pnpm --filter @pilote/mb-api test` (54 tests, dont 4 cas API key sur le middleware + 7 cas integration sur le module apiKey)
- [ ] `pnpm --filter @pilote/mb-api database:migration` en local pour appliquer la migration en dev
- [ ] Définir `API_KEY_HMAC_SECRET` (min 32 chars) en env de dev/CI/prod
- [ ] `pnpm --filter @pilote/mb-api api-key:generate -- --label="test"` → vérifier la clé imprimée
- [ ] `curl -H "Authorization: Bearer <clé>" http://mb-api.localhost/...` sur une route protégée → 200
- [ ] Même requête après `UPDATE api_key SET revoked_at = NOW()` → 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)