### PR TITLE
feat(mb-api): endpoint PUT /indicateurs (upsert)

### DIFF
--- a/apps/mb-api/src/indicateur/commands/upsertIndicateur.test.ts
+++ b/apps/mb-api/src/indicateur/commands/upsertIndicateur.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+
+import { db } from '@/framework/persistence/dbStore'
+import { upsertIndicateur } from '@/indicateur/commands/upsertIndicateur'
+import { fixtures } from '@/test/fixtures'
+import { integrationTest } from '@/test/integrationTest'
+import { testIndicateurId } from '@/test/randomIds'
+
+describe.concurrent('upsertIndicateur', () => {
+  it(
+    'crée un indicateur quand le publicId est libre',
+    integrationTest(async () => {
+      // Given
+      const indId = testIndicateurId()
+
+      // When
+      const result = await upsertIndicateur({ publicId: indId, nom: 'Nouvel indicateur' })
+
+      // Then
+      expect(result.isOk()).toBe(true)
+      expect(result._unsafeUnwrap()).toMatchObject({
+        id: indId,
+        nom: 'Nouvel indicateur',
+      })
+      const persisted = await db().indicateur.findUniqueOrThrow({ where: { publicId: indId } })
+      expect(persisted.nom).toBe('Nouvel indicateur')
+    }),
+  )
+
+  it(
+    "met à jour le nom et updatedAt quand l'indicateur existe déjà",
+    integrationTest(async () => {
+      // Given
+      const indId = testIndicateurId()
+      const original = await fixtures.indicateur({ publicId: indId, nom: 'Ancien nom' })
+
+      // When
+      const result = await upsertIndicateur({ publicId: indId, nom: 'Nom mis à jour' })
+
+      // Then
+      expect(result.isOk()).toBe(true)
+      expect(result._unsafeUnwrap()).toMatchObject({
+        id: indId,
+        nom: 'Nom mis à jour',
+        createdAt: original.createdAt.toISOString(),
+      })
+      expect(result._unsafeUnwrap().updatedAt >= original.updatedAt.toISOString()).toBe(true)
+    }),
+  )
+})

--- a/apps/mb-api/src/indicateur/commands/upsertIndicateur.ts
+++ b/apps/mb-api/src/indicateur/commands/upsertIndicateur.ts
@@ -1,0 +1,17 @@
+import { type IndicateurApiModel, type UpsertIndicateurBody } from '@pilote/mb-shared/indicateur'
+import { ResultAsync } from 'neverthrow'
+import { uuidv7 } from 'uuidv7'
+
+import { db } from '@/framework/persistence/dbStore'
+import { toIndicateurApiModel } from '@/indicateur/utils'
+
+export const upsertIndicateur = (
+  body: UpsertIndicateurBody,
+): ResultAsync<IndicateurApiModel, never> =>
+  ResultAsync.fromSafePromise(
+    db().indicateur.upsert({
+      where: { publicId: body.publicId },
+      update: { nom: body.nom },
+      create: { id: uuidv7(), publicId: body.publicId, nom: body.nom },
+    }),
+  ).map(toIndicateurApiModel)

--- a/apps/mb-api/src/indicateur/routes.ts
+++ b/apps/mb-api/src/indicateur/routes.ts
@@ -4,18 +4,21 @@ import {
   indicateurApiModelSchema,
   indicateurPublicIdSchema,
   listIndicateursQuerySchema,
+  upsertIndicateurBodySchema,
 } from '@pilote/mb-shared/indicateur'
 import { createPaginatedApiListSchema } from '@pilote/mb-shared/pagination'
 
 import { requireAuthentication } from '@/framework/auth/requireAuthentication'
 import { never } from '@/framework/errors/never'
 import { jsonResponseOk } from '@/framework/openapi/jsonResponse'
+import { upsertIndicateur } from '@/indicateur/commands/upsertIndicateur'
 import { getIndicateurByPublicId } from '@/indicateur/queries/getIndicateurByPublicId'
 import { listIndicateurs } from '@/indicateur/queries/listIndicateurs'
 
 const IndicateurApiModelSchema = indicateurApiModelSchema.openapi('IndicateurApiModel')
 const IndicateurListApiModelSchema =
   createPaginatedApiListSchema(indicateurApiModelSchema).openapi('IndicateurListApiModel')
+const UpsertIndicateurBodySchema = upsertIndicateurBodySchema.openapi('UpsertIndicateurBody')
 export const ErrorApiModelSchema = errorApiModelSchema.openapi('ErrorApiModel')
 
 // --- GET /indicateurs --------------------------------------------------------
@@ -68,6 +71,34 @@ const getIndicateurByIdRoute = createRoute({
   },
 })
 
+// --- PUT /indicateurs --------------------------------------------------------
+
+const upsertIndicateurRoute = createRoute({
+  method: 'put',
+  path: '/indicateurs',
+  tags: ['Indicateur'],
+  summary: 'Créer ou remplacer un indicateur',
+  description:
+    "Crée l'indicateur s'il n'existe pas, ou remplace son `nom` si un indicateur avec le même `publicId` existe déjà. Opération idempotente.",
+  middleware: [requireAuthentication],
+  request: {
+    body: {
+      content: { 'application/json': { schema: UpsertIndicateurBodySchema } },
+      required: true,
+    },
+  },
+  responses: {
+    200: {
+      content: { 'application/json': { schema: IndicateurApiModelSchema } },
+      description: 'Indicateur créé ou mis à jour',
+    },
+    400: {
+      content: { 'application/json': { schema: ErrorApiModelSchema } },
+      description: 'Corps de requête invalide',
+    },
+  },
+})
+
 // --- App registration --------------------------------------------------------
 
 export const indicateurRoutes = new OpenAPIHono()
@@ -91,6 +122,21 @@ indicateurRoutes.openapi(getIndicateurByIdRoute, async (context) => {
   const { id } = context.req.valid('param')
 
   return getIndicateurByPublicId(id).match(
+    (data) =>
+      jsonResponseOk({
+        context,
+        data,
+        schema: IndicateurApiModelSchema,
+        status: 200,
+      }),
+    never,
+  )
+})
+
+indicateurRoutes.openapi(upsertIndicateurRoute, async (context) => {
+  const body = context.req.valid('json')
+
+  return upsertIndicateur(body).match(
     (data) =>
       jsonResponseOk({
         context,

--- a/packages/mb-shared/src/indicateur.ts
+++ b/packages/mb-shared/src/indicateur.ts
@@ -19,3 +19,9 @@ export type IndicateurListApiModel = z.infer<typeof indicateurListApiModelSchema
 
 export const listIndicateursQuerySchema = listQuerySchema
 export type ListIndicateursQuery = z.infer<typeof listIndicateursQuerySchema>
+
+export const upsertIndicateurBodySchema = z.object({
+  publicId: indicateurPublicIdSchema,
+  nom: z.string().min(1).describe('Nom lisible de l\'indicateur.'),
+})
+export type UpsertIndicateurBody = z.infer<typeof upsertIndicateurBodySchema>


### PR DESCRIPTION
## Summary
- Ajoute `PUT /indicateurs` (idempotent) : crée un indicateur si le `publicId` est libre, met à jour son `nom` sinon
- Inaugure le pattern `commands/` à côté des `queries/` pour les mutations
- Body partagé via `mb-shared` : `upsertIndicateurBodySchema = { publicId, nom }`
- Auth : `requireAuthentication` (comme les GET existants)

## Test plan
- [x] Tests d'intégration (`upsertIndicateur.test.ts`) : création + mise à jour
- [x] `pnpm lint` clean (mb-api + mb-webapp)
- [ ] Smoke test manuel via Swagger UI avec une API key valide