### PR TITLE
feat(mb-api): endpoint PUT /referentiels/{id} (upsert)

### DIFF
--- a/apps/mb-api/src/indicateur/commands/upsertIndicateur.test.ts
+++ b/apps/mb-api/src/indicateur/commands/upsertIndicateur.test.ts
@@ -14,7 +14,7 @@ describe.concurrent('upsertIndicateur', () => {
       const indId = testIndicateurId()
 
       // When
-      const result = await upsertIndicateur({ publicId: indId, nom: 'Nouvel indicateur' })
+      const result = await upsertIndicateur(indId, { nom: 'Nouvel indicateur' })
 
       // Then
       expect(result.isOk()).toBe(true)
@@ -35,7 +35,7 @@ describe.concurrent('upsertIndicateur', () => {
       const original = await fixtures.indicateur({ publicId: indId, nom: 'Ancien nom' })
 
       // When
-      const result = await upsertIndicateur({ publicId: indId, nom: 'Nom mis à jour' })
+      const result = await upsertIndicateur(indId, { nom: 'Nom mis à jour' })
 
       // Then
       expect(result.isOk()).toBe(true)

--- a/apps/mb-api/src/indicateur/commands/upsertIndicateur.test.ts
+++ b/apps/mb-api/src/indicateur/commands/upsertIndicateur.test.ts
@@ -18,10 +18,6 @@ describe.concurrent('upsertIndicateur', () => {
 
       // Then
       expect(result.isOk()).toBe(true)
-      expect(result._unsafeUnwrap()).toMatchObject({
-        id: indId,
-        nom: 'Nouvel indicateur',
-      })
       const persisted = await db().indicateur.findUniqueOrThrow({ where: { publicId: indId } })
       expect(persisted.nom).toBe('Nouvel indicateur')
     }),
@@ -39,12 +35,10 @@ describe.concurrent('upsertIndicateur', () => {
 
       // Then
       expect(result.isOk()).toBe(true)
-      expect(result._unsafeUnwrap()).toMatchObject({
-        id: indId,
-        nom: 'Nom mis à jour',
-        createdAt: original.createdAt.toISOString(),
-      })
-      expect(result._unsafeUnwrap().updatedAt >= original.updatedAt.toISOString()).toBe(true)
+      const persisted = await db().indicateur.findUniqueOrThrow({ where: { publicId: indId } })
+      expect(persisted.nom).toBe('Nom mis à jour')
+      expect(persisted.createdAt).toEqual(original.createdAt)
+      expect(persisted.updatedAt >= original.updatedAt).toBe(true)
     }),
   )
 })

--- a/apps/mb-api/src/indicateur/commands/upsertIndicateur.ts
+++ b/apps/mb-api/src/indicateur/commands/upsertIndicateur.ts
@@ -6,12 +6,13 @@ import { db } from '@/framework/persistence/dbStore'
 import { toIndicateurApiModel } from '@/indicateur/utils'
 
 export const upsertIndicateur = (
+  publicId: string,
   body: UpsertIndicateurBody,
 ): ResultAsync<IndicateurApiModel, never> =>
   ResultAsync.fromSafePromise(
     db().indicateur.upsert({
-      where: { publicId: body.publicId },
+      where: { publicId },
       update: { nom: body.nom },
-      create: { id: uuidv7(), publicId: body.publicId, nom: body.nom },
+      create: { id: uuidv7(), publicId, nom: body.nom },
     }),
   ).map(toIndicateurApiModel)

--- a/apps/mb-api/src/indicateur/commands/upsertIndicateur.ts
+++ b/apps/mb-api/src/indicateur/commands/upsertIndicateur.ts
@@ -1,18 +1,19 @@
-import { type IndicateurApiModel, type UpsertIndicateurBody } from '@pilote/mb-shared/indicateur'
+import { type UpsertIndicateurBody } from '@pilote/mb-shared/indicateur'
 import { ResultAsync } from 'neverthrow'
 import { uuidv7 } from 'uuidv7'
 
 import { db } from '@/framework/persistence/dbStore'
-import { toIndicateurApiModel } from '@/indicateur/utils'
 
 export const upsertIndicateur = (
   publicId: string,
   body: UpsertIndicateurBody,
-): ResultAsync<IndicateurApiModel, never> =>
+): ResultAsync<void, never> =>
   ResultAsync.fromSafePromise(
-    db().indicateur.upsert({
-      where: { publicId },
-      update: { nom: body.nom },
-      create: { id: uuidv7(), publicId, nom: body.nom },
-    }),
-  ).map(toIndicateurApiModel)
+    db()
+      .indicateur.upsert({
+        where: { publicId },
+        update: { nom: body.nom },
+        create: { id: uuidv7(), publicId, nom: body.nom },
+      })
+      .then(() => undefined),
+  )

--- a/apps/mb-api/src/indicateur/routes.ts
+++ b/apps/mb-api/src/indicateur/routes.ts
@@ -71,17 +71,18 @@ const getIndicateurByIdRoute = createRoute({
   },
 })
 
-// --- PUT /indicateurs --------------------------------------------------------
+// --- PUT /indicateurs/:id ----------------------------------------------------
 
 const upsertIndicateurRoute = createRoute({
   method: 'put',
-  path: '/indicateurs',
+  path: '/indicateurs/{id}',
   tags: ['Indicateur'],
   summary: 'Créer ou remplacer un indicateur',
   description:
-    "Crée l'indicateur s'il n'existe pas, ou remplace son `nom` si un indicateur avec le même `publicId` existe déjà. Opération idempotente.",
+    "Crée l'indicateur s'il n'existe pas, ou remplace son `nom` si un indicateur avec le même identifiant public existe déjà. Opération idempotente.",
   middleware: [requireAuthentication],
   request: {
+    params: detailParamsSchema,
     body: {
       content: { 'application/json': { schema: UpsertIndicateurBodySchema } },
       required: true,
@@ -94,7 +95,7 @@ const upsertIndicateurRoute = createRoute({
     },
     400: {
       content: { 'application/json': { schema: ErrorApiModelSchema } },
-      description: 'Corps de requête invalide',
+      description: 'Requête invalide',
     },
   },
 })
@@ -134,9 +135,10 @@ indicateurRoutes.openapi(getIndicateurByIdRoute, async (context) => {
 })
 
 indicateurRoutes.openapi(upsertIndicateurRoute, async (context) => {
+  const { id } = context.req.valid('param')
   const body = context.req.valid('json')
 
-  return upsertIndicateur(body).match(
+  return upsertIndicateur(id, body).match(
     (data) =>
       jsonResponseOk({
         context,

--- a/apps/mb-api/src/indicateur/routes.ts
+++ b/apps/mb-api/src/indicateur/routes.ts
@@ -11,6 +11,7 @@ import { createPaginatedApiListSchema } from '@pilote/mb-shared/pagination'
 import { requireAuthentication } from '@/framework/auth/requireAuthentication'
 import { never } from '@/framework/errors/never'
 import { jsonResponseOk } from '@/framework/openapi/jsonResponse'
+import { withTransaction } from '@/framework/persistence/withTransaction'
 import { upsertIndicateur } from '@/indicateur/commands/upsertIndicateur'
 import { getIndicateurByPublicId } from '@/indicateur/queries/getIndicateurByPublicId'
 import { listIndicateurs } from '@/indicateur/queries/listIndicateurs'
@@ -138,7 +139,12 @@ indicateurRoutes.openapi(upsertIndicateurRoute, async (context) => {
   const { id } = context.req.valid('param')
   const body = context.req.valid('json')
 
-  return upsertIndicateur(id, body).match(
+  const result = await withTransaction(async () => {
+    await upsertIndicateur(id, body)
+    return getIndicateurByPublicId(id)
+  })
+
+  return result.match(
     (data) =>
       jsonResponseOk({
         context,

--- a/apps/mb-api/src/referentiel/commands/upsertReferentiel.test.ts
+++ b/apps/mb-api/src/referentiel/commands/upsertReferentiel.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from 'vitest'
+
+import { db } from '@/framework/persistence/dbStore'
+import { upsertReferentiel } from '@/referentiel/commands/upsertReferentiel'
+import { fixtures } from '@/test/fixtures'
+import { integrationTest } from '@/test/integrationTest'
+import { testDeptIds } from '@/test/randomIds'
+
+describe.concurrent('upsertReferentiel', () => {
+  it(
+    'crée un référentiel quand le publicId est libre',
+    integrationTest(async () => {
+      // When
+      const result = await upsertReferentiel('REF-NEW', {
+        nom: 'Nouveau référentiel',
+        description: 'Description initiale',
+      })
+
+      // Then
+      expect(result.isOk()).toBe(true)
+      expect(result._unsafeUnwrap()).toMatchObject({
+        id: 'REF-NEW',
+        nom: 'Nouveau référentiel',
+        description: 'Description initiale',
+        nombreIndividus: 0,
+      })
+      const persisted = await db().referentiel.findUniqueOrThrow({ where: { publicId: 'REF-NEW' } })
+      expect(persisted.nom).toBe('Nouveau référentiel')
+      expect(persisted.description).toBe('Description initiale')
+    }),
+  )
+
+  it(
+    'met à jour nom, description et updatedAt quand le référentiel existe déjà',
+    integrationTest(async () => {
+      // Given
+      const original = await fixtures.referentiel({
+        publicId: 'REF-UPD',
+        nom: 'Ancien nom',
+        description: 'Ancienne description',
+      })
+
+      // When
+      const result = await upsertReferentiel('REF-UPD', {
+        nom: 'Nouveau nom',
+        description: null,
+      })
+
+      // Then
+      expect(result.isOk()).toBe(true)
+      const value = result._unsafeUnwrap()
+      expect(value).toMatchObject({
+        id: 'REF-UPD',
+        nom: 'Nouveau nom',
+        description: null,
+        createdAt: original.createdAt.toISOString(),
+      })
+      expect(value.updatedAt >= original.updatedAt.toISOString()).toBe(true)
+    }),
+  )
+
+  it(
+    'crée et lie de nouveaux individus',
+    integrationTest(async () => {
+      // Given
+      const [dept1, dept2] = testDeptIds(2)
+
+      // When
+      const result = await upsertReferentiel('REF-INDS', {
+        nom: 'Avec individus',
+        description: null,
+        individus: [
+          { publicId: dept1, nom: 'Premier' },
+          { publicId: dept2, nom: 'Second' },
+        ],
+      })
+
+      // Then
+      expect(result._unsafeUnwrap().nombreIndividus).toBe(2)
+      const persistedDept1 = await db().individu.findUniqueOrThrow({ where: { publicId: dept1 } })
+      expect(persistedDept1.nom).toBe('Premier')
+      const liaisons = await db().referentielIndividu.findMany({
+        where: { referentiel: { publicId: 'REF-INDS' } },
+      })
+      expect(liaisons).toHaveLength(2)
+    }),
+  )
+
+  it(
+    "met à jour le nom d'un individu existant et ajoute la liaison",
+    integrationTest(async () => {
+      // Given
+      const [dept1] = testDeptIds(1)
+      await fixtures.individu({ publicId: dept1, nom: 'Ancien nom individu' })
+
+      // When
+      const result = await upsertReferentiel('REF-LINK', {
+        nom: 'Référentiel',
+        description: null,
+        individus: [{ publicId: dept1, nom: 'Nouveau nom individu' }],
+      })
+
+      // Then
+      expect(result._unsafeUnwrap().nombreIndividus).toBe(1)
+      const persisted = await db().individu.findUniqueOrThrow({ where: { publicId: dept1 } })
+      expect(persisted.nom).toBe('Nouveau nom individu')
+      const liaison = await db().referentielIndividu.findFirstOrThrow({
+        where: {
+          referentiel: { publicId: 'REF-LINK' },
+          individu: { publicId: dept1 },
+        },
+      })
+      expect(liaison).toBeDefined()
+    }),
+  )
+
+  it(
+    'ne retire pas les individus déjà liés mais absents du body (merge)',
+    integrationTest(async () => {
+      // Given
+      const [dept1, dept2] = testDeptIds(2)
+      await fixtures.referentielIndividu(
+        { referentiel: { publicId: 'REF-MERGE' }, individu: { publicId: dept1 } },
+        { referentiel: { publicId: 'REF-MERGE' }, individu: { publicId: dept2 } },
+      )
+
+      // When
+      const result = await upsertReferentiel('REF-MERGE', {
+        nom: 'Référentiel de test',
+        description: null,
+        individus: [{ publicId: dept1, nom: 'Individu de test' }],
+      })
+
+      // Then : les deux liaisons sont toujours là
+      expect(result._unsafeUnwrap().nombreIndividus).toBe(2)
+    }),
+  )
+
+  it(
+    "préserve les liaisons d'un individu vers d'autres référentiels",
+    integrationTest(async () => {
+      // Given
+      const [dept1] = testDeptIds(1)
+      await fixtures.referentielIndividu({
+        referentiel: { publicId: 'REF-OTHER' },
+        individu: { publicId: dept1 },
+      })
+
+      // When
+      await upsertReferentiel('REF-NEW2', {
+        nom: 'Nouveau référentiel',
+        description: null,
+        individus: [{ publicId: dept1, nom: 'Individu de test' }],
+      })
+
+      // Then : l'individu reste lié à REF-OTHER ET REF-NEW2
+      const liaisons = await db().referentielIndividu.findMany({
+        where: { individu: { publicId: dept1 } },
+        include: { referentiel: true },
+      })
+      const refIds = liaisons.map((l) => l.referentiel.publicId).sort()
+      expect(refIds).toEqual(['REF-NEW2', 'REF-OTHER'])
+    }),
+  )
+
+  it(
+    'fonctionne sans individus (champ omis)',
+    integrationTest(async () => {
+      // When
+      const result = await upsertReferentiel('REF-EMPTY', {
+        nom: 'Sans individus',
+        description: null,
+      })
+
+      // Then
+      expect(result._unsafeUnwrap().nombreIndividus).toBe(0)
+    }),
+  )
+})

--- a/apps/mb-api/src/referentiel/commands/upsertReferentiel.test.ts
+++ b/apps/mb-api/src/referentiel/commands/upsertReferentiel.test.ts
@@ -18,12 +18,6 @@ describe.concurrent('upsertReferentiel', () => {
 
       // Then
       expect(result.isOk()).toBe(true)
-      expect(result._unsafeUnwrap()).toMatchObject({
-        id: 'REF-NEW',
-        nom: 'Nouveau référentiel',
-        description: 'Description initiale',
-        nombreIndividus: 0,
-      })
       const persisted = await db().referentiel.findUniqueOrThrow({ where: { publicId: 'REF-NEW' } })
       expect(persisted.nom).toBe('Nouveau référentiel')
       expect(persisted.description).toBe('Description initiale')
@@ -48,14 +42,11 @@ describe.concurrent('upsertReferentiel', () => {
 
       // Then
       expect(result.isOk()).toBe(true)
-      const value = result._unsafeUnwrap()
-      expect(value).toMatchObject({
-        id: 'REF-UPD',
-        nom: 'Nouveau nom',
-        description: null,
-        createdAt: original.createdAt.toISOString(),
-      })
-      expect(value.updatedAt >= original.updatedAt.toISOString()).toBe(true)
+      const persisted = await db().referentiel.findUniqueOrThrow({ where: { publicId: 'REF-UPD' } })
+      expect(persisted.nom).toBe('Nouveau nom')
+      expect(persisted.description).toBeNull()
+      expect(persisted.createdAt).toEqual(original.createdAt)
+      expect(persisted.updatedAt >= original.updatedAt).toBe(true)
     }),
   )
 
@@ -66,7 +57,7 @@ describe.concurrent('upsertReferentiel', () => {
       const [dept1, dept2] = testDeptIds(2)
 
       // When
-      const result = await upsertReferentiel('REF-INDS', {
+      await upsertReferentiel('REF-INDS', {
         nom: 'Avec individus',
         description: null,
         individus: [
@@ -76,7 +67,6 @@ describe.concurrent('upsertReferentiel', () => {
       })
 
       // Then
-      expect(result._unsafeUnwrap().nombreIndividus).toBe(2)
       const persistedDept1 = await db().individu.findUniqueOrThrow({ where: { publicId: dept1 } })
       expect(persistedDept1.nom).toBe('Premier')
       const liaisons = await db().referentielIndividu.findMany({
@@ -94,14 +84,13 @@ describe.concurrent('upsertReferentiel', () => {
       await fixtures.individu({ publicId: dept1, nom: 'Ancien nom individu' })
 
       // When
-      const result = await upsertReferentiel('REF-LINK', {
+      await upsertReferentiel('REF-LINK', {
         nom: 'Référentiel',
         description: null,
         individus: [{ publicId: dept1, nom: 'Nouveau nom individu' }],
       })
 
       // Then
-      expect(result._unsafeUnwrap().nombreIndividus).toBe(1)
       const persisted = await db().individu.findUniqueOrThrow({ where: { publicId: dept1 } })
       expect(persisted.nom).toBe('Nouveau nom individu')
       const liaison = await db().referentielIndividu.findFirstOrThrow({
@@ -125,14 +114,17 @@ describe.concurrent('upsertReferentiel', () => {
       )
 
       // When
-      const result = await upsertReferentiel('REF-MERGE', {
+      await upsertReferentiel('REF-MERGE', {
         nom: 'Référentiel de test',
         description: null,
         individus: [{ publicId: dept1, nom: 'Individu de test' }],
       })
 
       // Then : les deux liaisons sont toujours là
-      expect(result._unsafeUnwrap().nombreIndividus).toBe(2)
+      const liaisons = await db().referentielIndividu.findMany({
+        where: { referentiel: { publicId: 'REF-MERGE' } },
+      })
+      expect(liaisons).toHaveLength(2)
     }),
   )
 
@@ -173,7 +165,11 @@ describe.concurrent('upsertReferentiel', () => {
       })
 
       // Then
-      expect(result._unsafeUnwrap().nombreIndividus).toBe(0)
+      expect(result.isOk()).toBe(true)
+      const persisted = await db().referentiel.findUniqueOrThrow({
+        where: { publicId: 'REF-EMPTY' },
+      })
+      expect(persisted.nom).toBe('Sans individus')
     }),
   )
 })

--- a/apps/mb-api/src/referentiel/commands/upsertReferentiel.ts
+++ b/apps/mb-api/src/referentiel/commands/upsertReferentiel.ts
@@ -1,14 +1,10 @@
-import { type ReferentielApiModel, type UpsertReferentielBody } from '@pilote/mb-shared/referentiel'
+import { type UpsertReferentielBody } from '@pilote/mb-shared/referentiel'
 import { ResultAsync } from 'neverthrow'
 import { uuidv7 } from 'uuidv7'
 
 import { db } from '@/framework/persistence/dbStore'
-import { toReferentielApiModel, type ReferentielWithCount } from '@/referentiel/utils'
 
-const performUpsert = async (
-  publicId: string,
-  body: UpsertReferentielBody,
-): Promise<ReferentielWithCount> => {
+const performUpsert = async (publicId: string, body: UpsertReferentielBody): Promise<void> => {
   const referentiel = await db().referentiel.upsert({
     where: { publicId },
     update: { nom: body.nom, description: body.description },
@@ -37,15 +33,9 @@ const performUpsert = async (
       create: { referentielId: referentiel.id, individuId: individu.id },
     })
   }
-
-  return db().referentiel.findUniqueOrThrow({
-    where: { id: referentiel.id },
-    include: { _count: { select: { individus: true } } },
-  })
 }
 
 export const upsertReferentiel = (
   publicId: string,
   body: UpsertReferentielBody,
-): ResultAsync<ReferentielApiModel, never> =>
-  ResultAsync.fromSafePromise(performUpsert(publicId, body)).map(toReferentielApiModel)
+): ResultAsync<void, never> => ResultAsync.fromSafePromise(performUpsert(publicId, body))

--- a/apps/mb-api/src/referentiel/commands/upsertReferentiel.ts
+++ b/apps/mb-api/src/referentiel/commands/upsertReferentiel.ts
@@ -1,0 +1,51 @@
+import { type ReferentielApiModel, type UpsertReferentielBody } from '@pilote/mb-shared/referentiel'
+import { ResultAsync } from 'neverthrow'
+import { uuidv7 } from 'uuidv7'
+
+import { db } from '@/framework/persistence/dbStore'
+import { toReferentielApiModel, type ReferentielWithCount } from '@/referentiel/utils'
+
+const performUpsert = async (
+  publicId: string,
+  body: UpsertReferentielBody,
+): Promise<ReferentielWithCount> => {
+  const referentiel = await db().referentiel.upsert({
+    where: { publicId },
+    update: { nom: body.nom, description: body.description },
+    create: {
+      id: uuidv7(),
+      publicId,
+      nom: body.nom,
+      description: body.description,
+    },
+  })
+
+  for (const item of body.individus ?? []) {
+    const individu = await db().individu.upsert({
+      where: { publicId: item.publicId },
+      update: { nom: item.nom },
+      create: { id: uuidv7(), publicId: item.publicId, nom: item.nom },
+    })
+    await db().referentielIndividu.upsert({
+      where: {
+        referentielId_individuId: {
+          referentielId: referentiel.id,
+          individuId: individu.id,
+        },
+      },
+      update: {},
+      create: { referentielId: referentiel.id, individuId: individu.id },
+    })
+  }
+
+  return db().referentiel.findUniqueOrThrow({
+    where: { id: referentiel.id },
+    include: { _count: { select: { individus: true } } },
+  })
+}
+
+export const upsertReferentiel = (
+  publicId: string,
+  body: UpsertReferentielBody,
+): ResultAsync<ReferentielApiModel, never> =>
+  ResultAsync.fromSafePromise(performUpsert(publicId, body)).map(toReferentielApiModel)

--- a/apps/mb-api/src/referentiel/routes.ts
+++ b/apps/mb-api/src/referentiel/routes.ts
@@ -164,7 +164,10 @@ referentielRoutes.openapi(upsertReferentielRoute, async (context) => {
   const { id } = context.req.valid('param')
   const body = context.req.valid('json')
 
-  const result = await withTransaction(async () => upsertReferentiel(id, body))
+  const result = await withTransaction(async () => {
+    await upsertReferentiel(id, body)
+    return getReferentielByPublicId(id)
+  })
 
   return result.match(
     (data) =>

--- a/apps/mb-api/src/referentiel/routes.ts
+++ b/apps/mb-api/src/referentiel/routes.ts
@@ -9,22 +9,24 @@ import {
   listReferentielsQuerySchema,
   referentielApiModelSchema,
   referentielPublicIdSchema,
+  upsertReferentielBodySchema,
 } from '@pilote/mb-shared/referentiel'
 
 import { requireAuthentication } from '@/framework/auth/requireAuthentication'
 import { never } from '@/framework/errors/never'
 import { jsonResponseOk } from '@/framework/openapi/jsonResponse'
+import { withTransaction } from '@/framework/persistence/withTransaction'
+import { upsertReferentiel } from '@/referentiel/commands/upsertReferentiel'
 import { getReferentielByPublicId } from '@/referentiel/queries/getReferentielByPublicId'
 import { listIndividusForReferentiel } from '@/referentiel/queries/listIndividusForReferentiel'
 import { listReferentiels } from '@/referentiel/queries/listReferentiels'
 
 const ReferentielApiModelSchema = referentielApiModelSchema.openapi('ReferentielApiModel')
-const ReferentielListApiModelSchema = createPaginatedApiListSchema(
-  referentielApiModelSchema,
-).openapi('ReferentielListApiModel')
-const IndividuListApiModelSchema = createPaginatedApiListSchema(individuApiModelSchema).openapi(
-  'IndividuListApiModel',
-)
+const ReferentielListApiModelSchema =
+  createPaginatedApiListSchema(referentielApiModelSchema).openapi('ReferentielListApiModel')
+const IndividuListApiModelSchema =
+  createPaginatedApiListSchema(individuApiModelSchema).openapi('IndividuListApiModel')
+const UpsertReferentielBodySchema = upsertReferentielBodySchema.openapi('UpsertReferentielBody')
 const ErrorApiModelSchema = errorApiModelSchema.openapi('ErrorApiModel')
 
 // --- GET /referentiels -------------------------------------------------------
@@ -35,7 +37,7 @@ const getReferentielsRoute = createRoute({
   tags: ['Referentiel'],
   summary: 'Lister les référentiels',
   description:
-    "Retourne la liste paginée des référentiels avec un filtre de recherche par nom. La pagination est cursor-based : passez `cursor` (renvoyé dans la réponse précédente) pour obtenir la page suivante. Chaque item inclut `nombreIndividus` (population du référentiel).",
+    'Retourne la liste paginée des référentiels avec un filtre de recherche par nom. La pagination est cursor-based : passez `cursor` (renvoyé dans la réponse précédente) pour obtenir la page suivante. Chaque item inclut `nombreIndividus` (population du référentiel).',
   middleware: [requireAuthentication],
   request: { query: listReferentielsQuerySchema },
   responses: {
@@ -61,13 +63,43 @@ const getReferentielByIdRoute = createRoute({
   path: '/referentiels/{id}',
   tags: ['Referentiel'],
   summary: 'Récupérer un référentiel par identifiant public',
-  description: 'Retourne un référentiel identifié par son identifiant public (format `REF-<SLUG>`).',
+  description:
+    'Retourne un référentiel identifié par son identifiant public (format `REF-<SLUG>`).',
   middleware: [requireAuthentication],
   request: { params: detailParamsSchema },
   responses: {
     200: {
       content: { 'application/json': { schema: ReferentielApiModelSchema } },
       description: 'Référentiel trouvé',
+    },
+  },
+})
+
+// --- PUT /referentiels/:id ---------------------------------------------------
+
+const upsertReferentielRoute = createRoute({
+  method: 'put',
+  path: '/referentiels/{id}',
+  tags: ['Referentiel'],
+  summary: 'Créer ou mettre à jour un référentiel',
+  description:
+    "Crée le référentiel s'il n'existe pas, ou met à jour son `nom` et sa `description` quand le référentiel existe déjà. Le tableau `individus` est optionnel et appliqué en mode merge : chaque individu est upsert (création/mise à jour du nom) et lié au référentiel ; les individus déjà liés et absents du body ne sont pas retirés. Opération idempotente, exécutée dans une transaction.",
+  middleware: [requireAuthentication],
+  request: {
+    params: detailParamsSchema,
+    body: {
+      content: { 'application/json': { schema: UpsertReferentielBodySchema } },
+      required: true,
+    },
+  },
+  responses: {
+    200: {
+      content: { 'application/json': { schema: ReferentielApiModelSchema } },
+      description: 'Référentiel créé ou mis à jour',
+    },
+    400: {
+      content: { 'application/json': { schema: ErrorApiModelSchema } },
+      description: 'Corps de requête ou paramètres invalides',
     },
   },
 })
@@ -80,7 +112,7 @@ const getIndividusForReferentielRoute = createRoute({
   tags: ['Referentiel'],
   summary: "Lister les individus d'un référentiel",
   description:
-    "Retourne la liste paginée des individus appartenant à la population du référentiel donné. Filtre optionnel `recherche` sur le nom. Pagination cursor-based.",
+    'Retourne la liste paginée des individus appartenant à la population du référentiel donné. Filtre optionnel `recherche` sur le nom. Pagination cursor-based.',
   middleware: [requireAuthentication],
   request: {
     params: detailParamsSchema,
@@ -117,6 +149,24 @@ referentielRoutes.openapi(getReferentielByIdRoute, async (context) => {
   const { id } = context.req.valid('param')
 
   return getReferentielByPublicId(id).match(
+    (data) =>
+      jsonResponseOk({
+        context,
+        data,
+        schema: ReferentielApiModelSchema,
+        status: 200,
+      }),
+    never,
+  )
+})
+
+referentielRoutes.openapi(upsertReferentielRoute, async (context) => {
+  const { id } = context.req.valid('param')
+  const body = context.req.valid('json')
+
+  const result = await withTransaction(async () => upsertReferentiel(id, body))
+
+  return result.match(
     (data) =>
       jsonResponseOk({
         context,

--- a/packages/mb-shared/src/indicateur.ts
+++ b/packages/mb-shared/src/indicateur.ts
@@ -21,7 +21,6 @@ export const listIndicateursQuerySchema = listQuerySchema
 export type ListIndicateursQuery = z.infer<typeof listIndicateursQuerySchema>
 
 export const upsertIndicateurBodySchema = z.object({
-  publicId: indicateurPublicIdSchema,
   nom: z.string().min(1).describe('Nom lisible de l\'indicateur.'),
 })
 export type UpsertIndicateurBody = z.infer<typeof upsertIndicateurBodySchema>

--- a/packages/mb-shared/src/individu.ts
+++ b/packages/mb-shared/src/individu.ts
@@ -1,17 +1,9 @@
 import { z } from 'zod'
 
 import { createPaginatedApiListSchema, listQuerySchema } from './pagination'
-import { referentielPublicIdSchema } from './referentiel'
+import { individuPublicIdSchema, referentielPublicIdSchema } from './publicIds'
 
-export const individuPublicIdSchema = z
-  .string()
-  .regex(
-    /^[A-Z][A-Z0-9-]{0,19}$/,
-    'Identifiant public d\'individu attendu (lettre majuscule suivie de lettres/chiffres/tirets, max 20 caractères)',
-  )
-  .describe(
-    "Identifiant public d'individu, format humain-friendly (ex. DEPT-84, REG-93, FR). Lettre majuscule puis lettres/chiffres/tirets, max 20 caractères.",
-  )
+export { individuPublicIdSchema } from './publicIds'
 
 export const individuApiModelSchema = z.object({
   id: individuPublicIdSchema,

--- a/packages/mb-shared/src/publicIds.ts
+++ b/packages/mb-shared/src/publicIds.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod'
+
+export const referentielPublicIdSchema = z
+  .string()
+  .regex(
+    /^REF-[A-Z0-9-]{1,16}$/,
+    'Identifiant public attendu au format REF-<SLUG> (max 20 caractères)',
+  )
+  .describe('Identifiant public du référentiel (format REF-<SLUG>, ex. REF-DEPT). Max 20 caractères.')
+
+export const individuPublicIdSchema = z
+  .string()
+  .regex(
+    /^[A-Z][A-Z0-9-]{0,19}$/,
+    'Identifiant public d\'individu attendu (lettre majuscule suivie de lettres/chiffres/tirets, max 20 caractères)',
+  )
+  .describe(
+    "Identifiant public d'individu, format humain-friendly (ex. DEPT-84, REG-93, FR). Lettre majuscule puis lettres/chiffres/tirets, max 20 caractères.",
+  )

--- a/packages/mb-shared/src/referentiel.ts
+++ b/packages/mb-shared/src/referentiel.ts
@@ -1,14 +1,9 @@
 import { z } from 'zod'
 
 import { createPaginatedApiListSchema, listQuerySchema } from './pagination'
+import { individuPublicIdSchema, referentielPublicIdSchema } from './publicIds'
 
-export const referentielPublicIdSchema = z
-  .string()
-  .regex(
-    /^REF-[A-Z0-9-]{1,16}$/,
-    'Identifiant public attendu au format REF-<SLUG> (max 20 caractères)',
-  )
-  .describe('Identifiant public du référentiel (format REF-<SLUG>, ex. REF-DEPT). Max 20 caractères.')
+export { referentielPublicIdSchema } from './publicIds'
 
 export const referentielApiModelSchema = z.object({
   id: referentielPublicIdSchema,
@@ -29,3 +24,21 @@ export type ReferentielListApiModel = z.infer<typeof referentielListApiModelSche
 
 export const listReferentielsQuerySchema = listQuerySchema
 export type ListReferentielsQuery = z.infer<typeof listReferentielsQuerySchema>
+
+export const upsertReferentielIndividuItemSchema = z.object({
+  publicId: individuPublicIdSchema,
+  nom: z.string().min(1).describe("Nom lisible de l'individu."),
+})
+export type UpsertReferentielIndividuItem = z.infer<typeof upsertReferentielIndividuItemSchema>
+
+export const upsertReferentielBodySchema = z.object({
+  nom: z.string().min(1).describe('Nom lisible du référentiel.'),
+  description: z.string().nullable().describe('Description du référentiel (peut être null).'),
+  individus: z
+    .array(upsertReferentielIndividuItemSchema)
+    .optional()
+    .describe(
+      "Individus à upsert et lier au référentiel. Sémantique merge : les individus déjà liés mais absents du body ne sont pas retirés.",
+    ),
+})
+export type UpsertReferentielBody = z.infer<typeof upsertReferentielBodySchema>


### PR DESCRIPTION
## Summary
- Ajoute un endpoint **PUT /referentiels/{id}** idempotent. Body : `{ nom, description: string|null, individus?: Array<{ publicId, nom }> }`. Le handler wrap l'appel command dans `withTransaction` (atomicité côté HTTP).
- Sémantique **merge** sur les individus : chaque item est upsert (création / mise à jour du `nom`) et lié au référentiel. Les individus déjà liés mais absents du body ne sont pas retirés. Les liaisons d'un individu vers d'autres référentiels sont préservées.
- Aligne le **PUT /indicateurs** sur le même pattern : `publicId` dans l'URL (`PUT /indicateurs/{id}`) plutôt que dans le body.
- Refactor `mb-shared` : nouveau fichier `publicIds.ts` qui héberge `referentielPublicIdSchema` et `individuPublicIdSchema`. Casse le cycle d'imports qui apparaissait en intégrant `individuPublicIdSchema` dans le body schema du référentiel. Les anciens imports (`@pilote/mb-shared/referentiel`, `@pilote/mb-shared/individu`) restent valides via re-export.

## Test plan
- [x] `pnpm lint` (eslint + tsc) sur mb-api
- [x] `pnpm test` sur mb-api : 67 tests / 15 fichiers — OK
- [x] Couverture nouveau fichier `upsertReferentiel.test.ts` : création, mise à jour nom/description, individus nouveaux, individu existant + liaison, merge (pas de retrait), préservation des liaisons vers d'autres référentiels, body sans `individus`
- [ ] Vérifier l'OpenAPI/Swagger pour les deux nouvelles routes (PUT référentiel + PUT indicateur réaligné)

🤖 Generated with [Claude Code](https://claude.com/claude-code)