### PR TITLE
[DITP-pilotage/pilote-2] bugfix: aligner secureCookie sur le scheme N…

### DIFF
--- a/apps/pilote-ppg/src/proxy.ts
+++ b/apps/pilote-ppg/src/proxy.ts
@@ -120,7 +120,7 @@ export async function proxy(request: NextRequest) {
     const token = await getToken({
       req: request,
       secret: process.env.NEXTAUTH_SECRET,
-      secureCookie: true,
+      secureCookie: process.env.NEXTAUTH_URL?.startsWith("https://") ?? false,
     });
 
     if (!token) {


### PR DESCRIPTION
…EXTAUTH_URL

Le middleware proxy.ts forçait secureCookie:true depuis #2101, ce qui faisait chercher le cookie __Secure-authjs.session-token même en HTTP. En CI (NEXTAUTH_URL=http://localhost:3030), NextAuth pose un cookie sans préfixe → getToken retourne null → boucle de redirection entre / et /accueil/chantier/... → les tests e2e prenaient ~35s/test et dépassaient le timeout CI de 30 min.

On détecte maintenant HTTPS comme NextAuth le fait en interne, ce qui fonctionne aussi bien pour le dev portless HTTPS que pour la CI HTTP.

Refs:
Project: pilote-2
Client: DITP-pilotage
Category: bugfix
Stack: typescript
Tags: tests, auth, e2e
Files-changed: 1