### PR TITLE
feat(mb): variation depuis la dernière MAJ sur la page indicateur (PIL-1459)

### DIFF
--- a/apps/mb-api/prisma/migrations/20260512120000_valeur_avancement_valeur_to_numeric/migration.sql
+++ b/apps/mb-api/prisma/migrations/20260512120000_valeur_avancement_valeur_to_numeric/migration.sql
@@ -1,3 +1,3 @@
 -- AlterTable
 ALTER TABLE "valeur_avancement"
-  ALTER COLUMN "valeur" SET DATA TYPE NUMERIC USING "valeur"::NUMERIC;
+  ALTER COLUMN "valeur" SET DATA TYPE NUMERIC(20, 2) USING ROUND("valeur"::NUMERIC, 2);

--- a/apps/mb-api/prisma/migrations/20260512120000_valeur_avancement_valeur_to_numeric/migration.sql
+++ b/apps/mb-api/prisma/migrations/20260512120000_valeur_avancement_valeur_to_numeric/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "valeur_avancement"
+  ALTER COLUMN "valeur" SET DATA TYPE NUMERIC USING "valeur"::NUMERIC;

--- a/apps/mb-api/prisma/schema.prisma
+++ b/apps/mb-api/prisma/schema.prisma
@@ -104,7 +104,7 @@ model ValeurAvancement {
   indicateurId String   @map("indicateur_id") @db.Uuid
   individuId   String   @map("individu_id")   @db.Uuid
   date         String
-  valeur       Decimal
+  valeur       Decimal  @db.Decimal(20, 2)
   createdAt    DateTime @default(now()) @map("created_at")
   updatedAt    DateTime @updatedAt      @map("updated_at")
 

--- a/apps/mb-api/prisma/schema.prisma
+++ b/apps/mb-api/prisma/schema.prisma
@@ -104,7 +104,7 @@ model ValeurAvancement {
   indicateurId String   @map("indicateur_id") @db.Uuid
   individuId   String   @map("individu_id")   @db.Uuid
   date         String
-  valeur       Float
+  valeur       Decimal
   createdAt    DateTime @default(now()) @map("created_at")
   updatedAt    DateTime @updatedAt      @map("updated_at")
 

--- a/apps/mb-api/prisma/seed.ts
+++ b/apps/mb-api/prisma/seed.ts
@@ -1,7 +1,7 @@
 import { PrismaPg } from '@prisma/adapter-pg'
 import { uuidv7 } from 'uuidv7'
 
-import { PrismaClient } from '../src/generated/prisma/client.js'
+import { Prisma, PrismaClient } from '../src/generated/prisma/client.js'
 
 import {
   individusSeed,
@@ -203,6 +203,7 @@ const main = async () => {
       where: { publicId: item.individuPublicId },
       select: { id: true },
     })
+    const valeur = new Prisma.Decimal(item.valeur)
     await prisma.valeurAvancement.upsert({
       where: {
         valeur_avancement_unique: {
@@ -211,13 +212,13 @@ const main = async () => {
           date: item.date,
         },
       },
-      update: { valeur: item.valeur },
+      update: { valeur },
       create: {
         id: uuidv7(),
         indicateurId: indicateur.id,
         individuId: individu.id,
         date: item.date,
-        valeur: item.valeur,
+        valeur,
       },
     })
   }

--- a/apps/mb-api/src/valeurAvancement/queries/listValeursRemarquablesForIndicateur.test.ts
+++ b/apps/mb-api/src/valeurAvancement/queries/listValeursRemarquablesForIndicateur.test.ts
@@ -1,0 +1,243 @@
+import { describe, expect, it } from 'vitest'
+
+import { fixtures } from '@/test/fixtures'
+import { integrationTest } from '@/test/integrationTest'
+import { testDeptId, testDeptIds, testIndicateurId } from '@/test/randomIds'
+import { listValeursRemarquablesForIndicateur } from '@/valeurAvancement/queries/listValeursRemarquablesForIndicateur'
+
+describe.concurrent('listValeursRemarquablesForIndicateur', () => {
+  it(
+    'retourne variation = null pour un individu sans valeur',
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const deptId = testDeptId()
+      await fixtures.indicateur({ publicId: indId, nom: 'T' })
+      await fixtures.individu({ publicId: deptId, nom: 'Vaucluse' })
+
+      const result = await listValeursRemarquablesForIndicateur(indId, { individus: [deptId] })
+
+      expect(result._unsafeUnwrap()).toEqual({
+        items: [{ individu: deptId, variation: null }],
+      })
+    }),
+  )
+
+  it(
+    "retourne variation = valeur lorsqu'il n'y a qu'une seule valeur",
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const deptId = testDeptId()
+      await fixtures.valeurAvancement({
+        indicateur: { publicId: indId, nom: 'T' },
+        individu: { publicId: deptId, nom: 'Vaucluse' },
+        date: '2026-01-01',
+        valeur: 50,
+      })
+
+      const result = await listValeursRemarquablesForIndicateur(indId, { individus: [deptId] })
+
+      expect(result._unsafeUnwrap()).toEqual({
+        items: [{ individu: deptId, variation: 50 }],
+      })
+    }),
+  )
+
+  it(
+    'retourne la variation entre les deux valeurs les plus récentes (positive)',
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const deptId = testDeptId()
+      await fixtures.valeurAvancement(
+        {
+          indicateur: { publicId: indId, nom: 'T' },
+          individu: { publicId: deptId, nom: 'Vaucluse' },
+          date: '2026-01-01',
+          valeur: 50,
+        },
+        {
+          indicateur: { publicId: indId },
+          individu: { publicId: deptId },
+          date: '2026-02-01',
+          valeur: 25,
+        },
+        {
+          indicateur: { publicId: indId },
+          individu: { publicId: deptId },
+          date: '2026-03-01',
+          valeur: 75,
+        },
+      )
+
+      const result = await listValeursRemarquablesForIndicateur(indId, { individus: [deptId] })
+
+      expect(result._unsafeUnwrap()).toEqual({
+        items: [{ individu: deptId, variation: 50 }],
+      })
+    }),
+  )
+
+  it(
+    'retourne la variation entre les deux valeurs les plus récentes (négative)',
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const deptId = testDeptId()
+      await fixtures.valeurAvancement(
+        {
+          indicateur: { publicId: indId, nom: 'T' },
+          individu: { publicId: deptId, nom: 'Vaucluse' },
+          date: '2026-01-01',
+          valeur: 50,
+        },
+        {
+          indicateur: { publicId: indId },
+          individu: { publicId: deptId },
+          date: '2026-02-01',
+          valeur: 25,
+        },
+      )
+
+      const result = await listValeursRemarquablesForIndicateur(indId, { individus: [deptId] })
+
+      expect(result._unsafeUnwrap()).toEqual({
+        items: [{ individu: deptId, variation: -25 }],
+      })
+    }),
+  )
+
+  it(
+    "se base sur la date de la valeur, pas la date de saisie (ordre d'insertion non pertinent)",
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const deptId = testDeptId()
+      // Insérée en dernier mais avec une date antérieure → ne doit pas influencer l'affichage
+      await fixtures.valeurAvancement(
+        {
+          indicateur: { publicId: indId, nom: 'T' },
+          individu: { publicId: deptId, nom: 'Vaucluse' },
+          date: '2026-02-01',
+          valeur: 10,
+        },
+        {
+          indicateur: { publicId: indId },
+          individu: { publicId: deptId },
+          date: '2026-03-01',
+          valeur: 75,
+        },
+        {
+          indicateur: { publicId: indId },
+          individu: { publicId: deptId },
+          date: '2026-01-01',
+          valeur: 50,
+        },
+      )
+
+      const result = await listValeursRemarquablesForIndicateur(indId, { individus: [deptId] })
+
+      expect(result._unsafeUnwrap()).toEqual({
+        items: [{ individu: deptId, variation: 65 }],
+      })
+    }),
+  )
+
+  it(
+    'retourne un item par individu existant, triés par publicId',
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const [dept1, dept2, dept3] = testDeptIds(3)
+      await fixtures.valeurAvancement(
+        {
+          indicateur: { publicId: indId, nom: 'T' },
+          individu: { publicId: dept1, nom: 'A' },
+          date: '2026-01-01',
+          valeur: 10,
+        },
+        {
+          indicateur: { publicId: indId },
+          individu: { publicId: dept1 },
+          date: '2026-02-01',
+          valeur: 30,
+        },
+        {
+          indicateur: { publicId: indId },
+          individu: { publicId: dept2, nom: 'B' },
+          date: '2026-01-01',
+          valeur: 5,
+        },
+      )
+      // dept3 sans valeur mais existe
+      await fixtures.individu({ publicId: dept3, nom: 'C' })
+
+      const result = await listValeursRemarquablesForIndicateur(indId, {
+        individus: [dept3, dept1, dept2],
+      })
+
+      expect(result._unsafeUnwrap()).toEqual({
+        items: [
+          { individu: dept1, variation: 20 },
+          { individu: dept2, variation: 5 },
+          { individu: dept3, variation: null },
+        ],
+      })
+    }),
+  )
+
+  it(
+    "ignore les valeurs d'autres indicateurs",
+    integrationTest(async () => {
+      const [indId, autreIndId] = [testIndicateurId(), testIndicateurId()]
+      const deptId = testDeptId()
+      await fixtures.valeurAvancement(
+        {
+          indicateur: { publicId: indId, nom: 'T' },
+          individu: { publicId: deptId, nom: 'Vaucluse' },
+          date: '2026-01-01',
+          valeur: 100,
+        },
+        {
+          indicateur: { publicId: autreIndId, nom: 'Autre' },
+          individu: { publicId: deptId },
+          date: '2026-02-01',
+          valeur: 9999,
+        },
+      )
+
+      const result = await listValeursRemarquablesForIndicateur(indId, { individus: [deptId] })
+
+      expect(result._unsafeUnwrap()).toEqual({
+        items: [{ individu: deptId, variation: 100 }],
+      })
+    }),
+  )
+
+  it(
+    'omet les individus inexistants',
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const deptId = testDeptId()
+      const inconnu = testDeptId()
+      await fixtures.valeurAvancement({
+        indicateur: { publicId: indId, nom: 'T' },
+        individu: { publicId: deptId, nom: 'Vaucluse' },
+        date: '2026-01-01',
+        valeur: 42,
+      })
+
+      const result = await listValeursRemarquablesForIndicateur(indId, {
+        individus: [deptId, inconnu],
+      })
+
+      expect(result._unsafeUnwrap()).toEqual({
+        items: [{ individu: deptId, variation: 42 }],
+      })
+    }),
+  )
+
+  it(
+    "rejette quand l'indicateur est introuvable",
+    integrationTest(async () => {
+      await expect(
+        listValeursRemarquablesForIndicateur(testIndicateurId(), { individus: [testDeptId()] }),
+      ).rejects.toThrow()
+    }),
+  )
+})

--- a/apps/mb-api/src/valeurAvancement/queries/listValeursRemarquablesForIndicateur.test.ts
+++ b/apps/mb-api/src/valeurAvancement/queries/listValeursRemarquablesForIndicateur.test.ts
@@ -233,6 +233,34 @@ describe.concurrent('listValeursRemarquablesForIndicateur', () => {
   )
 
   it(
+    'évite les erreurs de précision IEEE 754 sur la soustraction de décimaux',
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const deptId = testDeptId()
+      await fixtures.valeurAvancement(
+        {
+          indicateur: { publicId: indId, nom: 'T' },
+          individu: { publicId: deptId, nom: 'Vaucluse' },
+          date: '2026-01-01',
+          valeur: 0.15,
+        },
+        {
+          indicateur: { publicId: indId },
+          individu: { publicId: deptId },
+          date: '2026-02-01',
+          valeur: 0.3,
+        },
+      )
+
+      const result = await listValeursRemarquablesForIndicateur(indId, { individus: [deptId] })
+
+      expect(result._unsafeUnwrap()).toEqual({
+        items: [{ individu: deptId, variation: 0.15 }],
+      })
+    }),
+  )
+
+  it(
     "rejette quand l'indicateur est introuvable",
     integrationTest(async () => {
       await expect(

--- a/apps/mb-api/src/valeurAvancement/queries/listValeursRemarquablesForIndicateur.ts
+++ b/apps/mb-api/src/valeurAvancement/queries/listValeursRemarquablesForIndicateur.ts
@@ -1,0 +1,45 @@
+import {
+  type ListValeursRemarquablesForIndicateurQuery,
+  type ValeursRemarquablesListApiModel,
+} from '@pilote/mb-shared/valeurAvancement'
+import { ResultAsync } from 'neverthrow'
+
+import { db } from '@/framework/persistence/dbStore'
+
+const computeVariation = (valeurs: ReadonlyArray<{ valeur: number }>): number | null => {
+  if (valeurs.length === 0) return null
+  const [recente, precedente] = valeurs
+  return recente!.valeur - (precedente?.valeur ?? 0)
+}
+
+export const listValeursRemarquablesForIndicateur = (
+  indicateurPublicId: string,
+  params: ListValeursRemarquablesForIndicateurQuery,
+): ResultAsync<ValeursRemarquablesListApiModel, never> =>
+  ResultAsync.fromSafePromise(
+    db().indicateur.findUniqueOrThrow({
+      where: { publicId: indicateurPublicId },
+      select: { id: true },
+    }),
+  ).andThen((indicateur) =>
+    ResultAsync.fromSafePromise(
+      db().individu.findMany({
+        where: { publicId: { in: params.individus } },
+        orderBy: { publicId: 'asc' },
+        select: {
+          publicId: true,
+          valeurs: {
+            where: { indicateurId: indicateur.id },
+            orderBy: [{ date: 'desc' }, { id: 'desc' }],
+            take: 2,
+            select: { valeur: true },
+          },
+        },
+      }),
+    ).map((rows) => ({
+      items: rows.map((row) => ({
+        individu: row.publicId,
+        variation: computeVariation(row.valeurs),
+      })),
+    })),
+  )

--- a/apps/mb-api/src/valeurAvancement/queries/listValeursRemarquablesForIndicateur.ts
+++ b/apps/mb-api/src/valeurAvancement/queries/listValeursRemarquablesForIndicateur.ts
@@ -5,11 +5,13 @@ import {
 import { ResultAsync } from 'neverthrow'
 
 import { db } from '@/framework/persistence/dbStore'
+import { Prisma } from '@/generated/prisma/client'
 
-const computeVariation = (valeurs: ReadonlyArray<{ valeur: number }>): number | null => {
+const computeVariation = (valeurs: ReadonlyArray<{ valeur: Prisma.Decimal }>): number | null => {
   if (valeurs.length === 0) return null
   const [recente, precedente] = valeurs
-  return recente!.valeur - (precedente?.valeur ?? 0)
+  const precedenteValeur = precedente?.valeur ?? new Prisma.Decimal(0)
+  return recente!.valeur.minus(precedenteValeur).toNumber()
 }
 
 export const listValeursRemarquablesForIndicateur = (

--- a/apps/mb-api/src/valeurAvancement/routes.ts
+++ b/apps/mb-api/src/valeurAvancement/routes.ts
@@ -6,7 +6,9 @@ import {
   individuAvecValeursApiModelSchema,
   listIndividusWithValeursQuerySchema,
   listValeursForIndicateurQuerySchema,
+  listValeursRemarquablesForIndicateurQuerySchema,
   valeurAvancementListApiModelSchema,
+  valeursRemarquablesListApiModelSchema,
 } from '@pilote/mb-shared/valeurAvancement'
 
 import { requireAuthentication } from '@/framework/auth/requireAuthentication'
@@ -14,6 +16,7 @@ import { never } from '@/framework/errors/never'
 import { jsonResponseOk } from '@/framework/openapi/jsonResponse'
 import { listIndividusWithValeurs } from '@/valeurAvancement/queries/listIndividusWithValeurs'
 import { listValeursForIndicateur } from '@/valeurAvancement/queries/listValeursForIndicateur'
+import { listValeursRemarquablesForIndicateur } from '@/valeurAvancement/queries/listValeursRemarquablesForIndicateur'
 
 const ValeurAvancementListApiModelSchema = valeurAvancementListApiModelSchema.openapi(
   'ValeurAvancementListApiModel',
@@ -21,6 +24,9 @@ const ValeurAvancementListApiModelSchema = valeurAvancementListApiModelSchema.op
 const IndividusWithValeursListApiModelSchema = createPaginatedApiListSchema(
   individuAvecValeursApiModelSchema,
 ).openapi('IndividusWithValeursListApiModel')
+const ValeursRemarquablesListApiModelSchema = valeursRemarquablesListApiModelSchema.openapi(
+  'ValeursRemarquablesListApiModel',
+)
 const ErrorApiModelSchema = errorApiModelSchema.openapi('ErrorApiModel')
 
 const indicateurParamsSchema = z.object({
@@ -79,6 +85,36 @@ const getIndividusWithValeursRoute = createRoute({
   },
 })
 
+// --- GET /indicateurs/:id/valeurs-remarquables -------------------------------
+
+const getValeursRemarquablesForIndicateurRoute = createRoute({
+  method: 'get',
+  path: '/indicateurs/{id}/valeurs-remarquables',
+  tags: ['Indicateur'],
+  summary: 'Lister les valeurs remarquables pour un indicateur sur des individus',
+  description:
+    "Retourne, pour chaque individu demandé, une vue agrégée des valeurs remarquables de l'indicateur (variation depuis la dernière mise à jour). " +
+    'Le paramètre `individus` est obligatoire (1..N identifiants séparés par une virgule, ex. `DEPT-84,DEPT-13`). ' +
+    'Les individus inexistants sont omis de la réponse. ' +
+    'La variation est calculée sur la base de la date de la valeur (pas de la date de saisie) : null si aucune valeur, ' +
+    'égale à la valeur la plus récente si une seule (comparée à 0), sinon différence avec la valeur précédente.',
+  middleware: [requireAuthentication],
+  request: {
+    params: indicateurParamsSchema,
+    query: listValeursRemarquablesForIndicateurQuerySchema,
+  },
+  responses: {
+    200: {
+      content: { 'application/json': { schema: ValeursRemarquablesListApiModelSchema } },
+      description: 'Valeurs remarquables pour les individus demandés',
+    },
+    400: {
+      content: { 'application/json': { schema: ErrorApiModelSchema } },
+      description: 'Paramètres de requête invalides (ex. `individus` absent)',
+    },
+  },
+})
+
 // --- App registration --------------------------------------------------------
 
 export const valeurAvancementRoutes = new OpenAPIHono()
@@ -109,6 +145,22 @@ valeurAvancementRoutes.openapi(getIndividusWithValeursRoute, async (context) => 
         context,
         data,
         schema: IndividusWithValeursListApiModelSchema,
+        status: 200,
+      }),
+    never,
+  )
+})
+
+valeurAvancementRoutes.openapi(getValeursRemarquablesForIndicateurRoute, async (context) => {
+  const { id } = context.req.valid('param')
+  const { individus } = context.req.valid('query')
+
+  return listValeursRemarquablesForIndicateur(id, { individus }).match(
+    (data) =>
+      jsonResponseOk({
+        context,
+        data,
+        schema: ValeursRemarquablesListApiModelSchema,
         status: 200,
       }),
     never,

--- a/apps/mb-api/src/valeurAvancement/utils.ts
+++ b/apps/mb-api/src/valeurAvancement/utils.ts
@@ -17,7 +17,7 @@ export const toValeurAvancementApiModel = (
   indicateur: valeur.indicateur.publicId,
   individu: valeur.individu.publicId,
   date: valeur.date,
-  valeur: valeur.valeur,
+  valeur: valeur.valeur.toNumber(),
 })
 
 export type IndividuAvecValeursRow = IndividuWithReferentiels & {
@@ -38,7 +38,7 @@ export const toIndividuAvecValeursApiModel = (
     individu: toIndividuApiModel(row),
     derniereValeur: {
       date: derniere.date,
-      valeur: derniere.valeur,
+      valeur: derniere.valeur.toNumber(),
     },
     nombreValeurs: row._count.valeurs,
   }

--- a/apps/mb-webapp/src/api/indicateurs.ts
+++ b/apps/mb-webapp/src/api/indicateurs.ts
@@ -10,6 +10,8 @@ import {
   individusWithValeursListApiModelSchema,
   type ValeurAvancementListApiModel,
   valeurAvancementListApiModelSchema,
+  type ValeursRemarquablesListApiModel,
+  valeursRemarquablesListApiModelSchema,
 } from '@pilote/mb-shared/valeurAvancement'
 
 import { apiClient } from '@/api/client'
@@ -52,4 +54,16 @@ export const fetchValeursForIndicateur = async (
     })
     .json()
   return valeurAvancementListApiModelSchema.parse(json)
+}
+
+export const fetchValeursRemarquablesForIndicateur = async (
+  indicateurId: string,
+  params: { individus: string[] },
+): Promise<ValeursRemarquablesListApiModel> => {
+  const json = await apiClient
+    .get(`indicateurs/${indicateurId}/valeurs-remarquables`, {
+      searchParams: { individus: params.individus.join(',') },
+    })
+    .json()
+  return valeursRemarquablesListApiModelSchema.parse(json)
 }

--- a/apps/mb-webapp/src/queries/indicateurs.ts
+++ b/apps/mb-webapp/src/queries/indicateurs.ts
@@ -5,6 +5,7 @@ import {
   fetchIndicateurs,
   fetchIndividusForIndicateur,
   fetchValeursForIndicateur,
+  fetchValeursRemarquablesForIndicateur,
   type IndicateursQueryParams,
 } from '@/api/indicateurs'
 
@@ -38,5 +39,15 @@ export const indicateurValeursQueryOptions = (indicateurId: string, individuId: 
   queryOptions({
     queryKey: ['indicateur', indicateurId, 'valeurs', individuId],
     queryFn: () => fetchValeursForIndicateur(indicateurId, { individus: [individuId] }),
+    staleTime: DEFAULT_STALE_TIME,
+  })
+
+export const indicateurValeursRemarquablesQueryOptions = (
+  indicateurId: string,
+  individuId: string,
+) =>
+  queryOptions({
+    queryKey: ['indicateur', indicateurId, 'valeurs-remarquables', individuId],
+    queryFn: () => fetchValeursRemarquablesForIndicateur(indicateurId, { individus: [individuId] }),
     staleTime: DEFAULT_STALE_TIME,
   })

--- a/apps/mb-webapp/src/routes/_authenticated/indicateurs/$id.tsx
+++ b/apps/mb-webapp/src/routes/_authenticated/indicateurs/$id.tsx
@@ -1,5 +1,6 @@
 import { indicateurPublicIdSchema } from '@pilote/mb-shared/indicateur'
 import { individuPublicIdSchema } from '@pilote/mb-shared/individu'
+import { type ValeurDateApiModel } from '@pilote/mb-shared/valeurAvancement'
 import { useSuspenseQuery } from '@tanstack/react-query'
 import { createFileRoute, Link, redirect, useNavigate } from '@tanstack/react-router'
 import { ArrowLeft } from 'lucide-react'
@@ -21,6 +22,7 @@ import {
   indicateurIndividusQueryOptions,
   indicateurQueryOptions,
   indicateurValeursQueryOptions,
+  indicateurValeursRemarquablesQueryOptions,
 } from '@/queries/indicateurs'
 
 const paramsSchema = z.object({
@@ -56,7 +58,12 @@ export const Route = createFileRoute('/_authenticated/indicateurs/$id')({
     }
 
     // Préfetch des valeurs : useSuspenseQuery dans le composant tape le cache.
-    await context.queryClient.fetchQuery(indicateurValeursQueryOptions(params.id, deps.individu))
+    await Promise.all([
+      context.queryClient.fetchQuery(indicateurValeursQueryOptions(params.id, deps.individu)),
+      context.queryClient.fetchQuery(
+        indicateurValeursRemarquablesQueryOptions(params.id, deps.individu),
+      ),
+    ])
 
     return { indicateur, individus }
   },
@@ -126,6 +133,12 @@ function IndicateurDetailComponent() {
             </Select>
           </div>
 
+          <ValeursRemarquablesSection
+            indicateurId={id}
+            individuId={selectedIndividu.individu.id}
+            derniereValeur={selectedIndividu.derniereValeur}
+          />
+
           <Tabs defaultValue="valeurs">
             <TabsList>
               <TabsTrigger value="valeurs">Valeurs</TabsTrigger>
@@ -142,6 +155,57 @@ function IndicateurDetailComponent() {
           </Tabs>
         </>
       )}
+    </div>
+  )
+}
+
+function ValeursRemarquablesSection({
+  indicateurId,
+  individuId,
+  derniereValeur,
+}: {
+  indicateurId: string
+  individuId: string
+  derniereValeur: ValeurDateApiModel
+}) {
+  const { data } = useSuspenseQuery(
+    indicateurValeursRemarquablesQueryOptions(indicateurId, individuId),
+  )
+  const variation = data.items[0]?.variation ?? null
+
+  const numberFormatter = new Intl.NumberFormat('fr-FR')
+  const variationFormatter = new Intl.NumberFormat('fr-FR', { signDisplay: 'exceptZero' })
+
+  return (
+    <section className="grid gap-4 sm:grid-cols-2">
+      <StatCard label="Valeur la plus récente">
+        <p className="text-3xl font-semibold text-text">
+          {numberFormatter.format(derniereValeur.valeur)}
+        </p>
+        <p className="mt-1 text-xs text-text-muted">
+          au {new Date(derniereValeur.date).toLocaleDateString('fr-FR')}
+        </p>
+      </StatCard>
+
+      <StatCard label="Variation depuis la dernière MAJ">
+        <p className={`text-3xl font-semibold ${variationColorClass(variation)}`}>
+          {variation === null ? '—' : variationFormatter.format(variation)}
+        </p>
+      </StatCard>
+    </section>
+  )
+}
+
+const variationColorClass = (variation: number | null): string => {
+  if (variation === null || variation === 0) return 'text-text-muted'
+  return variation > 0 ? 'text-emerald-600' : 'text-rose-600'
+}
+
+function StatCard({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="rounded border border-border bg-surface p-6">
+      <h2 className="text-sm font-medium text-text-muted">{label}</h2>
+      <div className="mt-2">{children}</div>
     </div>
   )
 }

--- a/packages/mb-shared/src/valeurAvancement.ts
+++ b/packages/mb-shared/src/valeurAvancement.ts
@@ -90,6 +90,36 @@ export const listValeursForIndicateurQuerySchema = z
   )
 export type ListValeursForIndicateurQuery = z.infer<typeof listValeursForIndicateurQuerySchema>
 
+export const valeurRemarquableApiModelSchema = z.object({
+  individu: individuPublicIdSchema,
+  variation: z
+    .number()
+    .nullable()
+    .describe(
+      "Variation absolue entre la valeur la plus récente et la précédente (par date de la valeur). " +
+        "null si l'individu n'a aucune valeur ; égale à la valeur la plus récente s'il n'en a qu'une (comparée à 0).",
+    ),
+})
+export type ValeurRemarquableApiModel = z.infer<typeof valeurRemarquableApiModelSchema>
+
+export const valeursRemarquablesListApiModelSchema = z.object({
+  items: z
+    .array(valeurRemarquableApiModelSchema)
+    .describe('Valeurs remarquables pour chaque individu demandé ayant été trouvé.'),
+})
+export type ValeursRemarquablesListApiModel = z.infer<
+  typeof valeursRemarquablesListApiModelSchema
+>
+
+export const listValeursRemarquablesForIndicateurQuerySchema = z.object({
+  individus: individusCsvSchema.describe(
+    `Liste d'identifiants d'individus séparés par une virgule (ex. DEPT-84,DEPT-13). 1..${MAX_INDIVIDUS_PAR_REQUETE} identifiants.`,
+  ),
+})
+export type ListValeursRemarquablesForIndicateurQuery = z.infer<
+  typeof listValeursRemarquablesForIndicateurQuerySchema
+>
+
 export const individuAvecValeursApiModelSchema = z.object({
   individu: individuApiModelSchema,
   derniereValeur: valeurDateApiModelSchema.describe(


### PR DESCRIPTION
## Summary

- **mb-api** : nouvel endpoint `GET /indicateurs/{id}/valeurs-remarquables?individus=...` qui renvoie, pour chaque individu demandé, la variation entre les deux valeurs les plus récentes (calculée sur la date de la valeur, pas la date de saisie).
  - `null` si aucune valeur
  - égale à la valeur la plus récente s'il n'y en a qu'une (comparée à 0)
  - sinon, différence avec la valeur précédente
- **mb-webapp** : section "Valeur la plus récente" + "Variation depuis la dernière MAJ" (vert si positive, rouge si négative) sur la page détail indicateur.
- Schémas Zod partagés dans `@pilote/mb-shared/valeurAvancement`.
- **Précision exacte** : `valeur_avancement.valeur` migrée de `double precision` vers `numeric(20, 2)`, et les calculs côté serveur passent par `Prisma.Decimal` avant `.toNumber()` à la frontière API. Élimine le bruit IEEE 754 (ex. `0.30 - 0.15` renvoyait `0.15000000000000036`) y compris pour de futures agrégations SQL (`SUM`, `AVG`). Le contrat JSON reste `number` — webapp inchangée.

Le commit initial inclut aussi du reformatting Prettier sur des fichiers non liés (déclenché par `pnpm format` lors du dev — vérifié comme étant uniquement du formatting).

[PIL-1459](https://data-ditp.atlassian.net/browse/PIL-1459)

## Test plan

- [x] Tests unitaires/intégration mb-api (10 tests sur la query, dont un test de non-régression `0.30 - 0.15 = 0.15`) — `pnpm -F @pilote/mb-api test`
- [x] Lint + type-check mb-api et mb-webapp
- [x] Migration Prisma rejouée sur DB locale + seed adapté (`new Prisma.Decimal(item.valeur)`)
- [ ] Vérification manuelle dans le navigateur : carte affichée, variation +/-, couleurs vert/rouge, cas "1 valeur" et "aucune valeur"
- [ ] Vérifier le rendu sur mobile (grid `sm:grid-cols-2` qui stack)
- [ ] Vérifier que la migration s'applique proprement en CI/staging

## Choix techniques

- **`numeric(20, 2)`** plutôt que `numeric` non borné : Prisma interprète `Decimal` sans annotation comme `Decimal(65, 30)` par défaut, ce qui provoquait un drift à chaque `prisma migrate dev`. `(20, 2)` aligne schéma + DB, autorise jusqu'à 10^18 en valeur absolue et couvre les pourcentages/montants courants à 2 décimales.
- **Decimal serveur, number à la frontière** plutôt que `string` JSON : les graphiques côté front consomment `number` ; tous les calculs sensibles restent côté API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PIL-1459]: https://data-ditp.atlassian.net/browse/PIL-1459?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ