### PR TITLE
chore(mb): aligner prettier sur mb-api et mb-webapp + check en CI

### DIFF
--- a/apps/mb-api/docker-compose.yml
+++ b/apps/mb-api/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     image: postgres:17.9-alpine
     container_name: pilote_mb_postgres
     ports:
-      - "${POSTGRES_PORT:-5434}:5432"
+      - '${POSTGRES_PORT:-5434}:5432'
     environment:
       POSTGRES_DB: postgres
       POSTGRES_USER: postgres
@@ -15,7 +15,7 @@ services:
     image: postgres:17.9-alpine
     container_name: pilote_mb_postgres_test
     ports:
-      - "${POSTGRES_TEST_PORT:-5435}:5432"
+      - '${POSTGRES_TEST_PORT:-5435}:5432'
     environment:
       POSTGRES_DB: postgres
       POSTGRES_USER: postgres

--- a/apps/mb-api/package.json
+++ b/apps/mb-api/package.json
@@ -18,7 +18,7 @@
     "start": "node dist/index.js",
     "test": "vitest run",
     "test:watch": "vitest",
-    "lint": "eslint src scripts && tsc --noEmit",
+    "lint": "eslint src scripts && tsc --noEmit && prettier --check .",
     "lint:fix": "eslint src scripts --fix",
     "format": "prettier --write .",
     "format:check": "prettier --check .",

--- a/apps/mb-api/prisma/seed.ts
+++ b/apps/mb-api/prisma/seed.ts
@@ -66,9 +66,7 @@ const indicateursSeed: ReadonlyArray<{ publicId: string; nom: string }> = [
   { publicId: 'IND-045', nom: "Cyberattaques traitées par l'ANSSI" },
 ]
 
-const utilisateursSeed: ReadonlyArray<{ email: string }> = [
-  { email: 'ditp.admin@example.com' },
-]
+const utilisateursSeed: ReadonlyArray<{ email: string }> = [{ email: 'ditp.admin@example.com' }]
 
 // Clusters de mise à jour : plusieurs indicateurs peuvent partager la même
 // date de mise à jour (réaliste : on bouge plusieurs fiches le même jour).
@@ -88,9 +86,7 @@ const indicateurUpdatedAtClusters = [
   '2026-04-22T08:00:00Z',
 ] as const
 
-const indicateurDates = (
-  index: number,
-): { createdAt: Date; updatedAt: Date } => {
+const indicateurDates = (index: number): { createdAt: Date; updatedAt: Date } => {
   const updatedAt = new Date(
     indicateurUpdatedAtClusters[index % indicateurUpdatedAtClusters.length]!,
   )

--- a/apps/mb-api/prisma/seedData/geo.ts
+++ b/apps/mb-api/prisma/seedData/geo.ts
@@ -19,7 +19,7 @@ export const referentielsSeed = [
 export const individusSeed = [
   { publicId: 'FR', nom: 'France', referentiels: ['REF-NAT'] },
   { publicId: 'REG-11', nom: 'Île-de-France', referentiels: ['REF-REG'] },
-  { publicId: 'REG-93', nom: 'Provence-Alpes-Côte d\'Azur', referentiels: ['REF-REG'] },
+  { publicId: 'REG-93', nom: "Provence-Alpes-Côte d'Azur", referentiels: ['REF-REG'] },
   { publicId: 'REG-84', nom: 'Auvergne-Rhône-Alpes', referentiels: ['REF-REG'] },
   { publicId: 'DEPT-75', nom: 'Paris', referentiels: ['REF-DEPT'] },
   { publicId: 'DEPT-77', nom: 'Seine-et-Marne', referentiels: ['REF-DEPT'] },

--- a/apps/mb-api/scripts/generate-api-key.ts
+++ b/apps/mb-api/scripts/generate-api-key.ts
@@ -7,7 +7,7 @@ const printUsage = () => {
     [
       'Usage: tsx scripts/generate-api-key.ts --secret=<hmac-secret> [--label=<label>] [--expires-at=YYYY-MM-DD]',
       '',
-      "  --secret      Secret HMAC à utiliser pour calculer le hash (obligatoire ; sinon lu depuis API_KEY_HMAC_SECRET).",
+      '  --secret      Secret HMAC à utiliser pour calculer le hash (obligatoire ; sinon lu depuis API_KEY_HMAC_SECRET).',
       "  --label       Étiquette à utiliser dans la commande SQL d'insertion (optionnel ; défaut: 'à renseigner').",
       "  --expires-at  Date d'expiration ISO (optionnel ; sans cette option, la clé n'expire pas).",
       '',
@@ -50,7 +50,7 @@ const main = (): void => {
   const secret = values.secret ?? process.env['API_KEY_HMAC_SECRET']
   if (!secret || secret.length < 32) {
     process.stderr.write(
-      "Secret HMAC manquant ou trop court (32 chars min). Passez --secret=… ou définissez API_KEY_HMAC_SECRET.\n",
+      'Secret HMAC manquant ou trop court (32 chars min). Passez --secret=… ou définissez API_KEY_HMAC_SECRET.\n',
     )
     process.exit(2)
   }

--- a/apps/mb-api/src/app.ts
+++ b/apps/mb-api/src/app.ts
@@ -24,7 +24,7 @@ app.openAPIRegistry.registerComponent('securitySchemes', 'bearer', {
   type: 'http',
   scheme: 'bearer',
   description:
-    "Accepte un access token JWT (utilisateur OIDC) ou une API key au format `pilote_live_<secret>`.",
+    'Accepte un access token JWT (utilisateur OIDC) ou une API key au format `pilote_live_<secret>`.',
 })
 
 app.get('/', (context) => context.json({ hello: 'world' }))

--- a/apps/mb-api/src/env.ts
+++ b/apps/mb-api/src/env.ts
@@ -20,9 +20,7 @@ const envSchema = z.object({
   OIDC_JWKS_URI: z.url(),
   OIDC_AUDIENCE: z.string().min(1),
   API_KEY_HMAC_SECRET: z.string().min(32),
-  LOG_LEVEL: z
-    .enum(['fatal', 'error', 'warn', 'info', 'debug', 'trace', 'silent'])
-    .default('info'),
+  LOG_LEVEL: z.enum(['fatal', 'error', 'warn', 'info', 'debug', 'trace', 'silent']).default('info'),
   LOG_TO_DATABASE: z.stringbool().default(false),
 })
 

--- a/apps/mb-api/src/framework/auth/apiKey.test.ts
+++ b/apps/mb-api/src/framework/auth/apiKey.test.ts
@@ -10,7 +10,7 @@ describe.concurrent('apiKey', () => {
       expect(looksLikeApiKey('pilote_live_abc')).toBe(true)
     })
 
-    it("renvoie false pour un token de format JWT", () => {
+    it('renvoie false pour un token de format JWT', () => {
       expect(looksLikeApiKey('eyJhbGciOiJSUzI1NiJ9.payload.signature')).toBe(false)
     })
   })

--- a/apps/mb-api/src/framework/auth/authContext.test.ts
+++ b/apps/mb-api/src/framework/auth/authContext.test.ts
@@ -22,7 +22,8 @@ vi.mock('@/framework/auth/verifyApiKey', () => ({
 }))
 
 const { verifyAccessToken } = await import('@/authentication/jwks')
-const { getUtilisateurByProvider } = await import('@/authentication/queries/getUtilisateurByProvider')
+const { getUtilisateurByProvider } =
+  await import('@/authentication/queries/getUtilisateurByProvider')
 const { verifyApiKey } = await import('@/framework/auth/verifyApiKey')
 const verifyJwt = vi.mocked(verifyAccessToken)
 const lookup = vi.mocked(getUtilisateurByProvider)

--- a/apps/mb-api/src/framework/auth/requireAuthentication.test.ts
+++ b/apps/mb-api/src/framework/auth/requireAuthentication.test.ts
@@ -3,10 +3,7 @@ import { describe, expect, it } from 'vitest'
 
 import { UnauthorizedError } from '@/framework/auth/UnauthorizedError'
 import { requireAuthentication } from '@/framework/auth/requireAuthentication'
-import {
-  type Principal,
-  runWithPrincipal,
-} from '@/framework/auth/userContext'
+import { type Principal, runWithPrincipal } from '@/framework/auth/userContext'
 
 const buildApp = (principal: Principal | null) => {
   const app = new Hono()

--- a/apps/mb-api/src/framework/auth/userContext.ts
+++ b/apps/mb-api/src/framework/auth/userContext.ts
@@ -25,8 +25,7 @@ const storage = new AsyncLocalStorage<Store>()
 export const runWithPrincipal = <T>(principal: Principal | null, fn: () => T): T =>
   storage.run({ principal }, fn)
 
-export const getCurrentPrincipal = (): Principal | null =>
-  storage.getStore()?.principal ?? null
+export const getCurrentPrincipal = (): Principal | null => storage.getStore()?.principal ?? null
 
 export const requirePrincipal = (): Principal => {
   const principal = getCurrentPrincipal()

--- a/apps/mb-api/src/framework/auth/verifyApiKey.test.ts
+++ b/apps/mb-api/src/framework/auth/verifyApiKey.test.ts
@@ -27,10 +27,7 @@ describe.concurrent('verifyApiKey', () => {
   it(
     'renvoie null quand la clé est inconnue',
     integrationTest(async () => {
-      const result = await verifyApiKey(
-        'pilote_live_unknown_key_value_xx',
-        env.API_KEY_HMAC_SECRET,
-      )
+      const result = await verifyApiKey('pilote_live_unknown_key_value_xx', env.API_KEY_HMAC_SECRET)
       expect(result._unsafeUnwrap()).toBeNull()
     }),
   )

--- a/apps/mb-api/src/framework/auth/verifyApiKey.ts
+++ b/apps/mb-api/src/framework/auth/verifyApiKey.ts
@@ -20,18 +20,12 @@ const resolveApiKey = async (
   if (!row) return null
 
   if (row.revokedAt) {
-    logger.warn(
-      { event: 'auth.api_key.revoked', apiKeyId: row.id },
-      'Revoked API key used',
-    )
+    logger.warn({ event: 'auth.api_key.revoked', apiKeyId: row.id }, 'Revoked API key used')
     return null
   }
 
   if (row.expiresAt && row.expiresAt.getTime() <= Date.now()) {
-    logger.warn(
-      { event: 'auth.api_key.expired', apiKeyId: row.id },
-      'Expired API key used',
-    )
+    logger.warn({ event: 'auth.api_key.expired', apiKeyId: row.id }, 'Expired API key used')
     return null
   }
 

--- a/apps/mb-api/src/framework/errors/errorHandler.ts
+++ b/apps/mb-api/src/framework/errors/errorHandler.ts
@@ -27,10 +27,7 @@ export const registerErrorHandler = (app: OpenAPIHono): void => {
     if (error instanceof AppError) {
       const status = mapAppErrorToHttpStatus(error)
       const logFn = status >= 500 ? logger.error.bind(logger) : logger.warn.bind(logger)
-      logFn(
-        { method, url, code: error.code, status, details: error.details },
-        error.message,
-      )
+      logFn({ method, url, code: error.code, status, details: error.details }, error.message)
       return context.json(
         {
           code: error.code,
@@ -69,10 +66,7 @@ export const registerErrorHandler = (app: OpenAPIHono): void => {
       )
     }
 
-    if (
-      error instanceof Prisma.PrismaClientKnownRequestError &&
-      error.code === 'P2025'
-    ) {
+    if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2025') {
       logger.warn({ method, url, prismaCode: error.code }, error.message)
       return context.json(
         {

--- a/apps/mb-api/src/framework/logger/composite-logger.test.ts
+++ b/apps/mb-api/src/framework/logger/composite-logger.test.ts
@@ -22,10 +22,26 @@ describe('CompositeLogger', () => {
 
     for (const write of [a.write, b.write]) {
       expect(write).toHaveBeenCalledTimes(4)
-      expect(write.mock.calls[0]?.[0]).toMatchObject({ level: 'debug', message: 'debug message', context: { k: 'd' } })
-      expect(write.mock.calls[1]?.[0]).toMatchObject({ level: 'info', message: 'info message', context: { k: 'i' } })
-      expect(write.mock.calls[2]?.[0]).toMatchObject({ level: 'warn', message: 'warn message', context: { k: 'w' } })
-      expect(write.mock.calls[3]?.[0]).toMatchObject({ level: 'error', message: 'error message', context: { k: 'e' } })
+      expect(write.mock.calls[0]?.[0]).toMatchObject({
+        level: 'debug',
+        message: 'debug message',
+        context: { k: 'd' },
+      })
+      expect(write.mock.calls[1]?.[0]).toMatchObject({
+        level: 'info',
+        message: 'info message',
+        context: { k: 'i' },
+      })
+      expect(write.mock.calls[2]?.[0]).toMatchObject({
+        level: 'warn',
+        message: 'warn message',
+        context: { k: 'w' },
+      })
+      expect(write.mock.calls[3]?.[0]).toMatchObject({
+        level: 'error',
+        message: 'error message',
+        context: { k: 'e' },
+      })
     }
   })
 

--- a/apps/mb-api/src/framework/logger/sinks/pino-stdout.sink.ts
+++ b/apps/mb-api/src/framework/logger/sinks/pino-stdout.sink.ts
@@ -13,7 +13,13 @@ export class PinoStdoutSink implements LogSink {
       level: env.LOG_LEVEL,
       base: { app: 'mb-api' },
       redact: {
-        paths: ['req.headers.authorization', 'req.headers.cookie', 'token', '*.token', '*.refreshToken'],
+        paths: [
+          'req.headers.authorization',
+          'req.headers.cookie',
+          'token',
+          '*.token',
+          '*.refreshToken',
+        ],
         censor: '[REDACTED]',
       },
       ...(isDev

--- a/apps/mb-api/src/framework/persistence/dbStore.ts
+++ b/apps/mb-api/src/framework/persistence/dbStore.ts
@@ -9,9 +9,7 @@ const storage = new AsyncLocalStorage<DbClient>()
 export const db = (): DbClient => {
   const client = storage.getStore()
   if (!client) {
-    throw new Error(
-      'dbStore is empty — wrap the call site with withAppDatabase or withTransaction',
-    )
+    throw new Error('dbStore is empty — wrap the call site with withAppDatabase or withTransaction')
   }
   return client
 }

--- a/apps/mb-api/src/indicateur/queries/getIndicateurByPublicId.ts
+++ b/apps/mb-api/src/indicateur/queries/getIndicateurByPublicId.ts
@@ -5,6 +5,6 @@ import { db } from '@/framework/persistence/dbStore'
 import { toIndicateurApiModel } from '@/indicateur/utils'
 
 export const getIndicateurByPublicId = (publicId: string): ResultAsync<IndicateurApiModel, never> =>
-  ResultAsync.fromSafePromise(
-    db().indicateur.findUniqueOrThrow({ where: { publicId } }),
-  ).map(toIndicateurApiModel)
+  ResultAsync.fromSafePromise(db().indicateur.findUniqueOrThrow({ where: { publicId } })).map(
+    toIndicateurApiModel,
+  )

--- a/apps/mb-api/src/indicateur/queries/listIndicateurs.ts
+++ b/apps/mb-api/src/indicateur/queries/listIndicateurs.ts
@@ -1,4 +1,7 @@
-import { type IndicateurListApiModel, type ListIndicateursQuery } from '@pilote/mb-shared/indicateur'
+import {
+  type IndicateurListApiModel,
+  type ListIndicateursQuery,
+} from '@pilote/mb-shared/indicateur'
 import { ResultAsync } from 'neverthrow'
 
 import { db } from '@/framework/persistence/dbStore'

--- a/apps/mb-api/src/individu/queries/getIndividuByPublicId.test.ts
+++ b/apps/mb-api/src/individu/queries/getIndividuByPublicId.test.ts
@@ -7,7 +7,7 @@ import { testDeptId } from '@/test/randomIds'
 
 describe.concurrent('getIndividuByPublicId', () => {
   it(
-    'retourne l\'individu avec ses référentiels',
+    "retourne l'individu avec ses référentiels",
     integrationTest(async () => {
       const deptId = testDeptId()
       await fixtures.referentielIndividu(
@@ -33,7 +33,7 @@ describe.concurrent('getIndividuByPublicId', () => {
   )
 
   it(
-    'rejette quand l\'individu est introuvable',
+    "rejette quand l'individu est introuvable",
     integrationTest(async () => {
       await expect(getIndividuByPublicId(testDeptId())).rejects.toThrow()
     }),

--- a/apps/mb-api/src/referentiel/queries/getReferentielByPublicId.test.ts
+++ b/apps/mb-api/src/referentiel/queries/getReferentielByPublicId.test.ts
@@ -12,7 +12,11 @@ describe.concurrent('getReferentielByPublicId', () => {
       const [dept1, dept2] = testDeptIds(2)
       await fixtures.referentielIndividu(
         {
-          referentiel: { publicId: 'REF-TEST', nom: 'Référentiel de test', description: 'Description test' },
+          referentiel: {
+            publicId: 'REF-TEST',
+            nom: 'Référentiel de test',
+            description: 'Description test',
+          },
           individu: { publicId: dept1 },
         },
         {

--- a/apps/mb-api/src/referentiel/queries/listReferentiels.test.ts
+++ b/apps/mb-api/src/referentiel/queries/listReferentiels.test.ts
@@ -21,7 +21,7 @@ describe.concurrent('listReferentiels', () => {
   )
 
   it(
-    'retourne les référentiels avec leur nombre d\'individus',
+    "retourne les référentiels avec leur nombre d'individus",
     integrationTest(async () => {
       await fixtures.referentielIndividu(
         {

--- a/apps/mb-api/src/referentiel/utils.ts
+++ b/apps/mb-api/src/referentiel/utils.ts
@@ -6,9 +6,7 @@ export type ReferentielWithCount = ReferentielModel & {
   _count: { individus: number }
 }
 
-export const toReferentielApiModel = (
-  referentiel: ReferentielWithCount,
-): ReferentielApiModel => ({
+export const toReferentielApiModel = (referentiel: ReferentielWithCount): ReferentielApiModel => ({
   id: referentiel.publicId,
   nom: referentiel.nom,
   description: referentiel.description,

--- a/apps/mb-api/src/test/fixtures.ts
+++ b/apps/mb-api/src/test/fixtures.ts
@@ -307,9 +307,7 @@ function apiKey(
   o2: ApiKeyOverrides,
   ...rest: ApiKeyOverrides[]
 ): Promise<ApiKeyModel[]>
-async function apiKey(
-  ...overrides: ApiKeyOverrides[]
-): Promise<ApiKeyModel | ApiKeyModel[]> {
+async function apiKey(...overrides: ApiKeyOverrides[]): Promise<ApiKeyModel | ApiKeyModel[]> {
   if (overrides.length <= 1) return upsertApiKey(overrides[0])
   const results: ApiKeyModel[] = []
   for (const o of overrides) results.push(await upsertApiKey(o))

--- a/apps/mb-api/src/test/integrationTest.ts
+++ b/apps/mb-api/src/test/integrationTest.ts
@@ -2,16 +2,14 @@ import { withTransaction } from '@/framework/persistence/withTransaction'
 
 const ROLLBACK = Symbol('rollback')
 
-export const integrationTest =
-  (testFn: () => Promise<void>) =>
-  async (): Promise<void> => {
-    try {
-      await withTransaction(async () => {
-        await testFn()
-        // eslint-disable-next-line @typescript-eslint/only-throw-error -- sentinel symbol used to force a transaction rollback
-        throw ROLLBACK
-      })
-    } catch (error) {
-      if (error !== ROLLBACK) throw error
-    }
+export const integrationTest = (testFn: () => Promise<void>) => async (): Promise<void> => {
+  try {
+    await withTransaction(async () => {
+      await testFn()
+      // eslint-disable-next-line @typescript-eslint/only-throw-error -- sentinel symbol used to force a transaction rollback
+      throw ROLLBACK
+    })
+  } catch (error) {
+    if (error !== ROLLBACK) throw error
   }
+}

--- a/apps/mb-api/src/test/randomIds.ts
+++ b/apps/mb-api/src/test/randomIds.ts
@@ -1,6 +1,10 @@
 // Codes INSEE de régions françaises (https://www.insee.fr/fr/information/2114819)
 const REG_CODES = [
-  '01', '02', '03', '04', '06', // DROM (Guadeloupe, Martinique, Guyane, La Réunion, Mayotte)
+  '01',
+  '02',
+  '03',
+  '04',
+  '06', // DROM (Guadeloupe, Martinique, Guyane, La Réunion, Mayotte)
   '11', // Île-de-France
   '24', // Centre-Val de Loire
   '27', // Bourgogne-Franche-Comté
@@ -18,24 +22,115 @@ const REG_CODES = [
 
 // Codes INSEE de départements français (métropolitains 01-95 + 2A/2B + DOM 971-976)
 const DEPT_CODES = [
-  '01', '02', '03', '04', '05', '06', '07', '08', '09', '10',
-  '11', '12', '13', '14', '15', '16', '17', '18', '19',
-  '2A', '2B',
-  '21', '22', '23', '24', '25', '26', '27', '28', '29', '30',
-  '31', '32', '33', '34', '35', '36', '37', '38', '39', '40',
-  '41', '42', '43', '44', '45', '46', '47', '48', '49', '50',
-  '51', '52', '53', '54', '55', '56', '57', '58', '59', '60',
-  '61', '62', '63', '64', '65', '66', '67', '68', '69', '70',
-  '71', '72', '73', '74', '75', '76', '77', '78', '79', '80',
-  '81', '82', '83', '84', '85', '86', '87', '88', '89', '90',
-  '91', '92', '93', '94', '95',
-  '971', '972', '973', '974', '976',
+  '01',
+  '02',
+  '03',
+  '04',
+  '05',
+  '06',
+  '07',
+  '08',
+  '09',
+  '10',
+  '11',
+  '12',
+  '13',
+  '14',
+  '15',
+  '16',
+  '17',
+  '18',
+  '19',
+  '2A',
+  '2B',
+  '21',
+  '22',
+  '23',
+  '24',
+  '25',
+  '26',
+  '27',
+  '28',
+  '29',
+  '30',
+  '31',
+  '32',
+  '33',
+  '34',
+  '35',
+  '36',
+  '37',
+  '38',
+  '39',
+  '40',
+  '41',
+  '42',
+  '43',
+  '44',
+  '45',
+  '46',
+  '47',
+  '48',
+  '49',
+  '50',
+  '51',
+  '52',
+  '53',
+  '54',
+  '55',
+  '56',
+  '57',
+  '58',
+  '59',
+  '60',
+  '61',
+  '62',
+  '63',
+  '64',
+  '65',
+  '66',
+  '67',
+  '68',
+  '69',
+  '70',
+  '71',
+  '72',
+  '73',
+  '74',
+  '75',
+  '76',
+  '77',
+  '78',
+  '79',
+  '80',
+  '81',
+  '82',
+  '83',
+  '84',
+  '85',
+  '86',
+  '87',
+  '88',
+  '89',
+  '90',
+  '91',
+  '92',
+  '93',
+  '94',
+  '95',
+  '971',
+  '972',
+  '973',
+  '974',
+  '976',
 ] as const
 
-const pickRandom = <T>(items: ReadonlyArray<T>): T => items[Math.floor(Math.random() * items.length)]!
+const pickRandom = <T>(items: ReadonlyArray<T>): T =>
+  items[Math.floor(Math.random() * items.length)]!
 
-type FixedTuple<N extends number, T, Acc extends T[] = []> =
-  Acc['length'] extends N ? Acc : FixedTuple<N, T, [T, ...Acc]>
+type FixedTuple<N extends number, T, Acc extends T[] = []> = Acc['length'] extends N
+  ? Acc
+  : FixedTuple<N, T, [T, ...Acc]>
 
 const uniqueIds = <N extends number>(factory: () => string, count: N): FixedTuple<N, string> => {
   const ids = new Set<string>()
@@ -56,5 +151,4 @@ export const testIndicateurIds = <N extends number>(n: N): FixedTuple<N, string>
 export const testDeptIds = <N extends number>(n: N): FixedTuple<N, string> =>
   uniqueIds(testDeptId, n)
 
-export const testRegIds = <N extends number>(n: N): FixedTuple<N, string> =>
-  uniqueIds(testRegId, n)
+export const testRegIds = <N extends number>(n: N): FixedTuple<N, string> => uniqueIds(testRegId, n)

--- a/apps/mb-api/src/valeurAvancement/queries/listValeursForIndicateur.test.ts
+++ b/apps/mb-api/src/valeurAvancement/queries/listValeursForIndicateur.test.ts
@@ -130,7 +130,7 @@ describe.concurrent('listValeursForIndicateur', () => {
   )
 
   it(
-    'rejette quand l\'indicateur est introuvable',
+    "rejette quand l'indicateur est introuvable",
     integrationTest(async () => {
       await expect(
         listValeursForIndicateur(testIndicateurId(), { individus: [testDeptId()] }),

--- a/apps/mb-api/src/valeurAvancement/routes.ts
+++ b/apps/mb-api/src/valeurAvancement/routes.ts
@@ -59,7 +59,7 @@ const getIndividusWithValeursRoute = createRoute({
   method: 'get',
   path: '/indicateurs/{id}/individus',
   tags: ['Indicateur'],
-  summary: "Lister les individus disposant de valeurs pour un indicateur",
+  summary: 'Lister les individus disposant de valeurs pour un indicateur',
   description:
     "Retourne la liste paginée des individus ayant au moins une valeur pour l'indicateur. Filtre optionnel `referentiel` pour ne conserver que les individus appartenant à la population d'un référentiel donné. Chaque item inclut la dernière valeur et le nombre total de valeurs.",
   middleware: [requireAuthentication],

--- a/apps/mb-api/tsconfig.json
+++ b/apps/mb-api/tsconfig.json
@@ -27,6 +27,13 @@
       "@/env": ["./src/env"]
     }
   },
-  "include": ["src/**/*", "scripts/**/*", "vite.config.ts", "vitest.config.ts", "prisma.config.ts", "eslint.config.mjs"],
+  "include": [
+    "src/**/*",
+    "scripts/**/*",
+    "vite.config.ts",
+    "vitest.config.ts",
+    "prisma.config.ts",
+    "eslint.config.mjs"
+  ],
   "exclude": ["dist", "node_modules"]
 }

--- a/apps/mb-webapp/package.json
+++ b/apps/mb-webapp/package.json
@@ -18,7 +18,7 @@
     "deploy:bundle": "bash deploy-bundle.sh",
     "start": "node dist/server/index.js",
     "preview": "vite preview",
-    "lint": "tsr generate && eslint src && tsc --noEmit",
+    "lint": "tsr generate && eslint src && tsc --noEmit && prettier --check .",
     "lint:fix": "tsr generate && eslint src --fix",
     "format": "prettier --write .",
     "format:check": "prettier --check .",

--- a/apps/mb-webapp/src/auth.test.ts
+++ b/apps/mb-webapp/src/auth.test.ts
@@ -65,11 +65,7 @@ describe.sequential('auth singleton', () => {
         }),
       )
 
-      const calls = Promise.all([
-        refreshAccessToken(),
-        refreshAccessToken(),
-        refreshAccessToken(),
-      ])
+      const calls = Promise.all([refreshAccessToken(), refreshAccessToken(), refreshAccessToken()])
 
       await vi.waitFor(() => {
         expect(callCount).toBe(1)

--- a/apps/mb-webapp/src/auth.ts
+++ b/apps/mb-webapp/src/auth.ts
@@ -80,9 +80,7 @@ export const auth: Auth = {
     }
   },
   login(redirect) {
-    const url = redirect
-      ? `/auth/login?redirect=${encodeURIComponent(redirect)}`
-      : '/auth/login'
+    const url = redirect ? `/auth/login?redirect=${encodeURIComponent(redirect)}` : '/auth/login'
     window.location.assign(url)
   },
   async logout() {

--- a/apps/mb-webapp/src/components/RouteError.tsx
+++ b/apps/mb-webapp/src/components/RouteError.tsx
@@ -15,9 +15,7 @@ export function RouteError({ error, reset }: ErrorComponentProps) {
       <div className="space-y-3">
         <div className="rounded border border-amber-200 bg-amber-50 p-6 text-amber-900">
           <p className="font-medium">Ressource introuvable</p>
-          <p className="mt-1 text-sm">
-            La ressource demandée n'existe pas ou a été supprimée.
-          </p>
+          <p className="mt-1 text-sm">La ressource demandée n'existe pas ou a été supprimée.</p>
         </div>
         <Button variant="tertiary" size="sm" asChild>
           <Link to="/indicateurs" search={{}}>

--- a/apps/mb-webapp/src/components/RouteLoading.tsx
+++ b/apps/mb-webapp/src/components/RouteLoading.tsx
@@ -4,8 +4,6 @@ type RouteLoadingProps = {
 
 export function RouteLoading({ message = 'Chargement…' }: RouteLoadingProps) {
   return (
-    <div className="rounded border border-slate-200 bg-white p-6 text-slate-500">
-      {message}
-    </div>
+    <div className="rounded border border-slate-200 bg-white p-6 text-slate-500">{message}</div>
   )
 }

--- a/apps/mb-webapp/src/components/ui/Button.tsx
+++ b/apps/mb-webapp/src/components/ui/Button.tsx
@@ -38,21 +38,9 @@ export type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> &
     ref?: Ref<HTMLButtonElement>
   }
 
-export function Button({
-  className,
-  variant,
-  size,
-  asChild = false,
-  ref,
-  ...props
-}: ButtonProps) {
+export function Button({ className, variant, size, asChild = false, ref, ...props }: ButtonProps) {
   const Comp = asChild ? Slot : 'button'
   return (
-    <Comp
-      ref={ref}
-      className={clsxm(buttonVariants({ variant, size }), className)}
-      {...props}
-    />
+    <Comp ref={ref} className={clsxm(buttonVariants({ variant, size }), className)} {...props} />
   )
 }
-

--- a/apps/mb-webapp/src/components/ui/Pagination.tsx
+++ b/apps/mb-webapp/src/components/ui/Pagination.tsx
@@ -75,13 +75,7 @@ export function Pagination({
           <ChevronLeft />
           Page précédente
         </Button>
-        <Button
-          variant="secondary"
-          size="sm"
-          type="button"
-          disabled={!hasNext}
-          onClick={onNext}
-        >
+        <Button variant="secondary" size="sm" type="button" disabled={!hasNext} onClick={onNext}>
           Page suivante
           <ChevronRight />
         </Button>

--- a/apps/mb-webapp/src/components/ui/Select.tsx
+++ b/apps/mb-webapp/src/components/ui/Select.tsx
@@ -49,9 +49,7 @@ export function SelectContent({
         )}
         {...props}
       >
-        <SelectPrimitive.Viewport className="p-1">
-          {children}
-        </SelectPrimitive.Viewport>
+        <SelectPrimitive.Viewport className="p-1">{children}</SelectPrimitive.Viewport>
       </SelectPrimitive.Content>
     </SelectPrimitive.Portal>
   )

--- a/apps/mb-webapp/src/components/ui/Tabs.tsx
+++ b/apps/mb-webapp/src/components/ui/Tabs.tsx
@@ -5,22 +5,13 @@ import { clsxm } from '@/lib/clsxm'
 
 export const Tabs = TabsPrimitive.Root
 
-export function TabsList({
-  className,
-  ...props
-}: ComponentProps<typeof TabsPrimitive.List>) {
+export function TabsList({ className, ...props }: ComponentProps<typeof TabsPrimitive.List>) {
   return (
-    <TabsPrimitive.List
-      className={clsxm('flex border-b border-border', className)}
-      {...props}
-    />
+    <TabsPrimitive.List className={clsxm('flex border-b border-border', className)} {...props} />
   )
 }
 
-export function TabsTrigger({
-  className,
-  ...props
-}: ComponentProps<typeof TabsPrimitive.Trigger>) {
+export function TabsTrigger({ className, ...props }: ComponentProps<typeof TabsPrimitive.Trigger>) {
   return (
     <TabsPrimitive.Trigger
       className={clsxm(
@@ -35,10 +26,7 @@ export function TabsTrigger({
   )
 }
 
-export function TabsContent({
-  className,
-  ...props
-}: ComponentProps<typeof TabsPrimitive.Content>) {
+export function TabsContent({ className, ...props }: ComponentProps<typeof TabsPrimitive.Content>) {
   return (
     <TabsPrimitive.Content
       className={clsxm('pt-4 focus-visible:outline-none', className)}

--- a/apps/mb-webapp/src/queries/indicateurs.ts
+++ b/apps/mb-webapp/src/queries/indicateurs.ts
@@ -34,13 +34,9 @@ export const indicateurIndividusQueryOptions = (indicateurId: string) =>
     staleTime: DEFAULT_STALE_TIME,
   })
 
-export const indicateurValeursQueryOptions = (
-  indicateurId: string,
-  individuId: string,
-) =>
+export const indicateurValeursQueryOptions = (indicateurId: string, individuId: string) =>
   queryOptions({
     queryKey: ['indicateur', indicateurId, 'valeurs', individuId],
-    queryFn: () =>
-      fetchValeursForIndicateur(indicateurId, { individus: [individuId] }),
+    queryFn: () => fetchValeursForIndicateur(indicateurId, { individus: [individuId] }),
     staleTime: DEFAULT_STALE_TIME,
   })

--- a/apps/mb-webapp/src/queries/utils.ts
+++ b/apps/mb-webapp/src/queries/utils.ts
@@ -13,10 +13,7 @@ export const fetchAllPaginatedItems = async <T>(
   do {
     const page = await fetchPage(cursor)
     items.push(...page.items)
-    cursor =
-      page.pagination.hasMore && page.pagination.cursor
-        ? page.pagination.cursor
-        : undefined
+    cursor = page.pagination.hasMore && page.pagination.cursor ? page.pagination.cursor : undefined
   } while (cursor)
   return items
 }

--- a/apps/mb-webapp/src/routes/__root.tsx
+++ b/apps/mb-webapp/src/routes/__root.tsx
@@ -22,10 +22,7 @@ function RootComponent() {
     <div className="min-h-screen bg-background text-text">
       <header className="border-b border-border bg-surface">
         <div className="mx-auto flex max-w-5xl items-center justify-between px-6 py-3">
-          <Link
-            to="/"
-            className="text-lg font-semibold text-text hover:text-text-muted"
-          >
+          <Link to="/" className="text-lg font-semibold text-text hover:text-text-muted">
             Pilote MB
           </Link>
           <nav className="flex items-center gap-4 text-sm">

--- a/apps/mb-webapp/src/routes/_authenticated/indicateurs/index.tsx
+++ b/apps/mb-webapp/src/routes/_authenticated/indicateurs/index.tsx
@@ -1,9 +1,5 @@
 import { useSuspenseQuery } from '@tanstack/react-query'
-import {
-  createFileRoute,
-  Link,
-  useNavigate,
-} from '@tanstack/react-router'
+import { createFileRoute, Link, useNavigate } from '@tanstack/react-router'
 import { z } from 'zod'
 
 import { DEFAULT_PAGE_SIZE_OPTIONS, Pagination } from '@/components/ui/Pagination'
@@ -20,8 +16,7 @@ const indicateursSearchSchema = z.object({
 export const Route = createFileRoute('/_authenticated/indicateurs/')({
   validateSearch: indicateursSearchSchema,
   loaderDeps: ({ search }) => search,
-  loader: ({ context, deps }) =>
-    context.queryClient.fetchQuery(indicateursQueryOptions(deps)),
+  loader: ({ context, deps }) => context.queryClient.fetchQuery(indicateursQueryOptions(deps)),
   pendingComponent: () => <RouteLoading message="Chargement des indicateurs…" />,
   errorComponent: RouteError,
   component: IndicateursListComponent,

--- a/apps/mb-webapp/src/routes/index.tsx
+++ b/apps/mb-webapp/src/routes/index.tsx
@@ -27,9 +27,7 @@ function HomeComponent() {
 
       <section className="space-y-3">
         <h2 className="text-xl font-semibold">Démo TanStack Query (préservée)</h2>
-        <pre className="rounded bg-slate-900 p-4 text-sm text-slate-100">
-          {SHARED_GREETING}
-        </pre>
+        <pre className="rounded bg-slate-900 p-4 text-sm text-slate-100">{SHARED_GREETING}</pre>
         <pre className="rounded bg-slate-100 p-4 text-sm text-slate-800">
           {isPending && 'Chargement…'}
           {isError && `Erreur: ${error.message}`}

--- a/apps/mb-webapp/src/server/auth/router.ts
+++ b/apps/mb-webapp/src/server/auth/router.ts
@@ -153,7 +153,10 @@ authRouter.get('/callback', async (context) => {
 
   const claims = tokens.claims()
   if (!claims?.sub || !tokens.refresh_token || !tokens.id_token) {
-    logger.error({ event: 'auth.callback.missing_tokens' }, 'Missing claims, refresh token or id token')
+    logger.error(
+      { event: 'auth.callback.missing_tokens' },
+      'Missing claims, refresh token or id token',
+    )
     return context.text('Authentication failed', 401)
   }
 
@@ -173,10 +176,7 @@ authRouter.get('/callback', async (context) => {
   return checkUserProvisioned(accessToken).match(
     async (provisioned) => {
       if (!provisioned) {
-        logger.warn(
-          { event: 'auth.login.user_not_found', sub },
-          'PMB user not found',
-        )
+        logger.warn({ event: 'auth.login.user_not_found', sub }, 'PMB user not found')
         return context.redirect('/login-error')
       }
 

--- a/apps/mb-webapp/src/server/env.ts
+++ b/apps/mb-webapp/src/server/env.ts
@@ -19,9 +19,7 @@ const envSchema = z.object({
       'SESSION_SECRET still uses the placeholder value — set a real secret.',
     ),
   PUBLIC_BASE_URL: z.url(),
-  LOG_LEVEL: z
-    .enum(['fatal', 'error', 'warn', 'info', 'debug', 'trace', 'silent'])
-    .default('info'),
+  LOG_LEVEL: z.enum(['fatal', 'error', 'warn', 'info', 'debug', 'trace', 'silent']).default('info'),
 })
 
 export const serverEnv = envSchema.parse(process.env)

--- a/apps/mb-webapp/src/server/logger.ts
+++ b/apps/mb-webapp/src/server/logger.ts
@@ -8,7 +8,13 @@ export const logger = pino({
   level: serverEnv.LOG_LEVEL,
   base: { app: 'mb-webapp-bff' },
   redact: {
-    paths: ['req.headers.authorization', 'req.headers.cookie', 'token', '*.token', '*.refreshToken'],
+    paths: [
+      'req.headers.authorization',
+      'req.headers.cookie',
+      'token',
+      '*.token',
+      '*.refreshToken',
+    ],
     censor: '[REDACTED]',
   },
   ...(isDev

--- a/apps/mb-webapp/src/tests/factories/api.ts
+++ b/apps/mb-webapp/src/tests/factories/api.ts
@@ -9,9 +9,7 @@ export const buildMe = (override: Partial<MeApiModel> = {}): MeApiModel =>
     ...override,
   })
 
-export const buildIndicateur = (
-  override: Partial<IndicateurApiModel> = {},
-): IndicateurApiModel =>
+export const buildIndicateur = (override: Partial<IndicateurApiModel> = {}): IndicateurApiModel =>
   indicateurApiModelSchema.parse({
     id: 1,
     nom: 'Indicateur test',

--- a/apps/mb-webapp/src/tests/routing.test.tsx
+++ b/apps/mb-webapp/src/tests/routing.test.tsx
@@ -1,9 +1,5 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import {
-  createMemoryHistory,
-  createRouter,
-  RouterProvider,
-} from '@tanstack/react-router'
+import { createMemoryHistory, createRouter, RouterProvider } from '@tanstack/react-router'
 import { render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -53,18 +49,14 @@ describe('routing', () => {
   it("rend la page d'accueil", async () => {
     renderAt('/', stubAuth(null))
     await waitFor(() => {
-      expect(
-        screen.getByRole('heading', { level: 1, name: 'Pilote MB' }),
-      ).toBeInTheDocument()
+      expect(screen.getByRole('heading', { level: 1, name: 'Pilote MB' })).toBeInTheDocument()
     })
   })
 
   it('ne rend pas /indicateurs sans être authentifié (le beforeLoad bloque le rendu)', async () => {
     renderAt('/indicateurs', stubAuth(null))
     await new Promise((resolve) => setTimeout(resolve, 50))
-    expect(
-      screen.queryByRole('heading', { level: 1, name: 'Liste des indicateurs' }),
-    ).toBeNull()
+    expect(screen.queryByRole('heading', { level: 1, name: 'Liste des indicateurs' })).toBeNull()
   })
 
   it("permet d'accéder à /indicateurs après login", async () => {

--- a/apps/mb-webapp/src/tests/server.ts
+++ b/apps/mb-webapp/src/tests/server.ts
@@ -2,11 +2,7 @@ import { http, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'
 
 import { env } from '@/env'
-import {
-  buildIndicateur,
-  buildIndicateursList,
-  buildMe,
-} from '@/tests/factories/api'
+import { buildIndicateur, buildIndicateursList, buildMe } from '@/tests/factories/api'
 import { buildLogoutResponse, buildRefreshResponse } from '@/tests/factories/bff'
 
 const apiOrigin = new URL(env.apiUrl).origin

--- a/apps/mb-webapp/tsconfig.json
+++ b/apps/mb-webapp/tsconfig.json
@@ -27,10 +27,5 @@
     },
     "types": ["vite/client", "node", "@testing-library/jest-dom"]
   },
-  "include": [
-    "src",
-    "vite.config.ts",
-    "vite.server.config.ts",
-    "vitest.setup.ts"
-  ]
+  "include": ["src", "vite.config.ts", "vite.server.config.ts", "vitest.setup.ts"]
 }


### PR DESCRIPTION
## Summary

- `pnpm format` appliqué sur **mb-api** et **mb-webapp** pour rattraper la dérive Prettier accumulée depuis la dernière passe.
- Le script `lint` de chaque app inclut désormais `prettier --check .` : la CI échouera si la mise en forme dérive à nouveau.

> Note : j'ai préféré ajouter `prettier --check` au script `lint` plutôt que de passer par `eslint-plugin-prettier` — pas de nouvelle dep, plus rapide, et c'est la reco officielle Prettier. Si tu préfères une vraie règle ESLint, je peux changer.

## Test plan

- [x] `pnpm -F @pilote/mb-api lint` ✅
- [x] `pnpm -F @pilote/mb-webapp lint` ✅
- [ ] Vérifier que la CI passe sur cette PR
- [ ] Vérifier que la CI échoue si on commit un fichier mal formaté (peut être validé sur une future PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)