### PR TITLE
feat(mb-api): permissions Principal ↔ Indicateur

### DIFF
--- a/apps/mb-api/prisma/migrations/20260512120000_add_principal_and_permissions/migration.sql
+++ b/apps/mb-api/prisma/migrations/20260512120000_add_principal_and_permissions/migration.sql
@@ -1,0 +1,44 @@
+-- CreateEnum
+CREATE TYPE "permission_action_enum" AS ENUM ('READ', 'WRITE');
+
+-- CreateTable
+CREATE TABLE "principal" (
+    "id" UUID NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "principal_pkey" PRIMARY KEY ("id")
+);
+
+-- Backfill principal from existing utilisateur and api_key rows
+INSERT INTO "principal" ("id", "created_at")
+SELECT "id", "created_at" FROM "utilisateur"
+ON CONFLICT ("id") DO NOTHING;
+
+INSERT INTO "principal" ("id", "created_at")
+SELECT "id", "created_at" FROM "api_key"
+ON CONFLICT ("id") DO NOTHING;
+
+-- AddForeignKey
+ALTER TABLE "utilisateur" ADD CONSTRAINT "utilisateur_id_fkey" FOREIGN KEY ("id") REFERENCES "principal"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "api_key" ADD CONSTRAINT "api_key_id_fkey" FOREIGN KEY ("id") REFERENCES "principal"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- CreateTable
+CREATE TABLE "indicateur_permission" (
+    "principal_id" UUID NOT NULL,
+    "indicateur_id" UUID NOT NULL,
+    "action" "permission_action_enum" NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "indicateur_permission_pkey" PRIMARY KEY ("principal_id", "indicateur_id", "action")
+);
+
+-- CreateIndex
+CREATE INDEX "indicateur_permission_indicateur_id_idx" ON "indicateur_permission"("indicateur_id");
+
+-- AddForeignKey
+ALTER TABLE "indicateur_permission" ADD CONSTRAINT "indicateur_permission_principal_id_fkey" FOREIGN KEY ("principal_id") REFERENCES "principal"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "indicateur_permission" ADD CONSTRAINT "indicateur_permission_indicateur_id_fkey" FOREIGN KEY ("indicateur_id") REFERENCES "indicateur"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/mb-api/prisma/schema.prisma
+++ b/apps/mb-api/prisma/schema.prisma
@@ -9,12 +9,25 @@ datasource db {
   provider = "postgresql"
 }
 
+model Principal {
+  id        String   @id @db.Uuid
+  createdAt DateTime @default(now()) @map("created_at")
+
+  utilisateur          Utilisateur?
+  apiKey               ApiKey?
+  indicateurPermissions IndicateurPermission[]
+
+  @@map("principal")
+}
+
 model Utilisateur {
   id          String   @id @db.Uuid
   email       String   @unique
   providerSub String?  @unique @map("provider_sub")
   createdAt   DateTime @default(now()) @map("created_at")
   updatedAt   DateTime @updatedAt      @map("updated_at")
+
+  principal Principal @relation(fields: [id], references: [id], onDelete: Cascade)
 
   @@map("utilisateur")
 }
@@ -29,6 +42,8 @@ model ApiKey {
   revokedAt  DateTime? @map("revoked_at")
   lastUsedAt DateTime? @map("last_used_at")
 
+  principal Principal @relation(fields: [id], references: [id], onDelete: Cascade)
+
   @@index([prefix])
   @@map("api_key")
 }
@@ -40,9 +55,31 @@ model Indicateur {
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt      @map("updated_at")
 
-  valeurs ValeurAvancement[]
+  valeurs     ValeurAvancement[]
+  permissions IndicateurPermission[]
 
   @@map("indicateur")
+}
+
+enum PermissionAction {
+  READ
+  WRITE
+
+  @@map("permission_action_enum")
+}
+
+model IndicateurPermission {
+  principalId  String           @map("principal_id")  @db.Uuid
+  indicateurId String           @map("indicateur_id") @db.Uuid
+  action       PermissionAction
+  createdAt    DateTime         @default(now()) @map("created_at")
+
+  principal  Principal  @relation(fields: [principalId],  references: [id], onDelete: Cascade)
+  indicateur Indicateur @relation(fields: [indicateurId], references: [id], onDelete: Cascade)
+
+  @@id([principalId, indicateurId, action])
+  @@index([indicateurId])
+  @@map("indicateur_permission")
 }
 
 model Referentiel {

--- a/apps/mb-api/prisma/seed.ts
+++ b/apps/mb-api/prisma/seed.ts
@@ -111,14 +111,13 @@ const main = async () => {
     })
   }
   for (const item of utilisateursSeed) {
-    await prisma.utilisateur.upsert({
-      where: { email: item.email },
-      update: {},
-      create: {
-        id: uuidv7(),
-        email: item.email,
-      },
-    })
+    const existing = await prisma.utilisateur.findUnique({ where: { email: item.email } })
+    if (existing) continue
+    const id = uuidv7()
+    await prisma.$transaction([
+      prisma.principal.create({ data: { id } }),
+      prisma.utilisateur.create({ data: { id, email: item.email } }),
+    ])
   }
 
   for (const item of referentielsSeed) {

--- a/apps/mb-api/scripts/generate-api-key.ts
+++ b/apps/mb-api/scripts/generate-api-key.ts
@@ -59,10 +59,14 @@ const main = (): void => {
   const expiresAt = parseExpiresAt(values['expires-at'])
   const generated = buildApiKey(secret)
 
-  const sqlInsert =
+  const sqlInsert = [
+    'BEGIN;',
+    `INSERT INTO principal (id) VALUES (${sqlString(generated.id)});`,
     `INSERT INTO api_key (id, label, key_hash, prefix, expires_at) VALUES (` +
-    `${sqlString(generated.id)}, ${sqlString(label)}, ${sqlString(generated.keyHash)}, ${sqlString(generated.prefix)}, ` +
-    `${expiresAt ? sqlString(expiresAt.toISOString()) : 'NULL'});`
+      `${sqlString(generated.id)}, ${sqlString(label)}, ${sqlString(generated.keyHash)}, ${sqlString(generated.prefix)}, ` +
+      `${expiresAt ? sqlString(expiresAt.toISOString()) : 'NULL'});`,
+    'COMMIT;',
+  ].join('\n  ')
 
   process.stdout.write(
     [

--- a/apps/mb-api/src/framework/auth/userContext.ts
+++ b/apps/mb-api/src/framework/auth/userContext.ts
@@ -33,6 +33,11 @@ export const requirePrincipal = (): Principal => {
   return principal
 }
 
+export const requireCurrentPrincipalId = (): string => {
+  const principal = requirePrincipal()
+  return principal.kind === 'user' ? principal.user.id : principal.apiKey.id
+}
+
 export const getCurrentUser = (): UtilisateurAuthentifie | null => {
   const principal = getCurrentPrincipal()
   return principal?.kind === 'user' ? principal.user : null

--- a/apps/mb-api/src/framework/errors/AppError.ts
+++ b/apps/mb-api/src/framework/errors/AppError.ts
@@ -16,3 +16,8 @@ export class EntityNotFoundError extends AppError {
   readonly code = 'ENTITY_NOT_FOUND'
   readonly kind = 'not-found' as const
 }
+
+export class ForbiddenError extends AppError {
+  readonly code = 'FORBIDDEN'
+  readonly kind = 'forbidden' as const
+}

--- a/apps/mb-api/src/indicateur/commands/upsertIndicateur.test.ts
+++ b/apps/mb-api/src/indicateur/commands/upsertIndicateur.test.ts
@@ -5,40 +5,63 @@ import { upsertIndicateur } from '@/indicateur/commands/upsertIndicateur'
 import { fixtures } from '@/test/fixtures'
 import { integrationTest } from '@/test/integrationTest'
 import { testIndicateurId } from '@/test/randomIds'
+import { runAsPrincipal } from '@/test/runAsPrincipal'
 
 describe.concurrent('upsertIndicateur', () => {
   it(
-    'crée un indicateur quand le publicId est libre',
+    'crée un indicateur quand le publicId est libre et auto-grant READ+WRITE au créateur',
     integrationTest(async () => {
-      // Given
       const indId = testIndicateurId()
+      const apiKey = await fixtures.apiKey()
 
-      // When
-      const result = await upsertIndicateur(indId, { nom: 'Nouvel indicateur' })
+      const result = await runAsPrincipal(apiKey.id, () =>
+        upsertIndicateur(indId, { nom: 'Nouvel indicateur' }),
+      )
 
-      // Then
       expect(result.isOk()).toBe(true)
       const persisted = await db().indicateur.findUniqueOrThrow({ where: { publicId: indId } })
       expect(persisted.nom).toBe('Nouvel indicateur')
+      const grants = await db().indicateurPermission.findMany({
+        where: { principalId: apiKey.id, indicateurId: persisted.id },
+        orderBy: { action: 'asc' },
+      })
+      expect(grants.map((g) => g.action)).toEqual(['READ', 'WRITE'])
     }),
   )
 
   it(
-    "met à jour le nom et updatedAt quand l'indicateur existe déjà",
+    'met à jour le nom quand le principal a la permission WRITE',
     integrationTest(async () => {
-      // Given
       const indId = testIndicateurId()
       const original = await fixtures.indicateur({ publicId: indId, nom: 'Ancien nom' })
+      const apiKey = await fixtures.apiKey({
+        permissions: [{ indicateur: { publicId: indId }, action: 'WRITE' }],
+      })
 
-      // When
-      const result = await upsertIndicateur(indId, { nom: 'Nom mis à jour' })
+      const result = await runAsPrincipal(apiKey.id, () =>
+        upsertIndicateur(indId, { nom: 'Nom mis à jour' }),
+      )
 
-      // Then
       expect(result.isOk()).toBe(true)
       const persisted = await db().indicateur.findUniqueOrThrow({ where: { publicId: indId } })
       expect(persisted.nom).toBe('Nom mis à jour')
       expect(persisted.createdAt).toEqual(original.createdAt)
       expect(persisted.updatedAt >= original.updatedAt).toBe(true)
+    }),
+  )
+
+  it(
+    "rejette la mise à jour quand le principal n'a pas la permission WRITE",
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      await fixtures.indicateur({ publicId: indId, nom: 'Ancien nom' })
+      const apiKey = await fixtures.apiKey({
+        permissions: [{ indicateur: { publicId: indId }, action: 'READ' }],
+      })
+
+      await expect(
+        runAsPrincipal(apiKey.id, () => upsertIndicateur(indId, { nom: 'Nom mis à jour' })),
+      ).rejects.toThrow(/permission/i)
     }),
   )
 })

--- a/apps/mb-api/src/indicateur/commands/upsertIndicateur.test.ts
+++ b/apps/mb-api/src/indicateur/commands/upsertIndicateur.test.ts
@@ -15,7 +15,7 @@ describe.concurrent('upsertIndicateur', () => {
       const apiKey = await fixtures.apiKey()
 
       const result = await runAsPrincipal(apiKey.id, () =>
-        upsertIndicateur(indId, { nom: 'Nouvel indicateur' }),
+        upsertIndicateur({ publicId: indId, body: { nom: 'Nouvel indicateur' } }),
       )
 
       expect(result.isOk()).toBe(true)
@@ -39,7 +39,7 @@ describe.concurrent('upsertIndicateur', () => {
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>
-        upsertIndicateur(indId, { nom: 'Nom mis à jour' }),
+        upsertIndicateur({ publicId: indId, body: { nom: 'Nom mis à jour' } }),
       )
 
       expect(result.isOk()).toBe(true)
@@ -60,7 +60,9 @@ describe.concurrent('upsertIndicateur', () => {
       })
 
       await expect(
-        runAsPrincipal(apiKey.id, () => upsertIndicateur(indId, { nom: 'Nom mis à jour' })),
+        runAsPrincipal(apiKey.id, () =>
+          upsertIndicateur({ publicId: indId, body: { nom: 'Nom mis à jour' } }),
+        ),
       ).rejects.toThrow(/permission/i)
     }),
   )

--- a/apps/mb-api/src/indicateur/commands/upsertIndicateur.ts
+++ b/apps/mb-api/src/indicateur/commands/upsertIndicateur.ts
@@ -5,44 +5,63 @@ import { uuidv7 } from 'uuidv7'
 import { requireCurrentPrincipalId } from '@/framework/auth/userContext'
 import { ForbiddenError } from '@/framework/errors/AppError'
 import { db } from '@/framework/persistence/dbStore'
+import { PermissionAction } from '@/generated/prisma/enums'
+
+const assertWritePermission = async (indicateurId: string, principalId: string): Promise<void> => {
+  const hasWrite = await db().indicateurPermission.findUnique({
+    where: {
+      principalId_indicateurId_action: {
+        principalId,
+        indicateurId,
+        action: PermissionAction.WRITE,
+      },
+    },
+    select: { action: true },
+  })
+  if (!hasWrite) {
+    throw new ForbiddenError("Vous n'avez pas la permission de modifier cet indicateur")
+  }
+}
+
+const updateExisting = async (
+  publicId: string,
+  indicateurId: string,
+  body: UpsertIndicateurBody,
+  principalId: string,
+): Promise<void> => {
+  await assertWritePermission(indicateurId, principalId)
+  await db().indicateur.update({ where: { publicId }, data: { nom: body.nom } })
+}
+
+const createWithGrants = async (
+  publicId: string,
+  body: UpsertIndicateurBody,
+  principalId: string,
+): Promise<void> => {
+  const id = uuidv7()
+  await db().indicateur.create({ data: { id, publicId, nom: body.nom } })
+  await db().indicateurPermission.createMany({
+    data: [
+      { principalId, indicateurId: id, action: PermissionAction.READ },
+      { principalId, indicateurId: id, action: PermissionAction.WRITE },
+    ],
+  })
+}
+
+const performUpsert = async (publicId: string, body: UpsertIndicateurBody): Promise<void> => {
+  const principalId = requireCurrentPrincipalId()
+  const existing = await db().indicateur.findUnique({
+    where: { publicId },
+    select: { id: true },
+  })
+  if (existing) {
+    await updateExisting(publicId, existing.id, body, principalId)
+    return
+  }
+  await createWithGrants(publicId, body, principalId)
+}
 
 export const upsertIndicateur = (
   publicId: string,
   body: UpsertIndicateurBody,
-): ResultAsync<void, never> =>
-  ResultAsync.fromSafePromise(
-    (async () => {
-      const principalId = requireCurrentPrincipalId()
-      const existing = await db().indicateur.findUnique({
-        where: { publicId },
-        select: { id: true },
-      })
-
-      if (existing) {
-        const hasWrite = await db().indicateurPermission.findUnique({
-          where: {
-            principalId_indicateurId_action: {
-              principalId,
-              indicateurId: existing.id,
-              action: 'WRITE',
-            },
-          },
-          select: { action: true },
-        })
-        if (!hasWrite) {
-          throw new ForbiddenError("Vous n'avez pas la permission de modifier cet indicateur")
-        }
-        await db().indicateur.update({ where: { publicId }, data: { nom: body.nom } })
-        return
-      }
-
-      const id = uuidv7()
-      await db().indicateur.create({ data: { id, publicId, nom: body.nom } })
-      await db().indicateurPermission.createMany({
-        data: [
-          { principalId, indicateurId: id, action: 'READ' },
-          { principalId, indicateurId: id, action: 'WRITE' },
-        ],
-      })
-    })(),
-  )
+): ResultAsync<void, never> => ResultAsync.fromSafePromise(performUpsert(publicId, body))

--- a/apps/mb-api/src/indicateur/commands/upsertIndicateur.ts
+++ b/apps/mb-api/src/indicateur/commands/upsertIndicateur.ts
@@ -7,7 +7,18 @@ import { ForbiddenError } from '@/framework/errors/AppError'
 import { db } from '@/framework/persistence/dbStore'
 import { PermissionAction } from '@/generated/prisma/enums'
 
-const assertWritePermission = async (indicateurId: string, principalId: string): Promise<void> => {
+type UpsertIndicateurParams = {
+  publicId: string
+  body: UpsertIndicateurBody
+}
+
+const assertWritePermission = async ({
+  indicateurId,
+  principalId,
+}: {
+  indicateurId: string
+  principalId: string
+}): Promise<void> => {
   const hasWrite = await db().indicateurPermission.findUnique({
     where: {
       principalId_indicateurId_action: {
@@ -16,28 +27,36 @@ const assertWritePermission = async (indicateurId: string, principalId: string):
         action: PermissionAction.WRITE,
       },
     },
-    select: { action: true },
   })
   if (!hasWrite) {
     throw new ForbiddenError("Vous n'avez pas la permission de modifier cet indicateur")
   }
 }
 
-const updateExisting = async (
-  publicId: string,
-  indicateurId: string,
-  body: UpsertIndicateurBody,
-  principalId: string,
-): Promise<void> => {
-  await assertWritePermission(indicateurId, principalId)
+const updateExisting = async ({
+  publicId,
+  indicateurId,
+  body,
+  principalId,
+}: {
+  publicId: string
+  indicateurId: string
+  body: UpsertIndicateurBody
+  principalId: string
+}): Promise<void> => {
+  await assertWritePermission({ indicateurId, principalId })
   await db().indicateur.update({ where: { publicId }, data: { nom: body.nom } })
 }
 
-const createWithGrants = async (
-  publicId: string,
-  body: UpsertIndicateurBody,
-  principalId: string,
-): Promise<void> => {
+const createWithGrants = async ({
+  publicId,
+  body,
+  principalId,
+}: {
+  publicId: string
+  body: UpsertIndicateurBody
+  principalId: string
+}): Promise<void> => {
   const id = uuidv7()
   await db().indicateur.create({ data: { id, publicId, nom: body.nom } })
   await db().indicateurPermission.createMany({
@@ -48,20 +67,15 @@ const createWithGrants = async (
   })
 }
 
-const performUpsert = async (publicId: string, body: UpsertIndicateurBody): Promise<void> => {
+const performUpsert = async ({ publicId, body }: UpsertIndicateurParams): Promise<void> => {
   const principalId = requireCurrentPrincipalId()
-  const existing = await db().indicateur.findUnique({
-    where: { publicId },
-    select: { id: true },
-  })
+  const existing = await db().indicateur.findUnique({ where: { publicId } })
   if (existing) {
-    await updateExisting(publicId, existing.id, body, principalId)
+    await updateExisting({ publicId, indicateurId: existing.id, body, principalId })
     return
   }
-  await createWithGrants(publicId, body, principalId)
+  await createWithGrants({ publicId, body, principalId })
 }
 
-export const upsertIndicateur = (
-  publicId: string,
-  body: UpsertIndicateurBody,
-): ResultAsync<void, never> => ResultAsync.fromSafePromise(performUpsert(publicId, body))
+export const upsertIndicateur = (params: UpsertIndicateurParams): ResultAsync<void, never> =>
+  ResultAsync.fromSafePromise(performUpsert(params))

--- a/apps/mb-api/src/indicateur/commands/upsertIndicateur.ts
+++ b/apps/mb-api/src/indicateur/commands/upsertIndicateur.ts
@@ -2,6 +2,8 @@ import { type UpsertIndicateurBody } from '@pilote/mb-shared/indicateur'
 import { ResultAsync } from 'neverthrow'
 import { uuidv7 } from 'uuidv7'
 
+import { requireCurrentPrincipalId } from '@/framework/auth/userContext'
+import { ForbiddenError } from '@/framework/errors/AppError'
 import { db } from '@/framework/persistence/dbStore'
 
 export const upsertIndicateur = (
@@ -9,11 +11,38 @@ export const upsertIndicateur = (
   body: UpsertIndicateurBody,
 ): ResultAsync<void, never> =>
   ResultAsync.fromSafePromise(
-    db()
-      .indicateur.upsert({
+    (async () => {
+      const principalId = requireCurrentPrincipalId()
+      const existing = await db().indicateur.findUnique({
         where: { publicId },
-        update: { nom: body.nom },
-        create: { id: uuidv7(), publicId, nom: body.nom },
+        select: { id: true },
       })
-      .then(() => undefined),
+
+      if (existing) {
+        const hasWrite = await db().indicateurPermission.findUnique({
+          where: {
+            principalId_indicateurId_action: {
+              principalId,
+              indicateurId: existing.id,
+              action: 'WRITE',
+            },
+          },
+          select: { action: true },
+        })
+        if (!hasWrite) {
+          throw new ForbiddenError("Vous n'avez pas la permission de modifier cet indicateur")
+        }
+        await db().indicateur.update({ where: { publicId }, data: { nom: body.nom } })
+        return
+      }
+
+      const id = uuidv7()
+      await db().indicateur.create({ data: { id, publicId, nom: body.nom } })
+      await db().indicateurPermission.createMany({
+        data: [
+          { principalId, indicateurId: id, action: 'READ' },
+          { principalId, indicateurId: id, action: 'WRITE' },
+        ],
+      })
+    })(),
   )

--- a/apps/mb-api/src/indicateur/permissions.ts
+++ b/apps/mb-api/src/indicateur/permissions.ts
@@ -1,0 +1,17 @@
+import { Prisma } from '@/generated/prisma/client'
+import { PermissionAction } from '@/generated/prisma/enums'
+
+const INDICATEUR_READ_PERMISSIONS: PermissionAction[] = [
+  PermissionAction.READ,
+  PermissionAction.WRITE,
+]
+
+export const withIndicateurReadPermission = (
+  where: Prisma.IndicateurWhereInput,
+  principalId: string,
+): Prisma.IndicateurWhereInput => ({
+  ...where,
+  permissions: {
+    some: { principalId, action: { in: INDICATEUR_READ_PERMISSIONS } },
+  },
+})

--- a/apps/mb-api/src/indicateur/queries/getIndicateurByPublicId.test.ts
+++ b/apps/mb-api/src/indicateur/queries/getIndicateurByPublicId.test.ts
@@ -4,17 +4,21 @@ import { getIndicateurByPublicId } from '@/indicateur/queries/getIndicateurByPub
 import { fixtures } from '@/test/fixtures'
 import { integrationTest } from '@/test/integrationTest'
 import { testIndicateurId } from '@/test/randomIds'
+import { runAsPrincipal } from '@/test/runAsPrincipal'
 
 describe.concurrent('getIndicateurByPublicId', () => {
   it(
-    "retourne l'indicateur correspondant au publicId",
+    "retourne l'indicateur quand le principal a la permission READ",
     integrationTest(async () => {
       // Given
       const indId = testIndicateurId()
       const created = await fixtures.indicateur({ publicId: indId, nom: 'Indicateur de test' })
+      const apiKey = await fixtures.apiKey({
+        permissions: [{ indicateur: { publicId: indId }, action: 'READ' }],
+      })
 
       // When
-      const result = await getIndicateurByPublicId(indId)
+      const result = await runAsPrincipal(apiKey.id, () => getIndicateurByPublicId(indId))
 
       // Then
       expect(result.isOk()).toBe(true)
@@ -28,10 +32,40 @@ describe.concurrent('getIndicateurByPublicId', () => {
   )
 
   it(
-    'lève une erreur Prisma quand aucun indicateur ne correspond',
+    "retourne l'indicateur quand le principal a la permission WRITE (WRITE implique READ)",
     integrationTest(async () => {
-      // When / Then
-      await expect(getIndicateurByPublicId(testIndicateurId())).rejects.toThrow()
+      const indId = testIndicateurId()
+      await fixtures.indicateur({ publicId: indId })
+      const apiKey = await fixtures.apiKey({
+        permissions: [{ indicateur: { publicId: indId }, action: 'WRITE' }],
+      })
+
+      const result = await runAsPrincipal(apiKey.id, () => getIndicateurByPublicId(indId))
+
+      expect(result.isOk()).toBe(true)
+    }),
+  )
+
+  it(
+    "lève une erreur quand le principal n'a aucune permission sur l'indicateur",
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      await fixtures.indicateur({ publicId: indId })
+      const apiKey = await fixtures.apiKey()
+
+      await expect(
+        runAsPrincipal(apiKey.id, () => getIndicateurByPublicId(indId)),
+      ).rejects.toThrow()
+    }),
+  )
+
+  it(
+    'lève une erreur quand aucun indicateur ne correspond',
+    integrationTest(async () => {
+      const apiKey = await fixtures.apiKey()
+      await expect(
+        runAsPrincipal(apiKey.id, () => getIndicateurByPublicId(testIndicateurId())),
+      ).rejects.toThrow()
     }),
   )
 })

--- a/apps/mb-api/src/indicateur/queries/getIndicateurByPublicId.ts
+++ b/apps/mb-api/src/indicateur/queries/getIndicateurByPublicId.ts
@@ -3,10 +3,8 @@ import { ResultAsync } from 'neverthrow'
 
 import { requireCurrentPrincipalId } from '@/framework/auth/userContext'
 import { db } from '@/framework/persistence/dbStore'
-import { PermissionAction } from '@/generated/prisma/enums'
+import { withIndicateurReadPermission } from '@/indicateur/permissions'
 import { toIndicateurApiModel } from '@/indicateur/utils'
-
-const READ_ACTIONS: PermissionAction[] = [PermissionAction.READ, PermissionAction.WRITE]
 
 export const getIndicateurByPublicId = (
   publicId: string,
@@ -14,10 +12,7 @@ export const getIndicateurByPublicId = (
   const principalId = requireCurrentPrincipalId()
   return ResultAsync.fromSafePromise(
     db().indicateur.findFirstOrThrow({
-      where: {
-        publicId,
-        permissions: { some: { principalId, action: { in: READ_ACTIONS } } },
-      },
+      where: withIndicateurReadPermission({ publicId }, principalId),
     }),
   ).map(toIndicateurApiModel)
 }

--- a/apps/mb-api/src/indicateur/queries/getIndicateurByPublicId.ts
+++ b/apps/mb-api/src/indicateur/queries/getIndicateurByPublicId.ts
@@ -1,10 +1,23 @@
 import { type IndicateurApiModel } from '@pilote/mb-shared/indicateur'
 import { ResultAsync } from 'neverthrow'
 
+import { requireCurrentPrincipalId } from '@/framework/auth/userContext'
 import { db } from '@/framework/persistence/dbStore'
+import { PermissionAction } from '@/generated/prisma/enums'
 import { toIndicateurApiModel } from '@/indicateur/utils'
 
-export const getIndicateurByPublicId = (publicId: string): ResultAsync<IndicateurApiModel, never> =>
-  ResultAsync.fromSafePromise(db().indicateur.findUniqueOrThrow({ where: { publicId } })).map(
-    toIndicateurApiModel,
-  )
+const READ_ACTIONS: PermissionAction[] = [PermissionAction.READ, PermissionAction.WRITE]
+
+export const getIndicateurByPublicId = (
+  publicId: string,
+): ResultAsync<IndicateurApiModel, never> => {
+  const principalId = requireCurrentPrincipalId()
+  return ResultAsync.fromSafePromise(
+    db().indicateur.findFirstOrThrow({
+      where: {
+        publicId,
+        permissions: { some: { principalId, action: { in: READ_ACTIONS } } },
+      },
+    }),
+  ).map(toIndicateurApiModel)
+}

--- a/apps/mb-api/src/indicateur/queries/listIndicateurs.test.ts
+++ b/apps/mb-api/src/indicateur/queries/listIndicateurs.test.ts
@@ -5,12 +5,14 @@ import { listIndicateurs } from '@/indicateur/queries/listIndicateurs'
 import { fixtures } from '@/test/fixtures'
 import { integrationTest } from '@/test/integrationTest'
 import { testIndicateurIds } from '@/test/randomIds'
+import { runAsPrincipal } from '@/test/runAsPrincipal'
 
 describe.concurrent('listIndicateurs', () => {
   it(
     "retourne une liste vide quand aucun indicateur n'existe",
     integrationTest(async () => {
-      const result = await listIndicateurs({})
+      const apiKey = await fixtures.apiKey()
+      const result = await runAsPrincipal(apiKey.id, () => listIndicateurs({}))
 
       expect(result.isOk()).toBe(true)
       expect(result._unsafeUnwrap()).toEqual({
@@ -22,7 +24,24 @@ describe.concurrent('listIndicateurs', () => {
   )
 
   it(
-    'retourne tous les indicateurs quand leur nombre est inférieur à la taille de page',
+    "n'inclut que les indicateurs sur lesquels le principal a une permission",
+    integrationTest(async () => {
+      const [accessible, hidden] = testIndicateurIds(2)
+      await fixtures.indicateur({ publicId: accessible }, { publicId: hidden })
+      const apiKey = await fixtures.apiKey({
+        permissions: [{ indicateur: { publicId: accessible }, action: 'READ' }],
+      })
+
+      const result = await runAsPrincipal(apiKey.id, () => listIndicateurs({}))
+
+      const value = result._unsafeUnwrap()
+      expect(value.items.map((i) => i.id)).toEqual([accessible])
+      expect(value.total).toBe(1)
+    }),
+  )
+
+  it(
+    'retourne tous les indicateurs autorisés quand leur nombre est inférieur à la taille de page',
     integrationTest(async () => {
       const [ind1, ind2, ind3] = testIndicateurIds(3)
       await fixtures.indicateur(
@@ -30,8 +49,15 @@ describe.concurrent('listIndicateurs', () => {
         { publicId: ind2, nom: 'Bravo' },
         { publicId: ind3, nom: 'Charlie' },
       )
+      const apiKey = await fixtures.apiKey({
+        permissions: [
+          { indicateur: { publicId: ind1 }, action: 'READ' },
+          { indicateur: { publicId: ind2 }, action: 'READ' },
+          { indicateur: { publicId: ind3 }, action: 'READ' },
+        ],
+      })
 
-      const result = await listIndicateurs({})
+      const result = await runAsPrincipal(apiKey.id, () => listIndicateurs({}))
 
       const value = result._unsafeUnwrap()
       expect(value.items.map((i) => i.id)).toEqual([ind1, ind2, ind3])
@@ -52,8 +78,14 @@ describe.concurrent('listIndicateurs', () => {
         { publicId: ids[4] },
         { publicId: ids[5] },
       )
+      const apiKey = await fixtures.apiKey({
+        permissions: ids.map((publicId) => ({
+          indicateur: { publicId },
+          action: 'READ' as const,
+        })),
+      })
 
-      const result = await listIndicateurs({ pageSize: 5 })
+      const result = await runAsPrincipal(apiKey.id, () => listIndicateurs({ pageSize: 5 }))
 
       const value = result._unsafeUnwrap()
       expect(value.items.map((i) => i.id)).toEqual(ids.slice(0, 5))
@@ -74,8 +106,16 @@ describe.concurrent('listIndicateurs', () => {
         { publicId: ids[4] },
         { publicId: ids[5] },
       )
+      const apiKey = await fixtures.apiKey({
+        permissions: ids.map((publicId) => ({
+          indicateur: { publicId },
+          action: 'READ' as const,
+        })),
+      })
 
-      const result = await listIndicateurs({ cursor: encodeCursor(created[4]!.id) })
+      const result = await runAsPrincipal(apiKey.id, () =>
+        listIndicateurs({ cursor: encodeCursor(created[4]!.id) }),
+      )
 
       const value = result._unsafeUnwrap()
       expect(value.items.map((i) => i.id)).toEqual([ids[5]])
@@ -93,8 +133,17 @@ describe.concurrent('listIndicateurs', () => {
         { publicId: ind2, nom: 'Délai moyen' },
         { publicId: ind3, nom: 'SATISFACTION client' },
       )
+      const apiKey = await fixtures.apiKey({
+        permissions: [
+          { indicateur: { publicId: ind1 }, action: 'READ' },
+          { indicateur: { publicId: ind2 }, action: 'READ' },
+          { indicateur: { publicId: ind3 }, action: 'READ' },
+        ],
+      })
 
-      const result = await listIndicateurs({ recherche: 'satisfaction' })
+      const result = await runAsPrincipal(apiKey.id, () =>
+        listIndicateurs({ recherche: 'satisfaction' }),
+      )
 
       const value = result._unsafeUnwrap()
       expect(value.items.map((i) => i.id)).toEqual([ind1, ind3])
@@ -116,8 +165,16 @@ describe.concurrent('listIndicateurs', () => {
         { publicId: ids[5], nom: 'Satisfaction 6' },
         { publicId: ids[6], nom: 'Délai moyen' },
       )
+      const apiKey = await fixtures.apiKey({
+        permissions: ids.map((publicId) => ({
+          indicateur: { publicId },
+          action: 'READ' as const,
+        })),
+      })
 
-      const result = await listIndicateurs({ recherche: 'satisfaction', pageSize: 5 })
+      const result = await runAsPrincipal(apiKey.id, () =>
+        listIndicateurs({ recherche: 'satisfaction', pageSize: 5 }),
+      )
 
       const value = result._unsafeUnwrap()
       expect(value.items.map((i) => i.id)).toEqual(ids.slice(0, 5))

--- a/apps/mb-api/src/indicateur/queries/listIndicateurs.ts
+++ b/apps/mb-api/src/indicateur/queries/listIndicateurs.ts
@@ -7,21 +7,17 @@ import { ResultAsync } from 'neverthrow'
 import { requireCurrentPrincipalId } from '@/framework/auth/userContext'
 import { db } from '@/framework/persistence/dbStore'
 import { buildPaginationArgs, toPaginatedResponse } from '@/framework/persistence/paginate'
-import { PermissionAction } from '@/generated/prisma/enums'
+import { withIndicateurReadPermission } from '@/indicateur/permissions'
 import { toIndicateurApiModel } from '@/indicateur/utils'
-
-const READ_ACTIONS: PermissionAction[] = [PermissionAction.READ, PermissionAction.WRITE]
 
 export const listIndicateurs = (
   params: ListIndicateursQuery,
 ): ResultAsync<IndicateurListApiModel, never> => {
   const principalId = requireCurrentPrincipalId()
-  const where = {
-    permissions: { some: { principalId, action: { in: READ_ACTIONS } } },
-    ...(params.recherche
-      ? { nom: { contains: params.recherche, mode: 'insensitive' as const } }
-      : {}),
-  }
+  const where = withIndicateurReadPermission(
+    params.recherche ? { nom: { contains: params.recherche, mode: 'insensitive' } } : {},
+    principalId,
+  )
 
   const fetchPage = db().indicateur.findMany({
     where,

--- a/apps/mb-api/src/indicateur/queries/listIndicateurs.ts
+++ b/apps/mb-api/src/indicateur/queries/listIndicateurs.ts
@@ -4,16 +4,24 @@ import {
 } from '@pilote/mb-shared/indicateur'
 import { ResultAsync } from 'neverthrow'
 
+import { requireCurrentPrincipalId } from '@/framework/auth/userContext'
 import { db } from '@/framework/persistence/dbStore'
 import { buildPaginationArgs, toPaginatedResponse } from '@/framework/persistence/paginate'
+import { PermissionAction } from '@/generated/prisma/enums'
 import { toIndicateurApiModel } from '@/indicateur/utils'
+
+const READ_ACTIONS: PermissionAction[] = [PermissionAction.READ, PermissionAction.WRITE]
 
 export const listIndicateurs = (
   params: ListIndicateursQuery,
 ): ResultAsync<IndicateurListApiModel, never> => {
-  const where = params.recherche
-    ? { nom: { contains: params.recherche, mode: 'insensitive' as const } }
-    : {}
+  const principalId = requireCurrentPrincipalId()
+  const where = {
+    permissions: { some: { principalId, action: { in: READ_ACTIONS } } },
+    ...(params.recherche
+      ? { nom: { contains: params.recherche, mode: 'insensitive' as const } }
+      : {}),
+  }
 
   const fetchPage = db().indicateur.findMany({
     where,

--- a/apps/mb-api/src/indicateur/routes.ts
+++ b/apps/mb-api/src/indicateur/routes.ts
@@ -140,7 +140,7 @@ indicateurRoutes.openapi(upsertIndicateurRoute, async (context) => {
   const body = context.req.valid('json')
 
   const result = await withTransaction(async () => {
-    await upsertIndicateur(id, body)
+    await upsertIndicateur({ publicId: id, body })
     return getIndicateurByPublicId(id)
   })
 

--- a/apps/mb-api/src/test/fixtures.ts
+++ b/apps/mb-api/src/test/fixtures.ts
@@ -6,12 +6,15 @@ import { db } from '@/framework/persistence/dbStore'
 import {
   type ApiKeyModel,
   type IndicateurModel,
+  type IndicateurPermissionModel,
   type IndividuModel,
   type ReferentielIndividuModel,
   type ReferentielModel,
   type RelationModel,
+  type UtilisateurModel,
   type ValeurAvancementModel,
 } from '@/generated/prisma/models'
+import { PermissionAction } from '@/generated/prisma/enums'
 
 // --- Indicateur --------------------------------------------------------------
 
@@ -260,6 +263,11 @@ async function valeurAvancement(
 
 // --- ApiKey ------------------------------------------------------------------
 
+type PrincipalIndicateurPermissionOverrides = {
+  indicateur: IndicateurOverrides
+  action: PermissionAction
+}
+
 type ApiKeyOverrides = Partial<{
   id: string
   label: string
@@ -268,6 +276,7 @@ type ApiKeyOverrides = Partial<{
   expiresAt: Date | null
   revokedAt: Date | null
   lastUsedAt: Date | null
+  permissions: PrincipalIndicateurPermissionOverrides[]
 }>
 
 const DEFAULT_API_KEY = {
@@ -275,6 +284,16 @@ const DEFAULT_API_KEY = {
   rawKey: 'pilote_live_test_default_key_value_xx',
   prefix: 'pilote_live_test_def',
 } as const
+
+const grantPermissions = async (
+  principalId: string,
+  permissions: PrincipalIndicateurPermissionOverrides[] | undefined,
+): Promise<void> => {
+  if (!permissions || permissions.length === 0) return
+  for (const p of permissions) {
+    await upsertIndicateurPermission({ principalId, ...p })
+  }
+}
 
 const upsertApiKey = async (o: ApiKeyOverrides = {}) => {
   const rawKey = o.rawKey ?? DEFAULT_API_KEY.rawKey
@@ -288,16 +307,17 @@ const upsertApiKey = async (o: ApiKeyOverrides = {}) => {
     revokedAt: o.revokedAt ?? null,
     lastUsedAt: o.lastUsedAt ?? null,
   }
-  const { id: _id, rawKey: _raw, ...update } = o
-  if (Object.keys(update).length === 0) {
-    const existing = await db().apiKey.findUnique({ where: { keyHash } })
-    if (existing) return existing
+  const { id: _id, rawKey: _raw, permissions, ...update } = o
+  const existing = await db().apiKey.findUnique({ where: { keyHash } })
+  if (existing) {
+    await grantPermissions(existing.id, permissions)
+    if (Object.keys(update).length === 0) return existing
+    return db().apiKey.update({ where: { keyHash }, data: update })
   }
-  return db().apiKey.upsert({
-    where: { keyHash },
-    update,
-    create,
-  })
+  await db().principal.create({ data: { id: create.id } })
+  const created = await db().apiKey.create({ data: create })
+  await grantPermissions(created.id, permissions)
+  return created
 }
 
 function apiKey(): Promise<ApiKeyModel>
@@ -314,6 +334,101 @@ async function apiKey(...overrides: ApiKeyOverrides[]): Promise<ApiKeyModel | Ap
   return results
 }
 
+// --- Utilisateur -------------------------------------------------------------
+
+type UtilisateurOverrides = Partial<{
+  id: string
+  email: string
+  providerSub: string | null
+  permissions: PrincipalIndicateurPermissionOverrides[]
+}>
+
+const DEFAULT_UTILISATEUR = {
+  email: 'utilisateur-test@example.com',
+  providerSub: null,
+} as const
+
+const upsertUtilisateur = async (o: UtilisateurOverrides = {}) => {
+  const email = o.email ?? DEFAULT_UTILISATEUR.email
+  const existing = await db().utilisateur.findUnique({ where: { email } })
+  if (existing) {
+    await grantPermissions(existing.id, o.permissions)
+    const { id: _id, email: _email, permissions: _p, ...update } = o
+    if (Object.keys(update).length === 0) return existing
+    return db().utilisateur.update({ where: { email }, data: update })
+  }
+  const id = o.id ?? uuidv7()
+  const create = {
+    id,
+    email,
+    providerSub: o.providerSub ?? DEFAULT_UTILISATEUR.providerSub,
+  }
+  await db().principal.create({ data: { id } })
+  const created = await db().utilisateur.create({ data: create })
+  await grantPermissions(created.id, o.permissions)
+  return created
+}
+
+function utilisateur(): Promise<UtilisateurModel>
+function utilisateur(override: UtilisateurOverrides): Promise<UtilisateurModel>
+function utilisateur(
+  o1: UtilisateurOverrides,
+  o2: UtilisateurOverrides,
+  ...rest: UtilisateurOverrides[]
+): Promise<UtilisateurModel[]>
+async function utilisateur(
+  ...overrides: UtilisateurOverrides[]
+): Promise<UtilisateurModel | UtilisateurModel[]> {
+  if (overrides.length <= 1) return upsertUtilisateur(overrides[0])
+  const results: UtilisateurModel[] = []
+  for (const o of overrides) results.push(await upsertUtilisateur(o))
+  return results
+}
+
+// --- IndicateurPermission (deps requises) ------------------------------------
+
+type IndicateurPermissionOverrides = {
+  principalId: string
+  indicateur: IndicateurOverrides
+  action: PermissionAction
+}
+
+const upsertIndicateurPermission = async (o: IndicateurPermissionOverrides) => {
+  const indicateurRow = await upsertIndicateur(o.indicateur)
+  return db().indicateurPermission.upsert({
+    where: {
+      principalId_indicateurId_action: {
+        principalId: o.principalId,
+        indicateurId: indicateurRow.id,
+        action: o.action,
+      },
+    },
+    update: {},
+    create: {
+      principalId: o.principalId,
+      indicateurId: indicateurRow.id,
+      action: o.action,
+    },
+  })
+}
+
+function indicateurPermission(
+  override: IndicateurPermissionOverrides,
+): Promise<IndicateurPermissionModel>
+function indicateurPermission(
+  o1: IndicateurPermissionOverrides,
+  o2: IndicateurPermissionOverrides,
+  ...rest: IndicateurPermissionOverrides[]
+): Promise<IndicateurPermissionModel[]>
+async function indicateurPermission(
+  ...overrides: IndicateurPermissionOverrides[]
+): Promise<IndicateurPermissionModel | IndicateurPermissionModel[]> {
+  if (overrides.length === 1) return upsertIndicateurPermission(overrides[0]!)
+  const results: IndicateurPermissionModel[] = []
+  for (const o of overrides) results.push(await upsertIndicateurPermission(o))
+  return results
+}
+
 export const fixtures = {
   indicateur,
   referentiel,
@@ -322,4 +437,6 @@ export const fixtures = {
   relation,
   valeurAvancement,
   apiKey,
+  utilisateur,
+  indicateurPermission,
 }

--- a/apps/mb-api/src/test/runAsPrincipal.ts
+++ b/apps/mb-api/src/test/runAsPrincipal.ts
@@ -1,0 +1,4 @@
+import { runWithPrincipal } from '@/framework/auth/userContext'
+
+export const runAsPrincipal = <T>(principalId: string, fn: () => T): T =>
+  runWithPrincipal({ kind: 'apiKey', apiKey: { id: principalId, label: 'test' } }, fn)

--- a/apps/mb-api/src/valeurAvancement/queries/listIndividusWithValeurs.test.ts
+++ b/apps/mb-api/src/valeurAvancement/queries/listIndividusWithValeurs.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 import { fixtures } from '@/test/fixtures'
 import { integrationTest } from '@/test/integrationTest'
 import { testDeptId, testDeptIds, testIndicateurId, testRegId } from '@/test/randomIds'
+import { runAsPrincipal } from '@/test/runAsPrincipal'
 import { listIndividusWithValeurs } from '@/valeurAvancement/queries/listIndividusWithValeurs'
 
 describe.concurrent('listIndividusWithValeurs', () => {
@@ -32,8 +33,11 @@ describe.concurrent('listIndividusWithValeurs', () => {
           valeur: 5,
         },
       )
+      const apiKey = await fixtures.apiKey({
+        permissions: [{ indicateur: { publicId: indId }, action: 'READ' }],
+      })
 
-      const result = await listIndividusWithValeurs(indId, {})
+      const result = await runAsPrincipal(apiKey.id, () => listIndividusWithValeurs(indId, {}))
 
       expect(result._unsafeUnwrap()).toEqual({
         items: [
@@ -96,8 +100,13 @@ describe.concurrent('listIndividusWithValeurs', () => {
           valeur: 2,
         },
       )
+      const apiKey = await fixtures.apiKey({
+        permissions: [{ indicateur: { publicId: indId }, action: 'READ' }],
+      })
 
-      const result = await listIndividusWithValeurs(indId, { referentiel: 'REF-REG' })
+      const result = await runAsPrincipal(apiKey.id, () =>
+        listIndividusWithValeurs(indId, { referentiel: 'REF-REG' }),
+      )
 
       expect(result._unsafeUnwrap()).toEqual({
         items: [
@@ -122,7 +131,10 @@ describe.concurrent('listIndividusWithValeurs', () => {
   it(
     "retourne une liste vide quand l'indicateur est introuvable",
     integrationTest(async () => {
-      const result = await listIndividusWithValeurs(testIndicateurId(), {})
+      const apiKey = await fixtures.apiKey()
+      const result = await runAsPrincipal(apiKey.id, () =>
+        listIndividusWithValeurs(testIndicateurId(), {}),
+      )
 
       expect(result._unsafeUnwrap()).toEqual({
         items: [],
@@ -137,8 +149,36 @@ describe.concurrent('listIndividusWithValeurs', () => {
     integrationTest(async () => {
       const indId = testIndicateurId()
       await fixtures.indicateur({ publicId: indId, nom: 'T' })
+      const apiKey = await fixtures.apiKey({
+        permissions: [{ indicateur: { publicId: indId }, action: 'READ' }],
+      })
 
-      const result = await listIndividusWithValeurs(indId, { referentiel: 'REF-INCONNU' })
+      const result = await runAsPrincipal(apiKey.id, () =>
+        listIndividusWithValeurs(indId, { referentiel: 'REF-INCONNU' }),
+      )
+
+      expect(result._unsafeUnwrap()).toEqual({
+        items: [],
+        pagination: { cursor: null, hasMore: false },
+        total: 0,
+      })
+    }),
+  )
+
+  it(
+    "retourne une liste vide quand le principal n'a pas READ sur l'indicateur",
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const deptId = testDeptId()
+      await fixtures.valeurAvancement({
+        indicateur: { publicId: indId },
+        individu: { publicId: deptId },
+        date: '2024-01-01',
+        valeur: 1,
+      })
+      const apiKey = await fixtures.apiKey()
+
+      const result = await runAsPrincipal(apiKey.id, () => listIndividusWithValeurs(indId, {}))
 
       expect(result._unsafeUnwrap()).toEqual({
         items: [],

--- a/apps/mb-api/src/valeurAvancement/queries/listIndividusWithValeurs.ts
+++ b/apps/mb-api/src/valeurAvancement/queries/listIndividusWithValeurs.ts
@@ -7,10 +7,8 @@ import { ResultAsync } from 'neverthrow'
 import { requireCurrentPrincipalId } from '@/framework/auth/userContext'
 import { db } from '@/framework/persistence/dbStore'
 import { buildPaginationArgs, toPaginatedResponse } from '@/framework/persistence/paginate'
-import { PermissionAction } from '@/generated/prisma/enums'
+import { withIndicateurReadPermission } from '@/indicateur/permissions'
 import { toIndividuAvecValeursApiModel } from '@/valeurAvancement/utils'
-
-const READ_ACTIONS: PermissionAction[] = [PermissionAction.READ, PermissionAction.WRITE]
 
 export const listIndividusWithValeurs = (
   indicateurPublicId: string,
@@ -18,10 +16,7 @@ export const listIndividusWithValeurs = (
 ): ResultAsync<IndividusWithValeursListApiModel, never> => {
   const principalId = requireCurrentPrincipalId()
   const indicateurFilter = {
-    indicateur: {
-      publicId: indicateurPublicId,
-      permissions: { some: { principalId, action: { in: READ_ACTIONS } } },
-    },
+    indicateur: withIndicateurReadPermission({ publicId: indicateurPublicId }, principalId),
   }
   const where = {
     valeurs: { some: indicateurFilter },

--- a/apps/mb-api/src/valeurAvancement/queries/listIndividusWithValeurs.ts
+++ b/apps/mb-api/src/valeurAvancement/queries/listIndividusWithValeurs.ts
@@ -4,15 +4,25 @@ import {
 } from '@pilote/mb-shared/valeurAvancement'
 import { ResultAsync } from 'neverthrow'
 
+import { requireCurrentPrincipalId } from '@/framework/auth/userContext'
 import { db } from '@/framework/persistence/dbStore'
 import { buildPaginationArgs, toPaginatedResponse } from '@/framework/persistence/paginate'
+import { PermissionAction } from '@/generated/prisma/enums'
 import { toIndividuAvecValeursApiModel } from '@/valeurAvancement/utils'
+
+const READ_ACTIONS: PermissionAction[] = [PermissionAction.READ, PermissionAction.WRITE]
 
 export const listIndividusWithValeurs = (
   indicateurPublicId: string,
   params: ListIndividusWithValeursQuery,
 ): ResultAsync<IndividusWithValeursListApiModel, never> => {
-  const indicateurFilter = { indicateur: { publicId: indicateurPublicId } }
+  const principalId = requireCurrentPrincipalId()
+  const indicateurFilter = {
+    indicateur: {
+      publicId: indicateurPublicId,
+      permissions: { some: { principalId, action: { in: READ_ACTIONS } } },
+    },
+  }
   const where = {
     valeurs: { some: indicateurFilter },
     ...(params.referentiel

--- a/apps/mb-api/src/valeurAvancement/queries/listValeursForIndicateur.test.ts
+++ b/apps/mb-api/src/valeurAvancement/queries/listValeursForIndicateur.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 import { fixtures } from '@/test/fixtures'
 import { integrationTest } from '@/test/integrationTest'
 import { testDeptId, testDeptIds, testIndicateurId } from '@/test/randomIds'
+import { runAsPrincipal } from '@/test/runAsPrincipal'
 import { listValeursForIndicateur } from '@/valeurAvancement/queries/listValeursForIndicateur'
 
 describe.concurrent('listValeursForIndicateur', () => {
@@ -25,8 +26,13 @@ describe.concurrent('listValeursForIndicateur', () => {
           valeur: 7.8,
         },
       )
+      const apiKey = await fixtures.apiKey({
+        permissions: [{ indicateur: { publicId: indId }, action: 'READ' }],
+      })
 
-      const result = await listValeursForIndicateur(indId, { individus: [deptId] })
+      const result = await runAsPrincipal(apiKey.id, () =>
+        listValeursForIndicateur(indId, { individus: [deptId] }),
+      )
 
       const value = result._unsafeUnwrap()
       expect(value.items).toEqual([
@@ -61,8 +67,13 @@ describe.concurrent('listValeursForIndicateur', () => {
           valeur: 3,
         },
       )
+      const apiKey = await fixtures.apiKey({
+        permissions: [{ indicateur: { publicId: indId }, action: 'READ' }],
+      })
 
-      const result = await listValeursForIndicateur(indId, { individus: [dept1, dept2] })
+      const result = await runAsPrincipal(apiKey.id, () =>
+        listValeursForIndicateur(indId, { individus: [dept1, dept2] }),
+      )
 
       const value = result._unsafeUnwrap()
       const individus = value.items.map((v) => v.individu).sort()
@@ -102,12 +113,17 @@ describe.concurrent('listValeursForIndicateur', () => {
           valeur: 4,
         },
       )
-
-      const result = await listValeursForIndicateur(indId, {
-        individus: [deptId],
-        dateDebut: '2024-01-01',
-        dateFin: '2024-06-30',
+      const apiKey = await fixtures.apiKey({
+        permissions: [{ indicateur: { publicId: indId }, action: 'READ' }],
       })
+
+      const result = await runAsPrincipal(apiKey.id, () =>
+        listValeursForIndicateur(indId, {
+          individus: [deptId],
+          dateDebut: '2024-01-01',
+          dateFin: '2024-06-30',
+        }),
+      )
 
       const value = result._unsafeUnwrap()
       expect(value.items.map((v) => v.date)).toEqual(['2024-01-01', '2024-06-30'])
@@ -121,8 +137,13 @@ describe.concurrent('listValeursForIndicateur', () => {
       const deptId = testDeptId()
       await fixtures.indicateur({ publicId: indId, nom: 'T' })
       await fixtures.individu({ publicId: deptId, nom: 'Vaucluse' })
+      const apiKey = await fixtures.apiKey({
+        permissions: [{ indicateur: { publicId: indId }, action: 'READ' }],
+      })
 
-      const result = await listValeursForIndicateur(indId, { individus: [deptId] })
+      const result = await runAsPrincipal(apiKey.id, () =>
+        listValeursForIndicateur(indId, { individus: [deptId] }),
+      )
 
       const value = result._unsafeUnwrap()
       expect(value.items).toEqual([])
@@ -132,8 +153,30 @@ describe.concurrent('listValeursForIndicateur', () => {
   it(
     "rejette quand l'indicateur est introuvable",
     integrationTest(async () => {
+      const apiKey = await fixtures.apiKey()
       await expect(
-        listValeursForIndicateur(testIndicateurId(), { individus: [testDeptId()] }),
+        runAsPrincipal(apiKey.id, () =>
+          listValeursForIndicateur(testIndicateurId(), { individus: [testDeptId()] }),
+        ),
+      ).rejects.toThrow()
+    }),
+  )
+
+  it(
+    "rejette quand le principal n'a pas READ sur l'indicateur",
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const deptId = testDeptId()
+      await fixtures.valeurAvancement({
+        indicateur: { publicId: indId },
+        individu: { publicId: deptId },
+        date: '2024-01-01',
+        valeur: 1,
+      })
+      const apiKey = await fixtures.apiKey()
+
+      await expect(
+        runAsPrincipal(apiKey.id, () => listValeursForIndicateur(indId, { individus: [deptId] })),
       ).rejects.toThrow()
     }),
   )

--- a/apps/mb-api/src/valeurAvancement/queries/listValeursForIndicateur.ts
+++ b/apps/mb-api/src/valeurAvancement/queries/listValeursForIndicateur.ts
@@ -4,16 +4,24 @@ import {
 } from '@pilote/mb-shared/valeurAvancement'
 import { ResultAsync } from 'neverthrow'
 
+import { requireCurrentPrincipalId } from '@/framework/auth/userContext'
 import { db } from '@/framework/persistence/dbStore'
+import { PermissionAction } from '@/generated/prisma/enums'
 import { toValeurAvancementApiModel } from '@/valeurAvancement/utils'
+
+const READ_ACTIONS: PermissionAction[] = [PermissionAction.READ, PermissionAction.WRITE]
 
 export const listValeursForIndicateur = (
   indicateurPublicId: string,
   params: ListValeursForIndicateurQuery,
-): ResultAsync<ValeurAvancementListApiModel, never> =>
-  ResultAsync.fromSafePromise(
-    db().indicateur.findUniqueOrThrow({
-      where: { publicId: indicateurPublicId },
+): ResultAsync<ValeurAvancementListApiModel, never> => {
+  const principalId = requireCurrentPrincipalId()
+  return ResultAsync.fromSafePromise(
+    db().indicateur.findFirstOrThrow({
+      where: {
+        publicId: indicateurPublicId,
+        permissions: { some: { principalId, action: { in: READ_ACTIONS } } },
+      },
       select: { id: true },
     }),
   ).andThen((indicateur) => {
@@ -44,3 +52,4 @@ export const listValeursForIndicateur = (
       items: rows.map(toValeurAvancementApiModel),
     }))
   })
+}

--- a/apps/mb-api/src/valeurAvancement/queries/listValeursForIndicateur.ts
+++ b/apps/mb-api/src/valeurAvancement/queries/listValeursForIndicateur.ts
@@ -6,10 +6,8 @@ import { ResultAsync } from 'neverthrow'
 
 import { requireCurrentPrincipalId } from '@/framework/auth/userContext'
 import { db } from '@/framework/persistence/dbStore'
-import { PermissionAction } from '@/generated/prisma/enums'
+import { withIndicateurReadPermission } from '@/indicateur/permissions'
 import { toValeurAvancementApiModel } from '@/valeurAvancement/utils'
-
-const READ_ACTIONS: PermissionAction[] = [PermissionAction.READ, PermissionAction.WRITE]
 
 export const listValeursForIndicateur = (
   indicateurPublicId: string,
@@ -18,10 +16,7 @@ export const listValeursForIndicateur = (
   const principalId = requireCurrentPrincipalId()
   return ResultAsync.fromSafePromise(
     db().indicateur.findFirstOrThrow({
-      where: {
-        publicId: indicateurPublicId,
-        permissions: { some: { principalId, action: { in: READ_ACTIONS } } },
-      },
+      where: withIndicateurReadPermission({ publicId: indicateurPublicId }, principalId),
       select: { id: true },
     }),
   ).andThen((indicateur) => {


### PR DESCRIPTION
## Summary

- Introduit une table `Principal` (shared-PK avec `Utilisateur` et `ApiKey`) qui sert d'ancre commune pour les permissions.
- Ajoute une table `IndicateurPermission { principalId, indicateurId, action }` avec enum `PermissionAction { READ, WRITE }`.
- Gate les use cases d'indicateur et de valeur d'avancement sur les permissions du principal courant ; la création d'un indicateur via `PUT /indicateurs/{id}` auto-grant `READ+WRITE` au créateur.

## Détails

**Schéma & migration**
- `Principal { id, createdAt }`. `Utilisateur.id` et `ApiKey.id` deviennent FK shared-PK vers `Principal.id` (`onDelete: Cascade`).
- `IndicateurPermission` : PK composite `(principalId, indicateurId, action)`, FKs cascade des deux côtés, index sur `indicateurId`.
- Migration unique `20260512120000_add_principal_and_permissions` : création de l'enum + tables, backfill des `principal` depuis les rows existantes de `utilisateur` et `api_key`, ajout des FKs.

**Création de principal**
- `prisma/seed.ts` : `Principal` créé avant chaque `Utilisateur` (séquentiel, dans la tx du seed).
- `scripts/generate-api-key.ts` : SQL généré wrappé `BEGIN; INSERT principal; INSERT api_key; COMMIT;`.
- `src/test/fixtures.ts` : `apiKey()` et `utilisateur()` créent `Principal` + l'enfant ; nouvel option `permissions: [{ indicateur, action }]` (pattern nested entities) qui grant en cascade.

**Use cases gatés**
- `listIndicateurs` : where `permissions: { some: { principalId, action: { in: [READ, WRITE] } } }` (WRITE implique READ).
- `getIndicateurByPublicId` : `findFirstOrThrow` avec le même filtre → 404 (`ENTITY_NOT_FOUND` via P2025) si pas de permission.
- `listValeursForIndicateur` : check sur l'indicateur en amont (404 si pas accès).
- `listIndividusWithValeurs` : filtre sur l'indicateur dans le `where`/`include` (liste vide si pas accès).
- `upsertIndicateur` : si l'indicateur existe → check `WRITE` ou `ForbiddenError` (403) ; si crée → grant `READ+WRITE` au créateur dans la même tx.

**Framework**
- `ForbiddenError` (kind `forbidden` → 403, code `FORBIDDEN`) dans `framework/errors/AppError.ts`.
- `requireCurrentPrincipalId()` dans `framework/auth/userContext.ts` (renvoie l'ID partagé via le shared-PK).
- `runAsPrincipal(principalId, fn)` dans `src/test/runAsPrincipal.ts` (helper test-only pour wrapper avec un principal dans l'ALS).

**Tests**
- 73 tests passent (6 nouveaux). Couvre : WRITE implique READ, refus sans permission, auto-grant à la création, refus update sans WRITE, filtrage liste, accès aux valeurs gaté par l'indicateur.

## Trade-offs assumés

- Pas de contrainte DB-level qui empêche un même UUID d'exister dans `utilisateur` ET `api_key` (avec uuidv7 c'est de fait impossible ; le « kind » est garanti à l'entrée par le flow d'auth).
- Pas de seed de permissions cartésien : par défaut tout est en deny. Sans prod existante à préserver, le passage en explicit est immédiat.
- 404 (et non 403) sur lecture sans permission — convention pour ne pas révéler l'existence d'une ressource.

## Hors scope (PR suivants)

- Notion de panier (ensemble d'indicateurs) + permissions `Panier ↔ Principal` + résolution de granularité (union directe + via panier).
- Endpoints d'admin pour grant/revoke explicites.

## Test plan

- [ ] Migration appliquée localement (`pnpm prisma migrate deploy`)
- [ ] `pnpm test` → 73 tests verts
- [ ] `pnpm lint` → OK
- [ ] Smoke test manuel : créer un indicateur via `PUT /indicateurs/{id}` avec une API key, vérifier qu'on peut le re-lire ; tester avec une autre API key qu'on a bien 404 sur la lecture et 403 sur l'update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)