### PR TITLE
feat(mb): min/max/médiane sur la page indicateur

### DIFF
--- a/apps/mb-api/src/valeurAvancement/computeMax.test.ts
+++ b/apps/mb-api/src/valeurAvancement/computeMax.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+
+import { computeMax } from '@/valeurAvancement/computeMax'
+
+describe('computeMax', () => {
+  it('retourne null pour un tableau vide', () => {
+    expect(computeMax([])).toBeNull()
+  })
+
+  it('retourne la valeur unique pour un tableau de taille 1', () => {
+    expect(computeMax([42])).toBe(42)
+  })
+
+  it('retourne la plus grande valeur', () => {
+    expect(computeMax([3, 1, 2])).toBe(3)
+    expect(computeMax([10, 20, 30, 40, 50])).toBe(50)
+  })
+
+  it('gère les nombres négatifs', () => {
+    expect(computeMax([-5, -1, -3])).toBe(-1)
+    expect(computeMax([-10, -5, -50])).toBe(-5)
+  })
+
+  it('gère les valeurs décimales', () => {
+    expect(computeMax([1.5, 0.5, 2.5])).toBe(2.5)
+  })
+
+  it('gère les doublons', () => {
+    expect(computeMax([5, 5, 5])).toBe(5)
+    expect(computeMax([1, 2, 2])).toBe(2)
+  })
+})

--- a/apps/mb-api/src/valeurAvancement/computeMax.ts
+++ b/apps/mb-api/src/valeurAvancement/computeMax.ts
@@ -1,0 +1,4 @@
+export const computeMax = (values: ReadonlyArray<number>): number | null => {
+  if (values.length === 0) return null
+  return Math.max(...values)
+}

--- a/apps/mb-api/src/valeurAvancement/computeMediane.test.ts
+++ b/apps/mb-api/src/valeurAvancement/computeMediane.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+
+import { computeMediane } from '@/valeurAvancement/computeMediane'
+
+describe('computeMediane', () => {
+  it('retourne null pour un tableau vide', () => {
+    expect(computeMediane([])).toBeNull()
+  })
+
+  it('retourne la valeur unique pour un tableau de taille 1', () => {
+    expect(computeMediane([42])).toBe(42)
+  })
+
+  it('retourne la valeur centrale pour un nombre impair de valeurs', () => {
+    expect(computeMediane([1, 2, 3])).toBe(2)
+    expect(computeMediane([10, 20, 30, 40, 50])).toBe(30)
+  })
+
+  it('retourne la moyenne des deux valeurs centrales pour un nombre pair', () => {
+    expect(computeMediane([1, 2, 3, 4])).toBe(2.5)
+    expect(computeMediane([10, 20, 30, 40])).toBe(25)
+  })
+
+  it("trie les valeurs avant de calculer (l'ordre d'entrée n'importe pas)", () => {
+    expect(computeMediane([3, 1, 2])).toBe(2)
+    expect(computeMediane([40, 10, 30, 20])).toBe(25)
+  })
+
+  it('gère les nombres négatifs', () => {
+    expect(computeMediane([-5, -1, -3])).toBe(-3)
+    expect(computeMediane([-10, -5, 5, 10])).toBe(0)
+  })
+
+  it('gère les valeurs décimales', () => {
+    expect(computeMediane([1.5, 2.5, 3.5])).toBe(2.5)
+    expect(computeMediane([1.1, 2.2])).toBeCloseTo(1.65)
+  })
+
+  it('gère les doublons', () => {
+    expect(computeMediane([5, 5, 5])).toBe(5)
+    expect(computeMediane([1, 2, 2, 3])).toBe(2)
+  })
+
+  it('trie numériquement (pas lexicographiquement) pour distinguer 2 et 10', () => {
+    expect(computeMediane([10, 2, 1])).toBe(2)
+  })
+})

--- a/apps/mb-api/src/valeurAvancement/computeMediane.ts
+++ b/apps/mb-api/src/valeurAvancement/computeMediane.ts
@@ -1,0 +1,11 @@
+export const computeMediane = (values: ReadonlyArray<number>): number | null => {
+  if (values.length === 0) return null
+
+  const sorted = [...values].sort((a, b) => a - b)
+  const middle = sorted.length / 2
+
+  if (sorted.length % 2 === 1) {
+    return sorted[Math.floor(middle)]!
+  }
+  return (sorted[middle - 1]! + sorted[middle]!) / 2
+}

--- a/apps/mb-api/src/valeurAvancement/computeMin.test.ts
+++ b/apps/mb-api/src/valeurAvancement/computeMin.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+
+import { computeMin } from '@/valeurAvancement/computeMin'
+
+describe('computeMin', () => {
+  it('retourne null pour un tableau vide', () => {
+    expect(computeMin([])).toBeNull()
+  })
+
+  it('retourne la valeur unique pour un tableau de taille 1', () => {
+    expect(computeMin([42])).toBe(42)
+  })
+
+  it('retourne la plus petite valeur', () => {
+    expect(computeMin([3, 1, 2])).toBe(1)
+    expect(computeMin([10, 20, 30, 40, 50])).toBe(10)
+  })
+
+  it('gère les nombres négatifs', () => {
+    expect(computeMin([-5, -1, -3])).toBe(-5)
+    expect(computeMin([-10, 5, 10])).toBe(-10)
+  })
+
+  it('gère les valeurs décimales', () => {
+    expect(computeMin([1.5, 0.5, 2.5])).toBe(0.5)
+  })
+
+  it('gère les doublons', () => {
+    expect(computeMin([5, 5, 5])).toBe(5)
+    expect(computeMin([1, 1, 2])).toBe(1)
+  })
+})

--- a/apps/mb-api/src/valeurAvancement/computeMin.ts
+++ b/apps/mb-api/src/valeurAvancement/computeMin.ts
@@ -1,0 +1,4 @@
+export const computeMin = (values: ReadonlyArray<number>): number | null => {
+  if (values.length === 0) return null
+  return Math.min(...values)
+}

--- a/apps/mb-api/src/valeurAvancement/queries/listValeursRemarquablesForIndicateur.test.ts
+++ b/apps/mb-api/src/valeurAvancement/queries/listValeursRemarquablesForIndicateur.test.ts
@@ -7,7 +7,7 @@ import { listValeursRemarquablesForIndicateur } from '@/valeurAvancement/queries
 
 describe.concurrent('listValeursRemarquablesForIndicateur', () => {
   it(
-    'retourne variation = null et stats à null pour un individu sans valeur',
+    "retourne variation = null et stats à null quand aucun individu n'a de valeur pour l'indicateur",
     integrationTest(async () => {
       const indId = testIndicateurId()
       const deptId = testDeptId()
@@ -21,6 +21,31 @@ describe.concurrent('listValeursRemarquablesForIndicateur', () => {
         min: null,
         max: null,
         mediane: null,
+      })
+    }),
+  )
+
+  it(
+    "retourne variation = null pour un individu sans valeur mais stats non nulles si d'autres individus ont des valeurs",
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const [dept1, dept2] = testDeptIds(2)
+      await fixtures.indicateur({ publicId: indId, nom: 'T' })
+      await fixtures.individu({ publicId: dept1, nom: 'Sans valeur' })
+      await fixtures.valeurAvancement({
+        indicateur: { publicId: indId },
+        individu: { publicId: dept2, nom: 'Avec valeur' },
+        date: '2026-01-01',
+        valeur: 42,
+      })
+
+      const result = await listValeursRemarquablesForIndicateur(indId, { individus: [dept1] })
+
+      expect(result._unsafeUnwrap()).toEqual({
+        items: [{ individu: dept1, variation: null }],
+        min: 42,
+        max: 42,
+        mediane: 42,
       })
     }),
   )

--- a/apps/mb-api/src/valeurAvancement/queries/listValeursRemarquablesForIndicateur.test.ts
+++ b/apps/mb-api/src/valeurAvancement/queries/listValeursRemarquablesForIndicateur.test.ts
@@ -7,7 +7,7 @@ import { listValeursRemarquablesForIndicateur } from '@/valeurAvancement/queries
 
 describe.concurrent('listValeursRemarquablesForIndicateur', () => {
   it(
-    'retourne variation = null pour un individu sans valeur',
+    'retourne variation = null et stats à null pour un individu sans valeur',
     integrationTest(async () => {
       const indId = testIndicateurId()
       const deptId = testDeptId()
@@ -18,6 +18,9 @@ describe.concurrent('listValeursRemarquablesForIndicateur', () => {
 
       expect(result._unsafeUnwrap()).toEqual({
         items: [{ individu: deptId, variation: null }],
+        min: null,
+        max: null,
+        mediane: null,
       })
     }),
   )
@@ -38,6 +41,9 @@ describe.concurrent('listValeursRemarquablesForIndicateur', () => {
 
       expect(result._unsafeUnwrap()).toEqual({
         items: [{ individu: deptId, variation: 50 }],
+        min: 50,
+        max: 50,
+        mediane: 50,
       })
     }),
   )
@@ -72,6 +78,9 @@ describe.concurrent('listValeursRemarquablesForIndicateur', () => {
 
       expect(result._unsafeUnwrap()).toEqual({
         items: [{ individu: deptId, variation: 50 }],
+        min: 75,
+        max: 75,
+        mediane: 75,
       })
     }),
   )
@@ -100,6 +109,9 @@ describe.concurrent('listValeursRemarquablesForIndicateur', () => {
 
       expect(result._unsafeUnwrap()).toEqual({
         items: [{ individu: deptId, variation: -25 }],
+        min: 25,
+        max: 25,
+        mediane: 25,
       })
     }),
   )
@@ -135,6 +147,9 @@ describe.concurrent('listValeursRemarquablesForIndicateur', () => {
 
       expect(result._unsafeUnwrap()).toEqual({
         items: [{ individu: deptId, variation: 65 }],
+        min: 75,
+        max: 75,
+        mediane: 75,
       })
     }),
   )
@@ -177,6 +192,9 @@ describe.concurrent('listValeursRemarquablesForIndicateur', () => {
           { individu: dept2, variation: 5 },
           { individu: dept3, variation: null },
         ],
+        min: 5,
+        max: 30,
+        mediane: 17.5,
       })
     }),
   )
@@ -205,6 +223,9 @@ describe.concurrent('listValeursRemarquablesForIndicateur', () => {
 
       expect(result._unsafeUnwrap()).toEqual({
         items: [{ individu: deptId, variation: 100 }],
+        min: 100,
+        max: 100,
+        mediane: 100,
       })
     }),
   )
@@ -228,6 +249,9 @@ describe.concurrent('listValeursRemarquablesForIndicateur', () => {
 
       expect(result._unsafeUnwrap()).toEqual({
         items: [{ individu: deptId, variation: 42 }],
+        min: 42,
+        max: 42,
+        mediane: 42,
       })
     }),
   )
@@ -256,6 +280,168 @@ describe.concurrent('listValeursRemarquablesForIndicateur', () => {
 
       expect(result._unsafeUnwrap()).toEqual({
         items: [{ individu: deptId, variation: 0.15 }],
+        min: 0.3,
+        max: 0.3,
+        mediane: 0.3,
+      })
+    }),
+  )
+
+  it(
+    'calcule min/max/médiane sur la valeur la plus récente de chaque individu (nombre impair)',
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const [dept1, dept2, dept3] = testDeptIds(3)
+      await fixtures.valeurAvancement(
+        {
+          indicateur: { publicId: indId, nom: 'T' },
+          individu: { publicId: dept1, nom: 'A' },
+          date: '2026-01-01',
+          valeur: 100,
+        },
+        {
+          indicateur: { publicId: indId },
+          individu: { publicId: dept1 },
+          date: '2026-02-01',
+          valeur: 10,
+        },
+        {
+          indicateur: { publicId: indId },
+          individu: { publicId: dept2, nom: 'B' },
+          date: '2026-01-01',
+          valeur: 50,
+        },
+        {
+          indicateur: { publicId: indId },
+          individu: { publicId: dept3, nom: 'C' },
+          date: '2026-01-01',
+          valeur: 30,
+        },
+      )
+
+      const result = await listValeursRemarquablesForIndicateur(indId, { individus: [dept1] })
+
+      // Valeurs récentes: dept1=10, dept2=50, dept3=30
+      expect(result._unsafeUnwrap()).toMatchObject({
+        min: 10,
+        max: 50,
+        mediane: 30,
+      })
+    }),
+  )
+
+  it(
+    'calcule la médiane comme moyenne des deux centrales (nombre pair)',
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const [dept1, dept2, dept3, dept4] = testDeptIds(4)
+      await fixtures.valeurAvancement(
+        {
+          indicateur: { publicId: indId, nom: 'T' },
+          individu: { publicId: dept1, nom: 'A' },
+          date: '2026-01-01',
+          valeur: 10,
+        },
+        {
+          indicateur: { publicId: indId },
+          individu: { publicId: dept2, nom: 'B' },
+          date: '2026-01-01',
+          valeur: 20,
+        },
+        {
+          indicateur: { publicId: indId },
+          individu: { publicId: dept3, nom: 'C' },
+          date: '2026-01-01',
+          valeur: 30,
+        },
+        {
+          indicateur: { publicId: indId },
+          individu: { publicId: dept4, nom: 'D' },
+          date: '2026-01-01',
+          valeur: 40,
+        },
+      )
+
+      const result = await listValeursRemarquablesForIndicateur(indId, { individus: [dept1] })
+
+      expect(result._unsafeUnwrap()).toMatchObject({
+        min: 10,
+        max: 40,
+        mediane: 25,
+      })
+    }),
+  )
+
+  it(
+    "min/max/médiane sont calculés sur tous les individus de l'indicateur, pas seulement ceux demandés",
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const [dept1, dept2, dept3] = testDeptIds(3)
+      await fixtures.valeurAvancement(
+        {
+          indicateur: { publicId: indId, nom: 'T' },
+          individu: { publicId: dept1, nom: 'A' },
+          date: '2026-01-01',
+          valeur: 5,
+        },
+        {
+          indicateur: { publicId: indId },
+          individu: { publicId: dept2, nom: 'B' },
+          date: '2026-01-01',
+          valeur: 50,
+        },
+        {
+          indicateur: { publicId: indId },
+          individu: { publicId: dept3, nom: 'C' },
+          date: '2026-01-01',
+          valeur: 100,
+        },
+      )
+
+      // Ne demande qu'un seul individu mais les stats portent sur les 3
+      const result = await listValeursRemarquablesForIndicateur(indId, { individus: [dept2] })
+
+      expect(result._unsafeUnwrap()).toEqual({
+        items: [{ individu: dept2, variation: 50 }],
+        min: 5,
+        max: 100,
+        mediane: 50,
+      })
+    }),
+  )
+
+  it(
+    "min/max/médiane ignorent les valeurs d'autres indicateurs",
+    integrationTest(async () => {
+      const [indId, autreIndId] = [testIndicateurId(), testIndicateurId()]
+      const [dept1, dept2] = testDeptIds(2)
+      await fixtures.valeurAvancement(
+        {
+          indicateur: { publicId: indId, nom: 'T' },
+          individu: { publicId: dept1, nom: 'A' },
+          date: '2026-01-01',
+          valeur: 10,
+        },
+        {
+          indicateur: { publicId: indId },
+          individu: { publicId: dept2, nom: 'B' },
+          date: '2026-01-01',
+          valeur: 20,
+        },
+        {
+          indicateur: { publicId: autreIndId, nom: 'Autre' },
+          individu: { publicId: dept1 },
+          date: '2026-01-01',
+          valeur: 9999,
+        },
+      )
+
+      const result = await listValeursRemarquablesForIndicateur(indId, { individus: [dept1] })
+
+      expect(result._unsafeUnwrap()).toMatchObject({
+        min: 10,
+        max: 20,
+        mediane: 15,
       })
     }),
   )

--- a/apps/mb-api/src/valeurAvancement/queries/listValeursRemarquablesForIndicateur.ts
+++ b/apps/mb-api/src/valeurAvancement/queries/listValeursRemarquablesForIndicateur.ts
@@ -15,6 +15,31 @@ const computeVariation = (valeurs: ReadonlyArray<{ valeur: Prisma.Decimal }>): n
   return recente!.valeur.minus(precedenteValeur).toNumber()
 }
 
+const fetchItemsAvecVariation = (indicateurId: string, individus: ReadonlyArray<string>) =>
+  db().individu.findMany({
+    where: { publicId: { in: [...individus] } },
+    orderBy: { publicId: 'asc' },
+    include: {
+      valeurs: {
+        where: { indicateurId },
+        orderBy: [{ date: 'desc' }, { id: 'desc' }],
+        take: 2,
+      },
+    },
+  })
+
+const fetchValeursRecentesPopulation = (indicateurId: string) =>
+  db().individu.findMany({
+    where: { valeurs: { some: { indicateurId } } },
+    include: {
+      valeurs: {
+        where: { indicateurId },
+        orderBy: [{ date: 'desc' }, { id: 'desc' }],
+        take: 1,
+      },
+    },
+  })
+
 export const listValeursRemarquablesForIndicateur = (
   indicateurPublicId: string,
   params: ListValeursRemarquablesForIndicateurQuery,
@@ -27,33 +52,11 @@ export const listValeursRemarquablesForIndicateur = (
   ).andThen((indicateur) =>
     ResultAsync.fromSafePromise(
       Promise.all([
-        db().individu.findMany({
-          where: { publicId: { in: params.individus } },
-          orderBy: { publicId: 'asc' },
-          select: {
-            publicId: true,
-            valeurs: {
-              where: { indicateurId: indicateur.id },
-              orderBy: [{ date: 'desc' }, { id: 'desc' }],
-              take: 2,
-              select: { valeur: true },
-            },
-          },
-        }),
-        db().individu.findMany({
-          where: { valeurs: { some: { indicateurId: indicateur.id } } },
-          select: {
-            valeurs: {
-              where: { indicateurId: indicateur.id },
-              orderBy: [{ date: 'desc' }, { id: 'desc' }],
-              take: 1,
-              select: { valeur: true },
-            },
-          },
-        }),
+        fetchItemsAvecVariation(indicateur.id, params.individus),
+        fetchValeursRecentesPopulation(indicateur.id),
       ]),
-    ).map(([rows, allRecents]) => {
-      const dernieresValeurs = allRecents
+    ).map(([itemsRows, populationRows]) => {
+      const dernieresValeurs = populationRows
         .map((row) => row.valeurs[0]?.valeur.toNumber())
         .filter((v): v is number => v !== undefined)
       const min = dernieresValeurs.length === 0 ? null : Math.min(...dernieresValeurs)
@@ -61,7 +64,7 @@ export const listValeursRemarquablesForIndicateur = (
       const mediane = computeMediane(dernieresValeurs)
 
       return {
-        items: rows.map((row) => ({
+        items: itemsRows.map((row) => ({
           individu: row.publicId,
           variation: computeVariation(row.valeurs),
         })),

--- a/apps/mb-api/src/valeurAvancement/queries/listValeursRemarquablesForIndicateur.ts
+++ b/apps/mb-api/src/valeurAvancement/queries/listValeursRemarquablesForIndicateur.ts
@@ -6,7 +6,9 @@ import { ResultAsync } from 'neverthrow'
 
 import { db } from '@/framework/persistence/dbStore'
 import { Prisma } from '@/generated/prisma/client'
+import { computeMax } from '@/valeurAvancement/computeMax'
 import { computeMediane } from '@/valeurAvancement/computeMediane'
+import { computeMin } from '@/valeurAvancement/computeMin'
 
 const computeVariation = (valeurs: ReadonlyArray<{ valeur: Prisma.Decimal }>): number | null => {
   if (valeurs.length === 0) return null
@@ -59,18 +61,15 @@ export const listValeursRemarquablesForIndicateur = (
       const dernieresValeurs = populationRows
         .map((row) => row.valeurs[0]?.valeur.toNumber())
         .filter((v): v is number => v !== undefined)
-      const min = dernieresValeurs.length === 0 ? null : Math.min(...dernieresValeurs)
-      const max = dernieresValeurs.length === 0 ? null : Math.max(...dernieresValeurs)
-      const mediane = computeMediane(dernieresValeurs)
 
       return {
         items: itemsRows.map((row) => ({
           individu: row.publicId,
           variation: computeVariation(row.valeurs),
         })),
-        min,
-        max,
-        mediane,
+        min: computeMin(dernieresValeurs),
+        max: computeMax(dernieresValeurs),
+        mediane: computeMediane(dernieresValeurs),
       }
     }),
   )

--- a/apps/mb-api/src/valeurAvancement/queries/listValeursRemarquablesForIndicateur.ts
+++ b/apps/mb-api/src/valeurAvancement/queries/listValeursRemarquablesForIndicateur.ts
@@ -6,6 +6,7 @@ import { ResultAsync } from 'neverthrow'
 
 import { db } from '@/framework/persistence/dbStore'
 import { Prisma } from '@/generated/prisma/client'
+import { computeMediane } from '@/valeurAvancement/computeMediane'
 
 const computeVariation = (valeurs: ReadonlyArray<{ valeur: Prisma.Decimal }>): number | null => {
   if (valeurs.length === 0) return null
@@ -25,23 +26,48 @@ export const listValeursRemarquablesForIndicateur = (
     }),
   ).andThen((indicateur) =>
     ResultAsync.fromSafePromise(
-      db().individu.findMany({
-        where: { publicId: { in: params.individus } },
-        orderBy: { publicId: 'asc' },
-        select: {
-          publicId: true,
-          valeurs: {
-            where: { indicateurId: indicateur.id },
-            orderBy: [{ date: 'desc' }, { id: 'desc' }],
-            take: 2,
-            select: { valeur: true },
+      Promise.all([
+        db().individu.findMany({
+          where: { publicId: { in: params.individus } },
+          orderBy: { publicId: 'asc' },
+          select: {
+            publicId: true,
+            valeurs: {
+              where: { indicateurId: indicateur.id },
+              orderBy: [{ date: 'desc' }, { id: 'desc' }],
+              take: 2,
+              select: { valeur: true },
+            },
           },
-        },
-      }),
-    ).map((rows) => ({
-      items: rows.map((row) => ({
-        individu: row.publicId,
-        variation: computeVariation(row.valeurs),
-      })),
-    })),
+        }),
+        db().individu.findMany({
+          where: { valeurs: { some: { indicateurId: indicateur.id } } },
+          select: {
+            valeurs: {
+              where: { indicateurId: indicateur.id },
+              orderBy: [{ date: 'desc' }, { id: 'desc' }],
+              take: 1,
+              select: { valeur: true },
+            },
+          },
+        }),
+      ]),
+    ).map(([rows, allRecents]) => {
+      const dernieresValeurs = allRecents
+        .map((row) => row.valeurs[0]?.valeur.toNumber())
+        .filter((v): v is number => v !== undefined)
+      const min = dernieresValeurs.length === 0 ? null : Math.min(...dernieresValeurs)
+      const max = dernieresValeurs.length === 0 ? null : Math.max(...dernieresValeurs)
+      const mediane = computeMediane(dernieresValeurs)
+
+      return {
+        items: rows.map((row) => ({
+          individu: row.publicId,
+          variation: computeVariation(row.valeurs),
+        })),
+        min,
+        max,
+        mediane,
+      }
+    }),
   )

--- a/apps/mb-api/src/valeurAvancement/queries/listValeursRemarquablesForIndicateur.ts
+++ b/apps/mb-api/src/valeurAvancement/queries/listValeursRemarquablesForIndicateur.ts
@@ -15,7 +15,7 @@ const computeVariation = (valeurs: ReadonlyArray<{ valeur: Prisma.Decimal }>): n
   return recente!.valeur.minus(precedenteValeur).toNumber()
 }
 
-const fetchItemsAvecVariation = (indicateurId: string, individus: ReadonlyArray<string>) =>
+const fetchItemsPourVariation = (indicateurId: string, individus: ReadonlyArray<string>) =>
   db().individu.findMany({
     where: { publicId: { in: [...individus] } },
     orderBy: { publicId: 'asc' },
@@ -52,7 +52,7 @@ export const listValeursRemarquablesForIndicateur = (
   ).andThen((indicateur) =>
     ResultAsync.fromSafePromise(
       Promise.all([
-        fetchItemsAvecVariation(indicateur.id, params.individus),
+        fetchItemsPourVariation(indicateur.id, params.individus),
         fetchValeursRecentesPopulation(indicateur.id),
       ]),
     ).map(([itemsRows, populationRows]) => {

--- a/apps/mb-api/src/valeurAvancement/routes.ts
+++ b/apps/mb-api/src/valeurAvancement/routes.ts
@@ -97,7 +97,10 @@ const getValeursRemarquablesForIndicateurRoute = createRoute({
     'Le paramètre `individus` est obligatoire (1..N identifiants séparés par une virgule, ex. `DEPT-84,DEPT-13`). ' +
     'Les individus inexistants sont omis de la réponse. ' +
     'La variation est calculée sur la base de la date de la valeur (pas de la date de saisie) : null si aucune valeur, ' +
-    'égale à la valeur la plus récente si une seule (comparée à 0), sinon différence avec la valeur précédente.',
+    'égale à la valeur la plus récente si une seule (comparée à 0), sinon différence avec la valeur précédente. ' +
+    "La réponse inclut également `min`/`max`/`mediane` calculés sur la valeur la plus récente de l'ensemble des " +
+    "individus ayant au moins une valeur pour l'indicateur (indépendamment du paramètre `individus`). " +
+    "Ces trois champs sont à `null` si aucun individu n'a de valeur pour l'indicateur.",
   middleware: [requireAuthentication],
   request: {
     params: indicateurParamsSchema,

--- a/apps/mb-webapp/src/routes/_authenticated/indicateurs/$id.tsx
+++ b/apps/mb-webapp/src/routes/_authenticated/indicateurs/$id.tsx
@@ -106,6 +106,11 @@ function IndicateurDetailComponent() {
         </p>
       ) : (
         <>
+          <StatistiquesPopulationSection
+            indicateurId={id}
+            individuId={selectedIndividu.individu.id}
+          />
+
           <div className="flex items-center gap-3">
             <label className="text-sm text-text-muted" htmlFor="individu-select">
               Individu
@@ -156,6 +161,36 @@ function IndicateurDetailComponent() {
         </>
       )}
     </div>
+  )
+}
+
+function StatistiquesPopulationSection({
+  indicateurId,
+  individuId,
+}: {
+  indicateurId: string
+  individuId: string
+}) {
+  const { data } = useSuspenseQuery(
+    indicateurValeursRemarquablesQueryOptions(indicateurId, individuId),
+  )
+
+  const numberFormatter = new Intl.NumberFormat('fr-FR')
+  const formatStat = (value: number | null): string =>
+    value === null ? '—' : numberFormatter.format(value)
+
+  return (
+    <section className="grid gap-4 sm:grid-cols-3">
+      <StatCard label="Minimum">
+        <p className="text-3xl font-semibold text-text">{formatStat(data.min)}</p>
+      </StatCard>
+      <StatCard label="Maximum">
+        <p className="text-3xl font-semibold text-text">{formatStat(data.max)}</p>
+      </StatCard>
+      <StatCard label="Médiane">
+        <p className="text-3xl font-semibold text-text">{formatStat(data.mediane)}</p>
+      </StatCard>
+    </section>
   )
 }
 

--- a/packages/mb-shared/src/valeurAvancement.ts
+++ b/packages/mb-shared/src/valeurAvancement.ts
@@ -106,6 +106,28 @@ export const valeursRemarquablesListApiModelSchema = z.object({
   items: z
     .array(valeurRemarquableApiModelSchema)
     .describe('Valeurs remarquables pour chaque individu demandé ayant été trouvé.'),
+  min: z
+    .number()
+    .nullable()
+    .describe(
+      "Plus petite valeur la plus récente parmi l'ensemble des individus ayant au moins une valeur " +
+        "pour l'indicateur. null si aucun individu n'a de valeur.",
+    ),
+  max: z
+    .number()
+    .nullable()
+    .describe(
+      "Plus grande valeur la plus récente parmi l'ensemble des individus ayant au moins une valeur " +
+        "pour l'indicateur. null si aucun individu n'a de valeur.",
+    ),
+  mediane: z
+    .number()
+    .nullable()
+    .describe(
+      "Médiane des valeurs les plus récentes parmi l'ensemble des individus ayant au moins une valeur " +
+        "pour l'indicateur. Moyenne des deux valeurs centrales si le nombre d'individus est pair. " +
+        "null si aucun individu n'a de valeur.",
+    ),
 })
 export type ValeursRemarquablesListApiModel = z.infer<
   typeof valeursRemarquablesListApiModelSchema


### PR DESCRIPTION
## Summary
- Ajoute 3 statistiques de population (min, max, médiane) sur la page indicateur, calculées sur la valeur la plus récente de chaque individu ayant une valeur pour l'indicateur (indépendant de l'individu sélectionné).
- Util générique `computeMediane` (cas pair = moyenne des deux centrales / impair = valeur centrale) avec ses propres tests.
- Affichage côté frontend placé entre le titre de l'indicateur et le sélecteur d'individu (puisque ces stats ne dépendent pas de l'individu).

## Détails techniques
- `valeursRemarquablesListApiModelSchema` étendu avec `min`/`max`/`mediane` (nullables) au niveau racine.
- `listValeursRemarquablesForIndicateur` récupère en parallèle (1) les items filtrés par `params.individus` (pour `variation`) et (2) la valeur la plus récente de chaque individu de l'indicateur (pour les stats globales).
- Les composants `StatistiquesPopulationSection` et `ValeursRemarquablesSection` partagent la même clé react-query → une seule requête réseau.
- Doc OpenAPI mise à jour pour expliquer la sémantique globale de min/max/médiane.

## Test plan
- [x] Tests unitaires `computeMediane` (vide, taille 1, impair, pair, tri, négatifs, décimaux, doublons, tri numérique)
- [x] Tests d'intégration `listValeursRemarquablesForIndicateur` mis à jour + nouveaux cas pair/impair, scope global, isolation par indicateur
- [x] Lint + typecheck mb-api / mb-shared / mb-webapp
- [ ] QA visuelle sur la page `/indicateurs/$id` : Min/Max/Médiane sous le titre, valeur récente + variation sous le select

🤖 Generated with [Claude Code](https://claude.com/claude-code)