### PR TITLE
feat(mb-api): seed des permissions ditp admin sur 5 premiers indicateurs

### DIFF
--- a/apps/mb-api/prisma/seed.ts
+++ b/apps/mb-api/prisma/seed.ts
@@ -120,6 +120,34 @@ const main = async () => {
     ])
   }
 
+  const ditpAdmin = await prisma.utilisateur.findUniqueOrThrow({
+    where: { email: 'ditp.admin@example.com' },
+    select: { id: true },
+  })
+  for (const item of indicateursSeed.slice(0, 5)) {
+    const indicateur = await prisma.indicateur.findUniqueOrThrow({
+      where: { publicId: item.publicId },
+      select: { id: true },
+    })
+    for (const action of ['READ', 'WRITE'] as const) {
+      await prisma.indicateurPermission.upsert({
+        where: {
+          principalId_indicateurId_action: {
+            principalId: ditpAdmin.id,
+            indicateurId: indicateur.id,
+            action,
+          },
+        },
+        update: {},
+        create: {
+          principalId: ditpAdmin.id,
+          indicateurId: indicateur.id,
+          action,
+        },
+      })
+    }
+  }
+
   for (const item of referentielsSeed) {
     await prisma.referentiel.upsert({
       where: { publicId: item.publicId },
@@ -222,8 +250,9 @@ const main = async () => {
     })
   }
 
+  const permissionsCount = 5 * 2
   console.log(
-    `Seed terminé : ${indicateursSeed.length} indicateurs, ${utilisateursSeed.length} utilisateurs, ${referentielsSeed.length} référentiels, ${individusSeed.length} individus, ${relationsSeed.length} relations, ${valeursAvancementSeed.length} valeurs.`,
+    `Seed terminé : ${indicateursSeed.length} indicateurs, ${utilisateursSeed.length} utilisateurs, ${permissionsCount} permissions, ${referentielsSeed.length} référentiels, ${individusSeed.length} individus, ${relationsSeed.length} relations, ${valeursAvancementSeed.length} valeurs.`,
   )
 }
 


### PR DESCRIPTION
## Summary
- Ajoute des permissions `READ` + `WRITE` pour l'utilisateur `ditp.admin@example.com` sur les 5 premiers indicateurs du seed (IND-001 à IND-005).
- Upsert idempotent (peut être ré-exécuté sans erreur).
- Met à jour le log final du seed pour inclure le nombre de permissions créées.

## Test plan
- [ ] Lancer `pnpm --filter @pilote/mb-api prisma db seed` sur une base vide → vérifier la ligne `Seed terminé` qui mentionne `10 permissions`.
- [ ] Relancer le seed → aucune erreur (upsert idempotent).
- [ ] Vérifier en base : `select * from indicateur_permission` retourne 10 lignes pour le principal de `ditp.admin@example.com`.