### PR TITLE
feat(mb-api): valeurs remarquables par référentiel + synthèse par individu (PIL-1456)

### DIFF
--- a/apps/mb-api/src/framework/array.test.ts
+++ b/apps/mb-api/src/framework/array.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+
+import { groupBy, unique } from '@/framework/array'
+
+describe('unique', () => {
+  it('retourne un tableau vide pour une entrée vide', () => {
+    expect(unique([])).toEqual([])
+  })
+
+  it("préserve l'ordre de première occurrence", () => {
+    expect(unique([3, 1, 2, 1, 3, 4])).toEqual([3, 1, 2, 4])
+  })
+
+  it('dédoublonne les chaînes', () => {
+    expect(unique(['a', 'b', 'a', 'c', 'b'])).toEqual(['a', 'b', 'c'])
+  })
+
+  it('utilise une égalité de référence pour les objets', () => {
+    const a = { x: 1 }
+    const b = { x: 1 }
+    expect(unique([a, b, a])).toEqual([a, b])
+  })
+})
+
+describe('groupBy', () => {
+  it('retourne une map vide pour une entrée vide', () => {
+    expect(groupBy<number, string>([], () => 'k')).toEqual(new Map())
+  })
+
+  it('groupe les éléments selon la clé', () => {
+    const result = groupBy([1, 2, 3, 4], (n) => (n % 2 === 0 ? 'pair' : 'impair'))
+    expect(result.get('pair')).toEqual([2, 4])
+    expect(result.get('impair')).toEqual([1, 3])
+  })
+
+  it("préserve l'ordre d'apparition au sein de chaque groupe", () => {
+    const result = groupBy([3, 1, 2], (n) => (n > 1 ? 'gt1' : 'le1'))
+    expect(result.get('gt1')).toEqual([3, 2])
+    expect(result.get('le1')).toEqual([1])
+  })
+
+  it('utilise des clés non-primitives via Map (référence)', () => {
+    const k1 = { id: 1 }
+    const k2 = { id: 2 }
+    const result = groupBy(
+      [
+        { tag: k1, v: 'a' },
+        { tag: k2, v: 'b' },
+        { tag: k1, v: 'c' },
+      ],
+      (item) => item.tag,
+    )
+    expect(result.get(k1)?.map((i) => i.v)).toEqual(['a', 'c'])
+    expect(result.get(k2)?.map((i) => i.v)).toEqual(['b'])
+  })
+})

--- a/apps/mb-api/src/framework/array.ts
+++ b/apps/mb-api/src/framework/array.ts
@@ -1,0 +1,12 @@
+export const unique = <T>(items: ReadonlyArray<T>): T[] => [...new Set(items)]
+
+export const groupBy = <T, K>(items: ReadonlyArray<T>, getKey: (item: T) => K): Map<K, T[]> => {
+  const result = new Map<K, T[]>()
+  for (const item of items) {
+    const key = getKey(item)
+    const arr = result.get(key) ?? []
+    arr.push(item)
+    result.set(key, arr)
+  }
+  return result
+}

--- a/apps/mb-api/src/framework/decimal.ts
+++ b/apps/mb-api/src/framework/decimal.ts
@@ -1,0 +1,4 @@
+import { Prisma } from '@/generated/prisma/client'
+
+export const Decimal = Prisma.Decimal
+export type Decimal = Prisma.Decimal

--- a/apps/mb-api/src/valeurAvancement/computeEcartMediane.test.ts
+++ b/apps/mb-api/src/valeurAvancement/computeEcartMediane.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+
+import { Decimal } from '@/framework/decimal'
+import { computeEcartMediane } from '@/valeurAvancement/computeEcartMediane'
+
+const d = (n: number): Decimal => new Decimal(n)
+
+describe('computeEcartMediane', () => {
+  it('retourne null si la dernière valeur est undefined', () => {
+    expect(computeEcartMediane(undefined, 10)).toBeNull()
+  })
+
+  it('retourne null si la médiane est null', () => {
+    expect(computeEcartMediane(d(10), null)).toBeNull()
+  })
+
+  it('retourne null si les deux sont absents', () => {
+    expect(computeEcartMediane(undefined, null)).toBeNull()
+  })
+
+  it("retourne l'écart positif quand la valeur est au-dessus de la médiane", () => {
+    expect(computeEcartMediane(d(50), 30)).toBe(20)
+  })
+
+  it("retourne l'écart négatif quand la valeur est en-dessous de la médiane", () => {
+    expect(computeEcartMediane(d(10), 30)).toBe(-20)
+  })
+
+  it('retourne 0 quand la valeur est égale à la médiane', () => {
+    expect(computeEcartMediane(d(42), 42)).toBe(0)
+  })
+
+  it('évite les erreurs de précision IEEE 754', () => {
+    expect(computeEcartMediane(d(0.3), 0.15)).toBeCloseTo(0.15)
+  })
+})

--- a/apps/mb-api/src/valeurAvancement/computeEcartMediane.ts
+++ b/apps/mb-api/src/valeurAvancement/computeEcartMediane.ts
@@ -1,0 +1,9 @@
+import { type Decimal } from '@/framework/decimal'
+
+export const computeEcartMediane = (
+  derniereValeur: Decimal | undefined,
+  mediane: number | null,
+): number | null => {
+  if (derniereValeur === undefined || mediane === null) return null
+  return derniereValeur.minus(mediane).toNumber()
+}

--- a/apps/mb-api/src/valeurAvancement/computeMax.test.ts
+++ b/apps/mb-api/src/valeurAvancement/computeMax.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest'
 
+import { Decimal } from '@/framework/decimal'
 import { computeMax } from '@/valeurAvancement/computeMax'
+
+const d = (n: number): Decimal => new Decimal(n)
 
 describe('computeMax', () => {
   it('retourne null pour un tableau vide', () => {
@@ -8,25 +11,25 @@ describe('computeMax', () => {
   })
 
   it('retourne la valeur unique pour un tableau de taille 1', () => {
-    expect(computeMax([42])).toBe(42)
+    expect(computeMax([d(42)])).toBe(42)
   })
 
   it('retourne la plus grande valeur', () => {
-    expect(computeMax([3, 1, 2])).toBe(3)
-    expect(computeMax([10, 20, 30, 40, 50])).toBe(50)
+    expect(computeMax([d(3), d(1), d(2)])).toBe(3)
+    expect(computeMax([d(10), d(20), d(30), d(40), d(50)])).toBe(50)
   })
 
   it('gère les nombres négatifs', () => {
-    expect(computeMax([-5, -1, -3])).toBe(-1)
-    expect(computeMax([-10, -5, -50])).toBe(-5)
+    expect(computeMax([d(-5), d(-1), d(-3)])).toBe(-1)
+    expect(computeMax([d(-10), d(-5), d(-50)])).toBe(-5)
   })
 
   it('gère les valeurs décimales', () => {
-    expect(computeMax([1.5, 0.5, 2.5])).toBe(2.5)
+    expect(computeMax([d(1.5), d(0.5), d(2.5)])).toBe(2.5)
   })
 
   it('gère les doublons', () => {
-    expect(computeMax([5, 5, 5])).toBe(5)
-    expect(computeMax([1, 2, 2])).toBe(2)
+    expect(computeMax([d(5), d(5), d(5)])).toBe(5)
+    expect(computeMax([d(1), d(2), d(2)])).toBe(2)
   })
 })

--- a/apps/mb-api/src/valeurAvancement/computeMax.ts
+++ b/apps/mb-api/src/valeurAvancement/computeMax.ts
@@ -1,4 +1,6 @@
-export const computeMax = (values: ReadonlyArray<number>): number | null => {
+import { type Decimal } from '@/framework/decimal'
+
+export const computeMax = (values: ReadonlyArray<Decimal>): number | null => {
   if (values.length === 0) return null
-  return Math.max(...values)
+  return Math.max(...values.map((v) => v.toNumber()))
 }

--- a/apps/mb-api/src/valeurAvancement/computeMediane.test.ts
+++ b/apps/mb-api/src/valeurAvancement/computeMediane.test.ts
@@ -1,13 +1,9 @@
 import { describe, expect, it } from 'vitest'
 
-import { Prisma } from '@/generated/prisma/client'
-import {
-  computeMediane,
-  computeMedianeFromDecimals,
-  groupMedianesByKey,
-} from '@/valeurAvancement/computeMediane'
+import { Decimal } from '@/framework/decimal'
+import { computeMediane, groupMedianesByKey } from '@/valeurAvancement/computeMediane'
 
-const d = (n: number): Prisma.Decimal => new Prisma.Decimal(n)
+const d = (n: number): Decimal => new Decimal(n)
 
 describe('computeMediane', () => {
   it('retourne null pour un tableau vide', () => {
@@ -15,65 +11,48 @@ describe('computeMediane', () => {
   })
 
   it('retourne la valeur unique pour un tableau de taille 1', () => {
-    expect(computeMediane([42])).toBe(42)
+    expect(computeMediane([d(42)])).toBe(42)
   })
 
   it('retourne la valeur centrale pour un nombre impair de valeurs', () => {
-    expect(computeMediane([1, 2, 3])).toBe(2)
-    expect(computeMediane([10, 20, 30, 40, 50])).toBe(30)
+    expect(computeMediane([d(1), d(2), d(3)])).toBe(2)
+    expect(computeMediane([d(10), d(20), d(30), d(40), d(50)])).toBe(30)
   })
 
   it('retourne la moyenne des deux valeurs centrales pour un nombre pair', () => {
-    expect(computeMediane([1, 2, 3, 4])).toBe(2.5)
-    expect(computeMediane([10, 20, 30, 40])).toBe(25)
+    expect(computeMediane([d(1), d(2), d(3), d(4)])).toBe(2.5)
+    expect(computeMediane([d(10), d(20), d(30), d(40)])).toBe(25)
   })
 
   it("trie les valeurs avant de calculer (l'ordre d'entrée n'importe pas)", () => {
-    expect(computeMediane([3, 1, 2])).toBe(2)
-    expect(computeMediane([40, 10, 30, 20])).toBe(25)
+    expect(computeMediane([d(3), d(1), d(2)])).toBe(2)
+    expect(computeMediane([d(40), d(10), d(30), d(20)])).toBe(25)
   })
 
   it('gère les nombres négatifs', () => {
-    expect(computeMediane([-5, -1, -3])).toBe(-3)
-    expect(computeMediane([-10, -5, 5, 10])).toBe(0)
+    expect(computeMediane([d(-5), d(-1), d(-3)])).toBe(-3)
+    expect(computeMediane([d(-10), d(-5), d(5), d(10)])).toBe(0)
   })
 
   it('gère les valeurs décimales', () => {
-    expect(computeMediane([1.5, 2.5, 3.5])).toBe(2.5)
-    expect(computeMediane([1.1, 2.2])).toBeCloseTo(1.65)
+    expect(computeMediane([d(1.5), d(2.5), d(3.5)])).toBe(2.5)
+    expect(computeMediane([d(1.1), d(2.2)])).toBeCloseTo(1.65)
   })
 
   it('gère les doublons', () => {
-    expect(computeMediane([5, 5, 5])).toBe(5)
-    expect(computeMediane([1, 2, 2, 3])).toBe(2)
+    expect(computeMediane([d(5), d(5), d(5)])).toBe(5)
+    expect(computeMediane([d(1), d(2), d(2), d(3)])).toBe(2)
   })
 
   it('trie numériquement (pas lexicographiquement) pour distinguer 2 et 10', () => {
-    expect(computeMediane([10, 2, 1])).toBe(2)
-  })
-})
-
-describe('computeMedianeFromDecimals', () => {
-  it('retourne null pour un tableau vide', () => {
-    expect(computeMedianeFromDecimals([])).toBeNull()
-  })
-
-  it('calcule la médiane sur les Decimal mappés en number', () => {
-    expect(computeMedianeFromDecimals([{ valeur: d(10) }, { valeur: d(30) }])).toBe(20)
-    expect(computeMedianeFromDecimals([{ valeur: d(1) }, { valeur: d(2) }, { valeur: d(3) }])).toBe(
-      2,
-    )
-  })
-
-  it('gère les décimaux Decimal sans perte de précision', () => {
-    expect(computeMedianeFromDecimals([{ valeur: d(0.1) }, { valeur: d(0.2) }])).toBeCloseTo(0.15)
+    expect(computeMediane([d(10), d(2), d(1)])).toBe(2)
   })
 })
 
 describe('groupMedianesByKey', () => {
   it('retourne une map vide pour une entrée vide', () => {
     expect(
-      groupMedianesByKey<{ key: string; valeur: Prisma.Decimal }, string>(
+      groupMedianesByKey<{ key: string; valeur: Decimal }, string>(
         [],
         (r) => r.key,
         (r) => r.valeur,

--- a/apps/mb-api/src/valeurAvancement/computeMediane.test.ts
+++ b/apps/mb-api/src/valeurAvancement/computeMediane.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from 'vitest'
 
-import { computeMediane } from '@/valeurAvancement/computeMediane'
+import { Prisma } from '@/generated/prisma/client'
+import {
+  computeMediane,
+  computeMedianeFromDecimals,
+  groupMedianesByKey,
+} from '@/valeurAvancement/computeMediane'
+
+const d = (n: number): Prisma.Decimal => new Prisma.Decimal(n)
 
 describe('computeMediane', () => {
   it('retourne null pour un tableau vide', () => {
@@ -43,5 +50,59 @@ describe('computeMediane', () => {
 
   it('trie numériquement (pas lexicographiquement) pour distinguer 2 et 10', () => {
     expect(computeMediane([10, 2, 1])).toBe(2)
+  })
+})
+
+describe('computeMedianeFromDecimals', () => {
+  it('retourne null pour un tableau vide', () => {
+    expect(computeMedianeFromDecimals([])).toBeNull()
+  })
+
+  it('calcule la médiane sur les Decimal mappés en number', () => {
+    expect(computeMedianeFromDecimals([{ valeur: d(10) }, { valeur: d(30) }])).toBe(20)
+    expect(computeMedianeFromDecimals([{ valeur: d(1) }, { valeur: d(2) }, { valeur: d(3) }])).toBe(
+      2,
+    )
+  })
+
+  it('gère les décimaux Decimal sans perte de précision', () => {
+    expect(computeMedianeFromDecimals([{ valeur: d(0.1) }, { valeur: d(0.2) }])).toBeCloseTo(0.15)
+  })
+})
+
+describe('groupMedianesByKey', () => {
+  it('retourne une map vide pour une entrée vide', () => {
+    expect(
+      groupMedianesByKey<{ key: string; valeur: Prisma.Decimal }, string>(
+        [],
+        (r) => r.key,
+        (r) => r.valeur,
+      ),
+    ).toEqual(new Map())
+  })
+
+  it('calcule la médiane indépendamment par groupe', () => {
+    const rows = [
+      { ref: 'A', valeur: d(10) },
+      { ref: 'A', valeur: d(30) },
+      { ref: 'B', valeur: d(100) },
+      { ref: 'B', valeur: d(200) },
+    ]
+    const result = groupMedianesByKey(
+      rows,
+      (r) => r.ref,
+      (r) => r.valeur,
+    )
+    expect(result.get('A')).toBe(20)
+    expect(result.get('B')).toBe(150)
+  })
+
+  it('retourne la valeur unique quand un groupe a un seul élément', () => {
+    const result = groupMedianesByKey(
+      [{ ref: 'A', valeur: d(42) }],
+      (r) => r.ref,
+      (r) => r.valeur,
+    )
+    expect(result.get('A')).toBe(42)
   })
 })

--- a/apps/mb-api/src/valeurAvancement/computeMediane.ts
+++ b/apps/mb-api/src/valeurAvancement/computeMediane.ts
@@ -1,3 +1,6 @@
+import { groupBy } from '@/framework/array'
+import { Prisma } from '@/generated/prisma/client'
+
 export const computeMediane = (values: ReadonlyArray<number>): number | null => {
   if (values.length === 0) return null
 
@@ -8,4 +11,21 @@ export const computeMediane = (values: ReadonlyArray<number>): number | null => 
     return sorted[Math.floor(middle)]!
   }
   return (sorted[middle - 1]! + sorted[middle]!) / 2
+}
+
+export const computeMedianeFromDecimals = (
+  rows: ReadonlyArray<{ valeur: Prisma.Decimal }>,
+): number | null => computeMediane(rows.map((row) => row.valeur.toNumber()))
+
+export const groupMedianesByKey = <T, K>(
+  rows: ReadonlyArray<T>,
+  getKey: (row: T) => K,
+  getValeur: (row: T) => Prisma.Decimal,
+): Map<K, number | null> => {
+  const grouped = groupBy(rows, getKey)
+  const result = new Map<K, number | null>()
+  for (const [key, group] of grouped) {
+    result.set(key, computeMedianeFromDecimals(group.map((row) => ({ valeur: getValeur(row) }))))
+  }
+  return result
 }

--- a/apps/mb-api/src/valeurAvancement/computeMediane.ts
+++ b/apps/mb-api/src/valeurAvancement/computeMediane.ts
@@ -1,10 +1,10 @@
 import { groupBy } from '@/framework/array'
-import { Prisma } from '@/generated/prisma/client'
+import { type Decimal } from '@/framework/decimal'
 
-export const computeMediane = (values: ReadonlyArray<number>): number | null => {
+export const computeMediane = (values: ReadonlyArray<Decimal>): number | null => {
   if (values.length === 0) return null
 
-  const sorted = [...values].sort((a, b) => a - b)
+  const sorted = values.map((v) => v.toNumber()).sort((a, b) => a - b)
   const middle = sorted.length / 2
 
   if (sorted.length % 2 === 1) {
@@ -13,19 +13,15 @@ export const computeMediane = (values: ReadonlyArray<number>): number | null => 
   return (sorted[middle - 1]! + sorted[middle]!) / 2
 }
 
-export const computeMedianeFromDecimals = (
-  rows: ReadonlyArray<{ valeur: Prisma.Decimal }>,
-): number | null => computeMediane(rows.map((row) => row.valeur.toNumber()))
-
 export const groupMedianesByKey = <T, K>(
   rows: ReadonlyArray<T>,
   getKey: (row: T) => K,
-  getValeur: (row: T) => Prisma.Decimal,
+  getValeur: (row: T) => Decimal,
 ): Map<K, number | null> => {
   const grouped = groupBy(rows, getKey)
   const result = new Map<K, number | null>()
   for (const [key, group] of grouped) {
-    result.set(key, computeMedianeFromDecimals(group.map((row) => ({ valeur: getValeur(row) }))))
+    result.set(key, computeMediane(group.map(getValeur)))
   }
   return result
 }

--- a/apps/mb-api/src/valeurAvancement/computeMin.test.ts
+++ b/apps/mb-api/src/valeurAvancement/computeMin.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest'
 
+import { Decimal } from '@/framework/decimal'
 import { computeMin } from '@/valeurAvancement/computeMin'
+
+const d = (n: number): Decimal => new Decimal(n)
 
 describe('computeMin', () => {
   it('retourne null pour un tableau vide', () => {
@@ -8,25 +11,25 @@ describe('computeMin', () => {
   })
 
   it('retourne la valeur unique pour un tableau de taille 1', () => {
-    expect(computeMin([42])).toBe(42)
+    expect(computeMin([d(42)])).toBe(42)
   })
 
   it('retourne la plus petite valeur', () => {
-    expect(computeMin([3, 1, 2])).toBe(1)
-    expect(computeMin([10, 20, 30, 40, 50])).toBe(10)
+    expect(computeMin([d(3), d(1), d(2)])).toBe(1)
+    expect(computeMin([d(10), d(20), d(30), d(40), d(50)])).toBe(10)
   })
 
   it('gère les nombres négatifs', () => {
-    expect(computeMin([-5, -1, -3])).toBe(-5)
-    expect(computeMin([-10, 5, 10])).toBe(-10)
+    expect(computeMin([d(-5), d(-1), d(-3)])).toBe(-5)
+    expect(computeMin([d(-10), d(5), d(10)])).toBe(-10)
   })
 
   it('gère les valeurs décimales', () => {
-    expect(computeMin([1.5, 0.5, 2.5])).toBe(0.5)
+    expect(computeMin([d(1.5), d(0.5), d(2.5)])).toBe(0.5)
   })
 
   it('gère les doublons', () => {
-    expect(computeMin([5, 5, 5])).toBe(5)
-    expect(computeMin([1, 1, 2])).toBe(1)
+    expect(computeMin([d(5), d(5), d(5)])).toBe(5)
+    expect(computeMin([d(1), d(1), d(2)])).toBe(1)
   })
 })

--- a/apps/mb-api/src/valeurAvancement/computeMin.ts
+++ b/apps/mb-api/src/valeurAvancement/computeMin.ts
@@ -1,4 +1,6 @@
-export const computeMin = (values: ReadonlyArray<number>): number | null => {
+import { type Decimal } from '@/framework/decimal'
+
+export const computeMin = (values: ReadonlyArray<Decimal>): number | null => {
   if (values.length === 0) return null
-  return Math.min(...values)
+  return Math.min(...values.map((v) => v.toNumber()))
 }

--- a/apps/mb-api/src/valeurAvancement/computeVariation.test.ts
+++ b/apps/mb-api/src/valeurAvancement/computeVariation.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+
+import { Decimal } from '@/framework/decimal'
+import { computeVariation } from '@/valeurAvancement/computeVariation'
+
+const d = (n: number): Decimal => new Decimal(n)
+
+describe('computeVariation', () => {
+  it('retourne null pour un tableau vide', () => {
+    expect(computeVariation([])).toBeNull()
+  })
+
+  it('retourne la valeur seule (comparée à 0) si une seule entrée', () => {
+    expect(computeVariation([{ valeur: d(50) }])).toBe(50)
+  })
+
+  it('retourne la différence entre la valeur la plus récente et la précédente', () => {
+    expect(computeVariation([{ valeur: d(75) }, { valeur: d(25) }])).toBe(50)
+    expect(computeVariation([{ valeur: d(25) }, { valeur: d(50) }])).toBe(-25)
+  })
+
+  it("n'utilise que les 2 premières entrées (les plus récentes)", () => {
+    expect(computeVariation([{ valeur: d(10) }, { valeur: d(5) }, { valeur: d(999) }])).toBe(5)
+  })
+
+  it('évite les erreurs de précision IEEE 754', () => {
+    expect(computeVariation([{ valeur: d(0.3) }, { valeur: d(0.15) }])).toBe(0.15)
+  })
+})

--- a/apps/mb-api/src/valeurAvancement/computeVariation.ts
+++ b/apps/mb-api/src/valeurAvancement/computeVariation.ts
@@ -1,0 +1,8 @@
+import { Decimal } from '@/framework/decimal'
+
+export const computeVariation = (valeurs: ReadonlyArray<{ valeur: Decimal }>): number | null => {
+  if (valeurs.length === 0) return null
+  const [recente, precedente] = valeurs
+  const precedenteValeur = precedente?.valeur ?? new Decimal(0)
+  return recente!.valeur.minus(precedenteValeur).toNumber()
+}

--- a/apps/mb-api/src/valeurAvancement/queries/listSyntheseIndividus.test.ts
+++ b/apps/mb-api/src/valeurAvancement/queries/listSyntheseIndividus.test.ts
@@ -1,0 +1,438 @@
+import { describe, expect, it } from 'vitest'
+
+import { fixtures } from '@/test/fixtures'
+import { integrationTest } from '@/test/integrationTest'
+import { testDeptId, testDeptIds, testIndicateurId } from '@/test/randomIds'
+import { listSyntheseIndividus } from '@/valeurAvancement/queries/listSyntheseIndividus'
+
+describe.concurrent('listSyntheseIndividus', () => {
+  it(
+    "retourne variation et ecartMediane à null quand l'individu n'a aucune valeur (seul dans son référentiel)",
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const deptId = testDeptId()
+      await fixtures.indicateur({ publicId: indId, nom: 'T' })
+      await fixtures.individu({ publicId: deptId, referentiel: { publicId: 'REF-A', nom: 'A' } })
+
+      const result = await listSyntheseIndividus(indId, { individus: [deptId] })
+
+      expect(result._unsafeUnwrap()).toEqual({
+        items: [{ individu: deptId, variation: null, ecartMediane: null }],
+      })
+    }),
+  )
+
+  it(
+    "retourne variation null et ecartMediane null pour un individu sans valeur, même si d'autres ont des valeurs dans son référentiel",
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const [dept1, dept2] = testDeptIds(2)
+      await fixtures.indicateur({ publicId: indId, nom: 'T' })
+      await fixtures.individu({ publicId: dept1, referentiel: { publicId: 'REF-A', nom: 'A' } })
+      await fixtures.valeurAvancement({
+        indicateur: { publicId: indId },
+        individu: { publicId: dept2, referentiel: { publicId: 'REF-A' } },
+        date: '2026-01-01',
+        valeur: 42,
+      })
+
+      const result = await listSyntheseIndividus(indId, { individus: [dept1] })
+
+      expect(result._unsafeUnwrap()).toEqual({
+        items: [{ individu: dept1, variation: null, ecartMediane: null }],
+      })
+    }),
+  )
+
+  it(
+    "retourne variation = valeur lorsqu'il n'y a qu'une seule valeur (seul dans son référentiel)",
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const deptId = testDeptId()
+      await fixtures.valeurAvancement({
+        indicateur: { publicId: indId, nom: 'T' },
+        individu: { publicId: deptId, referentiel: { publicId: 'REF-A', nom: 'A' } },
+        date: '2026-01-01',
+        valeur: 50,
+      })
+
+      const result = await listSyntheseIndividus(indId, { individus: [deptId] })
+
+      expect(result._unsafeUnwrap()).toEqual({
+        items: [{ individu: deptId, variation: 50, ecartMediane: 0 }],
+      })
+    }),
+  )
+
+  it(
+    'retourne la variation entre les deux valeurs les plus récentes',
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const deptId = testDeptId()
+      await fixtures.valeurAvancement(
+        {
+          indicateur: { publicId: indId, nom: 'T' },
+          individu: { publicId: deptId, referentiel: { publicId: 'REF-A', nom: 'A' } },
+          date: '2026-01-01',
+          valeur: 50,
+        },
+        {
+          indicateur: { publicId: indId },
+          individu: { publicId: deptId },
+          date: '2026-02-01',
+          valeur: 25,
+        },
+        {
+          indicateur: { publicId: indId },
+          individu: { publicId: deptId },
+          date: '2026-03-01',
+          valeur: 75,
+        },
+      )
+
+      const result = await listSyntheseIndividus(indId, { individus: [deptId] })
+
+      expect(result._unsafeUnwrap()).toEqual({
+        items: [{ individu: deptId, variation: 50, ecartMediane: 0 }],
+      })
+    }),
+  )
+
+  it(
+    'se base sur la date de la valeur, pas la date de saisie',
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const deptId = testDeptId()
+      await fixtures.valeurAvancement(
+        {
+          indicateur: { publicId: indId, nom: 'T' },
+          individu: { publicId: deptId, referentiel: { publicId: 'REF-A', nom: 'A' } },
+          date: '2026-02-01',
+          valeur: 10,
+        },
+        {
+          indicateur: { publicId: indId },
+          individu: { publicId: deptId },
+          date: '2026-03-01',
+          valeur: 75,
+        },
+        {
+          indicateur: { publicId: indId },
+          individu: { publicId: deptId },
+          date: '2026-01-01',
+          valeur: 50,
+        },
+      )
+
+      const result = await listSyntheseIndividus(indId, { individus: [deptId] })
+
+      expect(result._unsafeUnwrap()).toEqual({
+        items: [{ individu: deptId, variation: 65, ecartMediane: 0 }],
+      })
+    }),
+  )
+
+  it(
+    'retourne un item par individu existant, triés par publicId',
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const [dept1, dept2, dept3] = testDeptIds(3)
+      await fixtures.valeurAvancement(
+        {
+          indicateur: { publicId: indId, nom: 'T' },
+          individu: {
+            publicId: dept1,
+            nom: 'A',
+            referentiel: { publicId: 'REF-A', nom: 'A' },
+          },
+          date: '2026-01-01',
+          valeur: 10,
+        },
+        {
+          indicateur: { publicId: indId },
+          individu: { publicId: dept1 },
+          date: '2026-02-01',
+          valeur: 30,
+        },
+        {
+          indicateur: { publicId: indId },
+          individu: { publicId: dept2, nom: 'B', referentiel: { publicId: 'REF-A' } },
+          date: '2026-01-01',
+          valeur: 5,
+        },
+      )
+      // dept3 sans valeur mais existe
+      await fixtures.individu({
+        publicId: dept3,
+        nom: 'C',
+        referentiel: { publicId: 'REF-A' },
+      })
+
+      const result = await listSyntheseIndividus(indId, {
+        individus: [dept3, dept1, dept2],
+      })
+
+      // mediane des valeurs récentes de REF-A: dept1=30, dept2=5 → mediane=17.5
+      expect(result._unsafeUnwrap()).toEqual({
+        items: [
+          { individu: dept1, variation: 20, ecartMediane: 12.5 },
+          { individu: dept2, variation: 5, ecartMediane: -12.5 },
+          { individu: dept3, variation: null, ecartMediane: null },
+        ],
+      })
+    }),
+  )
+
+  it(
+    "ignore les valeurs d'autres indicateurs",
+    integrationTest(async () => {
+      const [indId, autreIndId] = [testIndicateurId(), testIndicateurId()]
+      const deptId = testDeptId()
+      await fixtures.valeurAvancement(
+        {
+          indicateur: { publicId: indId, nom: 'T' },
+          individu: { publicId: deptId, referentiel: { publicId: 'REF-A', nom: 'A' } },
+          date: '2026-01-01',
+          valeur: 100,
+        },
+        {
+          indicateur: { publicId: autreIndId, nom: 'Autre' },
+          individu: { publicId: deptId },
+          date: '2026-02-01',
+          valeur: 9999,
+        },
+      )
+
+      const result = await listSyntheseIndividus(indId, { individus: [deptId] })
+
+      expect(result._unsafeUnwrap()).toEqual({
+        items: [{ individu: deptId, variation: 100, ecartMediane: 0 }],
+      })
+    }),
+  )
+
+  it(
+    'omet les individus inexistants',
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const deptId = testDeptId()
+      const inconnu = testDeptId()
+      await fixtures.valeurAvancement({
+        indicateur: { publicId: indId, nom: 'T' },
+        individu: { publicId: deptId, referentiel: { publicId: 'REF-A', nom: 'A' } },
+        date: '2026-01-01',
+        valeur: 42,
+      })
+
+      const result = await listSyntheseIndividus(indId, {
+        individus: [deptId, inconnu],
+      })
+
+      expect(result._unsafeUnwrap()).toEqual({
+        items: [{ individu: deptId, variation: 42, ecartMediane: 0 }],
+      })
+    }),
+  )
+
+  it(
+    'évite les erreurs de précision IEEE 754 sur la variation',
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const deptId = testDeptId()
+      await fixtures.valeurAvancement(
+        {
+          indicateur: { publicId: indId, nom: 'T' },
+          individu: { publicId: deptId, referentiel: { publicId: 'REF-A', nom: 'A' } },
+          date: '2026-01-01',
+          valeur: 0.15,
+        },
+        {
+          indicateur: { publicId: indId },
+          individu: { publicId: deptId },
+          date: '2026-02-01',
+          valeur: 0.3,
+        },
+      )
+
+      const result = await listSyntheseIndividus(indId, { individus: [deptId] })
+
+      expect(result._unsafeUnwrap()).toEqual({
+        items: [{ individu: deptId, variation: 0.15, ecartMediane: 0 }],
+      })
+    }),
+  )
+
+  it(
+    "évite les erreurs de précision IEEE 754 sur l'écart à la médiane",
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const [dept1, dept2, dept3] = testDeptIds(3)
+      await fixtures.valeurAvancement(
+        {
+          indicateur: { publicId: indId, nom: 'T' },
+          individu: { publicId: dept1, referentiel: { publicId: 'REF-A', nom: 'A' } },
+          date: '2026-01-01',
+          valeur: 0.3,
+        },
+        {
+          indicateur: { publicId: indId },
+          individu: { publicId: dept2, referentiel: { publicId: 'REF-A' } },
+          date: '2026-01-01',
+          valeur: 0.15,
+        },
+        {
+          indicateur: { publicId: indId },
+          individu: { publicId: dept3, referentiel: { publicId: 'REF-A' } },
+          date: '2026-01-01',
+          valeur: 0.45,
+        },
+      )
+
+      const result = await listSyntheseIndividus(indId, { individus: [dept1] })
+
+      // mediane REF-A = 0.3 → ecart dept1 = 0
+      expect(result._unsafeUnwrap()).toMatchObject({
+        items: [{ individu: dept1, ecartMediane: 0 }],
+      })
+    }),
+  )
+
+  it(
+    "l'écart à la médiane utilise la valeur la plus récente de l'individu",
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const [dept1, dept2, dept3] = testDeptIds(3)
+      await fixtures.valeurAvancement(
+        {
+          indicateur: { publicId: indId, nom: 'T' },
+          individu: { publicId: dept1, referentiel: { publicId: 'REF-A', nom: 'A' } },
+          date: '2026-01-01',
+          valeur: 100,
+        },
+        {
+          indicateur: { publicId: indId },
+          individu: { publicId: dept1 },
+          date: '2026-02-01',
+          valeur: 40,
+        },
+        {
+          indicateur: { publicId: indId },
+          individu: { publicId: dept2, referentiel: { publicId: 'REF-A' } },
+          date: '2026-01-01',
+          valeur: 50,
+        },
+        {
+          indicateur: { publicId: indId },
+          individu: { publicId: dept3, referentiel: { publicId: 'REF-A' } },
+          date: '2026-01-01',
+          valeur: 30,
+        },
+      )
+
+      const result = await listSyntheseIndividus(indId, { individus: [dept1] })
+
+      // valeurs récentes REF-A: dept1=40, dept2=50, dept3=30 → mediane=40 → ecart dept1=0
+      expect(result._unsafeUnwrap()).toMatchObject({
+        items: [{ individu: dept1, ecartMediane: 0 }],
+      })
+    }),
+  )
+
+  it(
+    "l'écart à la médiane est scopé au référentiel de l'individu (ignore les autres référentiels)",
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const [deptA, deptB1, deptB2, deptB3] = testDeptIds(4)
+      await fixtures.valeurAvancement(
+        {
+          indicateur: { publicId: indId, nom: 'T' },
+          individu: { publicId: deptA, referentiel: { publicId: 'REF-A', nom: 'A' } },
+          date: '2026-01-01',
+          valeur: 100,
+        },
+        // REF-B : valeurs 10/50/90 → mediane = 50
+        {
+          indicateur: { publicId: indId },
+          individu: { publicId: deptB1, referentiel: { publicId: 'REF-B', nom: 'B' } },
+          date: '2026-01-01',
+          valeur: 10,
+        },
+        {
+          indicateur: { publicId: indId },
+          individu: { publicId: deptB2, referentiel: { publicId: 'REF-B' } },
+          date: '2026-01-01',
+          valeur: 50,
+        },
+        {
+          indicateur: { publicId: indId },
+          individu: { publicId: deptB3, referentiel: { publicId: 'REF-B' } },
+          date: '2026-01-01',
+          valeur: 90,
+        },
+      )
+
+      const result = await listSyntheseIndividus(indId, { individus: [deptA] })
+
+      // deptA est seul dans REF-A → mediane REF-A = 100 → ecart = 0
+      expect(result._unsafeUnwrap()).toEqual({
+        items: [{ individu: deptA, variation: 100, ecartMediane: 0 }],
+      })
+    }),
+  )
+
+  it(
+    'calcule un écart à la médiane indépendant par référentiel pour des individus de référentiels différents',
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const [deptA1, deptA2, deptB1, deptB2] = testDeptIds(4)
+      await fixtures.valeurAvancement(
+        // REF-A : 10, 30 → mediane = 20
+        {
+          indicateur: { publicId: indId, nom: 'T' },
+          individu: { publicId: deptA1, referentiel: { publicId: 'REF-A', nom: 'A' } },
+          date: '2026-01-01',
+          valeur: 10,
+        },
+        {
+          indicateur: { publicId: indId },
+          individu: { publicId: deptA2, referentiel: { publicId: 'REF-A' } },
+          date: '2026-01-01',
+          valeur: 30,
+        },
+        // REF-B : 100, 200 → mediane = 150
+        {
+          indicateur: { publicId: indId },
+          individu: { publicId: deptB1, referentiel: { publicId: 'REF-B', nom: 'B' } },
+          date: '2026-01-01',
+          valeur: 100,
+        },
+        {
+          indicateur: { publicId: indId },
+          individu: { publicId: deptB2, referentiel: { publicId: 'REF-B' } },
+          date: '2026-01-01',
+          valeur: 200,
+        },
+      )
+
+      const result = await listSyntheseIndividus(indId, {
+        individus: [deptA1, deptB1],
+      })
+
+      // (testDeptIds est trié, l'ordre du résultat suit l'ordre tri publicId asc)
+      const items = result._unsafeUnwrap().items
+      const itemA1 = items.find((i) => i.individu === deptA1)
+      const itemB1 = items.find((i) => i.individu === deptB1)
+      expect(itemA1).toEqual({ individu: deptA1, variation: 10, ecartMediane: -10 })
+      expect(itemB1).toEqual({ individu: deptB1, variation: 100, ecartMediane: -50 })
+    }),
+  )
+
+  it(
+    "rejette quand l'indicateur est introuvable",
+    integrationTest(async () => {
+      await expect(
+        listSyntheseIndividus(testIndicateurId(), { individus: [testDeptId()] }),
+      ).rejects.toThrow()
+    }),
+  )
+})

--- a/apps/mb-api/src/valeurAvancement/queries/listSyntheseIndividus.ts
+++ b/apps/mb-api/src/valeurAvancement/queries/listSyntheseIndividus.ts
@@ -4,9 +4,10 @@ import {
 } from '@pilote/mb-shared/valeurAvancement'
 import { ResultAsync } from 'neverthrow'
 
+import { unique } from '@/framework/array'
 import { db } from '@/framework/persistence/dbStore'
 import { Prisma } from '@/generated/prisma/client'
-import { computeMediane } from '@/valeurAvancement/computeMediane'
+import { groupMedianesByKey } from '@/valeurAvancement/computeMediane'
 
 const computeVariation = (valeurs: ReadonlyArray<{ valeur: Prisma.Decimal }>): number | null => {
   if (valeurs.length === 0) return null
@@ -23,13 +24,17 @@ const computeEcartMediane = (
   return derniereValeur.minus(mediane).toNumber()
 }
 
-const fetchItemsDemandes = (indicateurId: string, individus: ReadonlyArray<string>) =>
+const fetchLatestValeursIndividus = ({
+  indicateurId,
+  individuPublicIds,
+}: {
+  indicateurId: string
+  individuPublicIds: ReadonlyArray<string>
+}) =>
   db().individu.findMany({
-    where: { publicId: { in: [...individus] } },
+    where: { publicId: { in: [...individuPublicIds] } },
     orderBy: { publicId: 'asc' },
-    select: {
-      publicId: true,
-      referentielId: true,
+    include: {
       valeurs: {
         where: { indicateurId },
         orderBy: [{ date: 'desc' }, { id: 'desc' }],
@@ -38,73 +43,66 @@ const fetchItemsDemandes = (indicateurId: string, individus: ReadonlyArray<strin
     },
   })
 
-const fetchValeursRecentesParReferentielId = (
-  indicateurId: string,
-  referentielIds: ReadonlyArray<string>,
-) =>
+const fetchLatestValeursParReferentiel = ({
+  indicateurId,
+  referentielIds,
+}: {
+  indicateurId: string
+  referentielIds: ReadonlyArray<string>
+}) =>
   db().individu.findMany({
     where: {
       referentielId: { in: [...referentielIds] },
       valeurs: { some: { indicateurId } },
     },
-    select: {
-      referentielId: true,
+    include: {
       valeurs: {
         where: { indicateurId },
         orderBy: [{ date: 'desc' }, { id: 'desc' }],
         take: 1,
-        select: { valeur: true },
       },
     },
   })
 
-const computeMedianesParReferentiel = (
-  populationRows: ReadonlyArray<{
-    referentielId: string
-    valeurs: { valeur: Prisma.Decimal }[]
-  }>,
-): Map<string, number | null> => {
-  const valeursParRef = new Map<string, number[]>()
-  for (const row of populationRows) {
-    const valeur = row.valeurs[0]?.valeur.toNumber()
-    if (valeur === undefined) continue
-    const arr = valeursParRef.get(row.referentielId) ?? []
-    arr.push(valeur)
-    valeursParRef.set(row.referentielId, arr)
+const buildSynthese = async (
+  indicateurPublicId: string,
+  params: ListSyntheseIndividusQuery,
+): Promise<SyntheseIndividusListApiModel> => {
+  const indicateur = await db().indicateur.findUniqueOrThrow({
+    where: { publicId: indicateurPublicId },
+    select: { id: true },
+  })
+  const itemsRows = await fetchLatestValeursIndividus({
+    indicateurId: indicateur.id,
+    individuPublicIds: params.individus,
+  })
+  const referentielIds = unique(itemsRows.map((row) => row.referentielId))
+  const populationRows = referentielIds.length
+    ? await fetchLatestValeursParReferentiel({ indicateurId: indicateur.id, referentielIds })
+    : []
+  const valeursParRef = populationRows.flatMap((row) =>
+    row.valeurs.map((v) => ({ referentielId: row.referentielId, valeur: v.valeur })),
+  )
+  const medianeParRef = groupMedianesByKey(
+    valeursParRef,
+    (row) => row.referentielId,
+    (row) => row.valeur,
+  )
+
+  return {
+    items: itemsRows.map((row) => ({
+      individu: row.publicId,
+      variation: computeVariation(row.valeurs),
+      ecartMediane: computeEcartMediane(
+        row.valeurs[0]?.valeur,
+        medianeParRef.get(row.referentielId) ?? null,
+      ),
+    })),
   }
-  const medianeParRef = new Map<string, number | null>()
-  for (const [refId, valeurs] of valeursParRef) {
-    medianeParRef.set(refId, computeMediane(valeurs))
-  }
-  return medianeParRef
 }
 
 export const listSyntheseIndividus = (
   indicateurPublicId: string,
   params: ListSyntheseIndividusQuery,
 ): ResultAsync<SyntheseIndividusListApiModel, never> =>
-  ResultAsync.fromSafePromise(
-    (async () => {
-      const indicateur = await db().indicateur.findUniqueOrThrow({
-        where: { publicId: indicateurPublicId },
-        select: { id: true },
-      })
-      const itemsRows = await fetchItemsDemandes(indicateur.id, params.individus)
-      const referentielIds = [...new Set(itemsRows.map((row) => row.referentielId))]
-      const populationRows = referentielIds.length
-        ? await fetchValeursRecentesParReferentielId(indicateur.id, referentielIds)
-        : []
-      const medianeParRef = computeMedianesParReferentiel(populationRows)
-
-      return {
-        items: itemsRows.map((row) => ({
-          individu: row.publicId,
-          variation: computeVariation(row.valeurs),
-          ecartMediane: computeEcartMediane(
-            row.valeurs[0]?.valeur,
-            medianeParRef.get(row.referentielId) ?? null,
-          ),
-        })),
-      }
-    })(),
-  )
+  ResultAsync.fromSafePromise(buildSynthese(indicateurPublicId, params))

--- a/apps/mb-api/src/valeurAvancement/queries/listSyntheseIndividus.ts
+++ b/apps/mb-api/src/valeurAvancement/queries/listSyntheseIndividus.ts
@@ -1,0 +1,110 @@
+import {
+  type ListSyntheseIndividusQuery,
+  type SyntheseIndividusListApiModel,
+} from '@pilote/mb-shared/valeurAvancement'
+import { ResultAsync } from 'neverthrow'
+
+import { db } from '@/framework/persistence/dbStore'
+import { Prisma } from '@/generated/prisma/client'
+import { computeMediane } from '@/valeurAvancement/computeMediane'
+
+const computeVariation = (valeurs: ReadonlyArray<{ valeur: Prisma.Decimal }>): number | null => {
+  if (valeurs.length === 0) return null
+  const [recente, precedente] = valeurs
+  const precedenteValeur = precedente?.valeur ?? new Prisma.Decimal(0)
+  return recente!.valeur.minus(precedenteValeur).toNumber()
+}
+
+const computeEcartMediane = (
+  derniereValeur: Prisma.Decimal | undefined,
+  mediane: number | null,
+): number | null => {
+  if (derniereValeur === undefined || mediane === null) return null
+  return derniereValeur.minus(mediane).toNumber()
+}
+
+const fetchItemsDemandes = (indicateurId: string, individus: ReadonlyArray<string>) =>
+  db().individu.findMany({
+    where: { publicId: { in: [...individus] } },
+    orderBy: { publicId: 'asc' },
+    select: {
+      publicId: true,
+      referentielId: true,
+      valeurs: {
+        where: { indicateurId },
+        orderBy: [{ date: 'desc' }, { id: 'desc' }],
+        take: 2,
+      },
+    },
+  })
+
+const fetchValeursRecentesParReferentielId = (
+  indicateurId: string,
+  referentielIds: ReadonlyArray<string>,
+) =>
+  db().individu.findMany({
+    where: {
+      referentielId: { in: [...referentielIds] },
+      valeurs: { some: { indicateurId } },
+    },
+    select: {
+      referentielId: true,
+      valeurs: {
+        where: { indicateurId },
+        orderBy: [{ date: 'desc' }, { id: 'desc' }],
+        take: 1,
+        select: { valeur: true },
+      },
+    },
+  })
+
+const computeMedianesParReferentiel = (
+  populationRows: ReadonlyArray<{
+    referentielId: string
+    valeurs: { valeur: Prisma.Decimal }[]
+  }>,
+): Map<string, number | null> => {
+  const valeursParRef = new Map<string, number[]>()
+  for (const row of populationRows) {
+    const valeur = row.valeurs[0]?.valeur.toNumber()
+    if (valeur === undefined) continue
+    const arr = valeursParRef.get(row.referentielId) ?? []
+    arr.push(valeur)
+    valeursParRef.set(row.referentielId, arr)
+  }
+  const medianeParRef = new Map<string, number | null>()
+  for (const [refId, valeurs] of valeursParRef) {
+    medianeParRef.set(refId, computeMediane(valeurs))
+  }
+  return medianeParRef
+}
+
+export const listSyntheseIndividus = (
+  indicateurPublicId: string,
+  params: ListSyntheseIndividusQuery,
+): ResultAsync<SyntheseIndividusListApiModel, never> =>
+  ResultAsync.fromSafePromise(
+    (async () => {
+      const indicateur = await db().indicateur.findUniqueOrThrow({
+        where: { publicId: indicateurPublicId },
+        select: { id: true },
+      })
+      const itemsRows = await fetchItemsDemandes(indicateur.id, params.individus)
+      const referentielIds = [...new Set(itemsRows.map((row) => row.referentielId))]
+      const populationRows = referentielIds.length
+        ? await fetchValeursRecentesParReferentielId(indicateur.id, referentielIds)
+        : []
+      const medianeParRef = computeMedianesParReferentiel(populationRows)
+
+      return {
+        items: itemsRows.map((row) => ({
+          individu: row.publicId,
+          variation: computeVariation(row.valeurs),
+          ecartMediane: computeEcartMediane(
+            row.valeurs[0]?.valeur,
+            medianeParRef.get(row.referentielId) ?? null,
+          ),
+        })),
+      }
+    })(),
+  )

--- a/apps/mb-api/src/valeurAvancement/queries/listSyntheseIndividus.ts
+++ b/apps/mb-api/src/valeurAvancement/queries/listSyntheseIndividus.ts
@@ -6,23 +6,9 @@ import { ResultAsync } from 'neverthrow'
 
 import { unique } from '@/framework/array'
 import { db } from '@/framework/persistence/dbStore'
-import { Prisma } from '@/generated/prisma/client'
+import { computeEcartMediane } from '@/valeurAvancement/computeEcartMediane'
 import { groupMedianesByKey } from '@/valeurAvancement/computeMediane'
-
-const computeVariation = (valeurs: ReadonlyArray<{ valeur: Prisma.Decimal }>): number | null => {
-  if (valeurs.length === 0) return null
-  const [recente, precedente] = valeurs
-  const precedenteValeur = precedente?.valeur ?? new Prisma.Decimal(0)
-  return recente!.valeur.minus(precedenteValeur).toNumber()
-}
-
-const computeEcartMediane = (
-  derniereValeur: Prisma.Decimal | undefined,
-  mediane: number | null,
-): number | null => {
-  if (derniereValeur === undefined || mediane === null) return null
-  return derniereValeur.minus(mediane).toNumber()
-}
+import { computeVariation } from '@/valeurAvancement/computeVariation'
 
 const fetchLatestValeursIndividus = ({
   indicateurId,

--- a/apps/mb-api/src/valeurAvancement/queries/listValeursRemarquablesForIndicateur.test.ts
+++ b/apps/mb-api/src/valeurAvancement/queries/listValeursRemarquablesForIndicateur.test.ts
@@ -7,320 +7,50 @@ import { listValeursRemarquablesForIndicateur } from '@/valeurAvancement/queries
 
 describe.concurrent('listValeursRemarquablesForIndicateur', () => {
   it(
-    "retourne variation = null et stats à null quand aucun individu n'a de valeur pour l'indicateur",
+    'retourne des stats null pour un référentiel sans individu',
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      await fixtures.indicateur({ publicId: indId, nom: 'T' })
+      await fixtures.referentiel({ publicId: 'REF-VIDE', nom: 'Vide' })
+
+      const result = await listValeursRemarquablesForIndicateur(indId, {
+        referentiels: ['REF-VIDE'],
+      })
+
+      expect(result._unsafeUnwrap()).toEqual({
+        items: [{ referentiel: 'REF-VIDE', min: null, max: null, mediane: null }],
+      })
+    }),
+  )
+
+  it(
+    "retourne des stats null pour un référentiel dont aucun individu n'a de valeur",
     integrationTest(async () => {
       const indId = testIndicateurId()
       const deptId = testDeptId()
       await fixtures.indicateur({ publicId: indId, nom: 'T' })
-      await fixtures.individu({ publicId: deptId, nom: 'Vaucluse' })
+      await fixtures.individu({
+        publicId: deptId,
+        referentiel: { publicId: 'REF-A', nom: 'A' },
+      })
 
-      const result = await listValeursRemarquablesForIndicateur(indId, { individus: [deptId] })
+      const result = await listValeursRemarquablesForIndicateur(indId, { referentiels: ['REF-A'] })
 
       expect(result._unsafeUnwrap()).toEqual({
-        items: [{ individu: deptId, variation: null, ecartMediane: null }],
-        min: null,
-        max: null,
-        mediane: null,
+        items: [{ referentiel: 'REF-A', min: null, max: null, mediane: null }],
       })
     }),
   )
 
   it(
-    "retourne variation = null pour un individu sans valeur mais stats non nulles si d'autres individus ont des valeurs",
-    integrationTest(async () => {
-      const indId = testIndicateurId()
-      const [dept1, dept2] = testDeptIds(2)
-      await fixtures.indicateur({ publicId: indId, nom: 'T' })
-      await fixtures.individu({ publicId: dept1, nom: 'Sans valeur' })
-      await fixtures.valeurAvancement({
-        indicateur: { publicId: indId },
-        individu: { publicId: dept2, nom: 'Avec valeur' },
-        date: '2026-01-01',
-        valeur: 42,
-      })
-
-      const result = await listValeursRemarquablesForIndicateur(indId, { individus: [dept1] })
-
-      expect(result._unsafeUnwrap()).toEqual({
-        items: [{ individu: dept1, variation: null, ecartMediane: null }],
-        min: 42,
-        max: 42,
-        mediane: 42,
-      })
-    }),
-  )
-
-  it(
-    "retourne variation = valeur lorsqu'il n'y a qu'une seule valeur",
-    integrationTest(async () => {
-      const indId = testIndicateurId()
-      const deptId = testDeptId()
-      await fixtures.valeurAvancement({
-        indicateur: { publicId: indId, nom: 'T' },
-        individu: { publicId: deptId, nom: 'Vaucluse' },
-        date: '2026-01-01',
-        valeur: 50,
-      })
-
-      const result = await listValeursRemarquablesForIndicateur(indId, { individus: [deptId] })
-
-      expect(result._unsafeUnwrap()).toEqual({
-        items: [{ individu: deptId, variation: 50, ecartMediane: 0 }],
-        min: 50,
-        max: 50,
-        mediane: 50,
-      })
-    }),
-  )
-
-  it(
-    'retourne la variation entre les deux valeurs les plus récentes (positive)',
-    integrationTest(async () => {
-      const indId = testIndicateurId()
-      const deptId = testDeptId()
-      await fixtures.valeurAvancement(
-        {
-          indicateur: { publicId: indId, nom: 'T' },
-          individu: { publicId: deptId, nom: 'Vaucluse' },
-          date: '2026-01-01',
-          valeur: 50,
-        },
-        {
-          indicateur: { publicId: indId },
-          individu: { publicId: deptId },
-          date: '2026-02-01',
-          valeur: 25,
-        },
-        {
-          indicateur: { publicId: indId },
-          individu: { publicId: deptId },
-          date: '2026-03-01',
-          valeur: 75,
-        },
-      )
-
-      const result = await listValeursRemarquablesForIndicateur(indId, { individus: [deptId] })
-
-      expect(result._unsafeUnwrap()).toEqual({
-        items: [{ individu: deptId, variation: 50, ecartMediane: 0 }],
-        min: 75,
-        max: 75,
-        mediane: 75,
-      })
-    }),
-  )
-
-  it(
-    'retourne la variation entre les deux valeurs les plus récentes (négative)',
-    integrationTest(async () => {
-      const indId = testIndicateurId()
-      const deptId = testDeptId()
-      await fixtures.valeurAvancement(
-        {
-          indicateur: { publicId: indId, nom: 'T' },
-          individu: { publicId: deptId, nom: 'Vaucluse' },
-          date: '2026-01-01',
-          valeur: 50,
-        },
-        {
-          indicateur: { publicId: indId },
-          individu: { publicId: deptId },
-          date: '2026-02-01',
-          valeur: 25,
-        },
-      )
-
-      const result = await listValeursRemarquablesForIndicateur(indId, { individus: [deptId] })
-
-      expect(result._unsafeUnwrap()).toEqual({
-        items: [{ individu: deptId, variation: -25, ecartMediane: 0 }],
-        min: 25,
-        max: 25,
-        mediane: 25,
-      })
-    }),
-  )
-
-  it(
-    "se base sur la date de la valeur, pas la date de saisie (ordre d'insertion non pertinent)",
-    integrationTest(async () => {
-      const indId = testIndicateurId()
-      const deptId = testDeptId()
-      // Insérée en dernier mais avec une date antérieure → ne doit pas influencer l'affichage
-      await fixtures.valeurAvancement(
-        {
-          indicateur: { publicId: indId, nom: 'T' },
-          individu: { publicId: deptId, nom: 'Vaucluse' },
-          date: '2026-02-01',
-          valeur: 10,
-        },
-        {
-          indicateur: { publicId: indId },
-          individu: { publicId: deptId },
-          date: '2026-03-01',
-          valeur: 75,
-        },
-        {
-          indicateur: { publicId: indId },
-          individu: { publicId: deptId },
-          date: '2026-01-01',
-          valeur: 50,
-        },
-      )
-
-      const result = await listValeursRemarquablesForIndicateur(indId, { individus: [deptId] })
-
-      expect(result._unsafeUnwrap()).toEqual({
-        items: [{ individu: deptId, variation: 65, ecartMediane: 0 }],
-        min: 75,
-        max: 75,
-        mediane: 75,
-      })
-    }),
-  )
-
-  it(
-    'retourne un item par individu existant, triés par publicId',
+    'calcule min/max/médiane sur la valeur la plus récente de chaque individu du référentiel',
     integrationTest(async () => {
       const indId = testIndicateurId()
       const [dept1, dept2, dept3] = testDeptIds(3)
       await fixtures.valeurAvancement(
         {
           indicateur: { publicId: indId, nom: 'T' },
-          individu: { publicId: dept1, nom: 'A' },
-          date: '2026-01-01',
-          valeur: 10,
-        },
-        {
-          indicateur: { publicId: indId },
-          individu: { publicId: dept1 },
-          date: '2026-02-01',
-          valeur: 30,
-        },
-        {
-          indicateur: { publicId: indId },
-          individu: { publicId: dept2, nom: 'B' },
-          date: '2026-01-01',
-          valeur: 5,
-        },
-      )
-      // dept3 sans valeur mais existe
-      await fixtures.individu({ publicId: dept3, nom: 'C' })
-
-      const result = await listValeursRemarquablesForIndicateur(indId, {
-        individus: [dept3, dept1, dept2],
-      })
-
-      expect(result._unsafeUnwrap()).toEqual({
-        items: [
-          { individu: dept1, variation: 20, ecartMediane: 12.5 },
-          { individu: dept2, variation: 5, ecartMediane: -12.5 },
-          { individu: dept3, variation: null, ecartMediane: null },
-        ],
-        min: 5,
-        max: 30,
-        mediane: 17.5,
-      })
-    }),
-  )
-
-  it(
-    "ignore les valeurs d'autres indicateurs",
-    integrationTest(async () => {
-      const [indId, autreIndId] = [testIndicateurId(), testIndicateurId()]
-      const deptId = testDeptId()
-      await fixtures.valeurAvancement(
-        {
-          indicateur: { publicId: indId, nom: 'T' },
-          individu: { publicId: deptId, nom: 'Vaucluse' },
-          date: '2026-01-01',
-          valeur: 100,
-        },
-        {
-          indicateur: { publicId: autreIndId, nom: 'Autre' },
-          individu: { publicId: deptId },
-          date: '2026-02-01',
-          valeur: 9999,
-        },
-      )
-
-      const result = await listValeursRemarquablesForIndicateur(indId, { individus: [deptId] })
-
-      expect(result._unsafeUnwrap()).toEqual({
-        items: [{ individu: deptId, variation: 100, ecartMediane: 0 }],
-        min: 100,
-        max: 100,
-        mediane: 100,
-      })
-    }),
-  )
-
-  it(
-    'omet les individus inexistants',
-    integrationTest(async () => {
-      const indId = testIndicateurId()
-      const deptId = testDeptId()
-      const inconnu = testDeptId()
-      await fixtures.valeurAvancement({
-        indicateur: { publicId: indId, nom: 'T' },
-        individu: { publicId: deptId, nom: 'Vaucluse' },
-        date: '2026-01-01',
-        valeur: 42,
-      })
-
-      const result = await listValeursRemarquablesForIndicateur(indId, {
-        individus: [deptId, inconnu],
-      })
-
-      expect(result._unsafeUnwrap()).toEqual({
-        items: [{ individu: deptId, variation: 42, ecartMediane: 0 }],
-        min: 42,
-        max: 42,
-        mediane: 42,
-      })
-    }),
-  )
-
-  it(
-    'évite les erreurs de précision IEEE 754 sur la soustraction de décimaux',
-    integrationTest(async () => {
-      const indId = testIndicateurId()
-      const deptId = testDeptId()
-      await fixtures.valeurAvancement(
-        {
-          indicateur: { publicId: indId, nom: 'T' },
-          individu: { publicId: deptId, nom: 'Vaucluse' },
-          date: '2026-01-01',
-          valeur: 0.15,
-        },
-        {
-          indicateur: { publicId: indId },
-          individu: { publicId: deptId },
-          date: '2026-02-01',
-          valeur: 0.3,
-        },
-      )
-
-      const result = await listValeursRemarquablesForIndicateur(indId, { individus: [deptId] })
-
-      expect(result._unsafeUnwrap()).toEqual({
-        items: [{ individu: deptId, variation: 0.15, ecartMediane: 0 }],
-        min: 0.3,
-        max: 0.3,
-        mediane: 0.3,
-      })
-    }),
-  )
-
-  it(
-    'calcule min/max/médiane sur la valeur la plus récente de chaque individu (nombre impair)',
-    integrationTest(async () => {
-      const indId = testIndicateurId()
-      const [dept1, dept2, dept3] = testDeptIds(3)
-      await fixtures.valeurAvancement(
-        {
-          indicateur: { publicId: indId, nom: 'T' },
-          individu: { publicId: dept1, nom: 'A' },
+          individu: { publicId: dept1, nom: 'A', referentiel: { publicId: 'REF-A', nom: 'A' } },
           date: '2026-01-01',
           valeur: 100,
         },
@@ -332,25 +62,23 @@ describe.concurrent('listValeursRemarquablesForIndicateur', () => {
         },
         {
           indicateur: { publicId: indId },
-          individu: { publicId: dept2, nom: 'B' },
+          individu: { publicId: dept2, nom: 'B', referentiel: { publicId: 'REF-A' } },
           date: '2026-01-01',
           valeur: 50,
         },
         {
           indicateur: { publicId: indId },
-          individu: { publicId: dept3, nom: 'C' },
+          individu: { publicId: dept3, nom: 'C', referentiel: { publicId: 'REF-A' } },
           date: '2026-01-01',
           valeur: 30,
         },
       )
 
-      const result = await listValeursRemarquablesForIndicateur(indId, { individus: [dept1] })
+      const result = await listValeursRemarquablesForIndicateur(indId, { referentiels: ['REF-A'] })
 
       // Valeurs récentes: dept1=10, dept2=50, dept3=30
-      expect(result._unsafeUnwrap()).toMatchObject({
-        min: 10,
-        max: 50,
-        mediane: 30,
+      expect(result._unsafeUnwrap()).toEqual({
+        items: [{ referentiel: 'REF-A', min: 10, max: 50, mediane: 30 }],
       })
     }),
   )
@@ -363,93 +91,206 @@ describe.concurrent('listValeursRemarquablesForIndicateur', () => {
       await fixtures.valeurAvancement(
         {
           indicateur: { publicId: indId, nom: 'T' },
-          individu: { publicId: dept1, nom: 'A' },
+          individu: { publicId: dept1, nom: 'A', referentiel: { publicId: 'REF-A', nom: 'A' } },
           date: '2026-01-01',
           valeur: 10,
         },
         {
           indicateur: { publicId: indId },
-          individu: { publicId: dept2, nom: 'B' },
+          individu: { publicId: dept2, nom: 'B', referentiel: { publicId: 'REF-A' } },
           date: '2026-01-01',
           valeur: 20,
         },
         {
           indicateur: { publicId: indId },
-          individu: { publicId: dept3, nom: 'C' },
+          individu: { publicId: dept3, nom: 'C', referentiel: { publicId: 'REF-A' } },
           date: '2026-01-01',
           valeur: 30,
         },
         {
           indicateur: { publicId: indId },
-          individu: { publicId: dept4, nom: 'D' },
+          individu: { publicId: dept4, nom: 'D', referentiel: { publicId: 'REF-A' } },
           date: '2026-01-01',
           valeur: 40,
         },
       )
 
-      const result = await listValeursRemarquablesForIndicateur(indId, { individus: [dept1] })
+      const result = await listValeursRemarquablesForIndicateur(indId, { referentiels: ['REF-A'] })
 
-      expect(result._unsafeUnwrap()).toMatchObject({
-        min: 10,
-        max: 40,
-        mediane: 25,
+      expect(result._unsafeUnwrap()).toEqual({
+        items: [{ referentiel: 'REF-A', min: 10, max: 40, mediane: 25 }],
       })
     }),
   )
 
   it(
-    "min/max/médiane sont calculés sur tous les individus de l'indicateur, pas seulement ceux demandés",
+    "ignore les individus du référentiel n'ayant aucune valeur pour l'indicateur",
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const [dept1, dept2] = testDeptIds(2)
+      await fixtures.indicateur({ publicId: indId, nom: 'T' })
+      // dept1 sans valeur dans REF-A
+      await fixtures.individu({
+        publicId: dept1,
+        nom: 'A',
+        referentiel: { publicId: 'REF-A', nom: 'A' },
+      })
+      // dept2 avec valeur dans REF-A
+      await fixtures.valeurAvancement({
+        indicateur: { publicId: indId },
+        individu: { publicId: dept2, nom: 'B', referentiel: { publicId: 'REF-A' } },
+        date: '2026-01-01',
+        valeur: 42,
+      })
+
+      const result = await listValeursRemarquablesForIndicateur(indId, { referentiels: ['REF-A'] })
+
+      expect(result._unsafeUnwrap()).toEqual({
+        items: [{ referentiel: 'REF-A', min: 42, max: 42, mediane: 42 }],
+      })
+    }),
+  )
+
+  it(
+    'calcule des stats indépendantes pour chaque référentiel demandé',
     integrationTest(async () => {
       const indId = testIndicateurId()
       const [dept1, dept2, dept3] = testDeptIds(3)
       await fixtures.valeurAvancement(
         {
           indicateur: { publicId: indId, nom: 'T' },
-          individu: { publicId: dept1, nom: 'A' },
+          individu: { publicId: dept1, nom: 'A', referentiel: { publicId: 'REF-A', nom: 'A' } },
           date: '2026-01-01',
-          valeur: 5,
+          valeur: 10,
         },
         {
           indicateur: { publicId: indId },
-          individu: { publicId: dept2, nom: 'B' },
+          individu: { publicId: dept2, nom: 'B', referentiel: { publicId: 'REF-A' } },
           date: '2026-01-01',
-          valeur: 50,
+          valeur: 30,
         },
         {
           indicateur: { publicId: indId },
-          individu: { publicId: dept3, nom: 'C' },
+          individu: { publicId: dept3, nom: 'C', referentiel: { publicId: 'REF-B', nom: 'B' } },
           date: '2026-01-01',
           valeur: 100,
         },
       )
 
-      // Ne demande qu'un seul individu mais les stats portent sur les 3
-      const result = await listValeursRemarquablesForIndicateur(indId, { individus: [dept2] })
+      const result = await listValeursRemarquablesForIndicateur(indId, {
+        referentiels: ['REF-A', 'REF-B'],
+      })
 
       expect(result._unsafeUnwrap()).toEqual({
-        items: [{ individu: dept2, variation: 50, ecartMediane: 0 }],
-        min: 5,
-        max: 100,
-        mediane: 50,
+        items: [
+          { referentiel: 'REF-A', min: 10, max: 30, mediane: 20 },
+          { referentiel: 'REF-B', min: 100, max: 100, mediane: 100 },
+        ],
       })
     }),
   )
 
   it(
-    "min/max/médiane ignorent les valeurs d'autres indicateurs",
+    'omet les référentiels inexistants',
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const deptId = testDeptId()
+      await fixtures.valeurAvancement({
+        indicateur: { publicId: indId, nom: 'T' },
+        individu: { publicId: deptId, referentiel: { publicId: 'REF-A', nom: 'A' } },
+        date: '2026-01-01',
+        valeur: 42,
+      })
+
+      const result = await listValeursRemarquablesForIndicateur(indId, {
+        referentiels: ['REF-A', 'REF-INCONNU'],
+      })
+
+      expect(result._unsafeUnwrap()).toEqual({
+        items: [{ referentiel: 'REF-A', min: 42, max: 42, mediane: 42 }],
+      })
+    }),
+  )
+
+  it(
+    'trie les items par publicId de référentiel (asc)',
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const [dept1, dept2] = testDeptIds(2)
+      await fixtures.valeurAvancement(
+        {
+          indicateur: { publicId: indId, nom: 'T' },
+          individu: { publicId: dept1, referentiel: { publicId: 'REF-Z', nom: 'Z' } },
+          date: '2026-01-01',
+          valeur: 1,
+        },
+        {
+          indicateur: { publicId: indId },
+          individu: { publicId: dept2, referentiel: { publicId: 'REF-A', nom: 'A' } },
+          date: '2026-01-01',
+          valeur: 2,
+        },
+      )
+
+      const result = await listValeursRemarquablesForIndicateur(indId, {
+        referentiels: ['REF-Z', 'REF-A'],
+      })
+
+      const items = result._unsafeUnwrap().items
+      expect(items.map((i) => i.referentiel)).toEqual(['REF-A', 'REF-Z'])
+    }),
+  )
+
+  it(
+    'se base sur la date de la valeur, pas la date de saisie',
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const deptId = testDeptId()
+      // Insérée en dernier mais avec une date antérieure
+      await fixtures.valeurAvancement(
+        {
+          indicateur: { publicId: indId, nom: 'T' },
+          individu: { publicId: deptId, referentiel: { publicId: 'REF-A', nom: 'A' } },
+          date: '2026-02-01',
+          valeur: 10,
+        },
+        {
+          indicateur: { publicId: indId },
+          individu: { publicId: deptId },
+          date: '2026-03-01',
+          valeur: 75,
+        },
+        {
+          indicateur: { publicId: indId },
+          individu: { publicId: deptId },
+          date: '2026-01-01',
+          valeur: 50,
+        },
+      )
+
+      const result = await listValeursRemarquablesForIndicateur(indId, { referentiels: ['REF-A'] })
+
+      expect(result._unsafeUnwrap()).toEqual({
+        items: [{ referentiel: 'REF-A', min: 75, max: 75, mediane: 75 }],
+      })
+    }),
+  )
+
+  it(
+    "ignore les valeurs d'autres indicateurs",
     integrationTest(async () => {
       const [indId, autreIndId] = [testIndicateurId(), testIndicateurId()]
       const [dept1, dept2] = testDeptIds(2)
       await fixtures.valeurAvancement(
         {
           indicateur: { publicId: indId, nom: 'T' },
-          individu: { publicId: dept1, nom: 'A' },
+          individu: { publicId: dept1, referentiel: { publicId: 'REF-A', nom: 'A' } },
           date: '2026-01-01',
           valeur: 10,
         },
         {
           indicateur: { publicId: indId },
-          individu: { publicId: dept2, nom: 'B' },
+          individu: { publicId: dept2, referentiel: { publicId: 'REF-A' } },
           date: '2026-01-01',
           valeur: 20,
         },
@@ -461,12 +302,38 @@ describe.concurrent('listValeursRemarquablesForIndicateur', () => {
         },
       )
 
-      const result = await listValeursRemarquablesForIndicateur(indId, { individus: [dept1] })
+      const result = await listValeursRemarquablesForIndicateur(indId, { referentiels: ['REF-A'] })
 
-      expect(result._unsafeUnwrap()).toMatchObject({
-        min: 10,
-        max: 20,
-        mediane: 15,
+      expect(result._unsafeUnwrap()).toEqual({
+        items: [{ referentiel: 'REF-A', min: 10, max: 20, mediane: 15 }],
+      })
+    }),
+  )
+
+  it(
+    'ignore les individus appartenant à un autre référentiel',
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const [dept1, dept2] = testDeptIds(2)
+      await fixtures.valeurAvancement(
+        {
+          indicateur: { publicId: indId, nom: 'T' },
+          individu: { publicId: dept1, referentiel: { publicId: 'REF-A', nom: 'A' } },
+          date: '2026-01-01',
+          valeur: 10,
+        },
+        {
+          indicateur: { publicId: indId },
+          individu: { publicId: dept2, referentiel: { publicId: 'REF-B', nom: 'B' } },
+          date: '2026-01-01',
+          valeur: 9999,
+        },
+      )
+
+      const result = await listValeursRemarquablesForIndicateur(indId, { referentiels: ['REF-A'] })
+
+      expect(result._unsafeUnwrap()).toEqual({
+        items: [{ referentiel: 'REF-A', min: 10, max: 10, mediane: 10 }],
       })
     }),
   )
@@ -474,176 +341,10 @@ describe.concurrent('listValeursRemarquablesForIndicateur', () => {
   it(
     "rejette quand l'indicateur est introuvable",
     integrationTest(async () => {
+      await fixtures.referentiel({ publicId: 'REF-A', nom: 'A' })
       await expect(
-        listValeursRemarquablesForIndicateur(testIndicateurId(), { individus: [testDeptId()] }),
+        listValeursRemarquablesForIndicateur(testIndicateurId(), { referentiels: ['REF-A'] }),
       ).rejects.toThrow()
-    }),
-  )
-
-  it(
-    "calcule l'écart à la médiane pour chaque individu demandé (population impaire)",
-    integrationTest(async () => {
-      const indId = testIndicateurId()
-      const [dept1, dept2, dept3] = testDeptIds(3)
-      await fixtures.valeurAvancement(
-        {
-          indicateur: { publicId: indId, nom: 'T' },
-          individu: { publicId: dept1, nom: 'A' },
-          date: '2026-01-01',
-          valeur: 10,
-        },
-        {
-          indicateur: { publicId: indId },
-          individu: { publicId: dept2, nom: 'B' },
-          date: '2026-01-01',
-          valeur: 50,
-        },
-        {
-          indicateur: { publicId: indId },
-          individu: { publicId: dept3, nom: 'C' },
-          date: '2026-01-01',
-          valeur: 30,
-        },
-      )
-
-      const result = await listValeursRemarquablesForIndicateur(indId, {
-        individus: [dept1, dept2, dept3],
-      })
-
-      // mediane = 30 → ecartMediane: dept1=-20, dept2=20, dept3=0
-      expect(result._unsafeUnwrap()).toMatchObject({
-        items: [
-          { individu: dept1, ecartMediane: -20 },
-          { individu: dept2, ecartMediane: 20 },
-          { individu: dept3, ecartMediane: 0 },
-        ],
-        mediane: 30,
-      })
-    }),
-  )
-
-  it(
-    "calcule l'écart à la médiane quand la médiane est la moyenne de deux centrales (population paire)",
-    integrationTest(async () => {
-      const indId = testIndicateurId()
-      const [dept1, dept2, dept3, dept4] = testDeptIds(4)
-      await fixtures.valeurAvancement(
-        {
-          indicateur: { publicId: indId, nom: 'T' },
-          individu: { publicId: dept1, nom: 'A' },
-          date: '2026-01-01',
-          valeur: 10,
-        },
-        {
-          indicateur: { publicId: indId },
-          individu: { publicId: dept2, nom: 'B' },
-          date: '2026-01-01',
-          valeur: 20,
-        },
-        {
-          indicateur: { publicId: indId },
-          individu: { publicId: dept3, nom: 'C' },
-          date: '2026-01-01',
-          valeur: 30,
-        },
-        {
-          indicateur: { publicId: indId },
-          individu: { publicId: dept4, nom: 'D' },
-          date: '2026-01-01',
-          valeur: 40,
-        },
-      )
-
-      const result = await listValeursRemarquablesForIndicateur(indId, {
-        individus: [dept1, dept4],
-      })
-
-      // mediane = (20 + 30) / 2 = 25 → dept1=-15, dept4=15
-      expect(result._unsafeUnwrap()).toMatchObject({
-        items: [
-          { individu: dept1, ecartMediane: -15 },
-          { individu: dept4, ecartMediane: 15 },
-        ],
-        mediane: 25,
-      })
-    }),
-  )
-
-  it(
-    "l'écart à la médiane utilise la valeur la plus récente de l'individu",
-    integrationTest(async () => {
-      const indId = testIndicateurId()
-      const [dept1, dept2, dept3] = testDeptIds(3)
-      await fixtures.valeurAvancement(
-        {
-          indicateur: { publicId: indId, nom: 'T' },
-          individu: { publicId: dept1, nom: 'A' },
-          date: '2026-01-01',
-          valeur: 100,
-        },
-        {
-          indicateur: { publicId: indId },
-          individu: { publicId: dept1 },
-          date: '2026-02-01',
-          valeur: 40,
-        },
-        {
-          indicateur: { publicId: indId },
-          individu: { publicId: dept2, nom: 'B' },
-          date: '2026-01-01',
-          valeur: 50,
-        },
-        {
-          indicateur: { publicId: indId },
-          individu: { publicId: dept3, nom: 'C' },
-          date: '2026-01-01',
-          valeur: 30,
-        },
-      )
-
-      const result = await listValeursRemarquablesForIndicateur(indId, { individus: [dept1] })
-
-      // valeurs récentes: dept1=40, dept2=50, dept3=30 → mediane=40 → ecart dept1=0
-      expect(result._unsafeUnwrap()).toMatchObject({
-        items: [{ individu: dept1, ecartMediane: 0 }],
-        mediane: 40,
-      })
-    }),
-  )
-
-  it(
-    "évite les erreurs de précision IEEE 754 sur l'écart à la médiane",
-    integrationTest(async () => {
-      const indId = testIndicateurId()
-      const [dept1, dept2, dept3] = testDeptIds(3)
-      await fixtures.valeurAvancement(
-        {
-          indicateur: { publicId: indId, nom: 'T' },
-          individu: { publicId: dept1, nom: 'A' },
-          date: '2026-01-01',
-          valeur: 0.3,
-        },
-        {
-          indicateur: { publicId: indId },
-          individu: { publicId: dept2, nom: 'B' },
-          date: '2026-01-01',
-          valeur: 0.15,
-        },
-        {
-          indicateur: { publicId: indId },
-          individu: { publicId: dept3, nom: 'C' },
-          date: '2026-01-01',
-          valeur: 0.45,
-        },
-      )
-
-      const result = await listValeursRemarquablesForIndicateur(indId, { individus: [dept1] })
-
-      // mediane = 0.3 → ecart dept1 = 0
-      expect(result._unsafeUnwrap()).toMatchObject({
-        items: [{ individu: dept1, ecartMediane: 0 }],
-        mediane: 0.3,
-      })
     }),
   )
 })

--- a/apps/mb-api/src/valeurAvancement/queries/listValeursRemarquablesForIndicateur.test.ts
+++ b/apps/mb-api/src/valeurAvancement/queries/listValeursRemarquablesForIndicateur.test.ts
@@ -17,7 +17,7 @@ describe.concurrent('listValeursRemarquablesForIndicateur', () => {
       const result = await listValeursRemarquablesForIndicateur(indId, { individus: [deptId] })
 
       expect(result._unsafeUnwrap()).toEqual({
-        items: [{ individu: deptId, variation: null }],
+        items: [{ individu: deptId, variation: null, ecartMediane: null }],
         min: null,
         max: null,
         mediane: null,
@@ -42,7 +42,7 @@ describe.concurrent('listValeursRemarquablesForIndicateur', () => {
       const result = await listValeursRemarquablesForIndicateur(indId, { individus: [dept1] })
 
       expect(result._unsafeUnwrap()).toEqual({
-        items: [{ individu: dept1, variation: null }],
+        items: [{ individu: dept1, variation: null, ecartMediane: null }],
         min: 42,
         max: 42,
         mediane: 42,
@@ -65,7 +65,7 @@ describe.concurrent('listValeursRemarquablesForIndicateur', () => {
       const result = await listValeursRemarquablesForIndicateur(indId, { individus: [deptId] })
 
       expect(result._unsafeUnwrap()).toEqual({
-        items: [{ individu: deptId, variation: 50 }],
+        items: [{ individu: deptId, variation: 50, ecartMediane: 0 }],
         min: 50,
         max: 50,
         mediane: 50,
@@ -102,7 +102,7 @@ describe.concurrent('listValeursRemarquablesForIndicateur', () => {
       const result = await listValeursRemarquablesForIndicateur(indId, { individus: [deptId] })
 
       expect(result._unsafeUnwrap()).toEqual({
-        items: [{ individu: deptId, variation: 50 }],
+        items: [{ individu: deptId, variation: 50, ecartMediane: 0 }],
         min: 75,
         max: 75,
         mediane: 75,
@@ -133,7 +133,7 @@ describe.concurrent('listValeursRemarquablesForIndicateur', () => {
       const result = await listValeursRemarquablesForIndicateur(indId, { individus: [deptId] })
 
       expect(result._unsafeUnwrap()).toEqual({
-        items: [{ individu: deptId, variation: -25 }],
+        items: [{ individu: deptId, variation: -25, ecartMediane: 0 }],
         min: 25,
         max: 25,
         mediane: 25,
@@ -171,7 +171,7 @@ describe.concurrent('listValeursRemarquablesForIndicateur', () => {
       const result = await listValeursRemarquablesForIndicateur(indId, { individus: [deptId] })
 
       expect(result._unsafeUnwrap()).toEqual({
-        items: [{ individu: deptId, variation: 65 }],
+        items: [{ individu: deptId, variation: 65, ecartMediane: 0 }],
         min: 75,
         max: 75,
         mediane: 75,
@@ -213,9 +213,9 @@ describe.concurrent('listValeursRemarquablesForIndicateur', () => {
 
       expect(result._unsafeUnwrap()).toEqual({
         items: [
-          { individu: dept1, variation: 20 },
-          { individu: dept2, variation: 5 },
-          { individu: dept3, variation: null },
+          { individu: dept1, variation: 20, ecartMediane: 12.5 },
+          { individu: dept2, variation: 5, ecartMediane: -12.5 },
+          { individu: dept3, variation: null, ecartMediane: null },
         ],
         min: 5,
         max: 30,
@@ -247,7 +247,7 @@ describe.concurrent('listValeursRemarquablesForIndicateur', () => {
       const result = await listValeursRemarquablesForIndicateur(indId, { individus: [deptId] })
 
       expect(result._unsafeUnwrap()).toEqual({
-        items: [{ individu: deptId, variation: 100 }],
+        items: [{ individu: deptId, variation: 100, ecartMediane: 0 }],
         min: 100,
         max: 100,
         mediane: 100,
@@ -273,7 +273,7 @@ describe.concurrent('listValeursRemarquablesForIndicateur', () => {
       })
 
       expect(result._unsafeUnwrap()).toEqual({
-        items: [{ individu: deptId, variation: 42 }],
+        items: [{ individu: deptId, variation: 42, ecartMediane: 0 }],
         min: 42,
         max: 42,
         mediane: 42,
@@ -304,7 +304,7 @@ describe.concurrent('listValeursRemarquablesForIndicateur', () => {
       const result = await listValeursRemarquablesForIndicateur(indId, { individus: [deptId] })
 
       expect(result._unsafeUnwrap()).toEqual({
-        items: [{ individu: deptId, variation: 0.15 }],
+        items: [{ individu: deptId, variation: 0.15, ecartMediane: 0 }],
         min: 0.3,
         max: 0.3,
         mediane: 0.3,
@@ -427,7 +427,7 @@ describe.concurrent('listValeursRemarquablesForIndicateur', () => {
       const result = await listValeursRemarquablesForIndicateur(indId, { individus: [dept2] })
 
       expect(result._unsafeUnwrap()).toEqual({
-        items: [{ individu: dept2, variation: 50 }],
+        items: [{ individu: dept2, variation: 50, ecartMediane: 0 }],
         min: 5,
         max: 100,
         mediane: 50,
@@ -477,6 +477,173 @@ describe.concurrent('listValeursRemarquablesForIndicateur', () => {
       await expect(
         listValeursRemarquablesForIndicateur(testIndicateurId(), { individus: [testDeptId()] }),
       ).rejects.toThrow()
+    }),
+  )
+
+  it(
+    "calcule l'écart à la médiane pour chaque individu demandé (population impaire)",
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const [dept1, dept2, dept3] = testDeptIds(3)
+      await fixtures.valeurAvancement(
+        {
+          indicateur: { publicId: indId, nom: 'T' },
+          individu: { publicId: dept1, nom: 'A' },
+          date: '2026-01-01',
+          valeur: 10,
+        },
+        {
+          indicateur: { publicId: indId },
+          individu: { publicId: dept2, nom: 'B' },
+          date: '2026-01-01',
+          valeur: 50,
+        },
+        {
+          indicateur: { publicId: indId },
+          individu: { publicId: dept3, nom: 'C' },
+          date: '2026-01-01',
+          valeur: 30,
+        },
+      )
+
+      const result = await listValeursRemarquablesForIndicateur(indId, {
+        individus: [dept1, dept2, dept3],
+      })
+
+      // mediane = 30 → ecartMediane: dept1=-20, dept2=20, dept3=0
+      expect(result._unsafeUnwrap()).toMatchObject({
+        items: [
+          { individu: dept1, ecartMediane: -20 },
+          { individu: dept2, ecartMediane: 20 },
+          { individu: dept3, ecartMediane: 0 },
+        ],
+        mediane: 30,
+      })
+    }),
+  )
+
+  it(
+    "calcule l'écart à la médiane quand la médiane est la moyenne de deux centrales (population paire)",
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const [dept1, dept2, dept3, dept4] = testDeptIds(4)
+      await fixtures.valeurAvancement(
+        {
+          indicateur: { publicId: indId, nom: 'T' },
+          individu: { publicId: dept1, nom: 'A' },
+          date: '2026-01-01',
+          valeur: 10,
+        },
+        {
+          indicateur: { publicId: indId },
+          individu: { publicId: dept2, nom: 'B' },
+          date: '2026-01-01',
+          valeur: 20,
+        },
+        {
+          indicateur: { publicId: indId },
+          individu: { publicId: dept3, nom: 'C' },
+          date: '2026-01-01',
+          valeur: 30,
+        },
+        {
+          indicateur: { publicId: indId },
+          individu: { publicId: dept4, nom: 'D' },
+          date: '2026-01-01',
+          valeur: 40,
+        },
+      )
+
+      const result = await listValeursRemarquablesForIndicateur(indId, {
+        individus: [dept1, dept4],
+      })
+
+      // mediane = (20 + 30) / 2 = 25 → dept1=-15, dept4=15
+      expect(result._unsafeUnwrap()).toMatchObject({
+        items: [
+          { individu: dept1, ecartMediane: -15 },
+          { individu: dept4, ecartMediane: 15 },
+        ],
+        mediane: 25,
+      })
+    }),
+  )
+
+  it(
+    "l'écart à la médiane utilise la valeur la plus récente de l'individu",
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const [dept1, dept2, dept3] = testDeptIds(3)
+      await fixtures.valeurAvancement(
+        {
+          indicateur: { publicId: indId, nom: 'T' },
+          individu: { publicId: dept1, nom: 'A' },
+          date: '2026-01-01',
+          valeur: 100,
+        },
+        {
+          indicateur: { publicId: indId },
+          individu: { publicId: dept1 },
+          date: '2026-02-01',
+          valeur: 40,
+        },
+        {
+          indicateur: { publicId: indId },
+          individu: { publicId: dept2, nom: 'B' },
+          date: '2026-01-01',
+          valeur: 50,
+        },
+        {
+          indicateur: { publicId: indId },
+          individu: { publicId: dept3, nom: 'C' },
+          date: '2026-01-01',
+          valeur: 30,
+        },
+      )
+
+      const result = await listValeursRemarquablesForIndicateur(indId, { individus: [dept1] })
+
+      // valeurs récentes: dept1=40, dept2=50, dept3=30 → mediane=40 → ecart dept1=0
+      expect(result._unsafeUnwrap()).toMatchObject({
+        items: [{ individu: dept1, ecartMediane: 0 }],
+        mediane: 40,
+      })
+    }),
+  )
+
+  it(
+    "évite les erreurs de précision IEEE 754 sur l'écart à la médiane",
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const [dept1, dept2, dept3] = testDeptIds(3)
+      await fixtures.valeurAvancement(
+        {
+          indicateur: { publicId: indId, nom: 'T' },
+          individu: { publicId: dept1, nom: 'A' },
+          date: '2026-01-01',
+          valeur: 0.3,
+        },
+        {
+          indicateur: { publicId: indId },
+          individu: { publicId: dept2, nom: 'B' },
+          date: '2026-01-01',
+          valeur: 0.15,
+        },
+        {
+          indicateur: { publicId: indId },
+          individu: { publicId: dept3, nom: 'C' },
+          date: '2026-01-01',
+          valeur: 0.45,
+        },
+      )
+
+      const result = await listValeursRemarquablesForIndicateur(indId, { individus: [dept1] })
+
+      // mediane = 0.3 → ecart dept1 = 0
+      expect(result._unsafeUnwrap()).toMatchObject({
+        items: [{ individu: dept1, ecartMediane: 0 }],
+        mediane: 0.3,
+      })
     }),
   )
 })

--- a/apps/mb-api/src/valeurAvancement/queries/listValeursRemarquablesForIndicateur.ts
+++ b/apps/mb-api/src/valeurAvancement/queries/listValeursRemarquablesForIndicateur.ts
@@ -4,6 +4,7 @@ import {
 } from '@pilote/mb-shared/valeurAvancement'
 import { ResultAsync } from 'neverthrow'
 
+import { type Decimal } from '@/framework/decimal'
 import { db } from '@/framework/persistence/dbStore'
 import { computeMax } from '@/valeurAvancement/computeMax'
 import { computeMediane } from '@/valeurAvancement/computeMediane'
@@ -48,8 +49,8 @@ export const listValeursRemarquablesForIndicateur = (
     .map((rows) => ({
       items: rows.map((row) => {
         const dernieresValeurs = row.individus
-          .map((i) => i.valeurs[0]?.valeur.toNumber())
-          .filter((v): v is number => v !== undefined)
+          .map((i) => i.valeurs[0]?.valeur)
+          .filter((v): v is Decimal => v !== undefined)
         return {
           referentiel: row.publicId,
           min: computeMin(dernieresValeurs),

--- a/apps/mb-api/src/valeurAvancement/queries/listValeursRemarquablesForIndicateur.ts
+++ b/apps/mb-api/src/valeurAvancement/queries/listValeursRemarquablesForIndicateur.ts
@@ -5,47 +5,29 @@ import {
 import { ResultAsync } from 'neverthrow'
 
 import { db } from '@/framework/persistence/dbStore'
-import { Prisma } from '@/generated/prisma/client'
 import { computeMax } from '@/valeurAvancement/computeMax'
 import { computeMediane } from '@/valeurAvancement/computeMediane'
 import { computeMin } from '@/valeurAvancement/computeMin'
 
-const computeVariation = (valeurs: ReadonlyArray<{ valeur: Prisma.Decimal }>): number | null => {
-  if (valeurs.length === 0) return null
-  const [recente, precedente] = valeurs
-  const precedenteValeur = precedente?.valeur ?? new Prisma.Decimal(0)
-  return recente!.valeur.minus(precedenteValeur).toNumber()
-}
-
-const computeEcartMediane = (
-  derniereValeur: Prisma.Decimal | undefined,
-  mediane: number | null,
-): number | null => {
-  if (derniereValeur === undefined || mediane === null) return null
-  return derniereValeur.minus(mediane).toNumber()
-}
-
-const fetchItemsPourVariation = (indicateurId: string, individus: ReadonlyArray<string>) =>
-  db().individu.findMany({
-    where: { publicId: { in: [...individus] } },
+const fetchReferentielsAvecValeursRecentes = (
+  indicateurId: string,
+  referentiels: ReadonlyArray<string>,
+) =>
+  db().referentiel.findMany({
+    where: { publicId: { in: [...referentiels] } },
     orderBy: { publicId: 'asc' },
-    include: {
-      valeurs: {
-        where: { indicateurId },
-        orderBy: [{ date: 'desc' }, { id: 'desc' }],
-        take: 2,
-      },
-    },
-  })
-
-const fetchValeursRecentesPopulation = (indicateurId: string) =>
-  db().individu.findMany({
-    where: { valeurs: { some: { indicateurId } } },
-    include: {
-      valeurs: {
-        where: { indicateurId },
-        orderBy: [{ date: 'desc' }, { id: 'desc' }],
-        take: 1,
+    select: {
+      publicId: true,
+      individus: {
+        where: { valeurs: { some: { indicateurId } } },
+        select: {
+          valeurs: {
+            where: { indicateurId },
+            orderBy: [{ date: 'desc' }, { id: 'desc' }],
+            take: 1,
+            select: { valeur: true },
+          },
+        },
       },
     },
   })
@@ -59,28 +41,22 @@ export const listValeursRemarquablesForIndicateur = (
       where: { publicId: indicateurPublicId },
       select: { id: true },
     }),
-  ).andThen((indicateur) =>
-    ResultAsync.fromSafePromise(
-      Promise.all([
-        fetchItemsPourVariation(indicateur.id, params.individus),
-        fetchValeursRecentesPopulation(indicateur.id),
-      ]),
-    ).map(([itemsRows, populationRows]) => {
-      const dernieresValeurs = populationRows
-        .map((row) => row.valeurs[0]?.valeur.toNumber())
-        .filter((v): v is number => v !== undefined)
-
-      const mediane = computeMediane(dernieresValeurs)
-
-      return {
-        items: itemsRows.map((row) => ({
-          individu: row.publicId,
-          variation: computeVariation(row.valeurs),
-          ecartMediane: computeEcartMediane(row.valeurs[0]?.valeur, mediane),
-        })),
-        min: computeMin(dernieresValeurs),
-        max: computeMax(dernieresValeurs),
-        mediane,
-      }
-    }),
   )
+    .andThen((indicateur) =>
+      ResultAsync.fromSafePromise(
+        fetchReferentielsAvecValeursRecentes(indicateur.id, params.referentiels),
+      ),
+    )
+    .map((rows) => ({
+      items: rows.map((row) => {
+        const dernieresValeurs = row.individus
+          .map((i) => i.valeurs[0]?.valeur.toNumber())
+          .filter((v): v is number => v !== undefined)
+        return {
+          referentiel: row.publicId,
+          min: computeMin(dernieresValeurs),
+          max: computeMax(dernieresValeurs),
+          mediane: computeMediane(dernieresValeurs),
+        }
+      }),
+    }))

--- a/apps/mb-api/src/valeurAvancement/queries/listValeursRemarquablesForIndicateur.ts
+++ b/apps/mb-api/src/valeurAvancement/queries/listValeursRemarquablesForIndicateur.ts
@@ -17,6 +17,14 @@ const computeVariation = (valeurs: ReadonlyArray<{ valeur: Prisma.Decimal }>): n
   return recente!.valeur.minus(precedenteValeur).toNumber()
 }
 
+const computeEcartMediane = (
+  derniereValeur: Prisma.Decimal | undefined,
+  mediane: number | null,
+): number | null => {
+  if (derniereValeur === undefined || mediane === null) return null
+  return derniereValeur.minus(mediane).toNumber()
+}
+
 const fetchItemsPourVariation = (indicateurId: string, individus: ReadonlyArray<string>) =>
   db().individu.findMany({
     where: { publicId: { in: [...individus] } },
@@ -62,14 +70,17 @@ export const listValeursRemarquablesForIndicateur = (
         .map((row) => row.valeurs[0]?.valeur.toNumber())
         .filter((v): v is number => v !== undefined)
 
+      const mediane = computeMediane(dernieresValeurs)
+
       return {
         items: itemsRows.map((row) => ({
           individu: row.publicId,
           variation: computeVariation(row.valeurs),
+          ecartMediane: computeEcartMediane(row.valeurs[0]?.valeur, mediane),
         })),
         min: computeMin(dernieresValeurs),
         max: computeMax(dernieresValeurs),
-        mediane: computeMediane(dernieresValeurs),
+        mediane,
       }
     }),
   )

--- a/apps/mb-api/src/valeurAvancement/queries/listValeursRemarquablesForIndicateur.ts
+++ b/apps/mb-api/src/valeurAvancement/queries/listValeursRemarquablesForIndicateur.ts
@@ -16,16 +16,14 @@ const fetchReferentielsAvecValeursRecentes = (
   db().referentiel.findMany({
     where: { publicId: { in: [...referentiels] } },
     orderBy: { publicId: 'asc' },
-    select: {
-      publicId: true,
+    include: {
       individus: {
         where: { valeurs: { some: { indicateurId } } },
-        select: {
+        include: {
           valeurs: {
             where: { indicateurId },
             orderBy: [{ date: 'desc' }, { id: 'desc' }],
             take: 1,
-            select: { valeur: true },
           },
         },
       },

--- a/apps/mb-api/src/valeurAvancement/routes.ts
+++ b/apps/mb-api/src/valeurAvancement/routes.ts
@@ -5,8 +5,10 @@ import { createPaginatedApiListSchema } from '@pilote/mb-shared/pagination'
 import {
   individuAvecValeursApiModelSchema,
   listIndividusWithValeursQuerySchema,
+  listSyntheseIndividusQuerySchema,
   listValeursForIndicateurQuerySchema,
   listValeursRemarquablesForIndicateurQuerySchema,
+  syntheseIndividusListApiModelSchema,
   valeurAvancementListApiModelSchema,
   valeursRemarquablesListApiModelSchema,
 } from '@pilote/mb-shared/valeurAvancement'
@@ -15,6 +17,7 @@ import { requireAuthentication } from '@/framework/auth/requireAuthentication'
 import { never } from '@/framework/errors/never'
 import { jsonResponseOk } from '@/framework/openapi/jsonResponse'
 import { listIndividusWithValeurs } from '@/valeurAvancement/queries/listIndividusWithValeurs'
+import { listSyntheseIndividus } from '@/valeurAvancement/queries/listSyntheseIndividus'
 import { listValeursForIndicateur } from '@/valeurAvancement/queries/listValeursForIndicateur'
 import { listValeursRemarquablesForIndicateur } from '@/valeurAvancement/queries/listValeursRemarquablesForIndicateur'
 
@@ -26,6 +29,9 @@ const IndividusWithValeursListApiModelSchema = createPaginatedApiListSchema(
 ).openapi('IndividusWithValeursListApiModel')
 const ValeursRemarquablesListApiModelSchema = valeursRemarquablesListApiModelSchema.openapi(
   'ValeursRemarquablesListApiModel',
+)
+const SyntheseIndividusListApiModelSchema = syntheseIndividusListApiModelSchema.openapi(
+  'SyntheseIndividusListApiModel',
 )
 const ErrorApiModelSchema = errorApiModelSchema.openapi('ErrorApiModel')
 
@@ -91,16 +97,12 @@ const getValeursRemarquablesForIndicateurRoute = createRoute({
   method: 'get',
   path: '/indicateurs/{id}/valeurs-remarquables',
   tags: ['Indicateur'],
-  summary: 'Lister les valeurs remarquables pour un indicateur sur des individus',
+  summary: 'Lister les valeurs remarquables pour un indicateur par référentiel',
   description:
-    "Retourne, pour chaque individu demandé, une vue agrégée des valeurs remarquables de l'indicateur (variation depuis la dernière mise à jour). " +
-    'Le paramètre `individus` est obligatoire (1..N identifiants séparés par une virgule, ex. `DEPT-84,DEPT-13`). ' +
-    'Les individus inexistants sont omis de la réponse. ' +
-    'La variation est calculée sur la base de la date de la valeur (pas de la date de saisie) : null si aucune valeur, ' +
-    'égale à la valeur la plus récente si une seule (comparée à 0), sinon différence avec la valeur précédente. ' +
-    "La réponse inclut également `min`/`max`/`mediane` calculés sur la valeur la plus récente de l'ensemble des " +
-    "individus ayant au moins une valeur pour l'indicateur (indépendamment du paramètre `individus`). " +
-    "Ces trois champs sont à `null` si aucun individu n'a de valeur pour l'indicateur.",
+    "Retourne, pour chaque référentiel demandé existant, les stats `min`/`max`/`mediane` calculées sur la valeur la plus récente de chaque individu du référentiel ayant au moins une valeur pour l'indicateur. " +
+    'Le paramètre `referentiels` est obligatoire (1..N identifiants séparés par une virgule, ex. `REF-DEPT,REF-REG`). ' +
+    'Les référentiels inexistants sont omis de la réponse. ' +
+    "Si un référentiel n'a aucun individu avec valeur pour l'indicateur, les trois champs sont à `null` mais l'item est présent.",
   middleware: [requireAuthentication],
   request: {
     params: indicateurParamsSchema,
@@ -109,7 +111,39 @@ const getValeursRemarquablesForIndicateurRoute = createRoute({
   responses: {
     200: {
       content: { 'application/json': { schema: ValeursRemarquablesListApiModelSchema } },
-      description: 'Valeurs remarquables pour les individus demandés',
+      description: 'Valeurs remarquables agrégées pour les référentiels demandés',
+    },
+    400: {
+      content: { 'application/json': { schema: ErrorApiModelSchema } },
+      description: 'Paramètres de requête invalides (ex. `referentiels` absent)',
+    },
+  },
+})
+
+// --- GET /indicateurs/:id/synthese-individus ---------------------------------
+
+const getSyntheseIndividusRoute = createRoute({
+  method: 'get',
+  path: '/indicateurs/{id}/synthese-individus',
+  tags: ['Indicateur'],
+  summary: 'Lister la synthèse pour un indicateur sur des individus',
+  description:
+    'Retourne, pour chaque individu demandé existant, sa variation depuis la dernière mise à jour et son écart à la médiane de son référentiel. ' +
+    'Le paramètre `individus` est obligatoire (1..N identifiants séparés par une virgule, ex. `DEPT-84,DEPT-13`). ' +
+    'Les individus inexistants sont omis de la réponse. ' +
+    'La variation est calculée sur la base de la date de la valeur (pas de la date de saisie) : null si aucune valeur, ' +
+    'égale à la valeur la plus récente si une seule (comparée à 0), sinon différence avec la valeur précédente. ' +
+    "L'écart à la médiane est calculé par rapport à la médiane des valeurs récentes des individus du même référentiel " +
+    "ayant au moins une valeur pour l'indicateur ; null si l'individu n'a aucune valeur.",
+  middleware: [requireAuthentication],
+  request: {
+    params: indicateurParamsSchema,
+    query: listSyntheseIndividusQuerySchema,
+  },
+  responses: {
+    200: {
+      content: { 'application/json': { schema: SyntheseIndividusListApiModelSchema } },
+      description: 'Synthèse pour les individus demandés',
     },
     400: {
       content: { 'application/json': { schema: ErrorApiModelSchema } },
@@ -156,14 +190,30 @@ valeurAvancementRoutes.openapi(getIndividusWithValeursRoute, async (context) => 
 
 valeurAvancementRoutes.openapi(getValeursRemarquablesForIndicateurRoute, async (context) => {
   const { id } = context.req.valid('param')
-  const { individus } = context.req.valid('query')
+  const { referentiels } = context.req.valid('query')
 
-  return listValeursRemarquablesForIndicateur(id, { individus }).match(
+  return listValeursRemarquablesForIndicateur(id, { referentiels }).match(
     (data) =>
       jsonResponseOk({
         context,
         data,
         schema: ValeursRemarquablesListApiModelSchema,
+        status: 200,
+      }),
+    never,
+  )
+})
+
+valeurAvancementRoutes.openapi(getSyntheseIndividusRoute, async (context) => {
+  const { id } = context.req.valid('param')
+  const { individus } = context.req.valid('query')
+
+  return listSyntheseIndividus(id, { individus }).match(
+    (data) =>
+      jsonResponseOk({
+        context,
+        data,
+        schema: SyntheseIndividusListApiModelSchema,
         status: 200,
       }),
     never,

--- a/apps/mb-webapp/src/api/indicateurs.ts
+++ b/apps/mb-webapp/src/api/indicateurs.ts
@@ -8,6 +8,8 @@ import { type PaginateQuery } from '@pilote/mb-shared/pagination'
 import {
   type IndividusWithValeursListApiModel,
   individusWithValeursListApiModelSchema,
+  type SyntheseIndividusListApiModel,
+  syntheseIndividusListApiModelSchema,
   type ValeurAvancementListApiModel,
   valeurAvancementListApiModelSchema,
   type ValeursRemarquablesListApiModel,
@@ -58,12 +60,24 @@ export const fetchValeursForIndicateur = async (
 
 export const fetchValeursRemarquablesForIndicateur = async (
   indicateurId: string,
-  params: { individus: string[] },
+  params: { referentiels: string[] },
 ): Promise<ValeursRemarquablesListApiModel> => {
   const json = await apiClient
     .get(`indicateurs/${indicateurId}/valeurs-remarquables`, {
-      searchParams: { individus: params.individus.join(',') },
+      searchParams: { referentiels: params.referentiels.join(',') },
     })
     .json()
   return valeursRemarquablesListApiModelSchema.parse(json)
+}
+
+export const fetchSyntheseIndividus = async (
+  indicateurId: string,
+  params: { individus: string[] },
+): Promise<SyntheseIndividusListApiModel> => {
+  const json = await apiClient
+    .get(`indicateurs/${indicateurId}/synthese-individus`, {
+      searchParams: { individus: params.individus.join(',') },
+    })
+    .json()
+  return syntheseIndividusListApiModelSchema.parse(json)
 }

--- a/apps/mb-webapp/src/api/indicateurs.ts
+++ b/apps/mb-webapp/src/api/indicateurs.ts
@@ -3,11 +3,15 @@ import {
   indicateurApiModelSchema,
   type IndicateurListApiModel,
   indicateurListApiModelSchema,
+  type ListIndicateursQuery,
 } from '@pilote/mb-shared/indicateur'
-import { type PaginateQuery } from '@pilote/mb-shared/pagination'
 import {
   type IndividusWithValeursListApiModel,
   individusWithValeursListApiModelSchema,
+  type ListIndividusWithValeursQuery,
+  type ListSyntheseIndividusQuery,
+  type ListValeursForIndicateurQuery,
+  type ListValeursRemarquablesForIndicateurQuery,
   type SyntheseIndividusListApiModel,
   syntheseIndividusListApiModelSchema,
   type ValeurAvancementListApiModel,
@@ -18,12 +22,8 @@ import {
 
 import { apiClient } from '@/api/client'
 
-export type IndicateursQueryParams = PaginateQuery & {
-  recherche?: string | undefined
-}
-
 export const fetchIndicateurs = async (
-  params: IndicateursQueryParams,
+  params: ListIndicateursQuery,
 ): Promise<IndicateurListApiModel> => {
   // ky filters out `undefined` values from object-form searchParams (see
   // Ky.#normalizeSearchParams), so we can pass `params` directly.
@@ -38,7 +38,7 @@ export const fetchIndicateurById = async (id: string): Promise<IndicateurApiMode
 
 export const fetchIndividusForIndicateur = async (
   indicateurId: string,
-  params: { cursor?: string } = {},
+  params: ListIndividusWithValeursQuery,
 ): Promise<IndividusWithValeursListApiModel> => {
   const json = await apiClient
     .get(`indicateurs/${indicateurId}/individus`, { searchParams: params })
@@ -48,11 +48,15 @@ export const fetchIndividusForIndicateur = async (
 
 export const fetchValeursForIndicateur = async (
   indicateurId: string,
-  params: { individus: string[] },
+  params: ListValeursForIndicateurQuery,
 ): Promise<ValeurAvancementListApiModel> => {
   const json = await apiClient
     .get(`indicateurs/${indicateurId}/valeurs`, {
-      searchParams: { individus: params.individus.join(',') },
+      searchParams: {
+        individus: params.individus.join(','),
+        ...(params.dateDebut ? { dateDebut: params.dateDebut } : {}),
+        ...(params.dateFin ? { dateFin: params.dateFin } : {}),
+      },
     })
     .json()
   return valeurAvancementListApiModelSchema.parse(json)
@@ -60,7 +64,7 @@ export const fetchValeursForIndicateur = async (
 
 export const fetchValeursRemarquablesForIndicateur = async (
   indicateurId: string,
-  params: { referentiels: string[] },
+  params: ListValeursRemarquablesForIndicateurQuery,
 ): Promise<ValeursRemarquablesListApiModel> => {
   const json = await apiClient
     .get(`indicateurs/${indicateurId}/valeurs-remarquables`, {
@@ -72,7 +76,7 @@ export const fetchValeursRemarquablesForIndicateur = async (
 
 export const fetchSyntheseIndividus = async (
   indicateurId: string,
-  params: { individus: string[] },
+  params: ListSyntheseIndividusQuery,
 ): Promise<SyntheseIndividusListApiModel> => {
   const json = await apiClient
     .get(`indicateurs/${indicateurId}/synthese-individus`, {

--- a/apps/mb-webapp/src/queries/indicateurs.ts
+++ b/apps/mb-webapp/src/queries/indicateurs.ts
@@ -1,3 +1,4 @@
+import { type ListIndicateursQuery } from '@pilote/mb-shared/indicateur'
 import { queryOptions } from '@tanstack/react-query'
 
 import {
@@ -7,12 +8,11 @@ import {
   fetchSyntheseIndividus,
   fetchValeursForIndicateur,
   fetchValeursRemarquablesForIndicateur,
-  type IndicateursQueryParams,
 } from '@/api/indicateurs'
 
 import { DEFAULT_STALE_TIME, fetchAllPaginatedItems } from './utils'
 
-export const indicateursQueryOptions = (params: IndicateursQueryParams) =>
+export const indicateursQueryOptions = (params: ListIndicateursQuery) =>
   queryOptions({
     queryKey: ['indicateurs', params],
     queryFn: () => fetchIndicateurs(params),

--- a/apps/mb-webapp/src/queries/indicateurs.ts
+++ b/apps/mb-webapp/src/queries/indicateurs.ts
@@ -4,6 +4,7 @@ import {
   fetchIndicateurById,
   fetchIndicateurs,
   fetchIndividusForIndicateur,
+  fetchSyntheseIndividus,
   fetchValeursForIndicateur,
   fetchValeursRemarquablesForIndicateur,
   type IndicateursQueryParams,
@@ -44,10 +45,18 @@ export const indicateurValeursQueryOptions = (indicateurId: string, individuId: 
 
 export const indicateurValeursRemarquablesQueryOptions = (
   indicateurId: string,
-  individuId: string,
+  referentielId: string,
 ) =>
   queryOptions({
-    queryKey: ['indicateur', indicateurId, 'valeurs-remarquables', individuId],
-    queryFn: () => fetchValeursRemarquablesForIndicateur(indicateurId, { individus: [individuId] }),
+    queryKey: ['indicateur', indicateurId, 'valeurs-remarquables', referentielId],
+    queryFn: () =>
+      fetchValeursRemarquablesForIndicateur(indicateurId, { referentiels: [referentielId] }),
+    staleTime: DEFAULT_STALE_TIME,
+  })
+
+export const indicateurSyntheseIndividuQueryOptions = (indicateurId: string, individuId: string) =>
+  queryOptions({
+    queryKey: ['indicateur', indicateurId, 'synthese-individus', individuId],
+    queryFn: () => fetchSyntheseIndividus(indicateurId, { individus: [individuId] }),
     staleTime: DEFAULT_STALE_TIME,
   })

--- a/apps/mb-webapp/src/routes/_authenticated/indicateurs/$id.tsx
+++ b/apps/mb-webapp/src/routes/_authenticated/indicateurs/$id.tsx
@@ -89,7 +89,9 @@ export const Route = createFileRoute('/_authenticated/indicateurs/$id')({
       context.queryClient.fetchQuery(
         indicateurValeursRemarquablesQueryOptions(params.id, selected.referentiel),
       ),
-      context.queryClient.fetchQuery(indicateurSyntheseIndividuQueryOptions(params.id, selected.id)),
+      context.queryClient.fetchQuery(
+        indicateurSyntheseIndividuQueryOptions(params.id, selected.id),
+      ),
     ])
 
     return { indicateur }

--- a/apps/mb-webapp/src/routes/_authenticated/indicateurs/$id.tsx
+++ b/apps/mb-webapp/src/routes/_authenticated/indicateurs/$id.tsx
@@ -23,6 +23,7 @@ import {
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/Tabs'
 import {
   indicateurQueryOptions,
+  indicateurSyntheseIndividuQueryOptions,
   indicateurValeursQueryOptions,
   indicateurValeursRemarquablesQueryOptions,
 } from '@/queries/indicateurs'
@@ -84,10 +85,11 @@ export const Route = createFileRoute('/_authenticated/indicateurs/$id')({
     }
 
     await Promise.all([
-      context.queryClient.fetchQuery(indicateurValeursQueryOptions(params.id, deps.individu!)),
+      context.queryClient.fetchQuery(indicateurValeursQueryOptions(params.id, selected.id)),
       context.queryClient.fetchQuery(
-        indicateurValeursRemarquablesQueryOptions(params.id, deps.individu!),
+        indicateurValeursRemarquablesQueryOptions(params.id, selected.referentiel),
       ),
+      context.queryClient.fetchQuery(indicateurSyntheseIndividuQueryOptions(params.id, selected.id)),
     ])
 
     return { indicateur }
@@ -149,7 +151,10 @@ function IndicateurDetailComponent() {
         </p>
       ) : selectedIndividu === undefined ? null : (
         <>
-          <StatistiquesPopulationSection indicateurId={id} individuId={selectedIndividu.id} />
+          <StatistiquesPopulationSection
+            indicateurId={id}
+            referentielId={selectedIndividu.referentiel}
+          />
 
           <div className="flex items-center gap-3">
             <label className="text-sm text-text-muted" htmlFor="individu-select">
@@ -212,14 +217,15 @@ function IndicateurDetailComponent() {
 
 function StatistiquesPopulationSection({
   indicateurId,
-  individuId,
+  referentielId,
 }: {
   indicateurId: string
-  individuId: string
+  referentielId: string
 }) {
   const { data } = useSuspenseQuery(
-    indicateurValeursRemarquablesQueryOptions(indicateurId, individuId),
+    indicateurValeursRemarquablesQueryOptions(indicateurId, referentielId),
   )
+  const stats = data.items[0] ?? { min: null, max: null, mediane: null }
 
   const numberFormatter = new Intl.NumberFormat('fr-FR')
   const formatStat = (value: number | null): string =>
@@ -228,13 +234,13 @@ function StatistiquesPopulationSection({
   return (
     <section className="grid gap-4 sm:grid-cols-3">
       <StatCard label="Minimum">
-        <p className="text-3xl font-semibold text-text">{formatStat(data.min)}</p>
+        <p className="text-3xl font-semibold text-text">{formatStat(stats.min)}</p>
       </StatCard>
       <StatCard label="Maximum">
-        <p className="text-3xl font-semibold text-text">{formatStat(data.max)}</p>
+        <p className="text-3xl font-semibold text-text">{formatStat(stats.max)}</p>
       </StatCard>
       <StatCard label="Médiane">
-        <p className="text-3xl font-semibold text-text">{formatStat(data.mediane)}</p>
+        <p className="text-3xl font-semibold text-text">{formatStat(stats.mediane)}</p>
       </StatCard>
     </section>
   )
@@ -247,15 +253,15 @@ function ValeursRemarquablesSection({
   indicateurId: string
   individuId: string
 }) {
-  const { data: valeursRemarquables } = useSuspenseQuery(
-    indicateurValeursRemarquablesQueryOptions(indicateurId, individuId),
+  const { data: synthese } = useSuspenseQuery(
+    indicateurSyntheseIndividuQueryOptions(indicateurId, individuId),
   )
   const { data: valeurs } = useSuspenseQuery(
     indicateurValeursQueryOptions(indicateurId, individuId),
   )
 
   const derniereValeur = derniereValeurFromItems(valeurs.items)
-  const variation = valeursRemarquables.items[0]?.variation ?? null
+  const variation = synthese.items[0]?.variation ?? null
 
   const numberFormatter = new Intl.NumberFormat('fr-FR')
   const variationFormatter = new Intl.NumberFormat('fr-FR', { signDisplay: 'exceptZero' })

--- a/packages/mb-shared/src/valeurAvancement.ts
+++ b/packages/mb-shared/src/valeurAvancement.ts
@@ -90,7 +90,75 @@ export const listValeursForIndicateurQuerySchema = z
   )
 export type ListValeursForIndicateurQuery = z.infer<typeof listValeursForIndicateurQuerySchema>
 
-export const valeurRemarquableApiModelSchema = z.object({
+const MAX_REFERENTIELS_PAR_REQUETE = 100
+
+const referentielsCsvSchema = z
+  .string()
+  .min(1, 'Au moins un identifiant de référentiel est requis')
+  .transform((value) =>
+    value
+      .split(',')
+      .map((segment) => segment.trim())
+      .filter((segment) => segment.length > 0),
+  )
+  .pipe(
+    z
+      .array(referentielPublicIdSchema)
+      .min(1)
+      .max(
+        MAX_REFERENTIELS_PAR_REQUETE,
+        `Au plus ${MAX_REFERENTIELS_PAR_REQUETE} référentiels par requête`,
+      ),
+  )
+
+export const valeursRemarquablesReferentielApiModelSchema = z.object({
+  referentiel: referentielPublicIdSchema,
+  min: z
+    .number()
+    .nullable()
+    .describe(
+      "Plus petite valeur la plus récente parmi les individus du référentiel ayant au moins une valeur " +
+        "pour l'indicateur. null si aucun individu n'a de valeur.",
+    ),
+  max: z
+    .number()
+    .nullable()
+    .describe(
+      "Plus grande valeur la plus récente parmi les individus du référentiel ayant au moins une valeur " +
+        "pour l'indicateur. null si aucun individu n'a de valeur.",
+    ),
+  mediane: z
+    .number()
+    .nullable()
+    .describe(
+      "Médiane des valeurs les plus récentes des individus du référentiel ayant au moins une valeur " +
+        "pour l'indicateur. Moyenne des deux valeurs centrales si le nombre d'individus est pair. " +
+        "null si aucun individu n'a de valeur.",
+    ),
+})
+export type ValeursRemarquablesReferentielApiModel = z.infer<
+  typeof valeursRemarquablesReferentielApiModelSchema
+>
+
+export const valeursRemarquablesListApiModelSchema = z.object({
+  items: z
+    .array(valeursRemarquablesReferentielApiModelSchema)
+    .describe('Valeurs remarquables agrégées pour chaque référentiel demandé existant.'),
+})
+export type ValeursRemarquablesListApiModel = z.infer<
+  typeof valeursRemarquablesListApiModelSchema
+>
+
+export const listValeursRemarquablesForIndicateurQuerySchema = z.object({
+  referentiels: referentielsCsvSchema.describe(
+    `Liste d'identifiants de référentiels séparés par une virgule (ex. REF-DEPT,REF-REG). 1..${MAX_REFERENTIELS_PAR_REQUETE} identifiants.`,
+  ),
+})
+export type ListValeursRemarquablesForIndicateurQuery = z.infer<
+  typeof listValeursRemarquablesForIndicateurQuerySchema
+>
+
+export const syntheseIndividuApiModelSchema = z.object({
   individu: individuPublicIdSchema,
   variation: z
     .number()
@@ -104,51 +172,25 @@ export const valeurRemarquableApiModelSchema = z.object({
     .nullable()
     .describe(
       "Écart entre la valeur la plus récente de l'individu et la médiane des valeurs les plus récentes " +
-        "de tous les individus ayant au moins une valeur pour l'indicateur. " +
+        "des individus de son référentiel ayant au moins une valeur pour l'indicateur. " +
         "null si l'individu n'a aucune valeur ou si la médiane n'est pas calculable.",
     ),
 })
-export type ValeurRemarquableApiModel = z.infer<typeof valeurRemarquableApiModelSchema>
+export type SyntheseIndividuApiModel = z.infer<typeof syntheseIndividuApiModelSchema>
 
-export const valeursRemarquablesListApiModelSchema = z.object({
+export const syntheseIndividusListApiModelSchema = z.object({
   items: z
-    .array(valeurRemarquableApiModelSchema)
-    .describe('Valeurs remarquables pour chaque individu demandé ayant été trouvé.'),
-  min: z
-    .number()
-    .nullable()
-    .describe(
-      "Plus petite valeur la plus récente parmi l'ensemble des individus ayant au moins une valeur " +
-        "pour l'indicateur. null si aucun individu n'a de valeur.",
-    ),
-  max: z
-    .number()
-    .nullable()
-    .describe(
-      "Plus grande valeur la plus récente parmi l'ensemble des individus ayant au moins une valeur " +
-        "pour l'indicateur. null si aucun individu n'a de valeur.",
-    ),
-  mediane: z
-    .number()
-    .nullable()
-    .describe(
-      "Médiane des valeurs les plus récentes parmi l'ensemble des individus ayant au moins une valeur " +
-        "pour l'indicateur. Moyenne des deux valeurs centrales si le nombre d'individus est pair. " +
-        "null si aucun individu n'a de valeur.",
-    ),
+    .array(syntheseIndividuApiModelSchema)
+    .describe('Synthèse pour chaque individu demandé ayant été trouvé.'),
 })
-export type ValeursRemarquablesListApiModel = z.infer<
-  typeof valeursRemarquablesListApiModelSchema
->
+export type SyntheseIndividusListApiModel = z.infer<typeof syntheseIndividusListApiModelSchema>
 
-export const listValeursRemarquablesForIndicateurQuerySchema = z.object({
+export const listSyntheseIndividusQuerySchema = z.object({
   individus: individusCsvSchema.describe(
     `Liste d'identifiants d'individus séparés par une virgule (ex. DEPT-84,DEPT-13). 1..${MAX_INDIVIDUS_PAR_REQUETE} identifiants.`,
   ),
 })
-export type ListValeursRemarquablesForIndicateurQuery = z.infer<
-  typeof listValeursRemarquablesForIndicateurQuerySchema
->
+export type ListSyntheseIndividusQuery = z.infer<typeof listSyntheseIndividusQuerySchema>
 
 export const individuAvecValeursApiModelSchema = z.object({
   individu: individuApiModelSchema,

--- a/packages/mb-shared/src/valeurAvancement.ts
+++ b/packages/mb-shared/src/valeurAvancement.ts
@@ -99,6 +99,14 @@ export const valeurRemarquableApiModelSchema = z.object({
       "Variation absolue entre la valeur la plus récente et la précédente (par date de la valeur). " +
         "null si l'individu n'a aucune valeur ; égale à la valeur la plus récente s'il n'en a qu'une (comparée à 0).",
     ),
+  ecartMediane: z
+    .number()
+    .nullable()
+    .describe(
+      "Écart entre la valeur la plus récente de l'individu et la médiane des valeurs les plus récentes " +
+        "de tous les individus ayant au moins une valeur pour l'indicateur. " +
+        "null si l'individu n'a aucune valeur ou si la médiane n'est pas calculable.",
+    ),
 })
 export type ValeurRemarquableApiModel = z.infer<typeof valeurRemarquableApiModelSchema>
 


### PR DESCRIPTION
## Summary

Split de la route `GET /indicateurs/{id}/valeurs-remarquables` en deux endpoints, en tirant parti du passage Individu↔Référentiel en 1:N (#2137).

- **`/valeurs-remarquables?referentiels=…`** (changement de sens) : renvoie `min`/`max`/`mediane` agrégés **par référentiel** demandé, sur la valeur la plus récente de chaque individu du référentiel ayant ≥1 valeur. Référentiels inexistants omis ; référentiels vides → stats à `null`.
- **`/synthese-individus?individus=…`** (nouvelle) : renvoie `variation` + `ecartMediane` **par individu**. `ecartMediane` est désormais scopé au référentiel de l'individu (avant : médiane globale).

### Breaking changes OpenAPI

- `ValeursRemarquablesListApiModel` : items `{ referentiel, min, max, mediane }` (avant : `{ individu, variation, ecartMediane }` + min/max/mediane racine).
- Query param `valeurs-remarquables` : `referentiels` (était `individus`).

### Webapp

`StatistiquesPopulationSection` reçoit le `referentielId` de l'individu sélectionné et lit `items[0]`. `ValeursRemarquablesSection` utilise la nouvelle query synthese pour la variation. Les deux endpoints sont préfetch en parallèle dans le loader.

## Test plan

- [x] `pnpm vitest run` sur `mb-api` — 118/118 passent (13 + 13 nouveaux cas dédiés : référentiels inexistants omis, scoping par référentiel, médianes indépendantes, IEEE 754…)
- [x] `pnpm vitest run` sur `mb-webapp` — 21/21 passent
- [x] `pnpm -r lint` — OK (eslint + tsc + prettier sur mb-api/mb-webapp/ppg)

🤖 Generated with [Claude Code](https://claude.com/claude-code)