### PR TITLE
feat(mb-api): un individu n'appartient qu'à un seul référentiel

### DIFF
--- a/apps/mb-api/prisma/migrations/20260513120000_individu_single_referentiel/migration.sql
+++ b/apps/mb-api/prisma/migrations/20260513120000_individu_single_referentiel/migration.sql
@@ -1,0 +1,41 @@
+-- Cardinalité Individu → Referentiel passe de many-to-many (pivot) à many-to-one (FK directe).
+-- Pas encore de prod : on remet à zéro les individus et toutes leurs dépendances ; le seed les recrée.
+
+-- DropForeignKey
+ALTER TABLE "valeur_avancement" DROP CONSTRAINT "valeur_avancement_individu_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "relation" DROP CONSTRAINT "relation_parent_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "relation" DROP CONSTRAINT "relation_child_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "referentiel_individu" DROP CONSTRAINT "referentiel_individu_referentiel_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "referentiel_individu" DROP CONSTRAINT "referentiel_individu_individu_id_fkey";
+
+-- Wipe individu-dependent data (pas de prod)
+TRUNCATE TABLE "valeur_avancement", "relation", "referentiel_individu", "individu";
+
+-- DropTable
+DROP TABLE "referentiel_individu";
+
+-- AlterTable
+ALTER TABLE "individu" ADD COLUMN "referentiel_id" UUID NOT NULL;
+
+-- CreateIndex
+CREATE INDEX "individu_referentiel_id_idx" ON "individu"("referentiel_id");
+
+-- AddForeignKey
+ALTER TABLE "individu" ADD CONSTRAINT "individu_referentiel_id_fkey" FOREIGN KEY ("referentiel_id") REFERENCES "referentiel"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "relation" ADD CONSTRAINT "relation_parent_id_fkey" FOREIGN KEY ("parent_id") REFERENCES "individu"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "relation" ADD CONSTRAINT "relation_child_id_fkey" FOREIGN KEY ("child_id") REFERENCES "individu"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "valeur_avancement" ADD CONSTRAINT "valeur_avancement_individu_id_fkey" FOREIGN KEY ("individu_id") REFERENCES "individu"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/apps/mb-api/prisma/schema.prisma
+++ b/apps/mb-api/prisma/schema.prisma
@@ -90,36 +90,26 @@ model Referentiel {
   createdAt   DateTime @default(now()) @map("created_at")
   updatedAt   DateTime @updatedAt      @map("updated_at")
 
-  individus ReferentielIndividu[]
+  individus Individu[]
 
   @@map("referentiel")
 }
 
 model Individu {
-  id        String   @id @db.Uuid
-  publicId  String   @unique @map("public_id")
-  nom       String
-  createdAt DateTime @default(now()) @map("created_at")
-  updatedAt DateTime @updatedAt      @map("updated_at")
+  id            String   @id @db.Uuid
+  publicId      String   @unique @map("public_id")
+  nom           String
+  referentielId String   @map("referentiel_id") @db.Uuid
+  createdAt     DateTime @default(now()) @map("created_at")
+  updatedAt     DateTime @updatedAt      @map("updated_at")
 
-  referentiels      ReferentielIndividu[]
-  relationsAsParent Relation[]            @relation("relationParent")
-  relationsAsChild  Relation[]            @relation("relationChild")
+  referentiel       Referentiel        @relation(fields: [referentielId], references: [id], onDelete: Restrict)
+  relationsAsParent Relation[]         @relation("relationParent")
+  relationsAsChild  Relation[]         @relation("relationChild")
   valeurs           ValeurAvancement[]
 
+  @@index([referentielId])
   @@map("individu")
-}
-
-model ReferentielIndividu {
-  referentielId String @map("referentiel_id") @db.Uuid
-  individuId    String @map("individu_id")    @db.Uuid
-
-  referentiel Referentiel @relation(fields: [referentielId], references: [id], onDelete: Cascade)
-  individu    Individu    @relation(fields: [individuId],    references: [id], onDelete: Cascade)
-
-  @@id([referentielId, individuId])
-  @@index([individuId])
-  @@map("referentiel_individu")
 }
 
 model Relation {

--- a/apps/mb-api/prisma/seed.ts
+++ b/apps/mb-api/prisma/seed.ts
@@ -162,38 +162,20 @@ const main = async () => {
   }
 
   for (const item of individusSeed) {
+    const referentiel = await prisma.referentiel.findUniqueOrThrow({
+      where: { publicId: item.referentiel },
+      select: { id: true },
+    })
     await prisma.individu.upsert({
       where: { publicId: item.publicId },
-      update: { nom: item.nom },
+      update: { nom: item.nom, referentielId: referentiel.id },
       create: {
         id: uuidv7(),
         publicId: item.publicId,
         nom: item.nom,
+        referentielId: referentiel.id,
       },
     })
-  }
-
-  for (const item of individusSeed) {
-    const individu = await prisma.individu.findUniqueOrThrow({
-      where: { publicId: item.publicId },
-      select: { id: true },
-    })
-    for (const referentielPublicId of item.referentiels) {
-      const referentiel = await prisma.referentiel.findUniqueOrThrow({
-        where: { publicId: referentielPublicId },
-        select: { id: true },
-      })
-      await prisma.referentielIndividu.upsert({
-        where: {
-          referentielId_individuId: {
-            referentielId: referentiel.id,
-            individuId: individu.id,
-          },
-        },
-        update: {},
-        create: { referentielId: referentiel.id, individuId: individu.id },
-      })
-    }
   }
 
   for (const item of relationsSeed) {

--- a/apps/mb-api/prisma/seedData/geo.ts
+++ b/apps/mb-api/prisma/seedData/geo.ts
@@ -17,20 +17,20 @@ export const referentielsSeed = [
 ] as const
 
 export const individusSeed = [
-  { publicId: 'FR', nom: 'France', referentiels: ['REF-NAT'] },
-  { publicId: 'REG-11', nom: 'Île-de-France', referentiels: ['REF-REG'] },
-  { publicId: 'REG-93', nom: "Provence-Alpes-Côte d'Azur", referentiels: ['REF-REG'] },
-  { publicId: 'REG-84', nom: 'Auvergne-Rhône-Alpes', referentiels: ['REF-REG'] },
-  { publicId: 'DEPT-75', nom: 'Paris', referentiels: ['REF-DEPT'] },
-  { publicId: 'DEPT-77', nom: 'Seine-et-Marne', referentiels: ['REF-DEPT'] },
-  { publicId: 'DEPT-78', nom: 'Yvelines', referentiels: ['REF-DEPT'] },
-  { publicId: 'DEPT-13', nom: 'Bouches-du-Rhône', referentiels: ['REF-DEPT'] },
-  { publicId: 'DEPT-83', nom: 'Var', referentiels: ['REF-DEPT'] },
-  { publicId: 'DEPT-84', nom: 'Vaucluse', referentiels: ['REF-DEPT'] },
-  { publicId: 'DEPT-06', nom: 'Alpes-Maritimes', referentiels: ['REF-DEPT'] },
-  { publicId: 'DEPT-69', nom: 'Rhône', referentiels: ['REF-DEPT'] },
-  { publicId: 'DEPT-38', nom: 'Isère', referentiels: ['REF-DEPT'] },
-  { publicId: 'DEPT-73', nom: 'Savoie', referentiels: ['REF-DEPT'] },
+  { publicId: 'FR', nom: 'France', referentiel: 'REF-NAT' },
+  { publicId: 'REG-11', nom: 'Île-de-France', referentiel: 'REF-REG' },
+  { publicId: 'REG-93', nom: "Provence-Alpes-Côte d'Azur", referentiel: 'REF-REG' },
+  { publicId: 'REG-84', nom: 'Auvergne-Rhône-Alpes', referentiel: 'REF-REG' },
+  { publicId: 'DEPT-75', nom: 'Paris', referentiel: 'REF-DEPT' },
+  { publicId: 'DEPT-77', nom: 'Seine-et-Marne', referentiel: 'REF-DEPT' },
+  { publicId: 'DEPT-78', nom: 'Yvelines', referentiel: 'REF-DEPT' },
+  { publicId: 'DEPT-13', nom: 'Bouches-du-Rhône', referentiel: 'REF-DEPT' },
+  { publicId: 'DEPT-83', nom: 'Var', referentiel: 'REF-DEPT' },
+  { publicId: 'DEPT-84', nom: 'Vaucluse', referentiel: 'REF-DEPT' },
+  { publicId: 'DEPT-06', nom: 'Alpes-Maritimes', referentiel: 'REF-DEPT' },
+  { publicId: 'DEPT-69', nom: 'Rhône', referentiel: 'REF-DEPT' },
+  { publicId: 'DEPT-38', nom: 'Isère', referentiel: 'REF-DEPT' },
+  { publicId: 'DEPT-73', nom: 'Savoie', referentiel: 'REF-DEPT' },
 ] as const
 
 export const relationsSeed = [

--- a/apps/mb-api/src/individu/queries/getIndividuByPublicId.test.ts
+++ b/apps/mb-api/src/individu/queries/getIndividuByPublicId.test.ts
@@ -7,19 +7,14 @@ import { testDeptId } from '@/test/randomIds'
 
 describe.concurrent('getIndividuByPublicId', () => {
   it(
-    "retourne l'individu avec ses référentiels",
+    "retourne l'individu avec son référentiel",
     integrationTest(async () => {
       const deptId = testDeptId()
-      await fixtures.referentielIndividu(
-        {
-          referentiel: { publicId: 'REF-DEPT', nom: 'Départements' },
-          individu: { publicId: deptId, nom: 'Vaucluse' },
-        },
-        {
-          referentiel: { publicId: 'REF-PACA', nom: 'PACA' },
-          individu: { publicId: deptId },
-        },
-      )
+      await fixtures.individu({
+        publicId: deptId,
+        nom: 'Vaucluse',
+        referentiel: { publicId: 'REF-DEPT', nom: 'Départements' },
+      })
 
       const result = await getIndividuByPublicId(deptId)
 
@@ -27,8 +22,8 @@ describe.concurrent('getIndividuByPublicId', () => {
       expect(value).toMatchObject({
         id: deptId,
         nom: 'Vaucluse',
+        referentiel: 'REF-DEPT',
       })
-      expect(value.referentiels.sort()).toEqual(['REF-DEPT', 'REF-PACA'])
     }),
   )
 

--- a/apps/mb-api/src/individu/queries/getIndividuByPublicId.ts
+++ b/apps/mb-api/src/individu/queries/getIndividuByPublicId.ts
@@ -8,8 +8,6 @@ export const getIndividuByPublicId = (publicId: string): ResultAsync<IndividuApi
   ResultAsync.fromSafePromise(
     db().individu.findUniqueOrThrow({
       where: { publicId },
-      include: {
-        referentiels: { include: { referentiel: { select: { publicId: true } } } },
-      },
+      include: { referentiel: { select: { publicId: true } } },
     }),
   ).map(toIndividuApiModel)

--- a/apps/mb-api/src/individu/queries/getIndividuByPublicId.ts
+++ b/apps/mb-api/src/individu/queries/getIndividuByPublicId.ts
@@ -8,6 +8,6 @@ export const getIndividuByPublicId = (publicId: string): ResultAsync<IndividuApi
   ResultAsync.fromSafePromise(
     db().individu.findUniqueOrThrow({
       where: { publicId },
-      include: { referentiel: { select: { publicId: true } } },
+      include: { referentiel: true },
     }),
   ).map(toIndividuApiModel)

--- a/apps/mb-api/src/individu/routes.ts
+++ b/apps/mb-api/src/individu/routes.ts
@@ -18,7 +18,7 @@ const getIndividuByIdRoute = createRoute({
   tags: ['Individu'],
   summary: 'Récupérer un individu par identifiant public',
   description:
-    "Retourne un individu identifié par son identifiant public (ex. `DEPT-84`, `REG-93`, `FR`). Le payload inclut les référentiels auxquels l'individu appartient.",
+    "Retourne un individu identifié par son identifiant public (ex. `DEPT-84`, `REG-93`, `FR`). Le payload inclut le référentiel auquel l'individu appartient.",
   middleware: [requireAuthentication],
   request: { params: detailParamsSchema },
   responses: {

--- a/apps/mb-api/src/individu/utils.ts
+++ b/apps/mb-api/src/individu/utils.ts
@@ -1,15 +1,15 @@
 import { type IndividuApiModel } from '@pilote/mb-shared/individu'
 
-import { type IndividuModel, type ReferentielIndividuModel } from '@/generated/prisma/models'
+import { type IndividuModel } from '@/generated/prisma/models'
 
-export type IndividuWithReferentiels = IndividuModel & {
-  referentiels: Array<ReferentielIndividuModel & { referentiel: { publicId: string } }>
+export type IndividuWithReferentiel = IndividuModel & {
+  referentiel: { publicId: string }
 }
 
-export const toIndividuApiModel = (individu: IndividuWithReferentiels): IndividuApiModel => ({
+export const toIndividuApiModel = (individu: IndividuWithReferentiel): IndividuApiModel => ({
   id: individu.publicId,
   nom: individu.nom,
-  referentiels: individu.referentiels.map((rel) => rel.referentiel.publicId),
+  referentiel: individu.referentiel.publicId,
   createdAt: individu.createdAt.toISOString(),
   updatedAt: individu.updatedAt.toISOString(),
 })

--- a/apps/mb-api/src/referentiel/commands/upsertReferentiel.test.ts
+++ b/apps/mb-api/src/referentiel/commands/upsertReferentiel.test.ts
@@ -1,10 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import { db } from '@/framework/persistence/dbStore'
-import {
-  IndividuAlreadyAttachedError,
-  upsertReferentiel,
-} from '@/referentiel/commands/upsertReferentiel'
+import { upsertReferentiel } from '@/referentiel/commands/upsertReferentiel'
 import { fixtures } from '@/test/fixtures'
 import { integrationTest } from '@/test/integrationTest'
 import { testDeptIds } from '@/test/randomIds'
@@ -113,23 +110,34 @@ describe.concurrent('upsertReferentiel', () => {
   )
 
   it(
-    'rejette quand un individu listé est déjà rattaché à un autre référentiel',
+    'retourne une erreur listant tous les individus déjà rattachés à un autre référentiel',
     integrationTest(async () => {
       // Given
-      const [dept1] = testDeptIds(1)
-      await fixtures.individu({
-        publicId: dept1,
-        referentiel: { publicId: 'REF-OTHER' },
+      const [dept1, dept2, dept3] = testDeptIds(3)
+      await fixtures.individu(
+        { publicId: dept1, referentiel: { publicId: 'REF-OTHER-A' } },
+        { publicId: dept2, referentiel: { publicId: 'REF-OTHER-B' } },
+      )
+
+      // When
+      const result = await upsertReferentiel('REF-NEW2', {
+        nom: 'Nouveau référentiel',
+        description: null,
+        individus: [
+          { publicId: dept1, nom: 'Premier' },
+          { publicId: dept2, nom: 'Second' },
+          { publicId: dept3, nom: 'Troisième (libre)' },
+        ],
       })
 
-      // When / Then
-      await expect(
-        upsertReferentiel('REF-NEW2', {
-          nom: 'Nouveau référentiel',
-          description: null,
-          individus: [{ publicId: dept1, nom: 'Individu de test' }],
-        }),
-      ).rejects.toBeInstanceOf(IndividuAlreadyAttachedError)
+      // Then : dept1 et dept2 listés, dept3 ignoré (pas en conflit) ; aucune écriture
+      expect(result.isErr()).toBe(true)
+      expect(result._unsafeUnwrapErr()).toEqual({
+        type: 'INDIVIDUS_ALREADY_ATTACHED',
+        individuIds: [dept1, dept2].sort(),
+      })
+      const created = await db().referentiel.findUnique({ where: { publicId: 'REF-NEW2' } })
+      expect(created).toBeNull()
     }),
   )
 

--- a/apps/mb-api/src/referentiel/commands/upsertReferentiel.test.ts
+++ b/apps/mb-api/src/referentiel/commands/upsertReferentiel.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from 'vitest'
 
 import { db } from '@/framework/persistence/dbStore'
-import { upsertReferentiel } from '@/referentiel/commands/upsertReferentiel'
+import {
+  IndividuAlreadyAttachedError,
+  upsertReferentiel,
+} from '@/referentiel/commands/upsertReferentiel'
 import { fixtures } from '@/test/fixtures'
 import { integrationTest } from '@/test/integrationTest'
 import { testDeptIds } from '@/test/randomIds'
@@ -51,7 +54,7 @@ describe.concurrent('upsertReferentiel', () => {
   )
 
   it(
-    'crée et lie de nouveaux individus',
+    'crée et rattache de nouveaux individus',
     integrationTest(async () => {
       // Given
       const [dept1, dept2] = testDeptIds(2)
@@ -67,91 +70,66 @@ describe.concurrent('upsertReferentiel', () => {
       })
 
       // Then
-      const persistedDept1 = await db().individu.findUniqueOrThrow({ where: { publicId: dept1 } })
+      const persistedDept1 = await db().individu.findUniqueOrThrow({
+        where: { publicId: dept1 },
+        include: { referentiel: { select: { publicId: true } } },
+      })
       expect(persistedDept1.nom).toBe('Premier')
-      const liaisons = await db().referentielIndividu.findMany({
+      expect(persistedDept1.referentiel.publicId).toBe('REF-INDS')
+      const individusForRef = await db().individu.findMany({
         where: { referentiel: { publicId: 'REF-INDS' } },
       })
-      expect(liaisons).toHaveLength(2)
+      expect(individusForRef).toHaveLength(2)
     }),
   )
 
   it(
-    "met à jour le nom d'un individu existant et ajoute la liaison",
+    "met à jour le nom d'un individu existant déjà rattaché au référentiel cible",
     integrationTest(async () => {
       // Given
       const [dept1] = testDeptIds(1)
-      await fixtures.individu({ publicId: dept1, nom: 'Ancien nom individu' })
+      await fixtures.individu({
+        publicId: dept1,
+        nom: 'Ancien nom individu',
+        referentiel: { publicId: 'REF-LINK' },
+      })
 
       // When
-      await upsertReferentiel('REF-LINK', {
+      const result = await upsertReferentiel('REF-LINK', {
         nom: 'Référentiel',
         description: null,
         individus: [{ publicId: dept1, nom: 'Nouveau nom individu' }],
       })
 
       // Then
-      const persisted = await db().individu.findUniqueOrThrow({ where: { publicId: dept1 } })
+      expect(result.isOk()).toBe(true)
+      const persisted = await db().individu.findUniqueOrThrow({
+        where: { publicId: dept1 },
+        include: { referentiel: { select: { publicId: true } } },
+      })
       expect(persisted.nom).toBe('Nouveau nom individu')
-      const liaison = await db().referentielIndividu.findFirstOrThrow({
-        where: {
-          referentiel: { publicId: 'REF-LINK' },
-          individu: { publicId: dept1 },
-        },
-      })
-      expect(liaison).toBeDefined()
+      expect(persisted.referentiel.publicId).toBe('REF-LINK')
     }),
   )
 
   it(
-    'ne retire pas les individus déjà liés mais absents du body (merge)',
-    integrationTest(async () => {
-      // Given
-      const [dept1, dept2] = testDeptIds(2)
-      await fixtures.referentielIndividu(
-        { referentiel: { publicId: 'REF-MERGE' }, individu: { publicId: dept1 } },
-        { referentiel: { publicId: 'REF-MERGE' }, individu: { publicId: dept2 } },
-      )
-
-      // When
-      await upsertReferentiel('REF-MERGE', {
-        nom: 'Référentiel de test',
-        description: null,
-        individus: [{ publicId: dept1, nom: 'Individu de test' }],
-      })
-
-      // Then : les deux liaisons sont toujours là
-      const liaisons = await db().referentielIndividu.findMany({
-        where: { referentiel: { publicId: 'REF-MERGE' } },
-      })
-      expect(liaisons).toHaveLength(2)
-    }),
-  )
-
-  it(
-    "préserve les liaisons d'un individu vers d'autres référentiels",
+    'rejette quand un individu listé est déjà rattaché à un autre référentiel',
     integrationTest(async () => {
       // Given
       const [dept1] = testDeptIds(1)
-      await fixtures.referentielIndividu({
+      await fixtures.individu({
+        publicId: dept1,
         referentiel: { publicId: 'REF-OTHER' },
-        individu: { publicId: dept1 },
       })
 
-      // When
-      await upsertReferentiel('REF-NEW2', {
-        nom: 'Nouveau référentiel',
-        description: null,
-        individus: [{ publicId: dept1, nom: 'Individu de test' }],
-      })
-
-      // Then : l'individu reste lié à REF-OTHER ET REF-NEW2
-      const liaisons = await db().referentielIndividu.findMany({
-        where: { individu: { publicId: dept1 } },
-        include: { referentiel: true },
-      })
-      const refIds = liaisons.map((l) => l.referentiel.publicId).sort()
-      expect(refIds).toEqual(['REF-NEW2', 'REF-OTHER'])
+      // When / Then
+      await expect(
+        upsertReferentiel('REF-NEW2', {
+          nom: 'Nouveau référentiel',
+          description: null,
+          individus: [{ publicId: dept1, nom: 'Individu de test' }],
+        }),
+      ).rejects.toBeInstanceOf(IndividuAlreadyAttachedError)
     }),
   )
 

--- a/apps/mb-api/src/referentiel/commands/upsertReferentiel.ts
+++ b/apps/mb-api/src/referentiel/commands/upsertReferentiel.ts
@@ -2,7 +2,13 @@ import { type UpsertReferentielBody } from '@pilote/mb-shared/referentiel'
 import { ResultAsync } from 'neverthrow'
 import { uuidv7 } from 'uuidv7'
 
+import { AppError } from '@/framework/errors/AppError'
 import { db } from '@/framework/persistence/dbStore'
+
+export class IndividuAlreadyAttachedError extends AppError {
+  readonly code = 'INDIVIDU_ALREADY_ATTACHED'
+  readonly kind = 'conflict' as const
+}
 
 const performUpsert = async (publicId: string, body: UpsertReferentielBody): Promise<void> => {
   const referentiel = await db().referentiel.upsert({
@@ -17,20 +23,24 @@ const performUpsert = async (publicId: string, body: UpsertReferentielBody): Pro
   })
 
   for (const item of body.individus ?? []) {
-    const individu = await db().individu.upsert({
-      where: { publicId: item.publicId },
-      update: { nom: item.nom },
-      create: { id: uuidv7(), publicId: item.publicId, nom: item.nom },
-    })
-    await db().referentielIndividu.upsert({
-      where: {
-        referentielId_individuId: {
-          referentielId: referentiel.id,
-          individuId: individu.id,
-        },
+    const existing = await db().individu.findUnique({ where: { publicId: item.publicId } })
+    if (existing && existing.referentielId !== referentiel.id) {
+      throw new IndividuAlreadyAttachedError(
+        `L'individu ${item.publicId} est déjà rattaché à un autre référentiel.`,
+        { individuPublicId: item.publicId },
+      )
+    }
+    if (existing) {
+      await db().individu.update({ where: { id: existing.id }, data: { nom: item.nom } })
+      continue
+    }
+    await db().individu.create({
+      data: {
+        id: uuidv7(),
+        publicId: item.publicId,
+        nom: item.nom,
+        referentielId: referentiel.id,
       },
-      update: {},
-      create: { referentielId: referentiel.id, individuId: individu.id },
     })
   }
 }

--- a/apps/mb-api/src/referentiel/commands/upsertReferentiel.ts
+++ b/apps/mb-api/src/referentiel/commands/upsertReferentiel.ts
@@ -1,16 +1,44 @@
 import { type UpsertReferentielBody } from '@pilote/mb-shared/referentiel'
-import { ResultAsync } from 'neverthrow'
+import { err, ok, type Result, ResultAsync } from 'neverthrow'
 import { uuidv7 } from 'uuidv7'
 
-import { AppError } from '@/framework/errors/AppError'
 import { db } from '@/framework/persistence/dbStore'
 
-export class IndividuAlreadyAttachedError extends AppError {
-  readonly code = 'INDIVIDU_ALREADY_ATTACHED'
-  readonly kind = 'conflict' as const
+export type UpsertReferentielError = {
+  type: 'INDIVIDUS_ALREADY_ATTACHED'
+  individuIds: string[]
 }
 
-const performUpsert = async (publicId: string, body: UpsertReferentielBody): Promise<void> => {
+const detectConflicts = async (
+  referentielId: string | undefined,
+  individuPublicIds: string[],
+): Promise<string[]> => {
+  if (individuPublicIds.length === 0) return []
+  const existing = await db().individu.findMany({
+    where: { publicId: { in: individuPublicIds } },
+    select: { publicId: true, referentielId: true },
+  })
+  return existing
+    .filter((row) => row.referentielId !== referentielId)
+    .map((row) => row.publicId)
+    .sort()
+}
+
+const performUpsert = async (
+  publicId: string,
+  body: UpsertReferentielBody,
+): Promise<Result<void, UpsertReferentielError>> => {
+  const existingReferentiel = await db().referentiel.findUnique({
+    where: { publicId },
+    select: { id: true },
+  })
+
+  const individuPublicIds = body.individus?.map((i) => i.publicId) ?? []
+  const conflicts = await detectConflicts(existingReferentiel?.id, individuPublicIds)
+  if (conflicts.length > 0) {
+    return err({ type: 'INDIVIDUS_ALREADY_ATTACHED', individuIds: conflicts })
+  }
+
   const referentiel = await db().referentiel.upsert({
     where: { publicId },
     update: { nom: body.nom, description: body.description },
@@ -23,19 +51,10 @@ const performUpsert = async (publicId: string, body: UpsertReferentielBody): Pro
   })
 
   for (const item of body.individus ?? []) {
-    const existing = await db().individu.findUnique({ where: { publicId: item.publicId } })
-    if (existing && existing.referentielId !== referentiel.id) {
-      throw new IndividuAlreadyAttachedError(
-        `L'individu ${item.publicId} est déjà rattaché à un autre référentiel.`,
-        { individuPublicId: item.publicId },
-      )
-    }
-    if (existing) {
-      await db().individu.update({ where: { id: existing.id }, data: { nom: item.nom } })
-      continue
-    }
-    await db().individu.create({
-      data: {
+    await db().individu.upsert({
+      where: { publicId: item.publicId },
+      update: { nom: item.nom },
+      create: {
         id: uuidv7(),
         publicId: item.publicId,
         nom: item.nom,
@@ -43,9 +62,12 @@ const performUpsert = async (publicId: string, body: UpsertReferentielBody): Pro
       },
     })
   }
+
+  return ok()
 }
 
 export const upsertReferentiel = (
   publicId: string,
   body: UpsertReferentielBody,
-): ResultAsync<void, never> => ResultAsync.fromSafePromise(performUpsert(publicId, body))
+): ResultAsync<void, UpsertReferentielError> =>
+  ResultAsync.fromSafePromise(performUpsert(publicId, body)).andThen((r) => r)

--- a/apps/mb-api/src/referentiel/commands/upsertReferentiel.ts
+++ b/apps/mb-api/src/referentiel/commands/upsertReferentiel.ts
@@ -14,14 +14,15 @@ const detectConflicts = async (
   individuPublicIds: string[],
 ): Promise<string[]> => {
   if (individuPublicIds.length === 0) return []
-  const existing = await db().individu.findMany({
-    where: { publicId: { in: individuPublicIds } },
-    select: { publicId: true, referentielId: true },
+  const conflicts = await db().individu.findMany({
+    where: {
+      publicId: { in: individuPublicIds },
+      ...(referentielId ? { referentielId: { not: referentielId } } : {}),
+    },
+    select: { publicId: true },
+    orderBy: { publicId: 'asc' },
   })
-  return existing
-    .filter((row) => row.referentielId !== referentielId)
-    .map((row) => row.publicId)
-    .sort()
+  return conflicts.map((row) => row.publicId)
 }
 
 const performUpsert = async (

--- a/apps/mb-api/src/referentiel/queries/getReferentielByPublicId.test.ts
+++ b/apps/mb-api/src/referentiel/queries/getReferentielByPublicId.test.ts
@@ -10,18 +10,18 @@ describe.concurrent('getReferentielByPublicId', () => {
     'retourne le référentiel avec sa population',
     integrationTest(async () => {
       const [dept1, dept2] = testDeptIds(2)
-      await fixtures.referentielIndividu(
+      await fixtures.individu(
         {
+          publicId: dept1,
           referentiel: {
             publicId: 'REF-TEST',
             nom: 'Référentiel de test',
             description: 'Description test',
           },
-          individu: { publicId: dept1 },
         },
         {
+          publicId: dept2,
           referentiel: { publicId: 'REF-TEST' },
-          individu: { publicId: dept2 },
         },
       )
 

--- a/apps/mb-api/src/referentiel/queries/listIndividusForReferentiel.test.ts
+++ b/apps/mb-api/src/referentiel/queries/listIndividusForReferentiel.test.ts
@@ -8,18 +8,21 @@ describe.concurrent('listIndividusForReferentiel', () => {
   it(
     'retourne les individus de la population du référentiel',
     integrationTest(async () => {
-      await fixtures.referentielIndividu(
+      await fixtures.individu(
         {
+          publicId: 'P-1',
+          nom: 'Premier',
           referentiel: { publicId: 'REF-POP', nom: 'Pop' },
-          individu: { publicId: 'P-1', nom: 'Premier' },
         },
         {
+          publicId: 'P-2',
+          nom: 'Second',
           referentiel: { publicId: 'REF-POP' },
-          individu: { publicId: 'P-2', nom: 'Second' },
         },
         {
+          publicId: 'O-1',
+          nom: 'Hors population',
           referentiel: { publicId: 'REF-OTHER', nom: 'Other' },
-          individu: { publicId: 'O-1', nom: 'Hors population' },
         },
       )
 
@@ -30,14 +33,14 @@ describe.concurrent('listIndividusForReferentiel', () => {
           {
             id: 'P-1',
             nom: 'Premier',
-            referentiels: ['REF-POP'],
+            referentiel: 'REF-POP',
             createdAt: expect.any(String),
             updatedAt: expect.any(String),
           },
           {
             id: 'P-2',
             nom: 'Second',
-            referentiels: ['REF-POP'],
+            referentiel: 'REF-POP',
             createdAt: expect.any(String),
             updatedAt: expect.any(String),
           },
@@ -49,35 +52,23 @@ describe.concurrent('listIndividusForReferentiel', () => {
   )
 
   it(
-    'inclut les autres référentiels auxquels appartient un individu',
-    integrationTest(async () => {
-      await fixtures.referentielIndividu(
-        { referentiel: { publicId: 'REF-A', nom: 'A' }, individu: { publicId: 'I-1' } },
-        { referentiel: { publicId: 'REF-B', nom: 'B' }, individu: { publicId: 'I-1' } },
-      )
-
-      const result = await listIndividusForReferentiel('REF-A', {})
-
-      const value = result._unsafeUnwrap()
-      expect(value.items[0]?.referentiels.sort()).toEqual(['REF-A', 'REF-B'])
-    }),
-  )
-
-  it(
     'filtre par recherche sur le nom',
     integrationTest(async () => {
-      await fixtures.referentielIndividu(
+      await fixtures.individu(
         {
+          publicId: 'A-1',
+          nom: 'Alpha',
           referentiel: { publicId: 'REF-SEARCH', nom: 'Search' },
-          individu: { publicId: 'A-1', nom: 'Alpha' },
         },
         {
+          publicId: 'A-2',
+          nom: 'Bravo',
           referentiel: { publicId: 'REF-SEARCH' },
-          individu: { publicId: 'A-2', nom: 'Bravo' },
         },
         {
+          publicId: 'A-3',
+          nom: 'ALPHA majuscule',
           referentiel: { publicId: 'REF-SEARCH' },
-          individu: { publicId: 'A-3', nom: 'ALPHA majuscule' },
         },
       )
 
@@ -88,14 +79,14 @@ describe.concurrent('listIndividusForReferentiel', () => {
           {
             id: 'A-1',
             nom: 'Alpha',
-            referentiels: ['REF-SEARCH'],
+            referentiel: 'REF-SEARCH',
             createdAt: expect.any(String),
             updatedAt: expect.any(String),
           },
           {
             id: 'A-3',
             nom: 'ALPHA majuscule',
-            referentiels: ['REF-SEARCH'],
+            referentiel: 'REF-SEARCH',
             createdAt: expect.any(String),
             updatedAt: expect.any(String),
           },

--- a/apps/mb-api/src/referentiel/queries/listIndividusForReferentiel.ts
+++ b/apps/mb-api/src/referentiel/queries/listIndividusForReferentiel.ts
@@ -13,7 +13,7 @@ export const listIndividusForReferentiel = (
   params: ListIndividusForReferentielQuery,
 ): ResultAsync<IndividuListApiModel, never> => {
   const where = {
-    referentiels: { some: { referentiel: { publicId: referentielPublicId } } },
+    referentiel: { publicId: referentielPublicId },
     ...(params.recherche
       ? { nom: { contains: params.recherche, mode: 'insensitive' as const } }
       : {}),
@@ -22,7 +22,7 @@ export const listIndividusForReferentiel = (
   const fetchPage = db().individu.findMany({
     where,
     orderBy: { id: 'asc' },
-    include: { referentiels: { include: { referentiel: true } } },
+    include: { referentiel: { select: { publicId: true } } },
     ...buildPaginationArgs(params.cursor, params.pageSize),
   })
   const fetchTotal = db().individu.count({ where })

--- a/apps/mb-api/src/referentiel/queries/listIndividusForReferentiel.ts
+++ b/apps/mb-api/src/referentiel/queries/listIndividusForReferentiel.ts
@@ -22,7 +22,7 @@ export const listIndividusForReferentiel = (
   const fetchPage = db().individu.findMany({
     where,
     orderBy: { id: 'asc' },
-    include: { referentiel: { select: { publicId: true } } },
+    include: { referentiel: true },
     ...buildPaginationArgs(params.cursor, params.pageSize),
   })
   const fetchTotal = db().individu.count({ where })

--- a/apps/mb-api/src/referentiel/queries/listReferentiels.test.ts
+++ b/apps/mb-api/src/referentiel/queries/listReferentiels.test.ts
@@ -23,14 +23,14 @@ describe.concurrent('listReferentiels', () => {
   it(
     "retourne les référentiels avec leur nombre d'individus",
     integrationTest(async () => {
-      await fixtures.referentielIndividu(
+      await fixtures.individu(
         {
+          publicId: 'A-1',
           referentiel: { publicId: 'REF-ALPHA', nom: 'Alpha' },
-          individu: { publicId: 'A-1' },
         },
         {
+          publicId: 'A-2',
           referentiel: { publicId: 'REF-ALPHA' },
-          individu: { publicId: 'A-2' },
         },
       )
       await fixtures.referentiel({ publicId: 'REF-BETA', nom: 'Beta' })

--- a/apps/mb-api/src/referentiel/routes.ts
+++ b/apps/mb-api/src/referentiel/routes.ts
@@ -12,16 +12,11 @@ import {
   upsertReferentielBodySchema,
 } from '@pilote/mb-shared/referentiel'
 
-import { err, ok, type Result } from 'neverthrow'
-
 import { requireAuthentication } from '@/framework/auth/requireAuthentication'
 import { never } from '@/framework/errors/never'
 import { jsonResponseError, jsonResponseOk } from '@/framework/openapi/jsonResponse'
 import { withTransaction } from '@/framework/persistence/withTransaction'
-import {
-  type UpsertReferentielError,
-  upsertReferentiel,
-} from '@/referentiel/commands/upsertReferentiel'
+import { upsertReferentiel } from '@/referentiel/commands/upsertReferentiel'
 import { getReferentielByPublicId } from '@/referentiel/queries/getReferentielByPublicId'
 import { listIndividusForReferentiel } from '@/referentiel/queries/listIndividusForReferentiel'
 import { listReferentiels } from '@/referentiel/queries/listReferentiels'
@@ -173,15 +168,11 @@ referentielRoutes.openapi(upsertReferentielRoute, async (context) => {
   const { id } = context.req.valid('param')
   const body = context.req.valid('json')
 
-  type Outcome = Result<z.infer<typeof ReferentielApiModelSchema>, UpsertReferentielError>
-  const result = await withTransaction(async (): Promise<Outcome> => {
-    const upsertResult = await upsertReferentiel(id, body)
-    if (upsertResult.isErr()) return err(upsertResult.error)
-    const data = (await getReferentielByPublicId(id))._unsafeUnwrap()
-    return ok(data)
-  })
-
-  return result.match(
+  return (
+    await withTransaction(async () =>
+      upsertReferentiel(id, body).andThen(() => getReferentielByPublicId(id)),
+    )
+  ).match(
     (data) =>
       jsonResponseOk({
         context,

--- a/apps/mb-api/src/referentiel/routes.ts
+++ b/apps/mb-api/src/referentiel/routes.ts
@@ -12,11 +12,16 @@ import {
   upsertReferentielBodySchema,
 } from '@pilote/mb-shared/referentiel'
 
+import { err, ok, type Result } from 'neverthrow'
+
 import { requireAuthentication } from '@/framework/auth/requireAuthentication'
 import { never } from '@/framework/errors/never'
-import { jsonResponseOk } from '@/framework/openapi/jsonResponse'
+import { jsonResponseError, jsonResponseOk } from '@/framework/openapi/jsonResponse'
 import { withTransaction } from '@/framework/persistence/withTransaction'
-import { upsertReferentiel } from '@/referentiel/commands/upsertReferentiel'
+import {
+  type UpsertReferentielError,
+  upsertReferentiel,
+} from '@/referentiel/commands/upsertReferentiel'
 import { getReferentielByPublicId } from '@/referentiel/queries/getReferentielByPublicId'
 import { listIndividusForReferentiel } from '@/referentiel/queries/listIndividusForReferentiel'
 import { listReferentiels } from '@/referentiel/queries/listReferentiels'
@@ -168,9 +173,12 @@ referentielRoutes.openapi(upsertReferentielRoute, async (context) => {
   const { id } = context.req.valid('param')
   const body = context.req.valid('json')
 
-  const result = await withTransaction(async () => {
-    await upsertReferentiel(id, body)
-    return getReferentielByPublicId(id)
+  type Outcome = Result<z.infer<typeof ReferentielApiModelSchema>, UpsertReferentielError>
+  const result = await withTransaction(async (): Promise<Outcome> => {
+    const upsertResult = await upsertReferentiel(id, body)
+    if (upsertResult.isErr()) return err(upsertResult.error)
+    const data = (await getReferentielByPublicId(id))._unsafeUnwrap()
+    return ok(data)
   })
 
   return result.match(
@@ -181,7 +189,17 @@ referentielRoutes.openapi(upsertReferentielRoute, async (context) => {
         schema: ReferentielApiModelSchema,
         status: 200,
       }),
-    never,
+    (error) =>
+      jsonResponseError({
+        context,
+        error: {
+          code: error.type,
+          message: `Les individus suivants sont déjà rattachés à un autre référentiel : ${error.individuIds.join(', ')}`,
+          details: { individuIds: error.individuIds },
+        },
+        schema: ErrorApiModelSchema,
+        status: 409,
+      }),
   )
 })
 

--- a/apps/mb-api/src/referentiel/routes.ts
+++ b/apps/mb-api/src/referentiel/routes.ts
@@ -83,7 +83,7 @@ const upsertReferentielRoute = createRoute({
   tags: ['Referentiel'],
   summary: 'Créer ou mettre à jour un référentiel',
   description:
-    "Crée le référentiel s'il n'existe pas, ou met à jour son `nom` et sa `description` quand le référentiel existe déjà. Le tableau `individus` est optionnel et appliqué en mode merge : chaque individu est upsert (création/mise à jour du nom) et lié au référentiel ; les individus déjà liés et absents du body ne sont pas retirés. Opération idempotente, exécutée dans une transaction.",
+    "Crée le référentiel s'il n'existe pas, ou met à jour son `nom` et sa `description` quand le référentiel existe déjà. Le tableau `individus` est optionnel : chaque individu est créé et rattaché au référentiel, ou son nom est mis à jour s'il existe déjà et qu'il est déjà rattaché à ce même référentiel. Si un individu listé existe et est rattaché à un autre référentiel, la requête est rejetée (409). Opération idempotente, exécutée dans une transaction.",
   middleware: [requireAuthentication],
   request: {
     params: detailParamsSchema,
@@ -100,6 +100,10 @@ const upsertReferentielRoute = createRoute({
     400: {
       content: { 'application/json': { schema: ErrorApiModelSchema } },
       description: 'Corps de requête ou paramètres invalides',
+    },
+    409: {
+      content: { 'application/json': { schema: ErrorApiModelSchema } },
+      description: 'Un individu listé est déjà rattaché à un autre référentiel',
     },
   },
 })

--- a/apps/mb-api/src/test/fixtures.ts
+++ b/apps/mb-api/src/test/fixtures.ts
@@ -8,7 +8,6 @@ import {
   type IndicateurModel,
   type IndicateurPermissionModel,
   type IndividuModel,
-  type ReferentielIndividuModel,
   type ReferentielModel,
   type RelationModel,
   type UtilisateurModel,
@@ -99,7 +98,12 @@ async function referentiel(
 
 // --- Individu ----------------------------------------------------------------
 
-type IndividuOverrides = Partial<{ id: string; publicId: string; nom: string }>
+type IndividuOverrides = Partial<{
+  id: string
+  publicId: string
+  nom: string
+  referentiel: ReferentielOverrides
+}>
 
 const DEFAULT_INDIVIDU = {
   publicId: 'TEST-1',
@@ -107,16 +111,28 @@ const DEFAULT_INDIVIDU = {
 } as const
 
 const upsertIndividu = async (o: IndividuOverrides = {}) => {
-  const create = { id: uuidv7(), ...DEFAULT_INDIVIDU, ...o }
-  const { id: _id, publicId: _pub, ...update } = o
-  if (Object.keys(update).length === 0) {
-    const existing = await db().individu.findUnique({ where: { publicId: create.publicId } })
-    if (existing) return existing
+  const publicId = o.publicId ?? DEFAULT_INDIVIDU.publicId
+  const existing = await db().individu.findUnique({ where: { publicId } })
+
+  // Pas d'override referentiel et l'individu existe : on touche pas au rattachement.
+  if (existing && !o.referentiel) {
+    const { id: _id, publicId: _pub, referentiel: _ref, ...update } = o
+    if (Object.keys(update).length === 0) return existing
+    return db().individu.update({ where: { id: existing.id }, data: update })
   }
+
+  const referentielRow = await upsertReferentiel(o.referentiel)
+  const { id: _id, publicId: _pub, referentiel: _ref, ...rest } = o
+  const update = { ...rest, referentielId: referentielRow.id }
   return db().individu.upsert({
-    where: { publicId: create.publicId },
+    where: { publicId },
     update,
-    create,
+    create: {
+      id: o.id ?? uuidv7(),
+      publicId,
+      nom: o.nom ?? DEFAULT_INDIVIDU.nom,
+      referentielId: referentielRow.id,
+    },
   })
 }
 
@@ -133,45 +149,6 @@ async function individu(
   if (overrides.length <= 1) return upsertIndividu(overrides[0])
   const results: IndividuModel[] = []
   for (const o of overrides) results.push(await upsertIndividu(o))
-  return results
-}
-
-// --- ReferentielIndividu (deps requises) -------------------------------------
-
-type ReferentielIndividuOverrides = {
-  referentiel: ReferentielOverrides
-  individu: IndividuOverrides
-}
-
-const upsertReferentielIndividu = async (o: ReferentielIndividuOverrides) => {
-  const referentielRow = await upsertReferentiel(o.referentiel)
-  const individuRow = await upsertIndividu(o.individu)
-  return db().referentielIndividu.upsert({
-    where: {
-      referentielId_individuId: {
-        referentielId: referentielRow.id,
-        individuId: individuRow.id,
-      },
-    },
-    update: {},
-    create: { referentielId: referentielRow.id, individuId: individuRow.id },
-  })
-}
-
-function referentielIndividu(
-  override: ReferentielIndividuOverrides,
-): Promise<ReferentielIndividuModel>
-function referentielIndividu(
-  o1: ReferentielIndividuOverrides,
-  o2: ReferentielIndividuOverrides,
-  ...rest: ReferentielIndividuOverrides[]
-): Promise<ReferentielIndividuModel[]>
-async function referentielIndividu(
-  ...overrides: ReferentielIndividuOverrides[]
-): Promise<ReferentielIndividuModel | ReferentielIndividuModel[]> {
-  if (overrides.length === 1) return upsertReferentielIndividu(overrides[0]!)
-  const results: ReferentielIndividuModel[] = []
-  for (const o of overrides) results.push(await upsertReferentielIndividu(o))
   return results
 }
 
@@ -433,7 +410,6 @@ export const fixtures = {
   indicateur,
   referentiel,
   individu,
-  referentielIndividu,
   relation,
   valeurAvancement,
   apiKey,

--- a/apps/mb-api/src/valeurAvancement/queries/listIndividusWithValeurs.test.ts
+++ b/apps/mb-api/src/valeurAvancement/queries/listIndividusWithValeurs.test.ts
@@ -12,11 +12,27 @@ describe.concurrent('listIndividusWithValeurs', () => {
     integrationTest(async () => {
       const indId = testIndicateurId()
       const [dept1, dept2, dept3] = testDeptIds(3)
-      await fixtures.individu({ publicId: dept3, nom: 'AM' })
+      await fixtures.individu(
+        {
+          publicId: dept1,
+          nom: 'Vaucluse',
+          referentiel: { publicId: 'REF-DEPT', nom: 'Dept' },
+        },
+        {
+          publicId: dept2,
+          nom: 'BdR',
+          referentiel: { publicId: 'REF-DEPT' },
+        },
+        {
+          publicId: dept3,
+          nom: 'AM',
+          referentiel: { publicId: 'REF-DEPT' },
+        },
+      )
       await fixtures.valeurAvancement(
         {
           indicateur: { publicId: indId, nom: 'T' },
-          individu: { publicId: dept1, nom: 'Vaucluse' },
+          individu: { publicId: dept1 },
           date: '2024-01-01',
           valeur: 1,
         },
@@ -28,7 +44,7 @@ describe.concurrent('listIndividusWithValeurs', () => {
         },
         {
           indicateur: { publicId: indId },
-          individu: { publicId: dept2, nom: 'BdR' },
+          individu: { publicId: dept2 },
           date: '2024-01-01',
           valeur: 5,
         },
@@ -45,7 +61,7 @@ describe.concurrent('listIndividusWithValeurs', () => {
             individu: {
               id: dept1,
               nom: 'Vaucluse',
-              referentiels: [],
+              referentiel: 'REF-DEPT',
               createdAt: expect.any(String),
               updatedAt: expect.any(String),
             },
@@ -56,7 +72,7 @@ describe.concurrent('listIndividusWithValeurs', () => {
             individu: {
               id: dept2,
               nom: 'BdR',
-              referentiels: [],
+              referentiel: 'REF-DEPT',
               createdAt: expect.any(String),
               updatedAt: expect.any(String),
             },
@@ -76,14 +92,16 @@ describe.concurrent('listIndividusWithValeurs', () => {
       const indId = testIndicateurId()
       const deptId = testDeptId()
       const regId = testRegId()
-      await fixtures.referentielIndividu(
+      await fixtures.individu(
         {
+          publicId: deptId,
+          nom: 'Vaucluse',
           referentiel: { publicId: 'REF-DEPT', nom: 'Dept' },
-          individu: { publicId: deptId, nom: 'Vaucluse' },
         },
         {
+          publicId: regId,
+          nom: 'PACA',
           referentiel: { publicId: 'REF-REG', nom: 'Reg' },
-          individu: { publicId: regId, nom: 'PACA' },
         },
       )
       await fixtures.valeurAvancement(
@@ -114,7 +132,7 @@ describe.concurrent('listIndividusWithValeurs', () => {
             individu: {
               id: regId,
               nom: 'PACA',
-              referentiels: ['REF-REG'],
+              referentiel: 'REF-REG',
               createdAt: expect.any(String),
               updatedAt: expect.any(String),
             },

--- a/apps/mb-api/src/valeurAvancement/queries/listIndividusWithValeurs.ts
+++ b/apps/mb-api/src/valeurAvancement/queries/listIndividusWithValeurs.ts
@@ -27,7 +27,7 @@ export const listIndividusWithValeurs = (
     where,
     orderBy: { id: 'asc' },
     include: {
-      referentiel: { select: { publicId: true } },
+      referentiel: true,
       valeurs: {
         where: indicateurFilter,
         orderBy: [{ date: 'desc' }, { id: 'desc' }],

--- a/apps/mb-api/src/valeurAvancement/queries/listIndividusWithValeurs.ts
+++ b/apps/mb-api/src/valeurAvancement/queries/listIndividusWithValeurs.ts
@@ -20,16 +20,14 @@ export const listIndividusWithValeurs = (
   }
   const where = {
     valeurs: { some: indicateurFilter },
-    ...(params.referentiel
-      ? { referentiels: { some: { referentiel: { publicId: params.referentiel } } } }
-      : {}),
+    ...(params.referentiel ? { referentiel: { publicId: params.referentiel } } : {}),
   }
 
   const fetchPage = db().individu.findMany({
     where,
     orderBy: { id: 'asc' },
     include: {
-      referentiels: { include: { referentiel: true } },
+      referentiel: { select: { publicId: true } },
       valeurs: {
         where: indicateurFilter,
         orderBy: [{ date: 'desc' }, { id: 'desc' }],

--- a/apps/mb-api/src/valeurAvancement/utils.ts
+++ b/apps/mb-api/src/valeurAvancement/utils.ts
@@ -4,7 +4,7 @@ import {
 } from '@pilote/mb-shared/valeurAvancement'
 
 import { type ValeurAvancementModel } from '@/generated/prisma/models'
-import { type IndividuWithReferentiels, toIndividuApiModel } from '@/individu/utils'
+import { type IndividuWithReferentiel, toIndividuApiModel } from '@/individu/utils'
 
 export type ValeurAvancementWithRelations = ValeurAvancementModel & {
   indicateur: { publicId: string }
@@ -20,7 +20,7 @@ export const toValeurAvancementApiModel = (
   valeur: valeur.valeur.toNumber(),
 })
 
-export type IndividuAvecValeursRow = IndividuWithReferentiels & {
+export type IndividuAvecValeursRow = IndividuWithReferentiel & {
   valeurs: ValeurAvancementModel[]
   _count: { valeurs: number }
 }

--- a/packages/mb-shared/src/individu.ts
+++ b/packages/mb-shared/src/individu.ts
@@ -8,9 +8,7 @@ export { individuPublicIdSchema } from './publicIds'
 export const individuApiModelSchema = z.object({
   id: individuPublicIdSchema,
   nom: z.string().describe("Nom lisible de l'individu."),
-  referentiels: z
-    .array(referentielPublicIdSchema)
-    .describe("Référentiels auxquels l'individu appartient."),
+  referentiel: referentielPublicIdSchema.describe("Référentiel auquel l'individu appartient."),
   createdAt: z.string().datetime().describe('Date ISO 8601 de création.'),
   updatedAt: z.string().datetime().describe('Date ISO 8601 de dernière mise à jour.'),
 })

--- a/packages/mb-shared/src/referentiel.ts
+++ b/packages/mb-shared/src/referentiel.ts
@@ -38,7 +38,7 @@ export const upsertReferentielBodySchema = z.object({
     .array(upsertReferentielIndividuItemSchema)
     .optional()
     .describe(
-      "Individus à upsert et lier au référentiel. Sémantique merge : les individus déjà liés mais absents du body ne sont pas retirés.",
+      "Individus à upsert et rattacher à ce référentiel. Un individu ne peut appartenir qu'à un seul référentiel : si un individu listé existe déjà et est rattaché à un autre référentiel, la requête est rejetée (409).",
     ),
 })
 export type UpsertReferentielBody = z.infer<typeof upsertReferentielBodySchema>


### PR DESCRIPTION
## Summary
- Cardinalité `Individu ↔ Referentiel` passe de M:N (pivot `ReferentielIndividu`) à 1:N : FK `referentielId` NOT NULL sur `Individu`, table pivot supprimée.
- **Breaking OpenAPI** : `IndividuApiModel.referentiels: string[]` → `referentiel: string`.
- `PUT /referentiels/{id}` : si un ou plusieurs individus listés sont déjà rattachés à un autre référentiel, la requête est rejetée en **409** avec `{ code: 'INDIVIDUS_ALREADY_ATTACHED', details: { individuIds: [...] } }`. La pré-flight check liste **tous** les individus en conflit en un seul aller-retour (pas seulement le premier) ; aucune écriture n'est faite si conflit.
- Plus de sémantique merge — pas de prod, donc pas de migration de stock fancy : la migration `TRUNCATE` individus/valeurs/relations, le seed les recrée.

## Pattern d'erreur
`upsertReferentiel` retourne `ResultAsync<void, UpsertReferentielError>` où `UpsertReferentielError = { type: 'INDIVIDUS_ALREADY_ATTACHED', individuIds: string[] }`. La route fait `.match()` vers un 200 ou un 409 — pas de `throw` d'`AppError` depuis le use case.

## Test plan
- [x] `pnpm --filter @pilote/mb-api lint` (eslint + tsc + prettier)
- [x] `pnpm --filter @pilote/mb-api test` — 107/107
- [x] `pnpm --filter @pilote/mb-webapp exec tsc --noEmit` (le shared package est consommé côté webapp)
- [ ] Local : `pnpm --filter @pilote/mb-api database:init` puis vérifier le seed (les coéquipiers devront reset leur DB locale)
- [ ] Vérifier la doc OpenAPI sur `/api/docs` : `IndividuApiModel.referentiel` (singulier) + réponse 409 sur `PUT /referentiels/{id}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)