### PR TITLE
feat(mb-api): DELETE /indicateurs/:id/valeurs (suppression idempotente)

### DIFF
--- a/apps/mb-api/src/individu/permission.ts
+++ b/apps/mb-api/src/individu/permission.ts
@@ -5,11 +5,11 @@ import { db } from '@/framework/persistence/dbStore'
 export type IndividuInconnuError = { type: 'INDIVIDU_INCONNU'; individu: string }
 
 export const resolveAuthorizedIndividu = ({
-  indicateurId,
   individuPublicId,
+  indicateurId,
 }: {
-  indicateurId: string
   individuPublicId: string
+  indicateurId: string
 }): ResultAsync<{ id: string; publicId: string }, IndividuInconnuError> => {
   const unknownOrUnauthorized = (): IndividuInconnuError => ({
     type: 'INDIVIDU_INCONNU',

--- a/apps/mb-api/src/valeurAvancement/commands/deleteValeurAvancement.test.ts
+++ b/apps/mb-api/src/valeurAvancement/commands/deleteValeurAvancement.test.ts
@@ -1,0 +1,279 @@
+import { describe, expect, it } from 'vitest'
+
+import { ForbiddenError } from '@/framework/errors/AppError'
+import { db } from '@/framework/persistence/dbStore'
+import { Prisma } from '@/generated/prisma/client'
+import { deleteValeurAvancement } from '@/valeurAvancement/commands/deleteValeurAvancement'
+import { fixtures } from '@/test/fixtures'
+import { integrationTest } from '@/test/integrationTest'
+import { testDeptId, testIndicateurId, testReferentielId } from '@/test/randomIds'
+import { runAsPrincipal } from '@/test/runAsPrincipal'
+
+describe.concurrent('deleteValeurAvancement', () => {
+  it(
+    'supprime la valeur existante pour le triplet (indicateur, individu, date)',
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const refId = testReferentielId()
+      const individuId = testDeptId()
+      const link = await fixtures.indicateurReferentiel({
+        indicateur: { publicId: indId },
+        referentiel: { publicId: refId },
+      })
+      const individu = await fixtures.individu({
+        publicId: individuId,
+        referentiel: { publicId: refId },
+      })
+      await fixtures.valeurAvancement({
+        indicateur: { publicId: indId },
+        individu: { publicId: individuId, referentiel: { publicId: refId } },
+        date: '2025-03-01',
+        valeur: 12.34,
+      })
+      const apiKey = await fixtures.apiKey({
+        permissions: [{ indicateur: { publicId: indId }, action: 'WRITE' }],
+      })
+
+      const result = await runAsPrincipal(apiKey.id, () =>
+        deleteValeurAvancement({
+          indicateurPublicId: indId,
+          body: { individu: individu.publicId, date: '2025-03-01' },
+        }),
+      )
+
+      expect(result.isOk()).toBe(true)
+      const rows = await db().valeurAvancement.findMany({
+        where: {
+          indicateurId: link.indicateurId,
+          individuId: individu.id,
+          date: '2025-03-01',
+        },
+      })
+      expect(rows).toHaveLength(0)
+    }),
+  )
+
+  it(
+    "ne touche pas aux autres dates de l'individu pour cet indicateur",
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const refId = testReferentielId()
+      const individuId = testDeptId()
+      await fixtures.indicateurReferentiel({
+        indicateur: { publicId: indId },
+        referentiel: { publicId: refId },
+      })
+      const individu = await fixtures.individu({
+        publicId: individuId,
+        referentiel: { publicId: refId },
+      })
+      await fixtures.valeurAvancement({
+        indicateur: { publicId: indId },
+        individu: { publicId: individuId, referentiel: { publicId: refId } },
+        date: '2025-03-01',
+        valeur: 10,
+      })
+      await fixtures.valeurAvancement({
+        indicateur: { publicId: indId },
+        individu: { publicId: individuId, referentiel: { publicId: refId } },
+        date: '2025-04-01',
+        valeur: 20,
+      })
+      const apiKey = await fixtures.apiKey({
+        permissions: [{ indicateur: { publicId: indId }, action: 'WRITE' }],
+      })
+
+      const result = await runAsPrincipal(apiKey.id, () =>
+        deleteValeurAvancement({
+          indicateurPublicId: indId,
+          body: { individu: individu.publicId, date: '2025-03-01' },
+        }),
+      )
+
+      expect(result.isOk()).toBe(true)
+      const rows = await db().valeurAvancement.findMany({
+        where: { individuId: individu.id },
+        orderBy: { date: 'asc' },
+      })
+      expect(rows).toHaveLength(1)
+      expect(rows[0]!.date).toBe('2025-04-01')
+    }),
+  )
+
+  it(
+    "est idempotent : succès même si aucune valeur n'existe pour le triplet",
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const refId = testReferentielId()
+      const individuId = testDeptId()
+      await fixtures.indicateurReferentiel({
+        indicateur: { publicId: indId },
+        referentiel: { publicId: refId },
+      })
+      const individu = await fixtures.individu({
+        publicId: individuId,
+        referentiel: { publicId: refId },
+      })
+      const apiKey = await fixtures.apiKey({
+        permissions: [{ indicateur: { publicId: indId }, action: 'WRITE' }],
+      })
+
+      const result = await runAsPrincipal(apiKey.id, () =>
+        deleteValeurAvancement({
+          indicateurPublicId: indId,
+          body: { individu: individu.publicId, date: '2025-03-01' },
+        }),
+      )
+
+      expect(result.isOk()).toBe(true)
+    }),
+  )
+
+  it(
+    "rejette avec 404 quand l'indicateur n'existe pas",
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const refId = testReferentielId()
+      const individuId = testDeptId()
+      await fixtures.individu({
+        publicId: individuId,
+        referentiel: { publicId: refId },
+      })
+      const apiKey = await fixtures.apiKey()
+
+      await expect(
+        runAsPrincipal(apiKey.id, () =>
+          deleteValeurAvancement({
+            indicateurPublicId: indId,
+            body: { individu: individuId, date: '2025-03-01' },
+          }),
+        ),
+      ).rejects.toMatchObject({
+        constructor: Prisma.PrismaClientKnownRequestError,
+        code: 'P2025',
+      })
+    }),
+  )
+
+  it(
+    "rejette avec 404 quand le principal n'a aucune permission sur l'indicateur",
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const refId = testReferentielId()
+      const individuId = testDeptId()
+      await fixtures.indicateurReferentiel({
+        indicateur: { publicId: indId },
+        referentiel: { publicId: refId },
+      })
+      await fixtures.individu({
+        publicId: individuId,
+        referentiel: { publicId: refId },
+      })
+      const apiKey = await fixtures.apiKey()
+
+      await expect(
+        runAsPrincipal(apiKey.id, () =>
+          deleteValeurAvancement({
+            indicateurPublicId: indId,
+            body: { individu: individuId, date: '2025-03-01' },
+          }),
+        ),
+      ).rejects.toMatchObject({
+        constructor: Prisma.PrismaClientKnownRequestError,
+        code: 'P2025',
+      })
+    }),
+  )
+
+  it(
+    "rejette avec 403 quand le principal n'a que la permission READ",
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const refId = testReferentielId()
+      const individuId = testDeptId()
+      await fixtures.indicateurReferentiel({
+        indicateur: { publicId: indId },
+        referentiel: { publicId: refId },
+      })
+      await fixtures.individu({
+        publicId: individuId,
+        referentiel: { publicId: refId },
+      })
+      const apiKey = await fixtures.apiKey({
+        permissions: [{ indicateur: { publicId: indId }, action: 'READ' }],
+      })
+
+      const result = await runAsPrincipal(apiKey.id, () =>
+        deleteValeurAvancement({
+          indicateurPublicId: indId,
+          body: { individu: individuId, date: '2025-03-01' },
+        }),
+      )
+
+      expect(result.isErr()).toBe(true)
+      expect(result._unsafeUnwrapErr()).toBeInstanceOf(ForbiddenError)
+    }),
+  )
+
+  it(
+    "rejette avec INDIVIDU_INCONNU quand l'individu n'existe pas",
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const refId = testReferentielId()
+      await fixtures.indicateurReferentiel({
+        indicateur: { publicId: indId },
+        referentiel: { publicId: refId },
+      })
+      const apiKey = await fixtures.apiKey({
+        permissions: [{ indicateur: { publicId: indId }, action: 'WRITE' }],
+      })
+
+      const result = await runAsPrincipal(apiKey.id, () =>
+        deleteValeurAvancement({
+          indicateurPublicId: indId,
+          body: { individu: 'DEPT-999', date: '2025-03-01' },
+        }),
+      )
+
+      expect(result.isErr()).toBe(true)
+      expect(result._unsafeUnwrapErr()).toEqual({
+        type: 'INDIVIDU_INCONNU',
+        individu: 'DEPT-999',
+      })
+    }),
+  )
+
+  it(
+    "rejette avec INDIVIDU_INCONNU quand l'individu n'est pas dans un référentiel lié à l'indicateur",
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const refLie = testReferentielId()
+      const refOrphelin = testReferentielId()
+      const individuId = testDeptId()
+      await fixtures.indicateurReferentiel({
+        indicateur: { publicId: indId },
+        referentiel: { publicId: refLie },
+      })
+      await fixtures.individu({
+        publicId: individuId,
+        referentiel: { publicId: refOrphelin },
+      })
+      const apiKey = await fixtures.apiKey({
+        permissions: [{ indicateur: { publicId: indId }, action: 'WRITE' }],
+      })
+
+      const result = await runAsPrincipal(apiKey.id, () =>
+        deleteValeurAvancement({
+          indicateurPublicId: indId,
+          body: { individu: individuId, date: '2025-03-01' },
+        }),
+      )
+
+      expect(result.isErr()).toBe(true)
+      expect(result._unsafeUnwrapErr()).toEqual({
+        type: 'INDIVIDU_INCONNU',
+        individu: individuId,
+      })
+    }),
+  )
+})

--- a/apps/mb-api/src/valeurAvancement/commands/deleteValeurAvancement.ts
+++ b/apps/mb-api/src/valeurAvancement/commands/deleteValeurAvancement.ts
@@ -1,12 +1,7 @@
-import {
-  type UpsertValeurAvancementBody,
-  type ValeurAvancementApiModel,
-} from '@pilote/mb-shared/valeurAvancement'
+import { type DeleteValeurAvancementBody } from '@pilote/mb-shared/valeurAvancement'
 import { ResultAsync } from 'neverthrow'
-import { uuidv7 } from 'uuidv7'
 
 import { requireCurrentPrincipalId } from '@/framework/auth/userContext'
-import { Decimal } from '@/framework/decimal'
 import { type ForbiddenError } from '@/framework/errors/AppError'
 import { db } from '@/framework/persistence/dbStore'
 import {
@@ -17,21 +12,20 @@ import {
   type IndividuInconnuError,
   resolveAuthorizedIndividu,
 } from '@/valeurAvancement/resolveAuthorizedIndividu'
-import { toValeurAvancementApiModel } from '@/valeurAvancement/utils'
 
-export type UpsertValeurAvancementError = IndividuInconnuError
+export type DeleteValeurAvancementError = IndividuInconnuError
 
-type UpsertValeurAvancementParams = {
+type DeleteValeurAvancementParams = {
   indicateurPublicId: string
-  body: UpsertValeurAvancementBody
+  body: DeleteValeurAvancementBody
 }
 
-export const upsertValeurAvancement = ({
+export const deleteValeurAvancement = ({
   indicateurPublicId,
   body,
-}: UpsertValeurAvancementParams): ResultAsync<
-  ValeurAvancementApiModel,
-  UpsertValeurAvancementError | ForbiddenError
+}: DeleteValeurAvancementParams): ResultAsync<
+  void,
+  DeleteValeurAvancementError | ForbiddenError
 > => {
   const principalId = requireCurrentPrincipalId()
   return ResultAsync.fromSafePromise(
@@ -53,28 +47,14 @@ export const upsertValeurAvancement = ({
     )
     .andThen(({ indicateur, individu }) =>
       ResultAsync.fromSafePromise(
-        db().valeurAvancement.upsert({
+        db().valeurAvancement.deleteMany({
           where: {
-            valeur_avancement_unique: {
-              indicateurId: indicateur.id,
-              individuId: individu.id,
-              date: body.date,
-            },
-          },
-          update: { valeur: new Decimal(body.valeur) },
-          create: {
-            id: uuidv7(),
             indicateurId: indicateur.id,
             individuId: individu.id,
             date: body.date,
-            valeur: new Decimal(body.valeur),
-          },
-          include: {
-            indicateur: { select: { publicId: true } },
-            individu: { select: { publicId: true } },
           },
         }),
       ),
     )
-    .map(toValeurAvancementApiModel)
+    .map(() => undefined)
 }

--- a/apps/mb-api/src/valeurAvancement/commands/deleteValeurAvancement.ts
+++ b/apps/mb-api/src/valeurAvancement/commands/deleteValeurAvancement.ts
@@ -4,14 +4,11 @@ import { ResultAsync } from 'neverthrow'
 import { requireCurrentPrincipalId } from '@/framework/auth/userContext'
 import { type ForbiddenError } from '@/framework/errors/AppError'
 import { db } from '@/framework/persistence/dbStore'
+import { type IndividuInconnuError, resolveAuthorizedIndividu } from '@/individu/permission'
 import {
   ensureIndicateurWritePermission,
   withIndicateurReadPermission,
 } from '@/indicateur/permissions'
-import {
-  type IndividuInconnuError,
-  resolveAuthorizedIndividu,
-} from '@/valeurAvancement/resolveAuthorizedIndividu'
 
 export type DeleteValeurAvancementError = IndividuInconnuError
 
@@ -41,8 +38,8 @@ export const deleteValeurAvancement = ({
     )
     .andThen((indicateur) =>
       resolveAuthorizedIndividu({
-        indicateurId: indicateur.id,
         individuPublicId: body.individu,
+        indicateurId: indicateur.id,
       }).map((individu) => ({ indicateur, individu })),
     )
     .andThen(({ indicateur, individu }) =>

--- a/apps/mb-api/src/valeurAvancement/commands/upsertValeurAvancement.ts
+++ b/apps/mb-api/src/valeurAvancement/commands/upsertValeurAvancement.ts
@@ -9,14 +9,11 @@ import { requireCurrentPrincipalId } from '@/framework/auth/userContext'
 import { Decimal } from '@/framework/decimal'
 import { type ForbiddenError } from '@/framework/errors/AppError'
 import { db } from '@/framework/persistence/dbStore'
+import { type IndividuInconnuError, resolveAuthorizedIndividu } from '@/individu/permission'
 import {
   ensureIndicateurWritePermission,
   withIndicateurReadPermission,
 } from '@/indicateur/permissions'
-import {
-  type IndividuInconnuError,
-  resolveAuthorizedIndividu,
-} from '@/valeurAvancement/resolveAuthorizedIndividu'
 import { toValeurAvancementApiModel } from '@/valeurAvancement/utils'
 
 export type UpsertValeurAvancementError = IndividuInconnuError
@@ -47,8 +44,8 @@ export const upsertValeurAvancement = ({
     )
     .andThen((indicateur) =>
       resolveAuthorizedIndividu({
-        indicateurId: indicateur.id,
         individuPublicId: body.individu,
+        indicateurId: indicateur.id,
       }).map((individu) => ({ indicateur, individu })),
     )
     .andThen(({ indicateur, individu }) =>

--- a/apps/mb-api/src/valeurAvancement/resolveAuthorizedIndividu.ts
+++ b/apps/mb-api/src/valeurAvancement/resolveAuthorizedIndividu.ts
@@ -1,0 +1,41 @@
+import { errAsync, okAsync, ResultAsync } from 'neverthrow'
+
+import { db } from '@/framework/persistence/dbStore'
+
+export type IndividuInconnuError = { type: 'INDIVIDU_INCONNU'; individu: string }
+
+export const resolveAuthorizedIndividu = ({
+  indicateurId,
+  individuPublicId,
+}: {
+  indicateurId: string
+  individuPublicId: string
+}): ResultAsync<{ id: string; publicId: string }, IndividuInconnuError> => {
+  const unknownOrUnauthorized = (): IndividuInconnuError => ({
+    type: 'INDIVIDU_INCONNU',
+    individu: individuPublicId,
+  })
+  return ResultAsync.fromSafePromise(
+    db().individu.findUnique({
+      where: { publicId: individuPublicId },
+      select: { id: true, publicId: true, referentielId: true },
+    }),
+  )
+    .andThen((individu) => (individu ? okAsync(individu) : errAsync(unknownOrUnauthorized())))
+    .andThen((individu) =>
+      ResultAsync.fromSafePromise(
+        db().indicateurReferentiel.findUnique({
+          where: {
+            indicateurId_referentielId: {
+              indicateurId,
+              referentielId: individu.referentielId,
+            },
+          },
+        }),
+      ).andThen((link) =>
+        link
+          ? okAsync({ id: individu.id, publicId: individu.publicId })
+          : errAsync(unknownOrUnauthorized()),
+      ),
+    )
+}

--- a/apps/mb-api/src/valeurAvancement/routes.ts
+++ b/apps/mb-api/src/valeurAvancement/routes.ts
@@ -3,6 +3,7 @@ import { errorApiModelSchema } from '@pilote/mb-shared/error'
 import { indicateurPublicIdSchema } from '@pilote/mb-shared/indicateur'
 import { createPaginatedApiListSchema } from '@pilote/mb-shared/pagination'
 import {
+  deleteValeurAvancementBodySchema,
   individuAvecValeursApiModelSchema,
   listIndividusWithValeursQuerySchema,
   listSyntheseIndividusQuerySchema,
@@ -20,6 +21,7 @@ import { ForbiddenError } from '@/framework/errors/AppError'
 import { never } from '@/framework/errors/never'
 import { jsonResponseError, jsonResponseOk } from '@/framework/openapi/jsonResponse'
 import { withTransaction } from '@/framework/persistence/withTransaction'
+import { deleteValeurAvancement } from '@/valeurAvancement/commands/deleteValeurAvancement'
 import { upsertValeurAvancement } from '@/valeurAvancement/commands/upsertValeurAvancement'
 import { listIndividusWithValeurs } from '@/valeurAvancement/queries/listIndividusWithValeurs'
 import { listSyntheseIndividus } from '@/valeurAvancement/queries/listSyntheseIndividus'
@@ -34,6 +36,9 @@ const ValeurAvancementListApiModelSchema = valeurAvancementListApiModelSchema.op
 )
 const UpsertValeurAvancementBodySchema = upsertValeurAvancementBodySchema.openapi(
   'UpsertValeurAvancementBody',
+)
+const DeleteValeurAvancementBodySchema = deleteValeurAvancementBodySchema.openapi(
+  'DeleteValeurAvancementBody',
 )
 const IndividusWithValeursListApiModelSchema = createPaginatedApiListSchema(
   individuAvecValeursApiModelSchema,
@@ -98,6 +103,39 @@ const upsertValeurAvancementRoute = createRoute({
     200: {
       content: { 'application/json': { schema: ValeurAvancementApiModelSchema } },
       description: 'Valeur créée ou mise à jour',
+    },
+    400: {
+      content: { 'application/json': { schema: ErrorApiModelSchema } },
+      description: 'Requête invalide (body invalide ou individu inconnu/non autorisé)',
+    },
+    403: {
+      content: { 'application/json': { schema: ErrorApiModelSchema } },
+      description: 'Pas de permission WRITE sur cet indicateur',
+    },
+  },
+})
+
+// --- DELETE /indicateurs/:id/valeurs -----------------------------------------
+
+const deleteValeurAvancementRoute = createRoute({
+  method: 'delete',
+  path: '/indicateurs/{id}/valeurs',
+  tags: ['Indicateur'],
+  summary: 'Supprimer une valeur ponctuelle pour un individu',
+  description:
+    "Supprime la valeur identifiée par `(indicateur, individu, date)`. Idempotent : retourne `204` même si la valeur n'existait pas. " +
+    "L'individu doit appartenir à un référentiel lié à l'indicateur (sinon 400 `INDIVIDU_INCONNU`).",
+  middleware: [requireAuthentication],
+  request: {
+    params: indicateurParamsSchema,
+    body: {
+      content: { 'application/json': { schema: DeleteValeurAvancementBodySchema } },
+      required: true,
+    },
+  },
+  responses: {
+    204: {
+      description: 'Valeur supprimée (ou inexistante — idempotent)',
     },
     400: {
       content: { 'application/json': { schema: ErrorApiModelSchema } },
@@ -233,6 +271,40 @@ valeurAvancementRoutes.openapi(upsertValeurAvancementRoute, async (context) => {
         schema: ValeurAvancementApiModelSchema,
         status: 200,
       }),
+    (error) => {
+      if (error instanceof ForbiddenError) {
+        return jsonResponseError({
+          context,
+          error: { code: error.code, message: error.message },
+          schema: ErrorApiModelSchema,
+          status: 403,
+        })
+      }
+      return jsonResponseError({
+        context,
+        error: {
+          code: error.type,
+          message:
+            "L'individu est inconnu ou n'est pas rattaché à un référentiel lié à l'indicateur",
+          details: { individu: error.individu },
+        },
+        schema: ErrorApiModelSchema,
+        status: 400,
+      })
+    },
+  )
+})
+
+valeurAvancementRoutes.openapi(deleteValeurAvancementRoute, async (context) => {
+  const { id } = context.req.valid('param')
+  const body = context.req.valid('json')
+
+  const result = await withTransaction(async () =>
+    deleteValeurAvancement({ indicateurPublicId: id, body }),
+  )
+
+  return result.match(
+    () => context.body(null, 204),
     (error) => {
       if (error instanceof ForbiddenError) {
         return jsonResponseError({

--- a/packages/mb-shared/src/valeurAvancement.ts
+++ b/packages/mb-shared/src/valeurAvancement.ts
@@ -51,6 +51,12 @@ export const upsertValeurAvancementBodySchema = z.object({
 })
 export type UpsertValeurAvancementBody = z.infer<typeof upsertValeurAvancementBodySchema>
 
+export const deleteValeurAvancementBodySchema = z.object({
+  individu: individuPublicIdSchema,
+  date: dateSchema,
+})
+export type DeleteValeurAvancementBody = z.infer<typeof deleteValeurAvancementBodySchema>
+
 export const valeurAvancementListApiModelSchema = z.object({
   items: z
     .array(valeurAvancementApiModelSchema)


### PR DESCRIPTION
## Summary

- Nouveau endpoint `DELETE /indicateurs/{id}/valeurs` qui supprime la valeur identifiée par le triplet `(indicateur, individu, date)`. Body : `{ individu, date }`.
- **Idempotent** : `204 No Content` même si aucune ligne ne correspondait (via `deleteMany`, pas `delete`).
- Mêmes contrôles d'accès que le PUT : `404` si l'indicateur n'existe pas ou n'est pas accessible en READ, `403` si pas de permission WRITE, `400 INDIVIDU_INCONNU` si l'individu n'est pas rattaché à un référentiel lié à l'indicateur.
- Refacto : extraction de `resolveAuthorizedIndividu` (+ type `IndividuInconnuError`) dans `valeurAvancement/resolveAuthorizedIndividu.ts`, réutilisé par PUT et DELETE.

## Réponses

| Statut | Quand |
|--------|-------|
| `204` | Suppression effectuée OU triplet inexistant (idempotent) |
| `400 INDIVIDU_INCONNU` | Individu inexistant ou hors périmètre des référentiels liés |
| `403` | Pas de permission WRITE sur l'indicateur |
| `404` | Indicateur inexistant ou pas de permission READ |

## Test plan

- [x] `pnpm --filter @pilote/mb-api test src/valeurAvancement/commands/deleteValeurAvancement.test.ts` (8/8)
- [x] `pnpm --filter @pilote/mb-api test src/valeurAvancement/commands/upsertValeurAvancement.test.ts` (7/7, vérifie que le refacto ne casse pas le PUT)
- [x] Suite complète `pnpm --filter @pilote/mb-api test` (165/165)
- [x] `APP_PACKAGE=@pilote/mb-api pnpm lint` (eslint + tsc + prettier)

## Hors scope (PR séparée)

- Le champ `indicateur` redondant dans la **réponse** du PUT (déjà dans l'URL) — à traiter via 2 schémas dans `mb-shared` dans une PR dédiée.