### PR TITLE
fix(mb-api): fixtures avec IDs aléatoires par défaut (deadlock concurrent)

### DIFF
--- a/apps/mb-api/src/test/fixtures.ts
+++ b/apps/mb-api/src/test/fixtures.ts
@@ -4,6 +4,13 @@ import { env } from '@/env'
 import { hashApiKey } from '@/framework/auth/apiKey'
 import { db } from '@/framework/persistence/dbStore'
 import {
+  testApiKeyRawKey,
+  testEmail,
+  testIndicateurId,
+  testIndividuId,
+  testReferentielId,
+} from '@/test/randomIds'
+import {
   type ApiKeyModel,
   type IndicateurModel,
   type IndicateurPermissionModel,
@@ -20,10 +27,13 @@ import { PermissionAction } from '@/generated/prisma/enums'
 
 type IndicateurOverrides = Partial<{ id: string; publicId: string; nom: string }>
 
-const DEFAULT_INDICATEUR = { publicId: 'IND-1', nom: 'Indicateur de test' } as const
-
 const upsertIndicateur = async (o: IndicateurOverrides = {}) => {
-  const create = { id: uuidv7(), ...DEFAULT_INDICATEUR, ...o }
+  const create = {
+    id: uuidv7(),
+    publicId: testIndicateurId(),
+    nom: 'Indicateur de test',
+    ...o,
+  }
   const { id: _id, publicId: _pub, ...update } = o
   if (Object.keys(update).length === 0) {
     const existing = await db().indicateur.findUnique({ where: { publicId: create.publicId } })
@@ -61,14 +71,14 @@ type ReferentielOverrides = Partial<{
   description: string | null
 }>
 
-const DEFAULT_REFERENTIEL = {
-  publicId: 'REF-TEST',
-  nom: 'Référentiel de test',
-  description: null,
-} as const
-
 const upsertReferentiel = async (o: ReferentielOverrides = {}) => {
-  const create = { id: uuidv7(), ...DEFAULT_REFERENTIEL, ...o }
+  const create = {
+    id: uuidv7(),
+    publicId: testReferentielId(),
+    nom: 'Référentiel de test',
+    description: null,
+    ...o,
+  }
   const { id: _id, publicId: _pub, ...update } = o
   if (Object.keys(update).length === 0) {
     const existing = await db().referentiel.findUnique({ where: { publicId: create.publicId } })
@@ -106,13 +116,8 @@ type IndividuOverrides = Partial<{
   referentiel: ReferentielOverrides
 }>
 
-const DEFAULT_INDIVIDU = {
-  publicId: 'TEST-1',
-  nom: 'Individu de test',
-} as const
-
 const upsertIndividu = async (o: IndividuOverrides = {}) => {
-  const publicId = o.publicId ?? DEFAULT_INDIVIDU.publicId
+  const publicId = o.publicId ?? testIndividuId()
   const existing = await db().individu.findUnique({ where: { publicId } })
 
   // Pas d'override referentiel et l'individu existe : on touche pas au rattachement.
@@ -131,7 +136,7 @@ const upsertIndividu = async (o: IndividuOverrides = {}) => {
     create: {
       id: o.id ?? uuidv7(),
       publicId,
-      nom: o.nom ?? DEFAULT_INDIVIDU.nom,
+      nom: o.nom ?? 'Individu de test',
       referentielId: referentielRow.id,
     },
   })
@@ -296,12 +301,6 @@ type ApiKeyOverrides = Partial<{
   permissions: PrincipalIndicateurPermissionOverrides[]
 }>
 
-const DEFAULT_API_KEY = {
-  label: 'API key de test',
-  rawKey: 'pilote_live_test_default_key_value_xx',
-  prefix: 'pilote_live_test_def',
-} as const
-
 const grantPermissions = async (
   principalId: string,
   permissions: PrincipalIndicateurPermissionOverrides[] | undefined,
@@ -313,13 +312,13 @@ const grantPermissions = async (
 }
 
 const upsertApiKey = async (o: ApiKeyOverrides = {}) => {
-  const rawKey = o.rawKey ?? DEFAULT_API_KEY.rawKey
+  const rawKey = o.rawKey ?? testApiKeyRawKey()
   const keyHash = hashApiKey(rawKey, env.API_KEY_HMAC_SECRET)
   const create = {
     id: o.id ?? uuidv7(),
-    label: o.label ?? DEFAULT_API_KEY.label,
+    label: o.label ?? 'API key de test',
     keyHash,
-    prefix: o.prefix ?? DEFAULT_API_KEY.prefix,
+    prefix: o.prefix ?? rawKey.slice(0, 20),
     expiresAt: o.expiresAt ?? null,
     revokedAt: o.revokedAt ?? null,
     lastUsedAt: o.lastUsedAt ?? null,
@@ -360,13 +359,8 @@ type UtilisateurOverrides = Partial<{
   permissions: PrincipalIndicateurPermissionOverrides[]
 }>
 
-const DEFAULT_UTILISATEUR = {
-  email: 'utilisateur-test@example.com',
-  providerSub: null,
-} as const
-
 const upsertUtilisateur = async (o: UtilisateurOverrides = {}) => {
-  const email = o.email ?? DEFAULT_UTILISATEUR.email
+  const email = o.email ?? testEmail()
   const existing = await db().utilisateur.findUnique({ where: { email } })
   if (existing) {
     await grantPermissions(existing.id, o.permissions)
@@ -378,7 +372,7 @@ const upsertUtilisateur = async (o: UtilisateurOverrides = {}) => {
   const create = {
     id,
     email,
-    providerSub: o.providerSub ?? DEFAULT_UTILISATEUR.providerSub,
+    providerSub: o.providerSub ?? null,
   }
   await db().principal.create({ data: { id } })
   const created = await db().utilisateur.create({ data: create })

--- a/apps/mb-api/src/test/randomIds.ts
+++ b/apps/mb-api/src/test/randomIds.ts
@@ -138,15 +138,30 @@ const uniqueIds = <N extends number>(factory: () => string, count: N): FixedTupl
   return [...ids].sort() as FixedTuple<N, string>
 }
 
-export const testIndicateurId = (): string =>
-  `IND-${String(Math.floor(Math.random() * 999) + 1).padStart(3, '0')}`
+// 12 caractères alphanum ⇒ ~10^21 combinaisons : collisions négligeables même
+// entre tests parallèles d'un même run (limite la contention de row-locks).
+const ALPHANUM = 'abcdefghijklmnopqrstuvwxyz0123456789'
+const randomToken = (length: number): string => {
+  let out = ''
+  for (let i = 0; i < length; i++) out += ALPHANUM[Math.floor(Math.random() * ALPHANUM.length)]
+  return out
+}
 
-export const testReferentielId = (): string =>
-  `REF-${String(Math.floor(Math.random() * 999) + 1).padStart(3, '0')}`
+export const testIndicateurId = (): string => `IND-${randomToken(12)}`
+
+export const testReferentielId = (): string => `REF-${randomToken(12)}`
+
+export const testIndividuId = (): string => `TEST-${randomToken(12)}`
 
 export const testDeptId = (): string => `DEPT-${pickRandom(DEPT_CODES)}`
 
 export const testRegId = (): string => `REG-${pickRandom(REG_CODES)}`
+
+export const testEmail = (): string => `utilisateur-${randomToken(12)}@example.com`
+
+// `pilote_live_<token>` — préfixe imposé par looksLikeApiKey, longueur ≥ 20 pour
+// que le slice(0, 20) côté apiKey produise un préfixe stable.
+export const testApiKeyRawKey = (): string => `pilote_live_${randomToken(32)}`
 
 export const testIndicateurIds = <N extends number>(n: N): FixedTuple<N, string> =>
   uniqueIds(testIndicateurId, n)


### PR DESCRIPTION
## Contexte

Les tests d'intégration de `mb-api` tournent en `describe.concurrent` (cf. `apps/mb-api/vitest.config.ts`), ce qui provoquait des **deadlocks PostgreSQL intermittents** (SQLSTATE `40P01`) sur les fixtures partagées : `fixtures.apiKey()` (et `indicateur`/`referentiel`/`individu`/`utilisateur` en l'absence d'override) `upsert`aient systématiquement la même ligne (`DEFAULT_API_KEY.rawKey`, `'IND-1'`, `'REF-TEST'`, `'TEST-1'`, etc.). Les transactions concurrentes acquéraient leurs row-locks dans des ordres incohérents → deadlock.

Exemple d'échec observé en `pnpm test` :

```
FAIL  src/valeurAvancement/commands/upsertValeurAvancement.test.ts
DriverAdapterError: deadlock detected
 ❯ PgTransaction.onError @prisma/adapter-pg/dist/index.mjs:642:11
```

## Changement

Au lieu de gérer le symptôme (retry sur deadlock), on **supprime la contention à la source** : chaque appel à une fixture sans override crée désormais une **ligne unique**.

- `apps/mb-api/src/test/randomIds.ts` : ajout des helpers `testIndividuId()`, `testEmail()`, `testApiKeyRawKey()`, basés sur un `randomToken(12)` alphanum (36¹² ≈ 4.7×10¹⁸ combinaisons → collisions négligeables même sur des runs parallèles intensifs). Les helpers existants `testIndicateurId`/`testReferentielId` passent du même coup de 999 valeurs (collision quasi-certaine au-delà de 30 tests via le birthday paradox) au même schéma.
- `apps/mb-api/src/test/fixtures.ts` : suppression des constantes `DEFAULT_*` (`publicId`, `rawKey`, `email`), remplacées par un appel aux helpers dans chaque `upsertX`. Les tests qui passent un override explicite (publicId, rawKey, email) conservent leur comportement déterministe.

Aucun test à modifier : aucun n'asserte sur les anciennes valeurs par défaut, et le seul usage en dur de `'REF-TEST'` (dans `referentiel/queries/getReferentielByPublicId.test.ts`) le passe déjà en override explicite.

## Vérification

- `pnpm lint` ✅
- `pnpm test` lancé **10 fois consécutives** → 165/165 verts à chaque run
- **Bonus** : la suite passe de ~3.5s à ~2.4s (~30% plus rapide) parce qu'il n'y a plus de sérialisation implicite sur les rows partagées