### PR TITLE
feat(mb-api): valeurs dérivées par agrégation hiérarchique

### DIFF
--- a/.github/workflows/testAndLint.yml
+++ b/.github/workflows/testAndLint.yml
@@ -120,6 +120,12 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
 
+      - name: Apply Prisma migrations
+        # Required before `prisma generate --sql` introspects tables for TypedSQL types
+        run: pnpm -F @pilote/mb-api exec prisma migrate deploy
+        env:
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5435/postgres
+
       - name: Generate Prisma client
         run: pnpm -F @pilote/mb-api prisma:generate
         env:
@@ -140,8 +146,22 @@ jobs:
     if: needs.changes.outputs['mb-api'] == 'true' || needs.changes.outputs['mb-shared'] == 'true'
     runs-on: ubuntu-latest
     env:
-      # Dummy URL: prisma generate only validates the config schema, no DB connection needed
-      DATABASE_URL: postgresql://prisma:prisma@localhost:5432/prisma
+      # `prisma generate --sql` introspects tables to type TypedSQL queries — a real DB is required
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5436/postgres
+    services:
+      postgres:
+        image: postgres:17.9-alpine
+        env:
+          POSTGRES_DB: postgres
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5436:5432
     steps:
       - uses: actions/checkout@v4
 
@@ -149,6 +169,9 @@ jobs:
         uses: ./.github/actions/setupNodeAndPackages
         with:
           node-version: ${{ env.NODE_VERSION }}
+
+      - name: Apply Prisma migrations
+        run: pnpm -F @pilote/mb-api exec prisma migrate deploy
 
       - name: Generate Prisma client
         run: pnpm -F @pilote/mb-api prisma:generate

--- a/apps/mb-api/docs/architecture/valeurs-derivees-design.md
+++ b/apps/mb-api/docs/architecture/valeurs-derivees-design.md
@@ -1,7 +1,7 @@
 # Valeurs dérivées par agrégation hiérarchique — design
 
 Date : 2026-05-19
-Statut : en cours de spécification
+Statut : accepté
 
 ## Contexte
 
@@ -110,86 +110,74 @@ Ce choix permet d'itérer sans toucher aux endpoints existants. Une intégration
 plus transparente (calcul auto si pas de valeur saisie sur l'endpoint GET
 classique) pourra être envisagée plus tard.
 
+### D5. Modélisation de la hiérarchie (option A3)
+
+On garde `Relation` tel quel (graphe individu ↔ individu) et on ajoute
+l'**invariant métier** : *tous les enfants directs d'un même parent
+appartiennent au même référentiel*. Cet invariant est vérifié à l'upsert
+d'une `Relation` (pas via une contrainte schéma).
+
+Rationale : pas de duplication avec `Referentiel`, hiérarchie reste portée
+par les individus, mais on s'interdit les configurations incohérentes
+(ex. un département parent d'une commune et d'un autre département).
+
+### D6. Calcul à la volée (option B1)
+
+Pas de stockage des valeurs dérivées. Chaque appel à l'endpoint déclenche le
+calcul à partir des valeurs saisies et des valeurs dérivées des enfants
+directs (récursion en mémoire). Pas de table de cache, pas de matérialisation
+Prisma.
+
+Rationale : cohérence garantie sans logique d'invalidation. Volumétrie
+réévaluable plus tard via B2 ou B3 si nécessaire.
+
+### D7. Agrégateur SUM hardcodé pour le MVP
+
+Pas de configuration d'agrégateur dans le schéma : **SUM est l'agrégateur
+unique du MVP**. Une stratégie configurable (champ sur `Indicateur`, ou
+autre) sera introduite plus tard quand le besoin produit sera explicite.
+
+### D8. Couverture partielle exposée
+
+Si un parent a `n` enfants directs et que `k < n` d'entre eux ont une valeur
+(saisie ou dérivable), on **calcule quand même** et on expose la couverture
+(`k / n`) dans la réponse. Le consommateur (UI) décide quoi en faire (alerte,
+masquer, etc.). Aucune imputation automatique (pas de 0 par défaut).
+
+### D9. Saisie autorisée sur un individu non-feuille
+
+Saisir une valeur sur un individu qui a des enfants reste **autorisé**. La
+valeur saisie et la valeur dérivée coexistent (cf. D1) — c'est au
+consommateur d'arbitrer l'affichage.
+
+### D10. Pas de détection de cycles dans `Relation`
+
+On fait confiance aux données. La création de cycles dans `Relation` n'est
+pas empêchée par le code, et la traversée récursive ne détecte pas les
+cycles. Si un cycle existe en BD, le comportement est non défini (boucle ou
+crash).
+
+Rationale : le risque est jugé faible (peu de mutations sur `Relation`, pas
+d'API publique d'édition aujourd'hui). À reconsidérer si une API d'édition de
+`Relation` est ajoutée.
+
 ## Conséquences
 
-- **Pas de migration de schéma requise** pour le MVP : `Relation` existe déjà
+- **Pas de migration de schéma requise** : `Relation` existe déjà, pas de
+  nouveau champ
+- L'upsert de `Relation` (quand il sera exposé) devra valider l'invariant D5
 - Une nouvelle famille de queries doit être introduite pour traverser la
   hiérarchie (enfants directs d'un individu) et résoudre les valeurs par
   niveau
-- Le functional core gagne un opérateur d'agrégation paramétrable (au moins
-  SUM dans un premier temps)
-- La résolution récursive doit être bornée (profondeur max, ou détection de
-  cycles) car `Relation` est un graphe sans contrainte d'acyclicité
-
-## Questions ouvertes
-
-### Q1. Modélisation de la hiérarchie
-
-`Relation` est un graphe libre : aucun invariant n'empêche un cycle, ni un
-parent d'avoir des enfants dans plusieurs référentiels. Trois options :
-
-- **A1.** Statu quo (graphe libre) — flexible mais aucune garantie structurelle
-- **A2.** Ajouter `parentReferentielId` sur `Referentiel` — duplique l'info
-  avec `Relation`, hiérarchie stricte
-- **A3.** Garder `Relation` + invariant métier "tous les enfants d'un parent
-  appartiennent au même référentiel" — vérifié à l'upsert
-
-Penchant initial : **A3**, à confirmer.
-
-### Q2. Stockage des valeurs dérivées
-
-- **B1.** Calcul à la volée — cohérent, simple, coût lecture
-- **B2.** Stockage dans `valeur_avancement` avec champ `source` — lecture
-  uniforme mais invalidation en cascade complexe
-- **B3.** Table dédiée `valeur_derivee` — cache séparé
-
-Penchant initial : **B1** pour le MVP, réévaluation si volumétrie devient un
-problème.
-
-### Q3. Configuration de l'agrégateur
-
-Où attacher la stratégie d'agrégation ?
-
-- Sur `Indicateur` (un agrégateur par indicateur)
-- Sur la combinaison `Indicateur × Referentiel` (différent par niveau, rare)
-- Paramètre de query (le client choisit) — flexible mais peu sémantique
-- Hardcodé SUM pour le MVP, à étendre
-
-Penchant initial : SUM hardcodé pour MVP, champ sur `Indicateur` ensuite.
-
-### Q4. Couverture partielle
-
-Si un parent a 13 enfants mais que seuls 12 ont une valeur (saisie ou
-dérivée) à la date demandée, que fait-on ?
-
-- Calculer quand même et exposer la couverture (12/13) — recommandé
-- Refuser de calculer (404 / 422)
-- Calculer en imputant 0 aux manquants
-
-Penchant initial : calculer + exposer couverture, le consommateur décide.
-
-### Q5. Saisie sur un individu non-feuille
-
-D3 dit que saisie et dérivée coexistent. Mais doit-on permettre la saisie sur
-un individu qui a des enfants ? Probablement oui (cas INSEE : valeur officielle
-nationale ≠ somme régionale). À confirmer.
-
-### Q6. Détection de cycles dans `Relation`
-
-Le modèle actuel n'empêche pas un cycle (A parent de B, B parent de A). Le
-calcul récursif doit soit :
-
-- Faire confiance aux données (et boucler/exploser si cycle)
-- Détecter les cycles à la lecture
-- Empêcher la création de cycles à l'écriture sur `Relation`
-
-À trancher.
+- Le functional core gagne un opérateur d'agrégation `sum` (les autres
+  agrégateurs viendront plus tard)
+- La traversée récursive n'a pas de garde anti-cycle ; si on observe un
+  problème en prod, on ajoutera la détection à ce moment-là
 
 ## Prochaines étapes
 
-1. Trancher Q1 à Q6
-2. Spécifier précisément le schéma de réponse de
+1. Spécifier précisément le schéma de réponse de
    `GET /indicateurs/:id/individus/:individuId/valeur-derivee`
-3. Implémenter la traversée hiérarchique (query Prisma + functional core)
-4. Implémenter l'agrégateur SUM en functional core
-5. Ajouter la route + tests
+2. Implémenter la traversée hiérarchique (query Prisma + functional core)
+3. Implémenter l'agrégateur SUM en functional core
+4. Ajouter la route + tests

--- a/apps/mb-api/docs/architecture/valeurs-derivees-design.md
+++ b/apps/mb-api/docs/architecture/valeurs-derivees-design.md
@@ -1,0 +1,195 @@
+# Valeurs dérivées par agrégation hiérarchique — design
+
+Date : 2026-05-19
+Statut : en cours de spécification
+
+## Contexte
+
+Actuellement, le modèle `ValeurAvancement` permet de saisir une valeur sur un
+couple `(indicateur, individu, date)` où `individu` appartient à un
+`Referentiel`. Les individus possèdent déjà une hiérarchie via le modèle
+`Relation` (parent ↔ enfant), mais celle-ci n'est pas exploitée côté métier.
+
+Le besoin produit est de pouvoir **calculer la valeur d'un individu parent**
+comme agrégation des valeurs de ses enfants pour un même indicateur à une date
+donnée. Exemples :
+
+- Valeur d'une région = somme des valeurs de ses départements
+- Valeur de la France = somme des valeurs de ses régions
+- Cas non-somme : moyenne de France = moyenne des moyennes des régions
+  (≠ moyenne des départements directement)
+
+## État de l'existant
+
+- **Hiérarchie individu/individu** matérialisée via `Relation`, non exploitée
+  côté métier aujourd'hui
+- **Pas de hiérarchie entre référentiels** (référentiels plats)
+- **Calculs purs déjà extraits** dans `valeurAvancement/` (`computeMediane`,
+  `computeMin/Max`, `computeVariation`, `computeEcartMediane`)
+- **Synthèse par individu** (PIL-1456, `listSyntheseIndividus`) : voisin
+  fonctionnel le plus proche, sert de template
+- Routes en place : `GET/PUT/DELETE /indicateurs/:id/valeurs`,
+  `.../individus`, `.../valeurs-remarquables`, `.../synthese-individus`
+
+## Décisions
+
+### D1. Coexistence saisie ↔ dérivée (option D3)
+
+Une valeur saisie et une valeur dérivée **peuvent coexister** sur le même
+individu pour le même `(indicateur, date)`. Elles sont exposées distinctement
+par l'API. Aucun override automatique :
+
+- La valeur saisie reste celle de référence pour le système (source de vérité
+  humaine, ex. chiffre officiel INSEE)
+- La valeur dérivée est calculée à partir des enfants directs et exposée
+  comme valeur calculée distincte
+
+Cela laisse le consommateur (UI, audit) décider de l'affichage selon le
+contexte.
+
+### D2. Agrégation niveau par niveau (option E révisée)
+
+La valeur dérivée d'un parent est calculée en appliquant l'agrégateur sur les
+**valeurs de ses enfants directs uniquement** (saisies ou dérivées), pas sur
+l'ensemble des descendants à plat.
+
+Rationale : la propriété "somme à plat = somme par niveau" n'est vraie que
+pour les agrégateurs associatifs et exhaustifs (SUM, MIN, MAX). Pour la
+moyenne ou la médiane, descendre à plat donne un résultat sémantiquement
+différent. Pour garantir la cohérence multi-agrégateurs et préparer les
+besoins futurs (ex. moyenne nationale = moyenne des moyennes régionales),
+on traite chaque niveau indépendamment :
+
+```
+valeur_dérivée(parent) = agrégateur( valeur(enfant_i) pour enfant_i ∈ enfants_directs(parent) )
+```
+
+où `valeur(enfant_i)` est :
+- la valeur saisie si elle existe
+- sinon la valeur dérivée calculée récursivement
+- sinon absente (et l'enfant est ignoré ou produit un résultat partiel —
+  voir Questions ouvertes)
+
+### D3. Exposition des niveaux
+
+L'API doit permettre de consulter la valeur dérivée **à n'importe quel niveau
+de la hiérarchie** et exposer la décomposition (les enfants directs ayant
+contribué). Ceci permet :
+
+- Drill-down dans l'UI (région → départements contributeurs)
+- Audit / traçabilité du calcul
+- Détection de couvertures partielles (n enfants sur m ont une valeur)
+
+### D4. Endpoint API dédié (option F1)
+
+On introduit un **nouvel endpoint dédié** pour les valeurs dérivées, sans
+modifier les endpoints existants :
+
+```
+GET /indicateurs/:id/individus/:individuId/valeur-derivee?date=...
+```
+
+Forme provisoire de la réponse (à affiner) :
+
+```json
+{
+  "indicateurPublicId": "...",
+  "individuPublicId": "...",
+  "date": "2025-12",
+  "agregateur": "SUM",
+  "valeurDerivee": "1234.56",
+  "contributions": [
+    { "individuPublicId": "...", "valeur": "100.00", "source": "saisie" },
+    { "individuPublicId": "...", "valeur": "234.56", "source": "derivee" }
+  ],
+  "couverture": { "nEnfantsAvecValeur": 12, "nEnfantsTotal": 13 }
+}
+```
+
+Ce choix permet d'itérer sans toucher aux endpoints existants. Une intégration
+plus transparente (calcul auto si pas de valeur saisie sur l'endpoint GET
+classique) pourra être envisagée plus tard.
+
+## Conséquences
+
+- **Pas de migration de schéma requise** pour le MVP : `Relation` existe déjà
+- Une nouvelle famille de queries doit être introduite pour traverser la
+  hiérarchie (enfants directs d'un individu) et résoudre les valeurs par
+  niveau
+- Le functional core gagne un opérateur d'agrégation paramétrable (au moins
+  SUM dans un premier temps)
+- La résolution récursive doit être bornée (profondeur max, ou détection de
+  cycles) car `Relation` est un graphe sans contrainte d'acyclicité
+
+## Questions ouvertes
+
+### Q1. Modélisation de la hiérarchie
+
+`Relation` est un graphe libre : aucun invariant n'empêche un cycle, ni un
+parent d'avoir des enfants dans plusieurs référentiels. Trois options :
+
+- **A1.** Statu quo (graphe libre) — flexible mais aucune garantie structurelle
+- **A2.** Ajouter `parentReferentielId` sur `Referentiel` — duplique l'info
+  avec `Relation`, hiérarchie stricte
+- **A3.** Garder `Relation` + invariant métier "tous les enfants d'un parent
+  appartiennent au même référentiel" — vérifié à l'upsert
+
+Penchant initial : **A3**, à confirmer.
+
+### Q2. Stockage des valeurs dérivées
+
+- **B1.** Calcul à la volée — cohérent, simple, coût lecture
+- **B2.** Stockage dans `valeur_avancement` avec champ `source` — lecture
+  uniforme mais invalidation en cascade complexe
+- **B3.** Table dédiée `valeur_derivee` — cache séparé
+
+Penchant initial : **B1** pour le MVP, réévaluation si volumétrie devient un
+problème.
+
+### Q3. Configuration de l'agrégateur
+
+Où attacher la stratégie d'agrégation ?
+
+- Sur `Indicateur` (un agrégateur par indicateur)
+- Sur la combinaison `Indicateur × Referentiel` (différent par niveau, rare)
+- Paramètre de query (le client choisit) — flexible mais peu sémantique
+- Hardcodé SUM pour le MVP, à étendre
+
+Penchant initial : SUM hardcodé pour MVP, champ sur `Indicateur` ensuite.
+
+### Q4. Couverture partielle
+
+Si un parent a 13 enfants mais que seuls 12 ont une valeur (saisie ou
+dérivée) à la date demandée, que fait-on ?
+
+- Calculer quand même et exposer la couverture (12/13) — recommandé
+- Refuser de calculer (404 / 422)
+- Calculer en imputant 0 aux manquants
+
+Penchant initial : calculer + exposer couverture, le consommateur décide.
+
+### Q5. Saisie sur un individu non-feuille
+
+D3 dit que saisie et dérivée coexistent. Mais doit-on permettre la saisie sur
+un individu qui a des enfants ? Probablement oui (cas INSEE : valeur officielle
+nationale ≠ somme régionale). À confirmer.
+
+### Q6. Détection de cycles dans `Relation`
+
+Le modèle actuel n'empêche pas un cycle (A parent de B, B parent de A). Le
+calcul récursif doit soit :
+
+- Faire confiance aux données (et boucler/exploser si cycle)
+- Détecter les cycles à la lecture
+- Empêcher la création de cycles à l'écriture sur `Relation`
+
+À trancher.
+
+## Prochaines étapes
+
+1. Trancher Q1 à Q6
+2. Spécifier précisément le schéma de réponse de
+   `GET /indicateurs/:id/individus/:individuId/valeur-derivee`
+3. Implémenter la traversée hiérarchique (query Prisma + functional core)
+4. Implémenter l'agrégateur SUM en functional core
+5. Ajouter la route + tests

--- a/apps/mb-api/docs/architecture/valeurs-derivees-design.md
+++ b/apps/mb-api/docs/architecture/valeurs-derivees-design.md
@@ -86,23 +86,30 @@ On introduit un **nouvel endpoint dédié** pour les valeurs dérivées, sans
 modifier les endpoints existants :
 
 ```
-GET /indicateurs/:id/individus/:individuId/valeur-derivee?date=...
+GET /indicateurs/:id/individus/:individuId/valeur-derivee
 ```
+
+Pas de paramètre `date` : on prend systématiquement la **dernière valeur
+connue** de chaque enfant (cohérent avec `listSyntheseIndividus` et
+`listIndividusWithValeurs`). Motivation : la valeur portée par un individu
+est sa donnée la plus fraîche (s'il y avait 5 arbres en mai, il y en a
+toujours 5 en juin par défaut). Chaque contribution porte donc sa propre
+date.
 
 Forme provisoire de la réponse (à affiner) :
 
 ```json
 {
-  "indicateurPublicId": "...",
-  "individuPublicId": "...",
-  "date": "2025-12",
+  "indicateur": "IND-ARBRES",
+  "individu": "REG-PACA",
   "agregateur": "SUM",
-  "valeurDerivee": "1234.56",
+  "valeurDerivee": 1234.56,
   "contributions": [
-    { "individuPublicId": "...", "valeur": "100.00", "source": "saisie" },
-    { "individuPublicId": "...", "valeur": "234.56", "source": "derivee" }
+    { "individu": "DEPT-84", "valeur": 100.00, "date": "2025-12-01", "source": "saisie" },
+    { "individu": "DEPT-13", "valeur": 234.56, "date": "2025-11-01", "source": "derivee" },
+    { "individu": "DEPT-06", "valeur": null,   "date": null,         "source": "absente" }
   ],
-  "couverture": { "nEnfantsAvecValeur": 12, "nEnfantsTotal": 13 }
+  "couverture": { "nbEnfantsAvecValeur": 2, "nbEnfantsTotal": 3 }
 }
 ```
 
@@ -174,10 +181,168 @@ d'API publique d'édition aujourd'hui). À reconsidérer si une API d'édition d
 - La traversée récursive n'a pas de garde anti-cycle ; si on observe un
   problème en prod, on ajoutera la détection à ce moment-là
 
+## Plan d'implémentation
+
+### Architecture d'une requête
+
+Objectif : `O(profondeur)` queries, indépendant du nombre d'individus.
+Trois étapes orchestrées dans `queries/getValeurDerivee.ts`.
+
+#### Étape A — Charger la structure du sous-arbre (BFS niveau par niveau)
+
+Depuis l'individu cible, on charge les descendants par paliers de
+profondeur via `relation.findMany({ where: { parentId: { in: ... } } })`.
+On itère tant qu'il reste des enfants. **P queries** (P = profondeur du
+sous-arbre, typiquement 3–4 : France → Région → Département → ...).
+
+On collecte au passage `{ id, publicId, parentId }` pour reconstruire
+l'arbre côté Node.
+
+#### Étape B — Charger toutes les dernières valeurs en bulk (TypedSQL)
+
+Une seule query récupère la dernière valeur connue par individu pour
+l'indicateur, via Postgres `DISTINCT ON`. Implémentée en
+[**Prisma TypedSQL**](https://www.prisma.io/typedsql) :
+
+```sql
+-- prisma/sql/getDernieresValeursPourIndividus.sql
+SELECT DISTINCT ON (individu_id)
+  individu_id,
+  date,
+  valeur
+FROM valeur_avancement
+WHERE indicateur_id = $1
+  AND individu_id = ANY($2)
+ORDER BY individu_id, date DESC, id DESC;
+```
+
+Génération : `npx prisma generate --sql` produit une fonction typée
+importable depuis `@/generated/prisma/sql`. Appel :
+
+```ts
+import { getDernieresValeursPourIndividus } from '@/generated/prisma/sql'
+const rows = await db().$queryRawTyped(
+  getDernieresValeursPourIndividus(indicateurId, individuIds),
+)
+```
+
+Pourquoi TypedSQL plutôt que `$queryRaw` brut : type-safe (paramètres et
+retour), SQL vit dans un `.sql` reviewable, pas de mapping manuel des
+colonnes. Préféré à `findMany` + dédoublonnage en mémoire (transfert
+inutile de données).
+
+#### Étape C — Calcul en mémoire (functional core, pur)
+
+Une fois en main l'arbre des individus + le map
+`individuId → derniereValeur | undefined`, le calcul devient pur :
+
+```ts
+// functional core, pas de Prisma
+resolveValeurDerivee({
+  cibleId,
+  enfantsParParent,        // Map<parentId, Individu[]>
+  derniereValeurParIndividu, // Map<individuId, { valeur, date }>
+}): {
+  contributions: ContributionApiModel[]
+  valeurDerivee: Decimal | null
+  couverture: { nbEnfantsAvecValeur, nbEnfantsTotal }
+}
+```
+
+Logique récursive : pour chaque enfant direct du cible :
+
+1. Saisie présente → contribution `source: 'saisie'`
+2. Sinon a-t-il des enfants ? → résolution récursive → si non-null,
+   contribution `source: 'derivee'` (date = max des dates contributives)
+3. Sinon → contribution `source: 'absente'`, valeur null
+
+Cohérent avec D1 : pour le calcul du parent, la saisie d'un enfant prime
+sur la dérivation de ses propres enfants. La dérivée de cet enfant reste
+consultable via l'endpoint appliqué à cet enfant.
+
+### Bilan des queries
+
+| Étape | Nombre de queries |
+|---|---|
+| Charger l'indicateur (validation) | 1 |
+| Charger l'individu cible (validation) | 1 |
+| BFS structure du sous-arbre | P (~3–4) |
+| Dernières valeurs en bulk (TypedSQL) | 1 |
+| **Total** | **~6**, indépendant du nombre d'individus |
+
+### Découpage fichiers
+
+| Fichier | Rôle |
+|---|---|
+| `prisma/sql/getDernieresValeursPourIndividus.sql` | Étape B, query DISTINCT ON typée |
+| `valeurAvancement/computeSum.ts` (+ test) | Agrégateur pur SUM |
+| `valeurAvancement/resolveValeurDerivee.ts` (+ test) | Functional core, calcul récursif en mémoire |
+| `valeurAvancement/queries/getValeurDerivee.ts` (+ test) | Orchestration étapes A/B/C + ResultAsync |
+| `valeurAvancement/routes.ts` | Ajout de la route (fichier existant) |
+| `packages/mb-shared/src/valeurAvancement.ts` | Schémas Zod (cf. ci-dessous) |
+
+### Schémas API partagés (mb-shared)
+
+Ajouts dans `packages/mb-shared/src/valeurAvancement.ts` :
+
+```ts
+contributionSourceSchema = z.enum(['saisie', 'derivee', 'absente'])
+
+contributionApiModelSchema = z.object({
+  individu: individuPublicIdSchema,
+  valeur: z.number().nullable(),
+  date: dateSchema.nullable(),
+  source: contributionSourceSchema,
+})
+
+couvertureApiModelSchema = z.object({
+  nbEnfantsAvecValeur: z.number().int().nonnegative(),
+  nbEnfantsTotal: z.number().int().nonnegative(),
+})
+
+valeurDeriveeApiModelSchema = z.object({
+  indicateur: indicateurPublicIdSchema,
+  individu: individuPublicIdSchema,
+  agregateur: z.literal('SUM'),
+  valeurDerivee: z.number().nullable(),
+  contributions: z.array(contributionApiModelSchema),
+  couverture: couvertureApiModelSchema,
+})
+```
+
+### Tests
+
+Tests purs (functional core) sur `resolveValeurDerivee` : couvrent
+l'essentiel de la combinatoire sans DB.
+
+- Cible feuille (pas d'enfants) → `valeurDerivee: null`, couverture 0/0
+- 1 niveau, saisies complètes → SUM
+- 1 niveau, saisies partielles → SUM partiel + couverture
+- 2 niveaux (grand-parent), saisies aux feuilles → dérivée intermédiaire,
+  puis dérivée du grand-parent. Contributions du grand-parent = niveau
+  intermédiaire (source = derivee)
+- 2 niveaux, saisie sur niveau intermédiaire + saisie aux feuilles → la
+  saisie intermédiaire prime pour la contribution au grand-parent
+- Tous les enfants absents → `valeurDerivee: null`, couverture 0/n
+
+Tests d'intégration (1 scénario par bout du pipeline) :
+
+- Cas nominal grand-parent (France/Régions/Départements) end-to-end
+- 404 indicateur inexistant, 404 individu inexistant
+- 401 sans authentification
+
+### Hors scope MVP
+
+- Invariant D5 (validation côté code) : aucune route d'upsert `Relation`
+  n'existe aujourd'hui, à enforcer le jour où elle sera ajoutée
+- Détection de cycles dans `Relation` (D10)
+- Cap de profondeur (à ajouter si abus observé en prod)
+
 ## Prochaines étapes
 
-1. Spécifier précisément le schéma de réponse de
-   `GET /indicateurs/:id/individus/:individuId/valeur-derivee`
-2. Implémenter la traversée hiérarchique (query Prisma + functional core)
-3. Implémenter l'agrégateur SUM en functional core
-4. Ajouter la route + tests
+1. Implémenter `computeSum` + tests purs
+2. Implémenter `resolveValeurDerivee` + tests purs (functional core)
+3. Ajouter le `.sql` TypedSQL + valider la génération
+4. Implémenter `getValeurDerivee` (orchestration A/B/C)
+5. Ajouter la route dans `routes.ts` + tests d'intégration
+6. Ajouter les schémas Zod dans `mb-shared`

--- a/apps/mb-api/package.json
+++ b/apps/mb-api/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "dev": "portless run vite",
     "deploy:prepare": "bash deploy-prepare.sh",
-    "build": "prisma generate && prisma migrate deploy && prisma db seed && vite build",
+    "build": "prisma migrate deploy && prisma generate --sql && prisma db seed && vite build",
     "deploy:bundle": "bash deploy-bundle.sh",
     "start": "node dist/index.js",
     "test": "vitest run",
@@ -22,7 +22,7 @@
     "lint:fix": "eslint src scripts --fix",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "prisma:generate": "prisma generate",
+    "prisma:generate": "prisma generate --sql",
     "database:init": "prisma migrate reset --force",
     "database:migration": "prisma migrate dev",
     "api-key:generate": "tsx scripts/generate-api-key.ts"

--- a/apps/mb-api/prisma/schema.prisma
+++ b/apps/mb-api/prisma/schema.prisma
@@ -1,8 +1,9 @@
 generator client {
-  provider     = "prisma-client"
-  output       = "../src/generated/prisma"
-  moduleFormat = "esm"
-  runtime      = "nodejs"
+  provider        = "prisma-client"
+  output          = "../src/generated/prisma"
+  moduleFormat    = "esm"
+  runtime         = "nodejs"
+  previewFeatures = ["typedSql"]
 }
 
 datasource db {

--- a/apps/mb-api/prisma/sql/getDernieresValeursPourIndividus.sql
+++ b/apps/mb-api/prisma/sql/getDernieresValeursPourIndividus.sql
@@ -1,0 +1,10 @@
+-- Dernière valeur connue pour chaque individu, sur un indicateur donné.
+-- Utilisé par le calcul de valeur dérivée (somme niveau par niveau).
+SELECT DISTINCT ON (individu_id)
+  individu_id AS "individuId",
+  date,
+  valeur
+FROM valeur_avancement
+WHERE indicateur_id = $1
+  AND individu_id = ANY($2)
+ORDER BY individu_id, date DESC, id DESC;

--- a/apps/mb-api/src/valeurAvancement/computeSum.test.ts
+++ b/apps/mb-api/src/valeurAvancement/computeSum.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+
+import { Decimal } from '@/framework/decimal'
+import { computeSum } from '@/valeurAvancement/computeSum'
+
+const d = (n: number): Decimal => new Decimal(n)
+
+describe('computeSum', () => {
+  it('retourne null pour un tableau vide', () => {
+    expect(computeSum([])).toBeNull()
+  })
+
+  it('retourne la valeur unique pour un tableau de taille 1', () => {
+    expect(computeSum([d(42)])).toBe(42)
+  })
+
+  it('somme plusieurs valeurs positives', () => {
+    expect(computeSum([d(1), d(2), d(3)])).toBe(6)
+    expect(computeSum([d(10), d(20), d(30), d(40), d(50)])).toBe(150)
+  })
+
+  it('gère les nombres négatifs', () => {
+    expect(computeSum([d(-5), d(-1), d(-3)])).toBe(-9)
+    expect(computeSum([d(-10), d(10)])).toBe(0)
+  })
+
+  it('gère les valeurs décimales sans perte de précision', () => {
+    expect(computeSum([d(0.1), d(0.2)])).toBe(0.3)
+    expect(computeSum([d(1.5), d(2.5), d(3.5)])).toBe(7.5)
+  })
+
+  it("préserve l'ordre indépendant (somme commutative)", () => {
+    expect(computeSum([d(3), d(1), d(2)])).toBe(6)
+    expect(computeSum([d(2), d(3), d(1)])).toBe(6)
+  })
+})

--- a/apps/mb-api/src/valeurAvancement/computeSum.ts
+++ b/apps/mb-api/src/valeurAvancement/computeSum.ts
@@ -1,0 +1,6 @@
+import { Decimal } from '@/framework/decimal'
+
+export const computeSum = (values: ReadonlyArray<Decimal>): number | null => {
+  if (values.length === 0) return null
+  return values.reduce((acc, v) => acc.plus(v), new Decimal(0)).toNumber()
+}

--- a/apps/mb-api/src/valeurAvancement/queries/getValeurDerivee.test.ts
+++ b/apps/mb-api/src/valeurAvancement/queries/getValeurDerivee.test.ts
@@ -2,7 +2,13 @@ import { describe, expect, it } from 'vitest'
 
 import { fixtures } from '@/test/fixtures'
 import { integrationTest } from '@/test/integrationTest'
-import { testDeptId, testDeptIds, testIndicateurId, testRegId } from '@/test/randomIds'
+import {
+  testDeptId,
+  testDeptIds,
+  testIndicateurId,
+  testReferentielId,
+  testRegId,
+} from '@/test/randomIds'
 import { runAsPrincipal } from '@/test/runAsPrincipal'
 import { getValeurDerivee } from '@/valeurAvancement/queries/getValeurDerivee'
 
@@ -12,10 +18,11 @@ describe.concurrent('getValeurDerivee', () => {
     integrationTest(async () => {
       const indId = testIndicateurId()
       const deptId = testDeptId()
+      const refDept = testReferentielId()
       await fixtures.indicateur({ publicId: indId })
       await fixtures.individu({
         publicId: deptId,
-        referentiel: { publicId: 'REF-DEPT', nom: 'Dept' },
+        referentiel: { publicId: refDept, nom: 'Dept' },
       })
       const apiKey = await fixtures.apiKey({
         permissions: [{ indicateur: { publicId: indId }, action: 'READ' }],
@@ -40,14 +47,16 @@ describe.concurrent('getValeurDerivee', () => {
       const indId = testIndicateurId()
       const regId = testRegId()
       const [dept1, dept2] = testDeptIds(2)
+      const refReg = testReferentielId()
+      const refDept = testReferentielId()
       await fixtures.relation(
         {
-          parent: { publicId: regId, referentiel: { publicId: 'REF-REG', nom: 'Reg' } },
-          child: { publicId: dept1, referentiel: { publicId: 'REF-DEPT', nom: 'Dept' } },
+          parent: { publicId: regId, referentiel: { publicId: refReg, nom: 'Reg' } },
+          child: { publicId: dept1, referentiel: { publicId: refDept, nom: 'Dept' } },
         },
         {
           parent: { publicId: regId },
-          child: { publicId: dept2, referentiel: { publicId: 'REF-DEPT' } },
+          child: { publicId: dept2, referentiel: { publicId: refDept } },
         },
       )
       await fixtures.valeurAvancement(
@@ -90,23 +99,25 @@ describe.concurrent('getValeurDerivee', () => {
   )
 
   it(
-    'expose les enfants sans valeur comme `absente` (couverture partielle)',
+    'expose les enfants sans valeur comme `manquante` (couverture partielle)',
     integrationTest(async () => {
       const indId = testIndicateurId()
       const regId = testRegId()
       const [dept1, dept2, dept3] = testDeptIds(3)
+      const refReg = testReferentielId()
+      const refDept = testReferentielId()
       await fixtures.relation(
         {
-          parent: { publicId: regId, referentiel: { publicId: 'REF-REG', nom: 'Reg' } },
-          child: { publicId: dept1, referentiel: { publicId: 'REF-DEPT', nom: 'Dept' } },
+          parent: { publicId: regId, referentiel: { publicId: refReg, nom: 'Reg' } },
+          child: { publicId: dept1, referentiel: { publicId: refDept, nom: 'Dept' } },
         },
         {
           parent: { publicId: regId },
-          child: { publicId: dept2, referentiel: { publicId: 'REF-DEPT' } },
+          child: { publicId: dept2, referentiel: { publicId: refDept } },
         },
         {
           parent: { publicId: regId },
-          child: { publicId: dept3, referentiel: { publicId: 'REF-DEPT' } },
+          child: { publicId: dept3, referentiel: { publicId: refDept } },
         },
       )
       await fixtures.valeurAvancement({
@@ -124,7 +135,7 @@ describe.concurrent('getValeurDerivee', () => {
       const data = result._unsafeUnwrap()
       expect(data.valeurDerivee).toBe(100)
       expect(data.couverture).toEqual({ nbEnfantsAvecValeur: 1, nbEnfantsTotal: 3 })
-      expect(data.contributions.filter((contribution) => contribution.source === 'absente')).toHaveLength(2)
+      expect(data.contributions.filter((contribution) => contribution.source === 'manquante')).toHaveLength(2)
     }),
   )
 
@@ -135,32 +146,35 @@ describe.concurrent('getValeurDerivee', () => {
       const franceId = testRegId()
       const [regN, regS] = [testRegId(), testRegId()]
       const [deptN1, deptN2, deptS1, deptS2] = testDeptIds(4)
+      const refPays = testReferentielId()
+      const refReg = testReferentielId()
+      const refDept = testReferentielId()
 
       // France → 2 régions → chacune 2 départements (feuilles saisies)
       await fixtures.relation(
         {
-          parent: { publicId: franceId, referentiel: { publicId: 'REF-PAYS', nom: 'Pays' } },
-          child: { publicId: regN, referentiel: { publicId: 'REF-REG', nom: 'Reg' } },
+          parent: { publicId: franceId, referentiel: { publicId: refPays, nom: 'Pays' } },
+          child: { publicId: regN, referentiel: { publicId: refReg, nom: 'Reg' } },
         },
         {
           parent: { publicId: franceId },
-          child: { publicId: regS, referentiel: { publicId: 'REF-REG' } },
+          child: { publicId: regS, referentiel: { publicId: refReg } },
         },
         {
           parent: { publicId: regN },
-          child: { publicId: deptN1, referentiel: { publicId: 'REF-DEPT', nom: 'Dept' } },
+          child: { publicId: deptN1, referentiel: { publicId: refDept, nom: 'Dept' } },
         },
         {
           parent: { publicId: regN },
-          child: { publicId: deptN2, referentiel: { publicId: 'REF-DEPT' } },
+          child: { publicId: deptN2, referentiel: { publicId: refDept } },
         },
         {
           parent: { publicId: regS },
-          child: { publicId: deptS1, referentiel: { publicId: 'REF-DEPT' } },
+          child: { publicId: deptS1, referentiel: { publicId: refDept } },
         },
         {
           parent: { publicId: regS },
-          child: { publicId: deptS2, referentiel: { publicId: 'REF-DEPT' } },
+          child: { publicId: deptS2, referentiel: { publicId: refDept } },
         },
       )
       await fixtures.valeurAvancement(
@@ -214,18 +228,21 @@ describe.concurrent('getValeurDerivee', () => {
       const franceId = testRegId()
       const reg = testRegId()
       const [dept1, dept2] = testDeptIds(2)
+      const refPays = testReferentielId()
+      const refReg = testReferentielId()
+      const refDept = testReferentielId()
       await fixtures.relation(
         {
-          parent: { publicId: franceId, referentiel: { publicId: 'REF-PAYS', nom: 'Pays' } },
-          child: { publicId: reg, referentiel: { publicId: 'REF-REG', nom: 'Reg' } },
+          parent: { publicId: franceId, referentiel: { publicId: refPays, nom: 'Pays' } },
+          child: { publicId: reg, referentiel: { publicId: refReg, nom: 'Reg' } },
         },
         {
           parent: { publicId: reg },
-          child: { publicId: dept1, referentiel: { publicId: 'REF-DEPT', nom: 'Dept' } },
+          child: { publicId: dept1, referentiel: { publicId: refDept, nom: 'Dept' } },
         },
         {
           parent: { publicId: reg },
-          child: { publicId: dept2, referentiel: { publicId: 'REF-DEPT' } },
+          child: { publicId: dept2, referentiel: { publicId: refDept } },
         },
       )
       await fixtures.valeurAvancement(
@@ -267,10 +284,11 @@ describe.concurrent('getValeurDerivee', () => {
     integrationTest(async () => {
       const indId = testIndicateurId()
       const deptId = testDeptId()
+      const refDept = testReferentielId()
       await fixtures.indicateur({ publicId: indId })
       await fixtures.individu({
         publicId: deptId,
-        referentiel: { publicId: 'REF-DEPT', nom: 'Dept' },
+        referentiel: { publicId: refDept, nom: 'Dept' },
       })
       // apiKey sans permission sur indId
       const otherInd = testIndicateurId()
@@ -293,7 +311,7 @@ describe.concurrent('getValeurDerivee', () => {
       })
 
       await expect(
-        runAsPrincipal(apiKey.id, () => getValeurDerivee(indId, 'DEPT-INEXISTANT')),
+        runAsPrincipal(apiKey.id, () => getValeurDerivee(indId, testDeptId())),
       ).rejects.toThrow()
     }),
   )

--- a/apps/mb-api/src/valeurAvancement/queries/getValeurDerivee.test.ts
+++ b/apps/mb-api/src/valeurAvancement/queries/getValeurDerivee.test.ts
@@ -135,7 +135,9 @@ describe.concurrent('getValeurDerivee', () => {
       const data = result._unsafeUnwrap()
       expect(data.valeurDerivee).toBe(100)
       expect(data.couverture).toEqual({ nbEnfantsAvecValeur: 1, nbEnfantsTotal: 3 })
-      expect(data.contributions.filter((contribution) => contribution.source === 'manquante')).toHaveLength(2)
+      expect(
+        data.contributions.filter((contribution) => contribution.source === 'manquante'),
+      ).toHaveLength(2)
     }),
   )
 
@@ -214,7 +216,9 @@ describe.concurrent('getValeurDerivee', () => {
       expect(data.couverture).toEqual({ nbEnfantsAvecValeur: 2, nbEnfantsTotal: 2 })
       // Les contributions de France sont les régions (source dérivée), pas les départements
       expect(data.contributions).toHaveLength(2)
-      expect(data.contributions.every((contribution) => contribution.source === 'derivee')).toBe(true)
+      expect(data.contributions.every((contribution) => contribution.source === 'derivee')).toBe(
+        true,
+      )
       expect(data.contributions.map((contribution) => contribution.individu).sort()).toEqual(
         [regN, regS].sort(),
       )

--- a/apps/mb-api/src/valeurAvancement/queries/getValeurDerivee.test.ts
+++ b/apps/mb-api/src/valeurAvancement/queries/getValeurDerivee.test.ts
@@ -1,0 +1,300 @@
+import { describe, expect, it } from 'vitest'
+
+import { fixtures } from '@/test/fixtures'
+import { integrationTest } from '@/test/integrationTest'
+import { testDeptId, testDeptIds, testIndicateurId, testRegId } from '@/test/randomIds'
+import { runAsPrincipal } from '@/test/runAsPrincipal'
+import { getValeurDerivee } from '@/valeurAvancement/queries/getValeurDerivee'
+
+describe.concurrent('getValeurDerivee', () => {
+  it(
+    'retourne valeurDerivee null et couverture 0/0 pour une feuille (pas d’enfants)',
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const deptId = testDeptId()
+      await fixtures.indicateur({ publicId: indId })
+      await fixtures.individu({
+        publicId: deptId,
+        referentiel: { publicId: 'REF-DEPT', nom: 'Dept' },
+      })
+      const apiKey = await fixtures.apiKey({
+        permissions: [{ indicateur: { publicId: indId }, action: 'READ' }],
+      })
+
+      const result = await runAsPrincipal(apiKey.id, () => getValeurDerivee(indId, deptId))
+
+      expect(result._unsafeUnwrap()).toEqual({
+        indicateur: indId,
+        individu: deptId,
+        agregateur: 'SUM',
+        valeurDerivee: null,
+        contributions: [],
+        couverture: { nbEnfantsAvecValeur: 0, nbEnfantsTotal: 0 },
+      })
+    }),
+  )
+
+  it(
+    'somme les valeurs saisies des enfants directs (1 niveau, couverture complète)',
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const regId = testRegId()
+      const [dept1, dept2] = testDeptIds(2)
+      await fixtures.relation(
+        {
+          parent: { publicId: regId, referentiel: { publicId: 'REF-REG', nom: 'Reg' } },
+          child: { publicId: dept1, referentiel: { publicId: 'REF-DEPT', nom: 'Dept' } },
+        },
+        {
+          parent: { publicId: regId },
+          child: { publicId: dept2, referentiel: { publicId: 'REF-DEPT' } },
+        },
+      )
+      await fixtures.valeurAvancement(
+        {
+          indicateur: { publicId: indId, nom: 'T' },
+          individu: { publicId: dept1 },
+          date: '2025-01-01',
+          valeur: 10,
+        },
+        {
+          indicateur: { publicId: indId },
+          individu: { publicId: dept2 },
+          date: '2025-02-01',
+          valeur: 20,
+        },
+      )
+      const apiKey = await fixtures.apiKey({
+        permissions: [{ indicateur: { publicId: indId }, action: 'READ' }],
+      })
+
+      const result = await runAsPrincipal(apiKey.id, () => getValeurDerivee(indId, regId))
+
+      const data = result._unsafeUnwrap()
+      expect(data.valeurDerivee).toBe(30)
+      expect(data.couverture).toEqual({ nbEnfantsAvecValeur: 2, nbEnfantsTotal: 2 })
+      expect(data.contributions).toHaveLength(2)
+      expect(data.contributions).toContainEqual({
+        individu: dept1,
+        valeur: 10,
+        date: '2025-01-01',
+        source: 'saisie',
+      })
+      expect(data.contributions).toContainEqual({
+        individu: dept2,
+        valeur: 20,
+        date: '2025-02-01',
+        source: 'saisie',
+      })
+    }),
+  )
+
+  it(
+    'expose les enfants sans valeur comme `absente` (couverture partielle)',
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const regId = testRegId()
+      const [dept1, dept2, dept3] = testDeptIds(3)
+      await fixtures.relation(
+        {
+          parent: { publicId: regId, referentiel: { publicId: 'REF-REG', nom: 'Reg' } },
+          child: { publicId: dept1, referentiel: { publicId: 'REF-DEPT', nom: 'Dept' } },
+        },
+        {
+          parent: { publicId: regId },
+          child: { publicId: dept2, referentiel: { publicId: 'REF-DEPT' } },
+        },
+        {
+          parent: { publicId: regId },
+          child: { publicId: dept3, referentiel: { publicId: 'REF-DEPT' } },
+        },
+      )
+      await fixtures.valeurAvancement({
+        indicateur: { publicId: indId, nom: 'T' },
+        individu: { publicId: dept1 },
+        date: '2025-01-01',
+        valeur: 100,
+      })
+      const apiKey = await fixtures.apiKey({
+        permissions: [{ indicateur: { publicId: indId }, action: 'READ' }],
+      })
+
+      const result = await runAsPrincipal(apiKey.id, () => getValeurDerivee(indId, regId))
+
+      const data = result._unsafeUnwrap()
+      expect(data.valeurDerivee).toBe(100)
+      expect(data.couverture).toEqual({ nbEnfantsAvecValeur: 1, nbEnfantsTotal: 3 })
+      expect(data.contributions.filter((contribution) => contribution.source === 'absente')).toHaveLength(2)
+    }),
+  )
+
+  it(
+    'dérive le niveau intermédiaire à partir des feuilles (grand-parent, 2 niveaux)',
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const franceId = testRegId()
+      const [regN, regS] = [testRegId(), testRegId()]
+      const [deptN1, deptN2, deptS1, deptS2] = testDeptIds(4)
+
+      // France → 2 régions → chacune 2 départements (feuilles saisies)
+      await fixtures.relation(
+        {
+          parent: { publicId: franceId, referentiel: { publicId: 'REF-PAYS', nom: 'Pays' } },
+          child: { publicId: regN, referentiel: { publicId: 'REF-REG', nom: 'Reg' } },
+        },
+        {
+          parent: { publicId: franceId },
+          child: { publicId: regS, referentiel: { publicId: 'REF-REG' } },
+        },
+        {
+          parent: { publicId: regN },
+          child: { publicId: deptN1, referentiel: { publicId: 'REF-DEPT', nom: 'Dept' } },
+        },
+        {
+          parent: { publicId: regN },
+          child: { publicId: deptN2, referentiel: { publicId: 'REF-DEPT' } },
+        },
+        {
+          parent: { publicId: regS },
+          child: { publicId: deptS1, referentiel: { publicId: 'REF-DEPT' } },
+        },
+        {
+          parent: { publicId: regS },
+          child: { publicId: deptS2, referentiel: { publicId: 'REF-DEPT' } },
+        },
+      )
+      await fixtures.valeurAvancement(
+        {
+          indicateur: { publicId: indId, nom: 'T' },
+          individu: { publicId: deptN1 },
+          date: '2025-01-01',
+          valeur: 10,
+        },
+        {
+          indicateur: { publicId: indId },
+          individu: { publicId: deptN2 },
+          date: '2025-02-01',
+          valeur: 20,
+        },
+        {
+          indicateur: { publicId: indId },
+          individu: { publicId: deptS1 },
+          date: '2025-03-01',
+          valeur: 100,
+        },
+        {
+          indicateur: { publicId: indId },
+          individu: { publicId: deptS2 },
+          date: '2025-04-01',
+          valeur: 200,
+        },
+      )
+      const apiKey = await fixtures.apiKey({
+        permissions: [{ indicateur: { publicId: indId }, action: 'READ' }],
+      })
+
+      const result = await runAsPrincipal(apiKey.id, () => getValeurDerivee(indId, franceId))
+
+      const data = result._unsafeUnwrap()
+      expect(data.valeurDerivee).toBe(330)
+      expect(data.couverture).toEqual({ nbEnfantsAvecValeur: 2, nbEnfantsTotal: 2 })
+      // Les contributions de France sont les régions (source dérivée), pas les départements
+      expect(data.contributions).toHaveLength(2)
+      expect(data.contributions.every((contribution) => contribution.source === 'derivee')).toBe(true)
+      expect(data.contributions.map((contribution) => contribution.individu).sort()).toEqual(
+        [regN, regS].sort(),
+      )
+    }),
+  )
+
+  it(
+    'priorise la saisie sur un nœud intermédiaire (D1 : saisie ≻ dérivée pour la contribution au parent)',
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const franceId = testRegId()
+      const reg = testRegId()
+      const [dept1, dept2] = testDeptIds(2)
+      await fixtures.relation(
+        {
+          parent: { publicId: franceId, referentiel: { publicId: 'REF-PAYS', nom: 'Pays' } },
+          child: { publicId: reg, referentiel: { publicId: 'REF-REG', nom: 'Reg' } },
+        },
+        {
+          parent: { publicId: reg },
+          child: { publicId: dept1, referentiel: { publicId: 'REF-DEPT', nom: 'Dept' } },
+        },
+        {
+          parent: { publicId: reg },
+          child: { publicId: dept2, referentiel: { publicId: 'REF-DEPT' } },
+        },
+      )
+      await fixtures.valeurAvancement(
+        {
+          indicateur: { publicId: indId, nom: 'T' },
+          individu: { publicId: reg }, // saisie officielle sur la région
+          date: '2020-01-01',
+          valeur: 999,
+        },
+        {
+          indicateur: { publicId: indId },
+          individu: { publicId: dept1 },
+          date: '2025-01-01',
+          valeur: 10,
+        },
+        {
+          indicateur: { publicId: indId },
+          individu: { publicId: dept2 },
+          date: '2025-02-01',
+          valeur: 20,
+        },
+      )
+      const apiKey = await fixtures.apiKey({
+        permissions: [{ indicateur: { publicId: indId }, action: 'READ' }],
+      })
+
+      const result = await runAsPrincipal(apiKey.id, () => getValeurDerivee(indId, franceId))
+
+      const data = result._unsafeUnwrap()
+      expect(data.valeurDerivee).toBe(999)
+      expect(data.contributions).toEqual([
+        { individu: reg, valeur: 999, date: '2020-01-01', source: 'saisie' },
+      ])
+    }),
+  )
+
+  it(
+    "throw quand l'indicateur n'est pas accessible (permission absente)",
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const deptId = testDeptId()
+      await fixtures.indicateur({ publicId: indId })
+      await fixtures.individu({
+        publicId: deptId,
+        referentiel: { publicId: 'REF-DEPT', nom: 'Dept' },
+      })
+      // apiKey sans permission sur indId
+      const otherInd = testIndicateurId()
+      const apiKey = await fixtures.apiKey({
+        permissions: [{ indicateur: { publicId: otherInd }, action: 'READ' }],
+      })
+
+      await expect(
+        runAsPrincipal(apiKey.id, () => getValeurDerivee(indId, deptId)),
+      ).rejects.toThrow()
+    }),
+  )
+
+  it(
+    "throw quand l'individu n'existe pas",
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const apiKey = await fixtures.apiKey({
+        permissions: [{ indicateur: { publicId: indId, nom: 'T' }, action: 'READ' }],
+      })
+
+      await expect(
+        runAsPrincipal(apiKey.id, () => getValeurDerivee(indId, 'DEPT-INEXISTANT')),
+      ).rejects.toThrow()
+    }),
+  )
+})

--- a/apps/mb-api/src/valeurAvancement/queries/getValeurDerivee.ts
+++ b/apps/mb-api/src/valeurAvancement/queries/getValeurDerivee.ts
@@ -1,0 +1,98 @@
+import { type ValeurDeriveeApiModel } from '@pilote/mb-shared/valeurAvancement'
+import { ResultAsync } from 'neverthrow'
+
+import { requireCurrentPrincipalId } from '@/framework/auth/userContext'
+import { db } from '@/framework/persistence/dbStore'
+import { getDernieresValeursPourIndividus } from '@/generated/prisma/sql'
+import { withIndicateurReadPermission } from '@/indicateur/permissions'
+import {
+  type IndividuRef,
+  resolveValeurDerivee,
+  type ValeurSaisie,
+} from '@/valeurAvancement/resolveValeurDerivee'
+
+const loadSubtree = async (
+  rootIndividuId: string,
+): Promise<{
+  allIds: string[]
+  enfantsParParent: Map<string, IndividuRef[]>
+}> => {
+  const allIds: string[] = [rootIndividuId]
+  const enfantsParParent = new Map<string, IndividuRef[]>()
+  let currentLevel: string[] = [rootIndividuId]
+
+  while (currentLevel.length > 0) {
+    const relations = await db().relation.findMany({
+      where: { parentId: { in: currentLevel } },
+      select: {
+        parentId: true,
+        child: { select: { id: true, publicId: true } },
+      },
+    })
+    if (relations.length === 0) break
+
+    for (const relation of relations) {
+      const list = enfantsParParent.get(relation.parentId) ?? []
+      list.push({ id: relation.child.id, publicId: relation.child.publicId })
+      enfantsParParent.set(relation.parentId, list)
+    }
+
+    const nextLevel = relations.map((relation) => relation.child.id)
+    allIds.push(...nextLevel)
+    currentLevel = nextLevel
+  }
+
+  return { allIds, enfantsParParent }
+}
+
+const buildResult = async (
+  indicateurPublicId: string,
+  individuPublicId: string,
+): Promise<ValeurDeriveeApiModel> => {
+  const principalId = requireCurrentPrincipalId()
+
+  const indicateur = await db().indicateur.findFirstOrThrow({
+    where: withIndicateurReadPermission({ publicId: indicateurPublicId }, principalId),
+    select: { id: true, publicId: true },
+  })
+
+  const cible = await db().individu.findUniqueOrThrow({
+    where: { publicId: individuPublicId },
+    select: { id: true, publicId: true },
+  })
+
+  const { allIds, enfantsParParent } = await loadSubtree(cible.id)
+
+  const rows = await db().$queryRawTyped(
+    getDernieresValeursPourIndividus(indicateur.id, allIds),
+  )
+
+  const derniereValeurParIndividu = new Map<string, ValeurSaisie>()
+  for (const row of rows) {
+    if (row.individuId === null || row.date === null || row.valeur === null) continue
+    derniereValeurParIndividu.set(row.individuId, {
+      valeur: row.valeur,
+      date: row.date,
+    })
+  }
+
+  const resolved = resolveValeurDerivee(cible.id, {
+    enfantsParParent,
+    derniereValeurParIndividu,
+  })
+
+  return {
+    indicateur: indicateur.publicId,
+    individu: cible.publicId,
+    agregateur: 'SUM',
+    valeurDerivee: resolved.valeurDerivee,
+    contributions: resolved.contributions,
+    couverture: resolved.couverture,
+  }
+}
+
+export const getValeurDerivee = (
+  indicateurPublicId: string,
+  individuPublicId: string,
+): ResultAsync<ValeurDeriveeApiModel, never> =>
+  ResultAsync.fromSafePromise(buildResult(indicateurPublicId, individuPublicId))

--- a/apps/mb-api/src/valeurAvancement/queries/getValeurDerivee.ts
+++ b/apps/mb-api/src/valeurAvancement/queries/getValeurDerivee.ts
@@ -58,9 +58,7 @@ const buildResult = async (
 
   const { allIds, enfantsParParent } = await loadIndividuTree(cible.id)
 
-  const rows = await db().$queryRawTyped(
-    getDernieresValeursPourIndividus(indicateur.id, allIds),
-  )
+  const rows = await db().$queryRawTyped(getDernieresValeursPourIndividus(indicateur.id, allIds))
 
   const derniereValeurParIndividu = new Map<string, ValeurSaisie>()
   for (const row of rows) {

--- a/apps/mb-api/src/valeurAvancement/queries/getValeurDerivee.ts
+++ b/apps/mb-api/src/valeurAvancement/queries/getValeurDerivee.ts
@@ -11,7 +11,7 @@ import {
   type ValeurSaisie,
 } from '@/valeurAvancement/resolveValeurDerivee'
 
-const loadSubtree = async (
+const loadIndividuTree = async (
   rootIndividuId: string,
 ): Promise<{
   allIds: string[]
@@ -24,10 +24,7 @@ const loadSubtree = async (
   while (currentLevel.length > 0) {
     const relations = await db().relation.findMany({
       where: { parentId: { in: currentLevel } },
-      select: {
-        parentId: true,
-        child: { select: { id: true, publicId: true } },
-      },
+      include: { child: true },
     })
     if (relations.length === 0) break
 
@@ -53,15 +50,13 @@ const buildResult = async (
 
   const indicateur = await db().indicateur.findFirstOrThrow({
     where: withIndicateurReadPermission({ publicId: indicateurPublicId }, principalId),
-    select: { id: true, publicId: true },
   })
 
   const cible = await db().individu.findUniqueOrThrow({
     where: { publicId: individuPublicId },
-    select: { id: true, publicId: true },
   })
 
-  const { allIds, enfantsParParent } = await loadSubtree(cible.id)
+  const { allIds, enfantsParParent } = await loadIndividuTree(cible.id)
 
   const rows = await db().$queryRawTyped(
     getDernieresValeursPourIndividus(indicateur.id, allIds),
@@ -69,7 +64,6 @@ const buildResult = async (
 
   const derniereValeurParIndividu = new Map<string, ValeurSaisie>()
   for (const row of rows) {
-    if (row.individuId === null || row.date === null || row.valeur === null) continue
     derniereValeurParIndividu.set(row.individuId, {
       valeur: row.valeur,
       date: row.date,
@@ -85,9 +79,7 @@ const buildResult = async (
     indicateur: indicateur.publicId,
     individu: cible.publicId,
     agregateur: 'SUM',
-    valeurDerivee: resolved.valeurDerivee,
-    contributions: resolved.contributions,
-    couverture: resolved.couverture,
+    ...resolved,
   }
 }
 

--- a/apps/mb-api/src/valeurAvancement/queries/getValeurDerivee.ts
+++ b/apps/mb-api/src/valeurAvancement/queries/getValeurDerivee.ts
@@ -70,7 +70,7 @@ const buildResult = async (
     })
   }
 
-  const resolved = resolveValeurDerivee(cible.id, {
+  const { valeurDerivee, contributions, couverture } = resolveValeurDerivee(cible.id, {
     enfantsParParent,
     derniereValeurParIndividu,
   })
@@ -79,7 +79,9 @@ const buildResult = async (
     indicateur: indicateur.publicId,
     individu: cible.publicId,
     agregateur: 'SUM',
-    ...resolved,
+    valeurDerivee,
+    contributions,
+    couverture,
   }
 }
 

--- a/apps/mb-api/src/valeurAvancement/resolveValeurDerivee.test.ts
+++ b/apps/mb-api/src/valeurAvancement/resolveValeurDerivee.test.ts
@@ -1,0 +1,225 @@
+import { describe, expect, it } from 'vitest'
+
+import { Decimal } from '@/framework/decimal'
+import {
+  type IndividuRef,
+  resolveValeurDerivee,
+  type ResolveValeurDeriveeContext,
+  type ValeurSaisie,
+} from '@/valeurAvancement/resolveValeurDerivee'
+
+const ref = (id: string, publicId: string): IndividuRef => ({ id, publicId })
+const saisie = (valeur: number, date: string): ValeurSaisie => ({
+  valeur: new Decimal(valeur),
+  date,
+})
+
+const buildContext = (
+  enfants: Record<string, ReadonlyArray<IndividuRef>>,
+  valeurs: Record<string, ValeurSaisie>,
+): ResolveValeurDeriveeContext => ({
+  enfantsParParent: new Map(Object.entries(enfants)),
+  derniereValeurParIndividu: new Map(Object.entries(valeurs)),
+})
+
+describe('resolveValeurDerivee', () => {
+  it("retourne null et couverture 0/0 quand l'individu cible n'a pas d'enfants", () => {
+    const context = buildContext({}, {})
+
+    const result = resolveValeurDerivee('cible', context)
+
+    expect(result).toEqual({
+      contributions: [],
+      valeurDerivee: null,
+      couverture: { nbEnfantsAvecValeur: 0, nbEnfantsTotal: 0 },
+    })
+  })
+
+  it('somme les valeurs saisies de tous les enfants directs (1 niveau, couverture complète)', () => {
+    const context = buildContext(
+      {
+        'cible': [ref('a', 'DEPT-A'), ref('b', 'DEPT-B'), ref('c', 'DEPT-C')],
+      },
+      {
+        a: saisie(10, '2025-01-01'),
+        b: saisie(20, '2025-02-01'),
+        c: saisie(30, '2025-03-01'),
+      },
+    )
+
+    const result = resolveValeurDerivee('cible', context)
+
+    expect(result).toEqual({
+      contributions: [
+        { individu: 'DEPT-A', valeur: 10, date: '2025-01-01', source: 'saisie' },
+        { individu: 'DEPT-B', valeur: 20, date: '2025-02-01', source: 'saisie' },
+        { individu: 'DEPT-C', valeur: 30, date: '2025-03-01', source: 'saisie' },
+      ],
+      valeurDerivee: 60,
+      couverture: { nbEnfantsAvecValeur: 3, nbEnfantsTotal: 3 },
+    })
+  })
+
+  it('expose les enfants sans valeur comme `absente` et somme uniquement les présents (couverture partielle)', () => {
+    const context = buildContext(
+      {
+        'cible': [ref('a', 'DEPT-A'), ref('b', 'DEPT-B'), ref('c', 'DEPT-C')],
+      },
+      {
+        a: saisie(10, '2025-01-01'),
+        c: saisie(30, '2025-03-01'),
+      },
+    )
+
+    const result = resolveValeurDerivee('cible', context)
+
+    expect(result).toEqual({
+      contributions: [
+        { individu: 'DEPT-A', valeur: 10, date: '2025-01-01', source: 'saisie' },
+        { individu: 'DEPT-B', valeur: null, date: null, source: 'absente' },
+        { individu: 'DEPT-C', valeur: 30, date: '2025-03-01', source: 'saisie' },
+      ],
+      valeurDerivee: 40,
+      couverture: { nbEnfantsAvecValeur: 2, nbEnfantsTotal: 3 },
+    })
+  })
+
+  it('trie les contributions par publicId quel que soit l’ordre des enfants en entrée', () => {
+    const context = buildContext(
+      {
+        'cible': [ref('c', 'DEPT-Z'), ref('a', 'DEPT-A'), ref('b', 'DEPT-M')],
+      },
+      {
+        a: saisie(1, '2025-01-01'),
+        b: saisie(2, '2025-01-01'),
+        c: saisie(3, '2025-01-01'),
+      },
+    )
+
+    const result = resolveValeurDerivee('cible', context)
+
+    expect(result.contributions.map((c) => c.individu)).toEqual(['DEPT-A', 'DEPT-M', 'DEPT-Z'])
+  })
+
+  it('dérive le niveau intermédiaire à partir des feuilles (grand-parent, 2 niveaux)', () => {
+    // France → 2 régions → chacune 2 départements (feuilles saisies)
+    const context = buildContext(
+      {
+        'france': [ref('reg-n', 'REG-N'), ref('reg-s', 'REG-S')],
+        'reg-n': [ref('dept-n1', 'DEPT-N1'), ref('dept-n2', 'DEPT-N2')],
+        'reg-s': [ref('dept-s1', 'DEPT-S1'), ref('dept-s2', 'DEPT-S2')],
+      },
+      {
+        'dept-n1': saisie(10, '2025-01-01'),
+        'dept-n2': saisie(20, '2025-02-01'),
+        'dept-s1': saisie(100, '2025-03-01'),
+        'dept-s2': saisie(200, '2025-04-01'),
+      },
+    )
+
+    const result = resolveValeurDerivee('france', context)
+
+    // Contributions de France = les régions (source dérivée), pas les départements
+    expect(result).toEqual({
+      contributions: [
+        { individu: 'REG-N', valeur: 30, date: '2025-02-01', source: 'derivee' },
+        { individu: 'REG-S', valeur: 300, date: '2025-04-01', source: 'derivee' },
+      ],
+      valeurDerivee: 330,
+      couverture: { nbEnfantsAvecValeur: 2, nbEnfantsTotal: 2 },
+    })
+  })
+
+  it('priorise la saisie sur un nœud intermédiaire (D1 : saisie ≻ dérivée pour la contribution au parent)', () => {
+    // La région N a une saisie officielle ; ses départements ont aussi des saisies → on prend la saisie de la région
+    const context = buildContext(
+      {
+        'france': [ref('reg-n', 'REG-N'), ref('reg-s', 'REG-S')],
+        'reg-n': [ref('dept-n1', 'DEPT-N1'), ref('dept-n2', 'DEPT-N2')],
+        'reg-s': [ref('dept-s1', 'DEPT-S1'), ref('dept-s2', 'DEPT-S2')],
+      },
+      {
+        'reg-n': saisie(999, '2020-01-01'), // saisie officielle, ancienne mais prioritaire
+        'dept-n1': saisie(10, '2025-01-01'),
+        'dept-n2': saisie(20, '2025-02-01'),
+        'dept-s1': saisie(100, '2025-03-01'),
+        'dept-s2': saisie(200, '2025-04-01'),
+      },
+    )
+
+    const result = resolveValeurDerivee('france', context)
+
+    expect(result.contributions).toEqual([
+      { individu: 'REG-N', valeur: 999, date: '2020-01-01', source: 'saisie' },
+      { individu: 'REG-S', valeur: 300, date: '2025-04-01', source: 'derivee' },
+    ])
+    expect(result.valeurDerivee).toBe(1299)
+  })
+
+  it("marque comme absente un enfant qui n'a ni saisie ni descendants avec valeur", () => {
+    const context = buildContext(
+      {
+        'cible': [ref('reg-vide', 'REG-VIDE'), ref('reg-pleine', 'REG-PLEINE')],
+        'reg-vide': [ref('dept-vide', 'DEPT-VIDE')], // descendants existent mais aucune saisie
+        'reg-pleine': [ref('dept-p', 'DEPT-P')],
+      },
+      {
+        'dept-p': saisie(50, '2025-01-01'),
+      },
+    )
+
+    const result = resolveValeurDerivee('cible', context)
+
+    expect(result).toEqual({
+      contributions: [
+        { individu: 'REG-PLEINE', valeur: 50, date: '2025-01-01', source: 'derivee' },
+        { individu: 'REG-VIDE', valeur: null, date: null, source: 'absente' },
+      ],
+      valeurDerivee: 50,
+      couverture: { nbEnfantsAvecValeur: 1, nbEnfantsTotal: 2 },
+    })
+  })
+
+  it('retourne valeurDerivee null quand tous les enfants sont absents', () => {
+    const context = buildContext(
+      {
+        'cible': [ref('a', 'DEPT-A'), ref('b', 'DEPT-B')],
+      },
+      {},
+    )
+
+    const result = resolveValeurDerivee('cible', context)
+
+    expect(result).toEqual({
+      contributions: [
+        { individu: 'DEPT-A', valeur: null, date: null, source: 'absente' },
+        { individu: 'DEPT-B', valeur: null, date: null, source: 'absente' },
+      ],
+      valeurDerivee: null,
+      couverture: { nbEnfantsAvecValeur: 0, nbEnfantsTotal: 2 },
+    })
+  })
+
+  it('utilise la date la plus récente parmi les contributions dérivées', () => {
+    const context = buildContext(
+      {
+        'cible': [ref('reg', 'REG-X')],
+        'reg': [ref('d1', 'D1'), ref('d2', 'D2'), ref('d3', 'D3')],
+      },
+      {
+        d1: saisie(1, '2024-01-01'),
+        d2: saisie(2, '2025-06-15'),
+        d3: saisie(3, '2024-12-31'),
+      },
+    )
+
+    const result = resolveValeurDerivee('cible', context)
+
+    expect(result.contributions[0]).toEqual({
+      individu: 'REG-X',
+      valeur: 6,
+      date: '2025-06-15',
+      source: 'derivee',
+    })
+  })
+})

--- a/apps/mb-api/src/valeurAvancement/resolveValeurDerivee.test.ts
+++ b/apps/mb-api/src/valeurAvancement/resolveValeurDerivee.test.ts
@@ -8,8 +8,8 @@ import {
   type ValeurSaisie,
 } from '@/valeurAvancement/resolveValeurDerivee'
 
-const ref = (id: string, publicId: string): IndividuRef => ({ id, publicId })
-const saisie = (valeur: number, date: string): ValeurSaisie => ({
+const createIndividuRef = (id: string, publicId: string): IndividuRef => ({ id, publicId })
+const createValeurSaisie = (valeur: number, date: string): ValeurSaisie => ({
   valeur: new Decimal(valeur),
   date,
 })
@@ -38,12 +38,16 @@ describe('resolveValeurDerivee', () => {
   it('somme les valeurs saisies de tous les enfants directs (1 niveau, couverture complète)', () => {
     const context = buildContext(
       {
-        cible: [ref('a', 'DEPT-A'), ref('b', 'DEPT-B'), ref('c', 'DEPT-C')],
+        cible: [
+          createIndividuRef('a', 'DEPT-A'),
+          createIndividuRef('b', 'DEPT-B'),
+          createIndividuRef('c', 'DEPT-C'),
+        ],
       },
       {
-        a: saisie(10, '2025-01-01'),
-        b: saisie(20, '2025-02-01'),
-        c: saisie(30, '2025-03-01'),
+        a: createValeurSaisie(10, '2025-01-01'),
+        b: createValeurSaisie(20, '2025-02-01'),
+        c: createValeurSaisie(30, '2025-03-01'),
       },
     )
 
@@ -63,11 +67,15 @@ describe('resolveValeurDerivee', () => {
   it('expose les enfants sans valeur comme `manquante` et somme uniquement les présents (couverture partielle)', () => {
     const context = buildContext(
       {
-        cible: [ref('a', 'DEPT-A'), ref('b', 'DEPT-B'), ref('c', 'DEPT-C')],
+        cible: [
+          createIndividuRef('a', 'DEPT-A'),
+          createIndividuRef('b', 'DEPT-B'),
+          createIndividuRef('c', 'DEPT-C'),
+        ],
       },
       {
-        a: saisie(10, '2025-01-01'),
-        c: saisie(30, '2025-03-01'),
+        a: createValeurSaisie(10, '2025-01-01'),
+        c: createValeurSaisie(30, '2025-03-01'),
       },
     )
 
@@ -87,12 +95,16 @@ describe('resolveValeurDerivee', () => {
   it('trie les contributions par publicId quel que soit l’ordre des enfants en entrée', () => {
     const context = buildContext(
       {
-        cible: [ref('c', 'DEPT-Z'), ref('a', 'DEPT-A'), ref('b', 'DEPT-M')],
+        cible: [
+          createIndividuRef('c', 'DEPT-Z'),
+          createIndividuRef('a', 'DEPT-A'),
+          createIndividuRef('b', 'DEPT-M'),
+        ],
       },
       {
-        a: saisie(1, '2025-01-01'),
-        b: saisie(2, '2025-01-01'),
-        c: saisie(3, '2025-01-01'),
+        a: createValeurSaisie(1, '2025-01-01'),
+        b: createValeurSaisie(2, '2025-01-01'),
+        c: createValeurSaisie(3, '2025-01-01'),
       },
     )
 
@@ -105,15 +117,15 @@ describe('resolveValeurDerivee', () => {
     // France → 2 régions → chacune 2 départements (feuilles saisies)
     const context = buildContext(
       {
-        france: [ref('reg-n', 'REG-N'), ref('reg-s', 'REG-S')],
-        'reg-n': [ref('dept-n1', 'DEPT-N1'), ref('dept-n2', 'DEPT-N2')],
-        'reg-s': [ref('dept-s1', 'DEPT-S1'), ref('dept-s2', 'DEPT-S2')],
+        france: [createIndividuRef('reg-n', 'REG-N'), createIndividuRef('reg-s', 'REG-S')],
+        'reg-n': [createIndividuRef('dept-n1', 'DEPT-N1'), createIndividuRef('dept-n2', 'DEPT-N2')],
+        'reg-s': [createIndividuRef('dept-s1', 'DEPT-S1'), createIndividuRef('dept-s2', 'DEPT-S2')],
       },
       {
-        'dept-n1': saisie(10, '2025-01-01'),
-        'dept-n2': saisie(20, '2025-02-01'),
-        'dept-s1': saisie(100, '2025-03-01'),
-        'dept-s2': saisie(200, '2025-04-01'),
+        'dept-n1': createValeurSaisie(10, '2025-01-01'),
+        'dept-n2': createValeurSaisie(20, '2025-02-01'),
+        'dept-s1': createValeurSaisie(100, '2025-03-01'),
+        'dept-s2': createValeurSaisie(200, '2025-04-01'),
       },
     )
 
@@ -134,16 +146,16 @@ describe('resolveValeurDerivee', () => {
     // La région N a une saisie officielle ; ses départements ont aussi des saisies → on prend la saisie de la région
     const context = buildContext(
       {
-        france: [ref('reg-n', 'REG-N'), ref('reg-s', 'REG-S')],
-        'reg-n': [ref('dept-n1', 'DEPT-N1'), ref('dept-n2', 'DEPT-N2')],
-        'reg-s': [ref('dept-s1', 'DEPT-S1'), ref('dept-s2', 'DEPT-S2')],
+        france: [createIndividuRef('reg-n', 'REG-N'), createIndividuRef('reg-s', 'REG-S')],
+        'reg-n': [createIndividuRef('dept-n1', 'DEPT-N1'), createIndividuRef('dept-n2', 'DEPT-N2')],
+        'reg-s': [createIndividuRef('dept-s1', 'DEPT-S1'), createIndividuRef('dept-s2', 'DEPT-S2')],
       },
       {
-        'reg-n': saisie(999, '2020-01-01'), // saisie officielle, ancienne mais prioritaire
-        'dept-n1': saisie(10, '2025-01-01'),
-        'dept-n2': saisie(20, '2025-02-01'),
-        'dept-s1': saisie(100, '2025-03-01'),
-        'dept-s2': saisie(200, '2025-04-01'),
+        'reg-n': createValeurSaisie(999, '2020-01-01'), // saisie officielle, ancienne mais prioritaire
+        'dept-n1': createValeurSaisie(10, '2025-01-01'),
+        'dept-n2': createValeurSaisie(20, '2025-02-01'),
+        'dept-s1': createValeurSaisie(100, '2025-03-01'),
+        'dept-s2': createValeurSaisie(200, '2025-04-01'),
       },
     )
 
@@ -159,12 +171,15 @@ describe('resolveValeurDerivee', () => {
   it("marque comme manquante un enfant qui n'a ni saisie ni descendants avec valeur", () => {
     const context = buildContext(
       {
-        cible: [ref('reg-vide', 'REG-VIDE'), ref('reg-pleine', 'REG-PLEINE')],
-        'reg-vide': [ref('dept-vide', 'DEPT-VIDE')], // descendants existent mais aucune saisie
-        'reg-pleine': [ref('dept-p', 'DEPT-P')],
+        cible: [
+          createIndividuRef('reg-vide', 'REG-VIDE'),
+          createIndividuRef('reg-pleine', 'REG-PLEINE'),
+        ],
+        'reg-vide': [createIndividuRef('dept-vide', 'DEPT-VIDE')], // descendants existent mais aucune saisie
+        'reg-pleine': [createIndividuRef('dept-p', 'DEPT-P')],
       },
       {
-        'dept-p': saisie(50, '2025-01-01'),
+        'dept-p': createValeurSaisie(50, '2025-01-01'),
       },
     )
 
@@ -183,7 +198,7 @@ describe('resolveValeurDerivee', () => {
   it('retourne valeurDerivee null quand tous les enfants sont absents', () => {
     const context = buildContext(
       {
-        cible: [ref('a', 'DEPT-A'), ref('b', 'DEPT-B')],
+        cible: [createIndividuRef('a', 'DEPT-A'), createIndividuRef('b', 'DEPT-B')],
       },
       {},
     )
@@ -203,13 +218,17 @@ describe('resolveValeurDerivee', () => {
   it('utilise la date la plus récente parmi les contributions dérivées', () => {
     const context = buildContext(
       {
-        cible: [ref('reg', 'REG-X')],
-        reg: [ref('d1', 'D1'), ref('d2', 'D2'), ref('d3', 'D3')],
+        cible: [createIndividuRef('reg', 'REG-X')],
+        reg: [
+          createIndividuRef('d1', 'D1'),
+          createIndividuRef('d2', 'D2'),
+          createIndividuRef('d3', 'D3'),
+        ],
       },
       {
-        d1: saisie(1, '2024-01-01'),
-        d2: saisie(2, '2025-06-15'),
-        d3: saisie(3, '2024-12-31'),
+        d1: createValeurSaisie(1, '2024-01-01'),
+        d2: createValeurSaisie(2, '2025-06-15'),
+        d3: createValeurSaisie(3, '2024-12-31'),
       },
     )
 

--- a/apps/mb-api/src/valeurAvancement/resolveValeurDerivee.test.ts
+++ b/apps/mb-api/src/valeurAvancement/resolveValeurDerivee.test.ts
@@ -60,7 +60,7 @@ describe('resolveValeurDerivee', () => {
     })
   })
 
-  it('expose les enfants sans valeur comme `absente` et somme uniquement les présents (couverture partielle)', () => {
+  it('expose les enfants sans valeur comme `manquante` et somme uniquement les présents (couverture partielle)', () => {
     const context = buildContext(
       {
         'cible': [ref('a', 'DEPT-A'), ref('b', 'DEPT-B'), ref('c', 'DEPT-C')],
@@ -76,7 +76,7 @@ describe('resolveValeurDerivee', () => {
     expect(result).toEqual({
       contributions: [
         { individu: 'DEPT-A', valeur: 10, date: '2025-01-01', source: 'saisie' },
-        { individu: 'DEPT-B', valeur: null, date: null, source: 'absente' },
+        { individu: 'DEPT-B', valeur: null, date: null, source: 'manquante' },
         { individu: 'DEPT-C', valeur: 30, date: '2025-03-01', source: 'saisie' },
       ],
       valeurDerivee: 40,
@@ -156,7 +156,7 @@ describe('resolveValeurDerivee', () => {
     expect(result.valeurDerivee).toBe(1299)
   })
 
-  it("marque comme absente un enfant qui n'a ni saisie ni descendants avec valeur", () => {
+  it("marque comme manquante un enfant qui n'a ni saisie ni descendants avec valeur", () => {
     const context = buildContext(
       {
         'cible': [ref('reg-vide', 'REG-VIDE'), ref('reg-pleine', 'REG-PLEINE')],
@@ -173,7 +173,7 @@ describe('resolveValeurDerivee', () => {
     expect(result).toEqual({
       contributions: [
         { individu: 'REG-PLEINE', valeur: 50, date: '2025-01-01', source: 'derivee' },
-        { individu: 'REG-VIDE', valeur: null, date: null, source: 'absente' },
+        { individu: 'REG-VIDE', valeur: null, date: null, source: 'manquante' },
       ],
       valeurDerivee: 50,
       couverture: { nbEnfantsAvecValeur: 1, nbEnfantsTotal: 2 },
@@ -192,8 +192,8 @@ describe('resolveValeurDerivee', () => {
 
     expect(result).toEqual({
       contributions: [
-        { individu: 'DEPT-A', valeur: null, date: null, source: 'absente' },
-        { individu: 'DEPT-B', valeur: null, date: null, source: 'absente' },
+        { individu: 'DEPT-A', valeur: null, date: null, source: 'manquante' },
+        { individu: 'DEPT-B', valeur: null, date: null, source: 'manquante' },
       ],
       valeurDerivee: null,
       couverture: { nbEnfantsAvecValeur: 0, nbEnfantsTotal: 2 },

--- a/apps/mb-api/src/valeurAvancement/resolveValeurDerivee.test.ts
+++ b/apps/mb-api/src/valeurAvancement/resolveValeurDerivee.test.ts
@@ -38,7 +38,7 @@ describe('resolveValeurDerivee', () => {
   it('somme les valeurs saisies de tous les enfants directs (1 niveau, couverture complète)', () => {
     const context = buildContext(
       {
-        'cible': [ref('a', 'DEPT-A'), ref('b', 'DEPT-B'), ref('c', 'DEPT-C')],
+        cible: [ref('a', 'DEPT-A'), ref('b', 'DEPT-B'), ref('c', 'DEPT-C')],
       },
       {
         a: saisie(10, '2025-01-01'),
@@ -63,7 +63,7 @@ describe('resolveValeurDerivee', () => {
   it('expose les enfants sans valeur comme `manquante` et somme uniquement les présents (couverture partielle)', () => {
     const context = buildContext(
       {
-        'cible': [ref('a', 'DEPT-A'), ref('b', 'DEPT-B'), ref('c', 'DEPT-C')],
+        cible: [ref('a', 'DEPT-A'), ref('b', 'DEPT-B'), ref('c', 'DEPT-C')],
       },
       {
         a: saisie(10, '2025-01-01'),
@@ -87,7 +87,7 @@ describe('resolveValeurDerivee', () => {
   it('trie les contributions par publicId quel que soit l’ordre des enfants en entrée', () => {
     const context = buildContext(
       {
-        'cible': [ref('c', 'DEPT-Z'), ref('a', 'DEPT-A'), ref('b', 'DEPT-M')],
+        cible: [ref('c', 'DEPT-Z'), ref('a', 'DEPT-A'), ref('b', 'DEPT-M')],
       },
       {
         a: saisie(1, '2025-01-01'),
@@ -105,7 +105,7 @@ describe('resolveValeurDerivee', () => {
     // France → 2 régions → chacune 2 départements (feuilles saisies)
     const context = buildContext(
       {
-        'france': [ref('reg-n', 'REG-N'), ref('reg-s', 'REG-S')],
+        france: [ref('reg-n', 'REG-N'), ref('reg-s', 'REG-S')],
         'reg-n': [ref('dept-n1', 'DEPT-N1'), ref('dept-n2', 'DEPT-N2')],
         'reg-s': [ref('dept-s1', 'DEPT-S1'), ref('dept-s2', 'DEPT-S2')],
       },
@@ -134,7 +134,7 @@ describe('resolveValeurDerivee', () => {
     // La région N a une saisie officielle ; ses départements ont aussi des saisies → on prend la saisie de la région
     const context = buildContext(
       {
-        'france': [ref('reg-n', 'REG-N'), ref('reg-s', 'REG-S')],
+        france: [ref('reg-n', 'REG-N'), ref('reg-s', 'REG-S')],
         'reg-n': [ref('dept-n1', 'DEPT-N1'), ref('dept-n2', 'DEPT-N2')],
         'reg-s': [ref('dept-s1', 'DEPT-S1'), ref('dept-s2', 'DEPT-S2')],
       },
@@ -159,7 +159,7 @@ describe('resolveValeurDerivee', () => {
   it("marque comme manquante un enfant qui n'a ni saisie ni descendants avec valeur", () => {
     const context = buildContext(
       {
-        'cible': [ref('reg-vide', 'REG-VIDE'), ref('reg-pleine', 'REG-PLEINE')],
+        cible: [ref('reg-vide', 'REG-VIDE'), ref('reg-pleine', 'REG-PLEINE')],
         'reg-vide': [ref('dept-vide', 'DEPT-VIDE')], // descendants existent mais aucune saisie
         'reg-pleine': [ref('dept-p', 'DEPT-P')],
       },
@@ -183,7 +183,7 @@ describe('resolveValeurDerivee', () => {
   it('retourne valeurDerivee null quand tous les enfants sont absents', () => {
     const context = buildContext(
       {
-        'cible': [ref('a', 'DEPT-A'), ref('b', 'DEPT-B')],
+        cible: [ref('a', 'DEPT-A'), ref('b', 'DEPT-B')],
       },
       {},
     )
@@ -203,8 +203,8 @@ describe('resolveValeurDerivee', () => {
   it('utilise la date la plus récente parmi les contributions dérivées', () => {
     const context = buildContext(
       {
-        'cible': [ref('reg', 'REG-X')],
-        'reg': [ref('d1', 'D1'), ref('d2', 'D2'), ref('d3', 'D3')],
+        cible: [ref('reg', 'REG-X')],
+        reg: [ref('d1', 'D1'), ref('d2', 'D2'), ref('d3', 'D3')],
       },
       {
         d1: saisie(1, '2024-01-01'),

--- a/apps/mb-api/src/valeurAvancement/resolveValeurDerivee.ts
+++ b/apps/mb-api/src/valeurAvancement/resolveValeurDerivee.ts
@@ -1,0 +1,98 @@
+import {
+  type ContributionApiModel,
+  type CouvertureApiModel,
+} from '@pilote/mb-shared/valeurAvancement'
+
+import { Decimal } from '@/framework/decimal'
+import { computeSum } from '@/valeurAvancement/computeSum'
+
+export type IndividuRef = {
+  id: string
+  publicId: string
+}
+
+export type ValeurSaisie = {
+  valeur: Decimal
+  date: string
+}
+
+export type ResolveValeurDeriveeContext = {
+  enfantsParParent: ReadonlyMap<string, ReadonlyArray<IndividuRef>>
+  derniereValeurParIndividu: ReadonlyMap<string, ValeurSaisie>
+}
+
+export type ResolveValeurDeriveeResult = {
+  contributions: ContributionApiModel[]
+  valeurDerivee: number | null
+  couverture: CouvertureApiModel
+}
+
+type ValeurEffective = {
+  valeur: Decimal
+  date: string
+  source: 'saisie' | 'derivee'
+}
+
+const maxDate = (a: string, b: string): string => (a > b ? a : b)
+
+const resolveValeurEffective = (
+  individuId: string,
+  context: ResolveValeurDeriveeContext,
+): ValeurEffective | null => {
+  const saisie = context.derniereValeurParIndividu.get(individuId)
+  if (saisie) {
+    return { valeur: saisie.valeur, date: saisie.date, source: 'saisie' }
+  }
+
+  const enfants = context.enfantsParParent.get(individuId)
+  if (!enfants || enfants.length === 0) return null
+
+  const sousValeurs = enfants
+    .map((enfant) => resolveValeurEffective(enfant.id, context))
+    .filter((v): v is ValeurEffective => v !== null)
+  if (sousValeurs.length === 0) return null
+
+  const somme = sousValeurs.reduce((acc, v) => acc.plus(v.valeur), new Decimal(0))
+  const date = sousValeurs.reduce((acc, v) => maxDate(acc, v.date), sousValeurs[0]!.date)
+  return { valeur: somme, date, source: 'derivee' }
+}
+
+export const resolveValeurDerivee = (
+  cibleId: string,
+  context: ResolveValeurDeriveeContext,
+): ResolveValeurDeriveeResult => {
+  const enfants = context.enfantsParParent.get(cibleId) ?? []
+  const enfantsTries = [...enfants].sort((a, b) => a.publicId.localeCompare(b.publicId))
+
+  const contributions: ContributionApiModel[] = []
+  const valeursPourSomme: Decimal[] = []
+
+  for (const enfant of enfantsTries) {
+    const effective = resolveValeurEffective(enfant.id, context)
+    if (effective === null) {
+      contributions.push({
+        individu: enfant.publicId,
+        valeur: null,
+        date: null,
+        source: 'absente',
+      })
+      continue
+    }
+    contributions.push({
+      individu: enfant.publicId,
+      valeur: effective.valeur.toNumber(),
+      date: effective.date,
+      source: effective.source,
+    })
+    valeursPourSomme.push(effective.valeur)
+  }
+
+  return {
+    contributions,
+    valeurDerivee: computeSum(valeursPourSomme),
+    couverture: {
+      nbEnfantsAvecValeur: valeursPourSomme.length,
+      nbEnfantsTotal: enfantsTries.length,
+    },
+  }
+}

--- a/apps/mb-api/src/valeurAvancement/resolveValeurDerivee.ts
+++ b/apps/mb-api/src/valeurAvancement/resolveValeurDerivee.ts
@@ -74,7 +74,7 @@ export const resolveValeurDerivee = (
         individu: enfant.publicId,
         valeur: null,
         date: null,
-        source: 'absente',
+        source: 'manquante',
       })
       continue
     }

--- a/apps/mb-api/src/valeurAvancement/routes.ts
+++ b/apps/mb-api/src/valeurAvancement/routes.ts
@@ -1,6 +1,7 @@
 import { createRoute, OpenAPIHono, z } from '@hono/zod-openapi'
 import { errorApiModelSchema } from '@pilote/mb-shared/error'
 import { indicateurPublicIdSchema } from '@pilote/mb-shared/indicateur'
+import { individuPublicIdSchema } from '@pilote/mb-shared/individu'
 import { createPaginatedApiListSchema } from '@pilote/mb-shared/pagination'
 import {
   deleteValeurAvancementBodySchema,
@@ -13,6 +14,7 @@ import {
   upsertValeurAvancementBodySchema,
   valeurAvancementApiModelSchema,
   valeurAvancementListApiModelSchema,
+  valeurDeriveeApiModelSchema,
   valeursRemarquablesListApiModelSchema,
 } from '@pilote/mb-shared/valeurAvancement'
 
@@ -23,6 +25,7 @@ import { jsonResponseError, jsonResponseOk } from '@/framework/openapi/jsonRespo
 import { withTransaction } from '@/framework/persistence/withTransaction'
 import { deleteValeurAvancement } from '@/valeurAvancement/commands/deleteValeurAvancement'
 import { upsertValeurAvancement } from '@/valeurAvancement/commands/upsertValeurAvancement'
+import { getValeurDerivee } from '@/valeurAvancement/queries/getValeurDerivee'
 import { listIndividusWithValeurs } from '@/valeurAvancement/queries/listIndividusWithValeurs'
 import { listSyntheseIndividus } from '@/valeurAvancement/queries/listSyntheseIndividus'
 import { listValeursForIndicateur } from '@/valeurAvancement/queries/listValeursForIndicateur'
@@ -49,6 +52,7 @@ const ValeursRemarquablesListApiModelSchema = valeursRemarquablesListApiModelSch
 const SyntheseIndividusListApiModelSchema = syntheseIndividusListApiModelSchema.openapi(
   'SyntheseIndividusListApiModel',
 )
+const ValeurDeriveeApiModelSchema = valeurDeriveeApiModelSchema.openapi('ValeurDeriveeApiModel')
 const ErrorApiModelSchema = errorApiModelSchema.openapi('ErrorApiModel')
 
 const indicateurParamsSchema = z.object({
@@ -235,6 +239,41 @@ const getSyntheseIndividusRoute = createRoute({
   },
 })
 
+// --- GET /indicateurs/:id/individus/:individuId/valeur-derivee --------------
+
+const indicateurIndividuParamsSchema = z.object({
+  id: indicateurPublicIdSchema,
+  individuId: individuPublicIdSchema,
+})
+
+const getValeurDeriveeRoute = createRoute({
+  method: 'get',
+  path: '/indicateurs/{id}/individus/{individuId}/valeur-derivee',
+  tags: ['Indicateur'],
+  summary: 'Calculer la valeur dérivée d’un individu par agrégation hiérarchique',
+  description:
+    "Calcule la valeur de l'individu cible comme somme (SUM) des valeurs de ses enfants directs, " +
+    "niveau par niveau (la valeur d'un enfant intermédiaire est sa propre saisie si elle existe, " +
+    'sinon la dérivée récursive de ses descendants). La valeur retenue pour chaque enfant est sa ' +
+    'dernière valeur connue (pas de paramètre date). La réponse expose les contributions de chaque ' +
+    'enfant direct (drill-down) et la couverture (combien d’enfants ont contribué). ' +
+    "Retourne 200 avec `valeurDerivee: null` et `couverture: 0/0` si l'individu est une feuille.",
+  middleware: [requireAuthentication],
+  request: {
+    params: indicateurIndividuParamsSchema,
+  },
+  responses: {
+    200: {
+      content: { 'application/json': { schema: ValeurDeriveeApiModelSchema } },
+      description: 'Valeur dérivée calculée à partir des enfants directs',
+    },
+    404: {
+      content: { 'application/json': { schema: ErrorApiModelSchema } },
+      description: 'Indicateur ou individu inexistant',
+    },
+  },
+})
+
 // --- App registration --------------------------------------------------------
 
 export const valeurAvancementRoutes = new OpenAPIHono()
@@ -371,6 +410,21 @@ valeurAvancementRoutes.openapi(getSyntheseIndividusRoute, async (context) => {
         context,
         data,
         schema: SyntheseIndividusListApiModelSchema,
+        status: 200,
+      }),
+    never,
+  )
+})
+
+valeurAvancementRoutes.openapi(getValeurDeriveeRoute, async (context) => {
+  const { id, individuId } = context.req.valid('param')
+
+  return getValeurDerivee(id, individuId).match(
+    (data) =>
+      jsonResponseOk({
+        context,
+        data,
+        schema: ValeurDeriveeApiModelSchema,
         status: 200,
       }),
     never,

--- a/apps/mb-api/src/valeurAvancement/routes.ts
+++ b/apps/mb-api/src/valeurAvancement/routes.ts
@@ -267,10 +267,6 @@ const getValeurDeriveeRoute = createRoute({
       content: { 'application/json': { schema: ValeurDeriveeApiModelSchema } },
       description: 'Valeur dérivée calculée à partir des enfants directs',
     },
-    404: {
-      content: { 'application/json': { schema: ErrorApiModelSchema } },
-      description: 'Indicateur ou individu inexistant',
-    },
   },
 })
 

--- a/packages/mb-shared/src/valeurAvancement.ts
+++ b/packages/mb-shared/src/valeurAvancement.ts
@@ -235,9 +235,9 @@ export const listIndividusWithValeursQuerySchema = z.object({
 export type ListIndividusWithValeursQuery = z.infer<typeof listIndividusWithValeursQuerySchema>
 
 export const contributionSourceSchema = z
-  .enum(['saisie', 'derivee', 'absente'])
+  .enum(['saisie', 'derivee', 'manquante'])
   .describe(
-    "Origine de la valeur de l'enfant pour le calcul du parent : `saisie` (valeur saisie directement sur l'enfant, prioritaire), `derivee` (calculée récursivement à partir des descendants de l'enfant), `absente` (l'enfant n'a ni saisie ni descendant avec valeur).",
+    "Origine de la valeur de l'enfant pour le calcul du parent : `saisie` (valeur saisie directement sur l'enfant, prioritaire), `derivee` (calculée récursivement à partir des descendants de l'enfant), `manquante` (l'enfant n'a ni saisie ni descendant avec valeur).",
   )
 export type ContributionSource = z.infer<typeof contributionSourceSchema>
 
@@ -246,11 +246,11 @@ export const contributionApiModelSchema = z.object({
   valeur: z
     .number()
     .nullable()
-    .describe('Valeur retenue pour cet enfant, ou null si `source` vaut `absente`.'),
+    .describe('Valeur retenue pour cet enfant, ou null si `source` vaut `manquante`.'),
   date: dateSchema
     .nullable()
     .describe(
-      "Date de la valeur retenue. Pour `saisie`, date de la valeur saisie. Pour `derivee`, date la plus récente parmi les contributions ayant servi au calcul. null si `absente`.",
+      "Date de la valeur retenue. Pour `saisie`, date de la valeur saisie. Pour `derivee`, date la plus récente parmi les contributions ayant servi au calcul. null si `manquante`.",
     ),
   source: contributionSourceSchema,
 })

--- a/packages/mb-shared/src/valeurAvancement.ts
+++ b/packages/mb-shared/src/valeurAvancement.ts
@@ -233,3 +233,58 @@ export const listIndividusWithValeursQuerySchema = z.object({
   pageSize: pageSizeSchema,
 })
 export type ListIndividusWithValeursQuery = z.infer<typeof listIndividusWithValeursQuerySchema>
+
+export const contributionSourceSchema = z
+  .enum(['saisie', 'derivee', 'absente'])
+  .describe(
+    "Origine de la valeur de l'enfant pour le calcul du parent : `saisie` (valeur saisie directement sur l'enfant, prioritaire), `derivee` (calculée récursivement à partir des descendants de l'enfant), `absente` (l'enfant n'a ni saisie ni descendant avec valeur).",
+  )
+export type ContributionSource = z.infer<typeof contributionSourceSchema>
+
+export const contributionApiModelSchema = z.object({
+  individu: individuPublicIdSchema,
+  valeur: z
+    .number()
+    .nullable()
+    .describe('Valeur retenue pour cet enfant, ou null si `source` vaut `absente`.'),
+  date: dateSchema
+    .nullable()
+    .describe(
+      "Date de la valeur retenue. Pour `saisie`, date de la valeur saisie. Pour `derivee`, date la plus récente parmi les contributions ayant servi au calcul. null si `absente`.",
+    ),
+  source: contributionSourceSchema,
+})
+export type ContributionApiModel = z.infer<typeof contributionApiModelSchema>
+
+export const couvertureApiModelSchema = z.object({
+  nbEnfantsAvecValeur: z
+    .number()
+    .int()
+    .nonnegative()
+    .describe('Nombre d’enfants directs ayant contribué (saisie ou dérivée non nulle).'),
+  nbEnfantsTotal: z
+    .number()
+    .int()
+    .nonnegative()
+    .describe('Nombre total d’enfants directs du parent.'),
+})
+export type CouvertureApiModel = z.infer<typeof couvertureApiModelSchema>
+
+export const valeurDeriveeApiModelSchema = z.object({
+  indicateur: indicateurPublicIdSchema,
+  individu: individuPublicIdSchema,
+  agregateur: z.literal('SUM').describe('Agrégateur appliqué (SUM uniquement pour le moment).'),
+  valeurDerivee: z
+    .number()
+    .nullable()
+    .describe(
+      "Somme des valeurs retenues parmi les enfants directs. null si aucun enfant n'a de valeur.",
+    ),
+  contributions: z
+    .array(contributionApiModelSchema)
+    .describe(
+      "Une entrée par enfant direct du parent, dans l'ordre des publicId. Permet le drill-down et l'audit du calcul.",
+    ),
+  couverture: couvertureApiModelSchema,
+})
+export type ValeurDeriveeApiModel = z.infer<typeof valeurDeriveeApiModelSchema>


### PR DESCRIPTION
## Summary
- Ajoute `GET /indicateurs/:id/individus/:individuId/valeur-derivee` : calcule la valeur d'un individu parent comme somme (SUM) des valeurs de ses enfants directs, niveau par niveau
- Préparation d'arrière-plan : un document de design qui capture les décisions tranchées avec @user et liste les questions tranchées en cours de route
- Architecture optimisée pour éviter les N+1 : `O(profondeur)` queries indépendamment du nombre d'individus dans le sous-arbre

## Décisions de design (cf. `apps/mb-api/docs/architecture/valeurs-derivees-design.md`)
- **D1** Saisie et valeur dérivée coexistent ; pour le calcul du parent, la saisie d'un enfant prime sur la dérivée de ses descendants
- **D2** Agrégation niveau par niveau (associativité non garantie pour AVG/MEDIAN, on prépare ces agrégateurs)
- **D5** Invariant métier : tous les enfants d'un même parent partagent un référentiel (à enforcer à l'écriture quand `Relation` aura une API)
- **D6** Calcul à la volée (pas de stockage)
- **D7** SUM hardcodé pour le MVP

## Implémentation
| Fichier | Rôle |
|---|---|
| `packages/mb-shared/src/valeurAvancement.ts` | Schémas Zod publics |
| `apps/mb-api/prisma/schema.prisma` | `previewFeatures = ["typedSql"]` |
| `apps/mb-api/prisma/sql/getDernieresValeursPourIndividus.sql` | DISTINCT ON typé via TypedSQL |
| `valeurAvancement/computeSum.ts` | Agrégateur pur |
| `valeurAvancement/resolveValeurDerivee.ts` | Functional core, récursion en mémoire |
| `valeurAvancement/queries/getValeurDerivee.ts` | Orchestration : BFS sous-arbre + bulk valeurs + functional core |
| `valeurAvancement/routes.ts` | Nouvelle route Hono |

## Bilan queries
~6 queries au total, indépendant du nombre d'individus : 1 (indicateur) + 1 (individu cible) + P (BFS, P=profondeur ~3–4) + 1 (bulk valeurs).

## Test plan
- [ ] `pnpm prisma generate --sql` après pull (génère les types TypedSQL)
- [ ] Tests purs : `computeSum.test.ts`, `resolveValeurDerivee.test.ts`
- [ ] Tests d'intégration : `getValeurDerivee.test.ts` (feuille, 1 niveau complet/partiel, grand-parent, priorité saisie, permissions, individu inconnu)
- [ ] Vérifier la doc OpenAPI générée

🤖 Generated with [Claude Code](https://claude.com/claude-code)