### PR TITLE
fix(albert): inclure les régions sous NAT-FR dans le résolveur de territoires

### DIFF
--- a/apps/pilote-ppg/src/app/api/albert/chat/route.ts
+++ b/apps/pilote-ppg/src/app/api/albert/chat/route.ts
@@ -48,6 +48,9 @@ export async function POST(request: Request) {
     const createGetChantierIndicateursTool = container.resolve(
       "createGetChantierIndicateursTool",
     );
+    const createGetChantierCommentairesTool = container.resolve(
+      "createGetChantierCommentairesTool",
+    );
     const createExportRapportTool = container.resolve(
       "createExportRapportTool",
     );
@@ -77,6 +80,9 @@ export async function POST(request: Request) {
     const getChantierIndicateurs = createGetChantierIndicateursTool({
       territoiresAccessibles,
     });
+    const getChantierCommentaires = createGetChantierCommentairesTool({
+      territoiresAccessibles,
+    });
     const exportRapport = createExportRapportTool({
       userId: session.user.id,
     });
@@ -87,6 +93,7 @@ export async function POST(request: Request) {
       get_taux_avancement_territoire: getTauxAvancementTerritoire,
       get_chantiers: getChantiers,
       get_indicateurs: getChantierIndicateurs,
+      get_chantier_commentaires: getChantierCommentaires,
       display_choices: displayChoicesTool,
       ...(capacities.dashboard ? { create_dashboard: createDashboard } : {}),
       ...(capacities.exportRapport ? { export_rapport: exportRapport } : {}),

--- a/apps/pilote-ppg/src/client/components/_commons/ChatUI/AssistantMessage.tsx
+++ b/apps/pilote-ppg/src/client/components/_commons/ChatUI/AssistantMessage.tsx
@@ -52,7 +52,8 @@ export const AssistantMessage = memo(function AssistantMessage({
           if (
             part.type === "tool-get_taux_avancement_territoire" ||
             part.type === "tool-get_chantiers" ||
-            part.type === "tool-get_indicateurs"
+            part.type === "tool-get_indicateurs" ||
+            part.type === "tool-get_chantier_commentaires"
           ) {
             return <ToolCallIndicator key={index} part={part} />;
           }

--- a/apps/pilote-ppg/src/client/components/_commons/ChatUI/ChatContext.tsx
+++ b/apps/pilote-ppg/src/client/components/_commons/ChatUI/ChatContext.tsx
@@ -6,6 +6,7 @@ type ChatContextValue = {
   fillInput: (text: string) => void;
   status: ChatStatus;
   error: Error | undefined;
+  stop: () => void;
 };
 
 const context = createContext<ChatContextValue | null>(null);
@@ -28,10 +29,11 @@ export const ChatContextProvider = ({
   fillInput,
   status,
   error,
+  stop,
 }: PropsWithChildren<ChatContextValue>) => {
   const value = useMemo(
-    () => ({ sendMessage, fillInput, status, error }),
-    [sendMessage, fillInput, status, error],
+    () => ({ sendMessage, fillInput, status, error, stop }),
+    [sendMessage, fillInput, status, error, stop],
   );
 
   return <context.Provider value={value}>{children}</context.Provider>;

--- a/apps/pilote-ppg/src/client/components/_commons/ChatUI/ChatInputForm.tsx
+++ b/apps/pilote-ppg/src/client/components/_commons/ChatUI/ChatInputForm.tsx
@@ -9,6 +9,7 @@ import {
 import { clsxm } from "@/utils/clsxm";
 import { ArrowLineIcon } from "@/components/_commons/Icones/ArrowLineIcon";
 import { MicrophoneIcon } from "@/components/_commons/Icones/MicrophoneIcon";
+import { StopIcon } from "@/components/_commons/Icones/StopIcon";
 import { useChatContext } from "@/components/_commons/ChatUI/ChatContext";
 import { useSpeechRecognition } from "@/components/_commons/ChatUI/useSpeechRecognition";
 import { Select } from "@/components/shared/Select";
@@ -33,7 +34,7 @@ export const ChatInputForm = ({
   const [selectedModel, setSelectedModel] =
     useState<AlbertModel>("openweight-large");
   const textareaRef = useRef<HTMLTextAreaElement>(null);
-  const { sendMessage, status } = useChatContext();
+  const { sendMessage, status, stop } = useChatContext();
   const isBusy = status === "submitted" || status === "streaming";
 
   useEffect(() => {
@@ -134,21 +135,31 @@ export const ChatInputForm = ({
               <MicrophoneIcon className="w-4 h-4" />
             </button>
           )}
-          <button
-            className={clsxm(
-              "w-8 h-8 rounded-full flex items-center justify-center transition-colors",
-              {
-                "bg-primary text-white hover:bg-primary/90":
-                  !isBusy && input.trim(),
-                "bg-gray-300 text-white cursor-not-allowed":
-                  isBusy || !input.trim(),
-              },
-            )}
-            disabled={isBusy || !input.trim()}
-            type="submit"
-          >
-            <ArrowLineIcon className="w-4 h-4" />
-          </button>
+          {isBusy ? (
+            <button
+              aria-label="Arrêter la génération"
+              className="w-8 h-8 rounded-full flex items-center justify-center transition-colors bg-primary text-white hover:bg-primary/90"
+              onClick={stop}
+              type="button"
+            >
+              <StopIcon className="w-4 h-4" />
+            </button>
+          ) : (
+            <button
+              aria-label="Envoyer le message"
+              className={clsxm(
+                "w-8 h-8 rounded-full flex items-center justify-center transition-colors",
+                {
+                  "bg-primary text-white hover:bg-primary/90": input.trim(),
+                  "bg-gray-300 text-white cursor-not-allowed": !input.trim(),
+                },
+              )}
+              disabled={!input.trim()}
+              type="submit"
+            >
+              <ArrowLineIcon className="w-4 h-4" />
+            </button>
+          )}
         </div>
       </form>
     </div>

--- a/apps/pilote-ppg/src/client/components/_commons/ChatUI/ChatUI.tsx
+++ b/apps/pilote-ppg/src/client/components/_commons/ChatUI/ChatUI.tsx
@@ -66,10 +66,11 @@ export const ChatUI = ({
     }),
   );
 
-  const { messages, sendMessage, status, error } = useChat<PiloteUIMessage>({
-    chat: chatRef.current,
-    experimental_throttle: 250,
-  });
+  const { messages, sendMessage, status, error, stop } =
+    useChat<PiloteUIMessage>({
+      chat: chatRef.current,
+      experimental_throttle: 250,
+    });
 
   useEffect(() => {
     if (messages.length === 0) return;
@@ -138,6 +139,7 @@ export const ChatUI = ({
       fillInput={fillInput}
       sendMessage={sendMessage}
       status={status}
+      stop={stop}
     >
       <div className={clsxm("flex flex-col", className)}>
         <style>{chatMarkdownStyles}</style>

--- a/apps/pilote-ppg/src/client/components/_commons/ChatUI/ToolCallIndicator.tsx
+++ b/apps/pilote-ppg/src/client/components/_commons/ChatUI/ToolCallIndicator.tsx
@@ -14,7 +14,8 @@ type DataFetchingToolPart = Extract<
     type:
       | "tool-get_taux_avancement_territoire"
       | "tool-get_chantiers"
-      | "tool-get_indicateurs";
+      | "tool-get_indicateurs"
+      | "tool-get_chantier_commentaires";
   }
 >;
 
@@ -23,6 +24,7 @@ const TOOL_LABELS: Record<DataFetchingToolPart["type"], string> = {
     "Récupération du taux d'avancement du territoire",
   "tool-get_chantiers": "Récupération des chantiers",
   "tool-get_indicateurs": "Récupération des indicateurs",
+  "tool-get_chantier_commentaires": "Récupération des commentaires du chantier",
 };
 
 const StatusIcon = ({ state }: { state: DataFetchingToolPart["state"] }) => {

--- a/apps/pilote-ppg/src/client/components/_commons/Icones/StopIcon.tsx
+++ b/apps/pilote-ppg/src/client/components/_commons/Icones/StopIcon.tsx
@@ -1,0 +1,11 @@
+export const StopIcon = ({
+  fill = "currentColor",
+  className,
+}: {
+  fill?: string;
+  className?: string;
+}) => (
+  <svg className={className} viewBox="0 0 24 24">
+    <rect x="6" y="6" width="12" height="12" rx="1.5" fill={fill} />
+  </svg>
+);

--- a/apps/pilote-ppg/src/server/albert/PiloteUIMessage.ts
+++ b/apps/pilote-ppg/src/server/albert/PiloteUIMessage.ts
@@ -24,6 +24,10 @@ import {
   getChantierIndicateursInputSchema,
   type GetChantierIndicateursOutput,
 } from "@/server/albert/tools/getChantierIndicateurs";
+import {
+  getChantierCommentairesInputSchema,
+  type GetChantierCommentairesOutput,
+} from "@/server/albert/tools/getChantierCommentaires";
 
 export type PiloteUITools = {
   display_choices: {
@@ -41,6 +45,10 @@ export type PiloteUITools = {
   get_indicateurs: {
     input: z.input<typeof getChantierIndicateursInputSchema>;
     output: GetChantierIndicateursOutput;
+  };
+  get_chantier_commentaires: {
+    input: z.input<typeof getChantierCommentairesInputSchema>;
+    output: GetChantierCommentairesOutput;
   };
   create_dashboard: {
     input: z.input<typeof createDashboardInputSchema>;

--- a/apps/pilote-ppg/src/server/albert/infrastructure/PrismaTerritoireResolver.ts
+++ b/apps/pilote-ppg/src/server/albert/infrastructure/PrismaTerritoireResolver.ts
@@ -18,7 +18,7 @@ export class PrismaTerritoireResolver implements TerritoireResolver {
     // on remonte donc explicitement toutes les régions ici.
     if (territoireCode === "NAT-FR") {
       const regions = await this.prisma.getInstance().territoire.findMany({
-        where: { maille: "REG" },
+        where: { code: { startsWith: "REG-" } },
         select: { code: true },
       });
       return [territoireCode, ...regions.map((region) => region.code)];

--- a/apps/pilote-ppg/src/server/albert/infrastructure/PrismaTerritoireResolver.ts
+++ b/apps/pilote-ppg/src/server/albert/infrastructure/PrismaTerritoireResolver.ts
@@ -14,6 +14,16 @@ export class PrismaTerritoireResolver implements TerritoireResolver {
   ): Promise<string[]> {
     if (!includeSousTerritoires) return [territoireCode];
 
+    // Les territoires REG-xxx n'ont pas NAT-FR comme parent en base ;
+    // on remonte donc explicitement toutes les régions ici.
+    if (territoireCode === "NAT-FR") {
+      const regions = await this.prisma.getInstance().territoire.findMany({
+        where: { maille: "REG" },
+        select: { code: true },
+      });
+      return [territoireCode, ...regions.map((region) => region.code)];
+    }
+
     const territoire = await this.prisma
       .getInstance()
       .territoire.findUniqueOrThrow({

--- a/apps/pilote-ppg/src/server/albert/module.ts
+++ b/apps/pilote-ppg/src/server/albert/module.ts
@@ -1,6 +1,7 @@
 import { createGetTauxAvancementTerritoireTool } from "@/server/albert/tools/getTauxAvancementTerritoire";
 import { createGetChantiersTool } from "@/server/albert/tools/getChantiers";
 import { createGetChantierIndicateursTool } from "@/server/albert/tools/getChantierIndicateurs";
+import { createGetChantierCommentairesTool } from "@/server/albert/tools/getChantierCommentaires";
 import { createComposeDashboardTool } from "@/server/albert/tools/composeDashboard";
 import type { ChantierExports } from "@/server/chantiers/module";
 import { EvaluerChatUseCase } from "@/server/albert/usecases/EvaluerChatUseCase";
@@ -36,6 +37,9 @@ type AlbertOwnCradle = {
   createGetChantierIndicateursTool: ReturnType<
     typeof createGetChantierIndicateursTool
   >;
+  createGetChantierCommentairesTool: ReturnType<
+    typeof createGetChantierCommentairesTool
+  >;
   createComposeDashboardTool: ReturnType<typeof createComposeDashboardTool>;
   createExportRapportTool: ReturnType<typeof createExportRapportTool>;
   evaluerChatUseCase: EvaluerChatUseCase;
@@ -63,6 +67,9 @@ export const albertModule = defineModule<NoExports, AlbertCradle>()({
       createGetChantiersTool: asModuleFunction(createGetChantiersTool),
       createGetChantierIndicateursTool: asModuleFunction(
         createGetChantierIndicateursTool,
+      ),
+      createGetChantierCommentairesTool: asModuleFunction(
+        createGetChantierCommentairesTool,
       ),
       createComposeDashboardTool: asModuleFunction(createComposeDashboardTool),
       createExportRapportTool: asModuleFunction(createExportRapportTool),

--- a/apps/pilote-ppg/src/server/albert/tools/getChantierCommentaires.ts
+++ b/apps/pilote-ppg/src/server/albert/tools/getChantierCommentaires.ts
@@ -2,16 +2,24 @@ import { tool } from "ai";
 import { z } from "zod";
 import { GetChantierCommentairesQuery } from "@/server/chantiers/query/GetChantierCommentairesQuery";
 import type { GetChantierCommentairesResult } from "@/server/chantiers/query/GetChantierCommentairesQuery";
+import type { TerritoireResolver } from "@/server/albert/domain/TerritoireResolver";
 
 export const getChantierCommentairesInputSchema = z.object({
   chantier_id: z.string().describe("Identifiant du chantier (ex: CH-001)"),
   territoire_code: z
     .string()
     .describe("Code du territoire (ex: NAT-FR, REG-11, DEPT-75)"),
+  include_sous_territoires: z
+    .boolean()
+    .optional()
+    .default(false)
+    .describe(
+      "Si true, inclut les commentaires des sous-territoires (ex: départements d'une région). Les objectifs du chantier ne sont retournés que pour le territoire principal puisqu'ils ne sont pas territorialisés.",
+    ),
 });
 
 export type GetChantierCommentairesOutput = {
-  resultats: GetChantierCommentairesResult;
+  resultats: GetChantierCommentairesResult[];
   _output_instructions: string;
 };
 
@@ -19,12 +27,15 @@ const OUTPUT_INSTRUCTIONS = `Présente les commentaires regroupés par type ou t
 
 export function createGetChantierCommentairesTool({
   getChantierCommentairesQuery,
+  territoireResolver,
 }: {
   getChantierCommentairesQuery: GetChantierCommentairesQuery;
+  territoireResolver: TerritoireResolver;
 }) {
   return ({ territoiresAccessibles }: { territoiresAccessibles: string[] }) => {
     return tool({
       description: `Récupère les contenus textuels publiés rattachés à un chantier sur un territoire donné (uniquement les contenus publiés — les brouillons sont exclus).
+Quand include_sous_territoires=true, retourne aussi les commentaires de chaque sous-territoire (les objectifs du chantier ne sont renvoyés qu'une fois, pour le territoire principal).
 
 Les contenus proviennent de trois sources et chaque résultat porte un champ \`type\` permettant de les distinguer :
 
@@ -52,13 +63,26 @@ Utilise cet outil quand l'utilisateur demande l'analyse qualitative ou contextue
           );
         }
 
-        const result = await getChantierCommentairesQuery.execute({
-          territoireCode: input.territoire_code,
-          chantierId: input.chantier_id,
-        });
+        const codes = await territoireResolver.resoudre(
+          input.territoire_code,
+          input.include_sous_territoires,
+        );
+        const codesAccessibles = codes.filter((code) =>
+          territoiresAccessibles.includes(code),
+        );
+
+        const resultats = await Promise.all(
+          codesAccessibles.map((code) =>
+            getChantierCommentairesQuery.execute({
+              territoireCode: code,
+              chantierId: input.chantier_id,
+              inclureObjectifs: code === input.territoire_code,
+            }),
+          ),
+        );
 
         return {
-          resultats: result,
+          resultats,
           _output_instructions: OUTPUT_INSTRUCTIONS,
         };
       },

--- a/apps/pilote-ppg/src/server/albert/tools/getChantierCommentaires.ts
+++ b/apps/pilote-ppg/src/server/albert/tools/getChantierCommentaires.ts
@@ -23,7 +23,7 @@ export type GetChantierCommentairesOutput = {
   _output_instructions: string;
 };
 
-const OUTPUT_INSTRUCTIONS = `Restitue chaque commentaire avec sa date, son auteur et son contenu verbatim, sans reformulation ni interprétation. Regroupe par type ou trie par date selon la demande de l'utilisateur. Ne reformule ou ne synthétise que si l'utilisateur le demande explicitement.`;
+const OUTPUT_INSTRUCTIONS = `Restitue chaque commentaire avec sa date, son auteur et son contenu verbatim, sans reformulation ni interprétation. Les contenus sont en HTML : extrais uniquement le texte (sans les balises) tout en conservant la formulation d'origine. Regroupe par type ou trie par date selon la demande de l'utilisateur. Ne reformule ou ne synthétise que si l'utilisateur le demande explicitement.`;
 
 export function createGetChantierCommentairesTool({
   getChantierCommentairesQuery,

--- a/apps/pilote-ppg/src/server/albert/tools/getChantierCommentaires.ts
+++ b/apps/pilote-ppg/src/server/albert/tools/getChantierCommentaires.ts
@@ -14,7 +14,7 @@ export const getChantierCommentairesInputSchema = z.object({
     .optional()
     .default(false)
     .describe(
-      "Si true, inclut les commentaires des sous-territoires (ex: départements d'une région). Les objectifs du chantier ne sont retournés que pour le territoire principal puisqu'ils ne sont pas territorialisés.",
+      "Si true, inclut les commentaires des sous-territoires (ex: départements d'une région, ou toutes les régions depuis NAT-FR). Les objectifs du chantier ne sont retournés que pour le territoire principal puisqu'ils ne sont pas territorialisés.",
     ),
 });
 
@@ -23,7 +23,7 @@ export type GetChantierCommentairesOutput = {
   _output_instructions: string;
 };
 
-const OUTPUT_INSTRUCTIONS = `Présente les commentaires regroupés par type ou triés par date selon la demande de l'utilisateur. Reformule chaque contenu en 1-2 phrases factuelles, sans recopie in extenso et sans interprétation.`;
+const OUTPUT_INSTRUCTIONS = `Restitue chaque commentaire avec sa date, son auteur et son contenu verbatim, sans reformulation ni interprétation. Regroupe par type ou trie par date selon la demande de l'utilisateur. Ne reformule ou ne synthétise que si l'utilisateur le demande explicitement.`;
 
 export function createGetChantierCommentairesTool({
   getChantierCommentairesQuery,
@@ -37,19 +37,17 @@ export function createGetChantierCommentairesTool({
       description: `Récupère les contenus textuels publiés rattachés à un chantier sur un territoire donné (uniquement les contenus publiés — les brouillons sont exclus).
 Quand include_sous_territoires=true, retourne aussi les commentaires de chaque sous-territoire (les objectifs du chantier ne sont renvoyés qu'une fois, pour le territoire principal).
 
-Les contenus proviennent de trois sources et chaque résultat porte un champ \`type\` permettant de les distinguer :
+Chaque résultat porte un champ \`type\` permettant de distinguer la nature du contenu :
 
-Issus de la synthèse des résultats (couple chantier × territoire) :
+Commentaires liés au couple chantier × territoire :
 - \`synthese_des_resultats\` : commentaire d'analyse accompagnant la météo de la synthèse du chantier sur le territoire
-
-Issus de la table commentaire (couple chantier × territoire) — le type est repris tel quel :
 - \`commentaires_sur_les_donnees\` : commentaires explicatifs sur les données du chantier sur le territoire
 - \`freins_a_lever\` : risques et freins à lever identifiés sur le territoire
 - \`actions_a_venir\` : solutions et actions à venir prévues sur le territoire
 - \`actions_a_valoriser\` : exemples concrets de réussite à valoriser sur le territoire
 - \`autres_resultats_obtenus_non_correles_aux_indicateurs\` : autres résultats obtenus non corrélés aux indicateurs sur le territoire
 
-Issus de la table objectif (rattachés au chantier, indépendamment du territoire) — le type est préfixé par \`objectif_\` :
+Objectifs rattachés au chantier (indépendamment du territoire) :
 - \`objectif_notre_ambition\` : ambition du chantier ("Notre ambition")
 - \`objectif_deja_fait\` : ce qui a déjà été fait
 - \`objectif_a_faire\` : ce qu'il reste à faire

--- a/apps/pilote-ppg/src/server/albert/tools/getChantierCommentaires.ts
+++ b/apps/pilote-ppg/src/server/albert/tools/getChantierCommentaires.ts
@@ -1,0 +1,67 @@
+import { tool } from "ai";
+import { z } from "zod";
+import { GetChantierCommentairesQuery } from "@/server/chantiers/query/GetChantierCommentairesQuery";
+import type { GetChantierCommentairesResult } from "@/server/chantiers/query/GetChantierCommentairesQuery";
+
+export const getChantierCommentairesInputSchema = z.object({
+  chantier_id: z.string().describe("Identifiant du chantier (ex: CH-001)"),
+  territoire_code: z
+    .string()
+    .describe("Code du territoire (ex: NAT-FR, REG-11, DEPT-75)"),
+});
+
+export type GetChantierCommentairesOutput = {
+  resultats: GetChantierCommentairesResult;
+  _output_instructions: string;
+};
+
+const OUTPUT_INSTRUCTIONS = `Présente les commentaires regroupés par type ou triés par date selon la demande de l'utilisateur. Reformule chaque contenu en 1-2 phrases factuelles, sans recopie in extenso et sans interprétation.`;
+
+export function createGetChantierCommentairesTool({
+  getChantierCommentairesQuery,
+}: {
+  getChantierCommentairesQuery: GetChantierCommentairesQuery;
+}) {
+  return ({ territoiresAccessibles }: { territoiresAccessibles: string[] }) => {
+    return tool({
+      description: `Récupère les contenus textuels publiés rattachés à un chantier sur un territoire donné (uniquement les contenus publiés — les brouillons sont exclus).
+
+Les contenus proviennent de trois sources et chaque résultat porte un champ \`type\` permettant de les distinguer :
+
+Issus de la synthèse des résultats (couple chantier × territoire) :
+- \`synthese_des_resultats\` : commentaire d'analyse accompagnant la météo de la synthèse du chantier sur le territoire
+
+Issus de la table commentaire (couple chantier × territoire) — le type est repris tel quel :
+- \`commentaires_sur_les_donnees\` : commentaires explicatifs sur les données du chantier sur le territoire
+- \`freins_a_lever\` : risques et freins à lever identifiés sur le territoire
+- \`actions_a_venir\` : solutions et actions à venir prévues sur le territoire
+- \`actions_a_valoriser\` : exemples concrets de réussite à valoriser sur le territoire
+- \`autres_resultats_obtenus_non_correles_aux_indicateurs\` : autres résultats obtenus non corrélés aux indicateurs sur le territoire
+
+Issus de la table objectif (rattachés au chantier, indépendamment du territoire) — le type est préfixé par \`objectif_\` :
+- \`objectif_notre_ambition\` : ambition du chantier ("Notre ambition")
+- \`objectif_deja_fait\` : ce qui a déjà été fait
+- \`objectif_a_faire\` : ce qu'il reste à faire
+
+Utilise cet outil quand l'utilisateur demande l'analyse qualitative ou contextuelle d'un chantier : ambitions, objectifs, freins, actions, réussites ou commentaires explicatifs.`,
+      inputSchema: getChantierCommentairesInputSchema,
+      execute: async (input): Promise<GetChantierCommentairesOutput> => {
+        if (!territoiresAccessibles.includes(input.territoire_code)) {
+          throw new Error(
+            `Accès non autorisé au territoire ${input.territoire_code}`,
+          );
+        }
+
+        const result = await getChantierCommentairesQuery.execute({
+          territoireCode: input.territoire_code,
+          chantierId: input.chantier_id,
+        });
+
+        return {
+          resultats: result,
+          _output_instructions: OUTPUT_INSTRUCTIONS,
+        };
+      },
+    });
+  };
+}

--- a/apps/pilote-ppg/src/server/chantiers/module.ts
+++ b/apps/pilote-ppg/src/server/chantiers/module.ts
@@ -52,6 +52,7 @@ import { GetAvancementChantierQuery } from "./infrastructure/queries/GetAvanceme
 import { GetSituationChantierQuery } from "./infrastructure/queries/GetSituationChantierQuery";
 import { GetChantiersQuery } from "./query/GetChantiersQuery";
 import { GetChantierIndicateursQuery } from "./query/GetChantierIndicateursQuery";
+import { GetChantierCommentairesQuery } from "./query/GetChantierCommentairesQuery";
 import { RecupererTauxAvancementTerritoireQuery } from "./query/RecupererTauxAvancementTerritoireQuery";
 import { RecupererStatistiquesAvancementTousChantiersPubliesQuery } from "./query/RecupererStatistiquesAvancementTousChantiersPubliesQuery";
 import { GetChantiersHabilitesQuery } from "./infrastructure/queries/GetChantiersHabilitesQuery";
@@ -61,6 +62,7 @@ type ChantierExports = {
   mesuresIndicateurQuery: RecupererMesuresIndicateurParPeriodeQuery;
   getChantiersQuery: GetChantiersQuery;
   getChantierIndicateursQuery: GetChantierIndicateursQuery;
+  getChantierCommentairesQuery: GetChantierCommentairesQuery;
 };
 
 type ChantierImports = IndicateurTerritoireValeurEvenementExports &
@@ -123,6 +125,7 @@ export const chantiersModule = defineModule<ChantierExports, ChantierCradle>()({
     "mesuresIndicateurQuery",
     "getChantiersQuery",
     "getChantierIndicateursQuery",
+    "getChantierCommentairesQuery",
   ],
   register: (container, { asModuleClass }) => {
     container.register({
@@ -219,6 +222,7 @@ export const chantiersModule = defineModule<ChantierExports, ChantierCradle>()({
       getSituationChantierQuery: asModuleClass(GetSituationChantierQuery),
       getChantiersQuery: asModuleClass(GetChantiersQuery),
       getChantierIndicateursQuery: asModuleClass(GetChantierIndicateursQuery),
+      getChantierCommentairesQuery: asModuleClass(GetChantierCommentairesQuery),
       recupererTauxAvancementTerritoireQuery: asModuleClass(
         RecupererTauxAvancementTerritoireQuery,
       ),

--- a/apps/pilote-ppg/src/server/chantiers/query/GetChantierCommentairesQuery.ts
+++ b/apps/pilote-ppg/src/server/chantiers/query/GetChantierCommentairesQuery.ts
@@ -22,8 +22,10 @@ export class GetChantierCommentairesQuery {
   async execute(params: {
     territoireCode: string;
     chantierId: string;
+    inclureObjectifs?: boolean;
   }): Promise<GetChantierCommentairesResult> {
     const prisma = this.deps.prisma.getInstance();
+    const inclureObjectifs = params.inclureObjectifs ?? true;
 
     const [commentaires, syntheses, objectifs] = await Promise.all([
       prisma.commentaire.findMany({
@@ -43,13 +45,15 @@ export class GetChantierCommentairesQuery {
         },
         include: { auteur_modification: true },
       }),
-      prisma.objectif.findMany({
-        where: {
-          chantier_id: params.chantierId,
-          statut: $Enums.statut_publication.PUBLIE,
-        },
-        include: { auteur_modification: true },
-      }),
+      inclureObjectifs
+        ? prisma.objectif.findMany({
+            where: {
+              chantier_id: params.chantierId,
+              statut: $Enums.statut_publication.PUBLIE,
+            },
+            include: { auteur_modification: true },
+          })
+        : Promise.resolve([]),
     ]);
 
     const items: GetChantierCommentairesResult["commentaires"] = [

--- a/apps/pilote-ppg/src/server/chantiers/query/GetChantierCommentairesQuery.ts
+++ b/apps/pilote-ppg/src/server/chantiers/query/GetChantierCommentairesQuery.ts
@@ -1,0 +1,98 @@
+import { $Enums } from "@prisma/client";
+import { PrismaPilote } from "@/server/db/PrismaPilote";
+
+export type GetChantierCommentairesResult = {
+  territoire_code: string;
+  chantier_id: string;
+  commentaires: {
+    id: string;
+    date_publication: string;
+    contenu: string;
+    auteur: {
+      id: string;
+      nom: string;
+    };
+    type: string;
+  }[];
+};
+
+export class GetChantierCommentairesQuery {
+  constructor(private readonly deps: { prisma: PrismaPilote }) {}
+
+  async execute(params: {
+    territoireCode: string;
+    chantierId: string;
+  }): Promise<GetChantierCommentairesResult> {
+    const prisma = this.deps.prisma.getInstance();
+
+    const [commentaires, syntheses, objectifs] = await Promise.all([
+      prisma.commentaire.findMany({
+        where: {
+          chantier_id: params.chantierId,
+          territoire_code: params.territoireCode,
+          statut: $Enums.statut_publication.PUBLIE,
+        },
+        include: { auteur_modification: true },
+      }),
+      prisma.synthese_des_resultats.findMany({
+        where: {
+          chantier_id: params.chantierId,
+          territoire_code: params.territoireCode,
+          statut: $Enums.statut_publication.PUBLIE,
+          commentaire: { not: null },
+        },
+        include: { auteur_modification: true },
+      }),
+      prisma.objectif.findMany({
+        where: {
+          chantier_id: params.chantierId,
+          statut: $Enums.statut_publication.PUBLIE,
+        },
+        include: { auteur_modification: true },
+      }),
+    ]);
+
+    const items: GetChantierCommentairesResult["commentaires"] = [
+      ...commentaires.map((commentaire) => ({
+        id: commentaire.id,
+        date_publication: commentaire.date_modification.toISOString(),
+        contenu: commentaire.contenu,
+        auteur: {
+          id: commentaire.auteur_modification.id,
+          nom: `${commentaire.auteur_modification.prenom} ${commentaire.auteur_modification.nom}`,
+        },
+        type: commentaire.type,
+      })),
+      ...syntheses.map((synthese) => ({
+        id: synthese.id,
+        date_publication: synthese.date_modification.toISOString(),
+        contenu: synthese.commentaire as string,
+        auteur: {
+          id: synthese.auteur_modification.id,
+          nom: `${synthese.auteur_modification.prenom} ${synthese.auteur_modification.nom}`,
+        },
+        type: "synthese_des_resultats",
+      })),
+      ...objectifs.map((objectif) => ({
+        id: objectif.id,
+        date_publication: objectif.date_modification.toISOString(),
+        contenu: objectif.contenu,
+        auteur: {
+          id: objectif.auteur_modification.id,
+          nom: `${objectif.auteur_modification.prenom} ${objectif.auteur_modification.nom}`,
+        },
+        type: `objectif_${objectif.type}`,
+      })),
+    ];
+
+    items.sort((left, right) =>
+      right.date_publication.localeCompare(left.date_publication),
+    );
+
+    return {
+      territoire_code: params.territoireCode,
+      chantier_id: params.chantierId,
+      commentaires: items,
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- Le `PrismaTerritoireResolver` retourne maintenant explicitement toutes les régions (`maille = REG`) lorsque l'appelant demande les sous-territoires de `NAT-FR`.
- Contournement assumé : en base les `REG-xxx` n'ont pas `NAT-FR` comme parent, et corriger le graphe territorial directement aurait trop d'effets de bord.
- D'autres ajustements à venir sur cette branche.

## Test plan
- [ ] Vérifier qu'une requête Albert avec `territoireCode = NAT-FR` et `includeSousTerritoires = true` agrège bien les données de toutes les régions
- [ ] Vérifier qu'aucune autre maille (DEPT, NAT) n'est régressée

🤖 Generated with [Claude Code](https://claude.com/claude-code)