### PR TITLE
fix(albert): afficher la conversation sélectionnée dès le premier clic

### DIFF
--- a/apps/pilote-ppg/src/client/components/PageAccueil/BoutonSyntheseTerritoire.tsx
+++ b/apps/pilote-ppg/src/client/components/PageAccueil/BoutonSyntheseTerritoire.tsx
@@ -24,14 +24,24 @@ export const BoutonSyntheseTerritoire = ({
   const [activeChatId, setActiveChatId] = useState<string>(() =>
     crypto.randomUUID(),
   );
+  const [conversationPersistee, setConversationPersistee] = useState(false);
   const { data: conversationChargee, isFetched: conversationChargeeFetched } =
     api.albert.conversations.recuperer.useQuery(
       { id: activeChatId },
-      { enabled: ffHistorique === true && isOpen, retry: false },
+      {
+        enabled: ffHistorique === true && isOpen && conversationPersistee,
+        retry: false,
+      },
     );
-  const conversationPrete = !ffHistorique || conversationChargeeFetched;
+  const conversationPrete =
+    !ffHistorique || !conversationPersistee || conversationChargeeFetched;
+  const selectionnerConversation = (id: string) => {
+    setActiveChatId(id);
+    setConversationPersistee(true);
+  };
   const demarrerNouvelleConversation = () => {
     setActiveChatId(crypto.randomUUID());
+    setConversationPersistee(false);
   };
   const rafraichirHistorique = () => {
     utilsTrpc.albert.conversations.lister.invalidate();
@@ -149,7 +159,7 @@ Quelles sont les principales difficultés remontées dans les commentaires ?`,
             {ffHistorique ? (
               <ConversationHistoryDrawer
                 chatIdCourant={activeChatId}
-                onSelectionner={setActiveChatId}
+                onSelectionner={selectionnerConversation}
                 onNouvelleConversation={demarrerNouvelleConversation}
               />
             ) : null}

--- a/apps/pilote-ppg/src/client/components/PageAccueil/BoutonSyntheseTerritoire.tsx
+++ b/apps/pilote-ppg/src/client/components/PageAccueil/BoutonSyntheseTerritoire.tsx
@@ -5,6 +5,7 @@ import { Icone } from "@/components/_commons/Icone";
 import { SparklingIcon } from "@/components/_commons/Icones/SparklingIcon";
 import { ChatScenarios, ChatUI } from "@/components/_commons/ChatUI/ChatUI";
 import { ConversationHistoryDrawer } from "@/components/_commons/ChatUI/ConversationHistoryDrawer";
+import Loader from "@/components/_commons/Loader/Loader";
 import { ModalePleinEcran } from "@/components/shared/ModalePleinEcran";
 import api from "@/server/infrastructure/api/trpc/api";
 
@@ -23,11 +24,12 @@ export const BoutonSyntheseTerritoire = ({
   const [activeChatId, setActiveChatId] = useState<string>(() =>
     crypto.randomUUID(),
   );
-  const { data: conversationChargee } =
+  const { data: conversationChargee, isFetched: conversationChargeeFetched } =
     api.albert.conversations.recuperer.useQuery(
       { id: activeChatId },
       { enabled: ffHistorique === true && isOpen, retry: false },
     );
+  const conversationPrete = !ffHistorique || conversationChargeeFetched;
   const demarrerNouvelleConversation = () => {
     setActiveChatId(crypto.randomUUID());
   };
@@ -151,22 +153,26 @@ Quelles sont les principales difficultés remontées dans les commentaires ?`,
                 onNouvelleConversation={demarrerNouvelleConversation}
               />
             ) : null}
-            <div className="flex-1">
-              <ChatUI
-                key={activeChatId}
-                chatId={activeChatId}
-                initialMessages={conversationChargee?.messages}
-                onChatFinish={ffHistorique ? rafraichirHistorique : undefined}
-                endpoint="/api/albert/chat"
-                className="h-full"
-                placeholder="Posez une question sur ce territoire..."
-                scenarios={scenarios}
-                agentContext={{
-                  jalon,
-                  territoireCode,
-                  instructions: `Le territoire courant de l'utilisateur est ${territoire.nomAffiché} (code : ${territoireCode}). Utilise ce territoire par défaut lorsque l'utilisateur ne précise pas de territoire dans sa question.`,
-                }}
-              />
+            <div className="flex-1 relative">
+              {conversationPrete ? (
+                <ChatUI
+                  key={activeChatId}
+                  chatId={activeChatId}
+                  initialMessages={conversationChargee?.messages}
+                  onChatFinish={ffHistorique ? rafraichirHistorique : undefined}
+                  endpoint="/api/albert/chat"
+                  className="h-full"
+                  placeholder="Posez une question sur ce territoire..."
+                  scenarios={scenarios}
+                  agentContext={{
+                    jalon,
+                    territoireCode,
+                    instructions: `Le territoire courant de l'utilisateur est ${territoire.nomAffiché} (code : ${territoireCode}). Utilise ce territoire par défaut lorsque l'utilisateur ne précise pas de territoire dans sa question.`,
+                  }}
+                />
+              ) : (
+                <Loader />
+              )}
             </div>
           </div>
         </ModalePleinEcran>


### PR DESCRIPTION
## Summary

- L'historique des conversations Albert affichait le contenu uniquement au 3e clic (séquence A → B → A) au lieu du 1er.
- `ChatUI` capturait `initialMessages` via `useRef(new Chat(...))` au mount, donc quand `activeChatId` changeait, ChatUI remontait avant que la query tRPC `recuperer` ait résolu → `initialMessages=undefined` → instance Chat vide, et la mise à jour ultérieure des données n'était jamais propagée. Le cas qui "marche" au 3e clic, c'est juste le cache React Query qui rend la donnée disponible synchroniquement au remount.
- Effet de bord supprimé au passage : si l'utilisateur tapait un message dans ce chat "vide" mal chargé, `enregistrerConversation` écrasait la conversation persistée avec un seul échange.

## Fix

On attend que la query soit `isFetched` avant de monter `ChatUI`, avec un `Loader` pendant le fetch. Les conversations déjà visitées profitent du cache → pas de flash visible.

## Test plan

- [ ] Activer `NEXT_PUBLIC_FF_HISTORIQUE_ALBERT`, créer 2 conversations distinctes
- [ ] Recharger la page → cliquer sur la conversation A : son contenu s'affiche immédiatement
- [ ] Cliquer sur B : son contenu s'affiche immédiatement
- [ ] Re-cliquer sur A : son contenu s'affiche immédiatement (et pas celui de B)
- [ ] Nouvelle conversation : chat vide, scenarios visibles