### PR TITLE
chore: exclure next de minimumReleaseAge

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,3 +6,6 @@ packages:
 # (mitigation supply-chain : laisse le temps de détecter un package compromis)
 # https://pnpm.io/settings#minimumreleaseage
 minimumReleaseAge: 20160
+# https://pnpm.io/settings#minimumreleaseageexclude
+minimumReleaseAgeExclude:
+  - next


### PR DESCRIPTION
## Summary
- Ajoute `next` à `minimumReleaseAgeExclude` dans `pnpm-workspace.yaml`
- Débloque le CI (fetch sur `dev`) qui échouait car la dernière version de `next` a été publiée il y a moins de 2 semaines

Ref: https://pnpm.io/settings#minimumreleaseageexclude

## Test plan
- [ ] CI fetch passe sur `dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)