### PR TITLE
chore: exclure next et @next/* de minimumReleaseAge

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,3 +6,7 @@ packages:
 # (mitigation supply-chain : laisse le temps de détecter un package compromis)
 # https://pnpm.io/settings#minimumreleaseage
 minimumReleaseAge: 20160
+# https://pnpm.io/settings#minimumreleaseageexclude
+minimumReleaseAgeExclude:
+  - next
+  - "@next/*"


### PR DESCRIPTION
## Summary
- Le build deploy échoue sur `@next/swc-linux-x64-musl@16.2.6` (publié il y a 13 jours, alors que `minimumReleaseAge` est à 14 jours)
- Ajout de `minimumReleaseAgeExclude` avec `next` et le pattern `@next/*` pour couvrir tous les binaires SWC transitifs (`@next/swc-linux-x64-musl`, `@next/swc-darwin-arm64`, etc.)
- Les patterns glob dans `minimumReleaseAgeExclude` sont supportés depuis pnpm 10.17 (on est en 10.28)

## Test plan
- [x] `pnpm install` passe en local
- [ ] CI deploy vert sur `pilote-ppg`

🤖 Generated with [Claude Code](https://claude.com/claude-code)