### PR TITLE
feat(albert): améliorations du system prompt et des outils (PIL-1522 / PIL-1525 / PIL-1527 / PIL-1528)

### DIFF
--- a/apps/pilote-ppg/src/server/albert/systemPrompt.ts
+++ b/apps/pilote-ppg/src/server/albert/systemPrompt.ts
@@ -233,9 +233,12 @@ Ces règles s'appliquent à TOUTES tes réponses, sans exception.
 - Extrais uniquement les idées clés sans interprétation ni jugement
 - Si aucun commentaire n'est disponible, écris "Pas de commentaire disponible"
 
-## Résultats vides
-- Si un outil retourne une liste vide, indique-le explicitement à l'utilisateur
-- Si aucun chantier n'est en retard ni en difficulté, dis-le — c'est une information utile
+## Résultats vides vs périmètre non interrogé
+**Règle d'or** : ne JAMAIS conclure "il n'y a pas de donnée" sans avoir appelé l'outil sur le périmètre concerné. L'absence de donnée dans ton contexte n'est PAS une absence de donnée — c'est juste que tu n'as pas interrogé l'outil sur ce périmètre.
+
+- Si un outil **retourne explicitement** une liste vide pour le périmètre demandé → tu peux dire "il n'y en a pas"
+- Si tu n'as **pas encore interrogé** l'outil sur le périmètre demandé (nouveau territoire, nouveau jalon, échelon non couvert) → tu DOIS appeler l'outil avant de répondre, jamais conclure depuis le contexte
+- Si aucun chantier n'est en retard ni en difficulté (résultat outil vide), dis-le — c'est une information utile
 
 ## Tableaux
 - N'utilise **pas de tableaux** pour présenter les listes de chantiers (en retard ou en difficulté)
@@ -393,8 +396,18 @@ côté client — ils fournissent des données que tu utilises dans ton texte ou
 le dashboard.
 Ne commente pas les chiffres du dashboard dans ta réponse textuelle (les valeurs sont résolues côté client).
 
-## Questions de suivi
-Pour une question de suivi sur un nouveau territoire ou un nouveau jalon, rappelle les outils nécessaires. Ne réutilise les résultats précédents que si le territoire et le jalon sont identiques.
+## Questions de suivi et élargissement de périmètre
+Une question de suivi qui élargit ou modifie le périmètre nécessite un **nouvel appel d'outils** sur le périmètre ajouté. Tu ne peux réutiliser les résultats précédents QUE si le périmètre (territoire + jalon + portée) est strictement identique.
+
+**Déclencheurs d'un nouvel appel d'outils** (liste non exhaustive) :
+- Nouveau territoire mentionné, même en complément d'un territoire déjà analysé ("ajoute aussi le Nord", "et la Bretagne ?")
+- Élargissement à l'échelon national ("ajoute le national", "et au niveau France entière ?", "complète avec NAT-FR")
+- Ajout des sous-territoires ("et ses départements", "détaille par département")
+- Nouveau jalon ("et en 2024 ?")
+- Nouveau chantier non analysé précédemment
+- Toute formulation de type "complète", "ajoute", "élargis", "et aussi…"
+
+**Exemple concret** : tu as analysé REG-32 et ses départements ; l'utilisateur demande "complète avec les commentaires au niveau national". Tu DOIS appeler les outils avec territoire_code=NAT-FR avant de répondre. Tu ne dois PAS conclure "il n'y a pas de commentaires nationaux" depuis ton contexte — tu n'as simplement pas encore interrogé NAT-FR (cf. règle d'or "Résultats vides vs périmètre non interrogé").
 
 ## display_choices
 **N'utilise PAS** display_choices pour :

--- a/apps/pilote-ppg/src/server/albert/systemPrompt.ts
+++ b/apps/pilote-ppg/src/server/albert/systemPrompt.ts
@@ -214,6 +214,7 @@ Tu es un assistant spécialisé dans l'analyse des données des chantiers priori
 - Répondre à des questions hors sujet (culture générale, météo réelle, code, etc.)
 - Formuler des opinions, des recommandations ou des jugements
 - Inventer des données ou des chiffres non issus de tes outils
+- Répondre aux questions sur les propositions de valeur d'avancement (PVA) — fonctionnalité non disponible via Albert
 
 Si l'utilisateur pose une question hors de ton périmètre, indique poliment que tu es un assistant spécialisé PILOTE et que tu ne peux pas répondre à cette question.
 
@@ -272,8 +273,10 @@ Les territoires suivent une hiérarchie à 3 niveaux :
 - **REG-XX** : Régions (XX = code INSEE de la région)
 - **DEPT-XX** : Départements (XX = code INSEE du département)
 
+Quand l'utilisateur parle de "la France", du "national", de "l'échelon national" ou de "France entière", il désigne **NAT-FR**.
+
 ## Météo
-La météo est un indicateur qualitatif de la situation d'un chantier sur un territoire, saisi par les équipes responsables. Échelle de sévérité (du meilleur au pire) :
+La météo est un indicateur qualitatif de la situation d'un chantier sur un territoire, saisi par les équipes responsables. Dans certaines vues de l'UI (cartographie notamment), la météo est également appelée **"niveau de confiance"** — les deux termes désignent la même donnée. Échelle de sévérité (du meilleur au pire) :
 
 1. **SOLEIL** — Objectifs sécurisés
 2. **COUVERT** — Objectifs atteignables
@@ -320,6 +323,20 @@ ${agentContextSection}
 
 Tu as accès aux territoires suivants pour l'utilisateur actuel :
 ${territoiresList}
+
+# Comprendre les demandes utilisateur
+
+Les utilisateurs (préfets, coordinateurs territoriaux, référents ministériels) n'utilisent pas toujours le vocabulaire officiel. Voici comment interpréter les expressions courantes :
+
+| Expression utilisateur | Interprétation |
+|---|---|
+| "chantiers qui vont mal", "où ça coince", "les points noirs", "ce sur quoi je dois me concentrer", "chantiers en alerte", "chantiers à risque" | Les deux catégories réunies : appelle get_chantiers(view='en_retard') ET get_chantiers(view='en_difficulte') |
+| "chantiers à la traîne", "en retard", "qui prennent du retard" | view='en_retard' uniquement |
+| "chantiers qui nécessitent un appui", "qui ont besoin d'aide" | view='en_difficulte' uniquement |
+| "chantiers compromis" | **Ambigu** : peut désigner la météo ORAGE ("Objectifs compromis") ou les chantiers les plus à risque. Par défaut, appelle les deux views pour couvrir les deux interprétations. |
+| "niveau de confiance" | Synonyme de météo |
+| "PPG" | Synonyme de chantier |
+| "la France", "national", "France entière" | NAT-FR |
 
 # Protocole d'utilisation des outils
 

--- a/apps/pilote-ppg/src/server/albert/systemPrompt.ts
+++ b/apps/pilote-ppg/src/server/albert/systemPrompt.ts
@@ -352,6 +352,7 @@ Les outils s'invoquent **uniquement** via le mécanisme de function calling four
 - Tu peux appeler plusieurs outils en parallèle si la question le nécessite.
 - Si la question ne nécessite pas d'outil de données, réponds directement sans appeler d'outil.
 - Sauf indication contraire de l'utilisateur, utilise toujours le jalon courant (${jalon}) pour tes requêtes.
+- Si la réponse d'un outil contient un champ \`non_applicable\` avec une \`raison\`, l'analyse demandée n'est pas calculable sur ce périmètre. Explique-le à l'utilisateur en reprenant fidèlement la raison fournie. Ne présente PAS de liste vide ni ne conclus à une absence de résultats : c'est l'analyse elle-même qui n'est pas pertinente, pas les données qui manquent.
 
 ## Patterns de workflow
 

--- a/apps/pilote-ppg/src/server/albert/tools/getChantiers.ts
+++ b/apps/pilote-ppg/src/server/albert/tools/getChantiers.ts
@@ -56,7 +56,7 @@ export type GetChantiersOutput = {
 };
 
 const NON_APPLICABLE_EN_RETARD_NAT_FR =
-  "L'analyse des chantiers en retard repose sur la comparaison du taux d'avancement de chaque chantier au taux médian observé sur les autres territoires. Elle n'est donc pas calculable au niveau national (NAT-FR), qui constitue l'agrégat de référence et n'a pas de médiane comparative.";
+  "L'analyse des chantiers en retard ne peut pas être réalisée au niveau national.\n\nEn effet, cet indicateur repose sur une comparaison entre le taux d'avancement d'un chantier pour un territoire donné et la valeur médiane observée sur l'ensemble des autres territoires.";
 
 function getOutputInstructions(input: GetChantiersInput): string {
   if (input.view === "en_retard") {

--- a/apps/pilote-ppg/src/server/albert/tools/getChantiers.ts
+++ b/apps/pilote-ppg/src/server/albert/tools/getChantiers.ts
@@ -51,8 +51,12 @@ type GetChantiersInput = z.infer<typeof getChantiersInputSchema>;
 
 export type GetChantiersOutput = {
   resultats: GetChantiersResult[];
+  non_applicable?: { raison: string };
   _output_instructions: string;
 };
+
+const NON_APPLICABLE_EN_RETARD_NAT_FR =
+  "L'analyse des chantiers en retard repose sur la comparaison du taux d'avancement de chaque chantier au taux médian observé sur les autres territoires. Elle n'est donc pas calculable au niveau national (NAT-FR), qui constitue l'agrégat de référence et n'a pas de médiane comparative.";
 
 function getOutputInstructions(input: GetChantiersInput): string {
   if (input.view === "en_retard") {
@@ -117,6 +121,19 @@ Quand include_sous_territoires=true, retourne aussi les chantiers de chaque sous
           throw new Error(
             `Accès non autorisé au territoire ${input.territoire_code}`,
           );
+        }
+
+        if (
+          input.territoire_code === "NAT-FR" &&
+          input.view === "en_retard" &&
+          !input.include_sous_territoires
+        ) {
+          return {
+            resultats: [],
+            non_applicable: { raison: NON_APPLICABLE_EN_RETARD_NAT_FR },
+            _output_instructions:
+              "L'analyse demandée n'est pas applicable au périmètre interrogé. Explique-le clairement à l'utilisateur en reprenant fidèlement la raison fournie dans non_applicable.raison. Ne présente pas de liste vide ni ne conclus 'aucun chantier en retard'.",
+          };
         }
 
         const filteredChantierIds = input.chantier_ids?.filter((id) =>


### PR DESCRIPTION
## Summary

Plusieurs ajustements du system prompt d'Albert et de ses outils pour mieux coller au comportement attendu :

### Alignement du vocabulaire (PIL-1522 / PIL-1525)
- Ajout d'une section "Comprendre les demandes utilisateur" mappant les expressions courantes ("points noirs", "à la traîne", "où ça coince", "en alerte"...) aux bonnes vues d'outils.
- Synonymes métier explicités : "niveau de confiance" = météo (libellé de la cartographie UI), "PPG" = chantier, "France" = NAT-FR.
- Exclusion explicite des PVA (fonctionnalité non disponible via Albert).

### Élargissement de périmètre (PIL-1527)
- Règle d'or "Résultats vides vs périmètre non interrogé" : interdit de conclure "absence de donnée" depuis le contexte sans avoir interrogé l'outil sur le périmètre concerné.
- Section "Questions de suivi" renforcée : liste des déclencheurs d'un nouvel appel d'outils (nouveau territoire, élargissement au national, ajout des sous-territoires, nouveau jalon...).
- Exemple concret ancrant le comportement attendu sur le cas d'usage du ticket (analyse régionale puis ajout du national).

### Cas non applicables (PIL-1528)
- Nouveau champ optionnel `non_applicable: { raison }` dans la sortie de `get_chantiers`.
- Détection précoce de la combinaison `NAT-FR + view='en_retard'` (sans sous-territoires) : l'écart à la médiane n'est pas calculable au niveau national, l'outil renvoie une raison métier qu'Albert reformule au lieu de retourner une liste vide.
- Bullet ajouté dans le protocole d'outils du system prompt pour qu'Albert sache lire le champ `non_applicable` et ne PAS conclure à une absence de résultats.

## Test plan
- [ ] Prompts vocabulaire : "les points noirs de ma région", "les PPG à la traîne", "comment va la France sur les chantiers compromis".
- [ ] Refus poli des questions sur les PVA.
- [ ] Synonyme "niveau de confiance" → lecture météo.
- [ ] Scénario PIL-1527 : analyser une région et ses départements, puis demander "complète avec le national" → Albert doit rappeler les outils sur NAT-FR, pas conclure "il n'y en a pas".
- [ ] Scénario PIL-1528 : demander "les chantiers en retard au niveau national" → Albert doit expliquer que l'analyse n'est pas calculable au niveau national (écart à la médiane), pas répondre "aucun chantier en retard".
- [ ] Vérifier que "synthèse de la France et de ses régions" (avec sous-territoires) fonctionne normalement (les régions ont bien un écart calculable).

Generated with Claude Code