### PR TITLE
feat(mb-webapp): graphique d'évolution des valeurs d'un indicateur

### DIFF
--- a/apps/mb-webapp/package.json
+++ b/apps/mb-webapp/package.json
@@ -37,6 +37,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "dotenv": "16.4.5",
+    "echarts-for-react": "3.0.6",
     "hono": "^4.12.18",
     "hono-rate-limiter": "^0.5.3",
     "iron-session": "^8.0.4",

--- a/apps/mb-webapp/src/components/indicateurs/IndicateurCard.tsx
+++ b/apps/mb-webapp/src/components/indicateurs/IndicateurCard.tsx
@@ -2,16 +2,12 @@ import type { IndicateurApiModel } from '@pilote/mb-shared/indicateur'
 import { Link } from '@tanstack/react-router'
 
 import { EntityCard } from '@/components/ui/EntityCard'
-
-const dateFormatter = new Intl.DateTimeFormat('fr-FR', {
-  month: '2-digit',
-  year: 'numeric',
-})
+import { formatMonthYearNumericFr } from '@/lib/format'
 
 function formatMiseAJour(iso: string): string {
   const date = new Date(iso)
   if (Number.isNaN(date.getTime())) return '—'
-  return dateFormatter.format(date)
+  return formatMonthYearNumericFr(date)
 }
 
 type IndicateurCardProps = {

--- a/apps/mb-webapp/src/components/indicateurs/IndicateurMetadonnees.tsx
+++ b/apps/mb-webapp/src/components/indicateurs/IndicateurMetadonnees.tsx
@@ -1,4 +1,5 @@
 import { DescriptionList } from '@/components/ui/DescriptionList'
+import { formatDateTimeFr } from '@/lib/format'
 
 type IndicateurMetadonneesProps = {
   indicateur: {
@@ -15,10 +16,10 @@ export function IndicateurMetadonnees({ indicateur }: IndicateurMetadonneesProps
       <DescriptionList.Item label="ID">{indicateur.id}</DescriptionList.Item>
       <DescriptionList.Item label="Nom">{indicateur.nom}</DescriptionList.Item>
       <DescriptionList.Item label="Créé le">
-        {new Date(indicateur.createdAt).toLocaleString('fr-FR')}
+        {formatDateTimeFr(indicateur.createdAt)}
       </DescriptionList.Item>
       <DescriptionList.Item label="Mis à jour le">
-        {new Date(indicateur.updatedAt).toLocaleString('fr-FR')}
+        {formatDateTimeFr(indicateur.updatedAt)}
       </DescriptionList.Item>
     </DescriptionList>
   )

--- a/apps/mb-webapp/src/components/indicateurs/IndicateurStatsPanel.tsx
+++ b/apps/mb-webapp/src/components/indicateurs/IndicateurStatsPanel.tsx
@@ -2,12 +2,11 @@ import { useSuspenseQuery } from '@tanstack/react-query'
 
 import { StatCard } from '@/components/ui/StatCard'
 import { StatGrid } from '@/components/ui/StatGrid'
+import { formatNumberFr } from '@/lib/format'
 import { indicateurValeursRemarquablesQueryOptions } from '@/queries/indicateurs'
 
-const numberFormatter = new Intl.NumberFormat('fr-FR')
-
 const formatStat = (value: number | null): string =>
-  value === null ? '—' : numberFormatter.format(value)
+  value === null ? '—' : formatNumberFr(value)
 
 type IndicateurStatsPanelProps = {
   indicateurId: string

--- a/apps/mb-webapp/src/components/indicateurs/IndicateurStatsPanel.tsx
+++ b/apps/mb-webapp/src/components/indicateurs/IndicateurStatsPanel.tsx
@@ -5,8 +5,7 @@ import { StatGrid } from '@/components/ui/StatGrid'
 import { formatNumberFr } from '@/lib/format'
 import { indicateurValeursRemarquablesQueryOptions } from '@/queries/indicateurs'
 
-const formatStat = (value: number | null): string =>
-  value === null ? '—' : formatNumberFr(value)
+const formatStat = (value: number | null): string => (value === null ? '—' : formatNumberFr(value))
 
 type IndicateurStatsPanelProps = {
   indicateurId: string

--- a/apps/mb-webapp/src/components/indicateurs/IndicateurValeursChart.tsx
+++ b/apps/mb-webapp/src/components/indicateurs/IndicateurValeursChart.tsx
@@ -2,98 +2,35 @@ import { useSuspenseQuery } from '@tanstack/react-query'
 import ReactECharts from 'echarts-for-react'
 import { useMemo } from 'react'
 
+import { buildMonthlySeries } from '@/components/indicateurs/MonthlySeries'
+import { formatMonthYearShortFr, formatNumberFr } from '@/lib/format'
 import { indicateurValeursQueryOptions } from '@/queries/indicateurs'
+
+// 13 (et non 12) pour faire apparaître deux occurrences du même mois sur les indicateurs saisis une fois par an.
+const DEFAULT_WINDOW = 13
 
 type IndicateurValeursChartProps = {
   indicateurId: string
   individuId: string
 }
 
-const monthLabelFormatter = new Intl.DateTimeFormat('fr-FR', {
-  month: 'short',
-  year: '2-digit',
-})
-const valueFormatter = new Intl.NumberFormat('fr-FR')
-
-// 13 (et non 12) pour faire apparaître deux occurrences du même mois sur les indicateurs saisis une fois par an.
-const DEFAULT_WINDOW = 13
-
-type Item = { date: string; valeur: number }
-type MonthRef = { year: number; month: number }
-
-function latestValuePerMonth(items: ReadonlyArray<Item>): Map<string, number> {
-  const lastDateByMonth = new Map<string, string>()
-  const valueByMonth = new Map<string, number>()
-  for (const item of items) {
-    const ym = item.date.slice(0, 7)
-    const lastDate = lastDateByMonth.get(ym)
-    if (!lastDate || item.date > lastDate) {
-      lastDateByMonth.set(ym, item.date)
-      valueByMonth.set(ym, item.valeur)
-    }
-  }
-  return valueByMonth
-}
-
-function monthRefFromDate(date: Date): MonthRef {
-  return { year: date.getUTCFullYear(), month: date.getUTCMonth() }
-}
-
-function range(items: ReadonlyArray<Item>): { start: MonthRef; end: MonthRef } {
-  let earliest: string | undefined
-  let latest: string | undefined
-  for (const item of items) {
-    if (!earliest || item.date < earliest) earliest = item.date
-    if (!latest || item.date > latest) latest = item.date
-  }
-  const end = monthRefFromDate(latest ? new Date(latest) : new Date())
-  const endIndex = end.year * 12 + end.month
-  const earliestRef = earliest ? monthRefFromDate(new Date(earliest)) : end
-  const earliestIndex = earliestRef.year * 12 + earliestRef.month
-  const minStartIndex = endIndex - (DEFAULT_WINDOW - 1)
-  const startIndex = Math.min(earliestIndex, minStartIndex)
-  const start = { year: Math.floor(startIndex / 12), month: ((startIndex % 12) + 12) % 12 }
-  return { start, end }
-}
-
-function monthsBetween(start: MonthRef, end: MonthRef) {
-  const startIndex = start.year * 12 + start.month
-  const endIndex = end.year * 12 + end.month
-  const months: { ym: string; date: Date }[] = []
-  for (let i = startIndex; i <= endIndex; i++) {
-    const year = Math.floor(i / 12)
-    const month = ((i % 12) + 12) % 12
-    const date = new Date(Date.UTC(year, month, 1))
-    const ym = `${year}-${String(month + 1).padStart(2, '0')}`
-    months.push({ ym, date })
-  }
-  return months
-}
-
 export function IndicateurValeursChart({ indicateurId, individuId }: IndicateurValeursChartProps) {
   const { data } = useSuspenseQuery(indicateurValeursQueryOptions(indicateurId, individuId))
 
-  const { labels, values, startIndex, endIndex } = useMemo(() => {
-    const valueByMonth = latestValuePerMonth(data.items)
-    const { start, end } = range(data.items)
-    const months = monthsBetween(start, end)
-    const last = months.length - 1
-    return {
-      labels: months.map((m) => monthLabelFormatter.format(m.date)),
-      values: months.map((m) => valueByMonth.get(m.ym) ?? null),
-      startIndex: Math.max(0, last - (DEFAULT_WINDOW - 1)),
-      endIndex: last,
-    }
-  }, [data.items])
+  const series = useMemo(
+    () => buildMonthlySeries({ valeurs: data.items, windowSize: DEFAULT_WINDOW }),
+    [data.items],
+  )
 
-  const showSlider = labels.length > DEFAULT_WINDOW
+  const labels = series.months.map((month) => formatMonthYearShortFr(month.date))
+  const showSlider = series.months.length > DEFAULT_WINDOW
 
   const option = {
     grid: { top: 32, right: 24, bottom: showSlider ? 60 : 32, left: 56 },
     tooltip: {
       trigger: 'axis',
-      valueFormatter: (val: unknown) =>
-        typeof val === 'number' ? valueFormatter.format(val) : '—',
+      valueFormatter: (value: unknown) =>
+        typeof value === 'number' ? formatNumberFr(value) : '—',
     },
     xAxis: {
       type: 'category',
@@ -103,13 +40,23 @@ export function IndicateurValeursChart({ indicateurId, individuId }: IndicateurV
     yAxis: {
       type: 'value',
       axisLabel: {
-        formatter: (val: number) => valueFormatter.format(val),
+        formatter: (value: number) => formatNumberFr(value),
       },
     },
     dataZoom: showSlider
       ? [
-          { type: 'inside', startValue: startIndex, endValue: endIndex },
-          { type: 'slider', startValue: startIndex, endValue: endIndex, height: 20, bottom: 16 },
+          {
+            type: 'inside',
+            startValue: series.defaultWindow.startIndex,
+            endValue: series.defaultWindow.endIndex,
+          },
+          {
+            type: 'slider',
+            startValue: series.defaultWindow.startIndex,
+            endValue: series.defaultWindow.endIndex,
+            height: 20,
+            bottom: 16,
+          },
         ]
       : undefined,
     series: [
@@ -118,7 +65,7 @@ export function IndicateurValeursChart({ indicateurId, individuId }: IndicateurV
         smooth: false,
         showSymbol: true,
         connectNulls: true,
-        data: values,
+        data: series.values,
       },
     ],
   }

--- a/apps/mb-webapp/src/components/indicateurs/IndicateurValeursChart.tsx
+++ b/apps/mb-webapp/src/components/indicateurs/IndicateurValeursChart.tsx
@@ -1,0 +1,127 @@
+import { useSuspenseQuery } from '@tanstack/react-query'
+import ReactECharts from 'echarts-for-react'
+import { useMemo } from 'react'
+
+import { indicateurValeursQueryOptions } from '@/queries/indicateurs'
+
+type IndicateurValeursChartProps = {
+  indicateurId: string
+  individuId: string
+}
+
+const monthLabelFormatter = new Intl.DateTimeFormat('fr-FR', {
+  month: 'short',
+  year: '2-digit',
+})
+const valueFormatter = new Intl.NumberFormat('fr-FR')
+
+// 13 (et non 12) pour faire apparaître deux occurrences du même mois sur les indicateurs saisis une fois par an.
+const DEFAULT_WINDOW = 13
+
+type Item = { date: string; valeur: number }
+type MonthRef = { year: number; month: number }
+
+function latestValuePerMonth(items: ReadonlyArray<Item>): Map<string, number> {
+  const lastDateByMonth = new Map<string, string>()
+  const valueByMonth = new Map<string, number>()
+  for (const item of items) {
+    const ym = item.date.slice(0, 7)
+    const lastDate = lastDateByMonth.get(ym)
+    if (!lastDate || item.date > lastDate) {
+      lastDateByMonth.set(ym, item.date)
+      valueByMonth.set(ym, item.valeur)
+    }
+  }
+  return valueByMonth
+}
+
+function monthRefFromDate(date: Date): MonthRef {
+  return { year: date.getUTCFullYear(), month: date.getUTCMonth() }
+}
+
+function range(items: ReadonlyArray<Item>): { start: MonthRef; end: MonthRef } {
+  let earliest: string | undefined
+  let latest: string | undefined
+  for (const item of items) {
+    if (!earliest || item.date < earliest) earliest = item.date
+    if (!latest || item.date > latest) latest = item.date
+  }
+  const end = monthRefFromDate(latest ? new Date(latest) : new Date())
+  const endIndex = end.year * 12 + end.month
+  const earliestRef = earliest ? monthRefFromDate(new Date(earliest)) : end
+  const earliestIndex = earliestRef.year * 12 + earliestRef.month
+  const minStartIndex = endIndex - (DEFAULT_WINDOW - 1)
+  const startIndex = Math.min(earliestIndex, minStartIndex)
+  const start = { year: Math.floor(startIndex / 12), month: ((startIndex % 12) + 12) % 12 }
+  return { start, end }
+}
+
+function monthsBetween(start: MonthRef, end: MonthRef) {
+  const startIndex = start.year * 12 + start.month
+  const endIndex = end.year * 12 + end.month
+  const months: { ym: string; date: Date }[] = []
+  for (let i = startIndex; i <= endIndex; i++) {
+    const year = Math.floor(i / 12)
+    const month = ((i % 12) + 12) % 12
+    const date = new Date(Date.UTC(year, month, 1))
+    const ym = `${year}-${String(month + 1).padStart(2, '0')}`
+    months.push({ ym, date })
+  }
+  return months
+}
+
+export function IndicateurValeursChart({ indicateurId, individuId }: IndicateurValeursChartProps) {
+  const { data } = useSuspenseQuery(indicateurValeursQueryOptions(indicateurId, individuId))
+
+  const { labels, values, startIndex, endIndex } = useMemo(() => {
+    const valueByMonth = latestValuePerMonth(data.items)
+    const { start, end } = range(data.items)
+    const months = monthsBetween(start, end)
+    const last = months.length - 1
+    return {
+      labels: months.map((m) => monthLabelFormatter.format(m.date)),
+      values: months.map((m) => valueByMonth.get(m.ym) ?? null),
+      startIndex: Math.max(0, last - (DEFAULT_WINDOW - 1)),
+      endIndex: last,
+    }
+  }, [data.items])
+
+  const showSlider = labels.length > DEFAULT_WINDOW
+
+  const option = {
+    grid: { top: 32, right: 24, bottom: showSlider ? 60 : 32, left: 56 },
+    tooltip: {
+      trigger: 'axis',
+      valueFormatter: (val: unknown) =>
+        typeof val === 'number' ? valueFormatter.format(val) : '—',
+    },
+    xAxis: {
+      type: 'category',
+      data: labels,
+      boundaryGap: false,
+    },
+    yAxis: {
+      type: 'value',
+      axisLabel: {
+        formatter: (val: number) => valueFormatter.format(val),
+      },
+    },
+    dataZoom: showSlider
+      ? [
+          { type: 'inside', startValue: startIndex, endValue: endIndex },
+          { type: 'slider', startValue: startIndex, endValue: endIndex, height: 20, bottom: 16 },
+        ]
+      : undefined,
+    series: [
+      {
+        type: 'line',
+        smooth: false,
+        showSymbol: true,
+        connectNulls: true,
+        data: values,
+      },
+    ],
+  }
+
+  return <ReactECharts option={option} style={{ height: 340 }} notMerge />
+}

--- a/apps/mb-webapp/src/components/indicateurs/IndicateurValeursChart.tsx
+++ b/apps/mb-webapp/src/components/indicateurs/IndicateurValeursChart.tsx
@@ -29,8 +29,7 @@ export function IndicateurValeursChart({ indicateurId, individuId }: IndicateurV
     grid: { top: 32, right: 24, bottom: showSlider ? 60 : 32, left: 56 },
     tooltip: {
       trigger: 'axis',
-      valueFormatter: (value: unknown) =>
-        typeof value === 'number' ? formatNumberFr(value) : '—',
+      valueFormatter: (value: unknown) => (typeof value === 'number' ? formatNumberFr(value) : '—'),
     },
     xAxis: {
       type: 'category',

--- a/apps/mb-webapp/src/components/indicateurs/IndicateurValeursRemarquables.tsx
+++ b/apps/mb-webapp/src/components/indicateurs/IndicateurValeursRemarquables.tsx
@@ -3,13 +3,11 @@ import { useSuspenseQuery } from '@tanstack/react-query'
 
 import { StatCard } from '@/components/ui/StatCard'
 import { StatGrid } from '@/components/ui/StatGrid'
+import { formatDateFr, formatNumberFr, formatVariationFr } from '@/lib/format'
 import {
   indicateurSyntheseIndividuQueryOptions,
   indicateurValeursQueryOptions,
 } from '@/queries/indicateurs'
-
-const numberFormatter = new Intl.NumberFormat('fr-FR')
-const variationFormatter = new Intl.NumberFormat('fr-FR', { signDisplay: 'exceptZero' })
 
 const derniereValeurFromItems = (
   items: ReadonlyArray<{ date: string; valeur: number }>,
@@ -48,17 +46,13 @@ export function IndicateurValeursRemarquables({
       <StatCard
         label="Valeur la plus récente"
         tone={derniereValeur ? 'neutral' : 'muted'}
-        value={derniereValeur ? numberFormatter.format(derniereValeur.valeur) : '—'}
-        caption={
-          derniereValeur
-            ? `au ${new Date(derniereValeur.date).toLocaleDateString('fr-FR')}`
-            : undefined
-        }
+        value={derniereValeur ? formatNumberFr(derniereValeur.valeur) : '—'}
+        caption={derniereValeur ? `au ${formatDateFr(derniereValeur.date)}` : undefined}
       />
       <StatCard
         label="Variation depuis la dernière MAJ"
         tone={variationTone(variation)}
-        value={variation === null ? '—' : variationFormatter.format(variation)}
+        value={variation === null ? '—' : formatVariationFr(variation)}
       />
     </StatGrid>
   )

--- a/apps/mb-webapp/src/components/indicateurs/IndicateurValeursTable.tsx
+++ b/apps/mb-webapp/src/components/indicateurs/IndicateurValeursTable.tsx
@@ -2,6 +2,7 @@ import { useSuspenseQuery } from '@tanstack/react-query'
 
 import { EmptyState } from '@/components/ui/EmptyState'
 import { Table } from '@/components/ui/Table'
+import { formatDateFr, formatNumberFr } from '@/lib/format'
 import { indicateurValeursQueryOptions } from '@/queries/indicateurs'
 
 type IndicateurValeursTableProps = {
@@ -29,8 +30,8 @@ export function IndicateurValeursTable({ indicateurId, individuId }: IndicateurV
       <Table.Body>
         {rows.map((row) => (
           <Table.Row key={row.date}>
-            <Table.Cell>{new Date(row.date).toLocaleDateString('fr-FR')}</Table.Cell>
-            <Table.Cell align="right">{row.valeur.toLocaleString('fr-FR')}</Table.Cell>
+            <Table.Cell>{formatDateFr(row.date)}</Table.Cell>
+            <Table.Cell align="right">{formatNumberFr(row.valeur)}</Table.Cell>
           </Table.Row>
         ))}
       </Table.Body>

--- a/apps/mb-webapp/src/components/indicateurs/MonthlySeries.ts
+++ b/apps/mb-webapp/src/components/indicateurs/MonthlySeries.ts
@@ -13,9 +13,13 @@ export type MonthlySeries = {
   defaultWindow: { startIndex: number; endIndex: number }
 }
 
+// Encode un mois sur un seul entier pour pouvoir l'additionner / soustraire sans
+// gérer manuellement le débordement d'année.
 const ordinalOf = ({ year, monthIndex }: { year: number; monthIndex: number }): number =>
   year * 12 + monthIndex
 
+// Inverse de `ordinalOf`. La double modulo `((x % 12) + 12) % 12` garantit un
+// `monthIndex` positif même pour des ordinaux négatifs (théoriques).
 const monthFromOrdinal = (ordinal: number): Month => {
   const year = Math.floor(ordinal / 12)
   const monthIndex = ((ordinal % 12) + 12) % 12
@@ -27,6 +31,8 @@ const monthFromOrdinal = (ordinal: number): Month => {
   }
 }
 
+// Lecture en UTC pour éviter qu'un fuseau négatif fasse glisser une date du
+// 1er du mois sur le mois précédent.
 const monthFromIsoDate = (isoDate: string): Month => {
   const parsed = new Date(isoDate)
   return monthFromOrdinal(
@@ -34,11 +40,14 @@ const monthFromIsoDate = (isoDate: string): Month => {
   )
 }
 
+// Fallback d'ancre quand l'indicateur n'a aucune valeur saisie.
 const currentMonth = (): Month => {
   const now = new Date()
   return monthFromOrdinal(ordinalOf({ year: now.getUTCFullYear(), monthIndex: now.getUTCMonth() }))
 }
 
+// Un même mois peut contenir plusieurs valeurs ; on conserve celle dont la date
+// est la plus récente dans le mois.
 const latestValueByMonthKey = (
   valeurs: ReadonlyArray<ValeurDateApiModel>,
 ): Map<string, number> => {
@@ -55,6 +64,7 @@ const latestValueByMonthKey = (
   return valueByKey
 }
 
+// Bornes temporelles de l'historique. `undefined` signifie « aucune valeur ».
 const monthBounds = (
   valeurs: ReadonlyArray<ValeurDateApiModel>,
 ): { earliest: Month | undefined; latest: Month | undefined } => {
@@ -70,6 +80,8 @@ const monthBounds = (
   }
 }
 
+// Génère la séquence continue de mois entre deux bornes (incluses), pour que
+// l'axe X reste régulier même si certains mois n'ont pas de valeur.
 const enumerateMonths = ({ start, end }: { start: Month; end: Month }): Month[] => {
   const startOrdinal = ordinalOf(start)
   const endOrdinal = ordinalOf(end)
@@ -80,6 +92,12 @@ const enumerateMonths = ({ start, end }: { start: Month; end: Month }): Month[] 
   return months
 }
 
+// Construit la série mensuelle consommée par le chart :
+// - ancre = mois de la dernière valeur, ou mois courant à défaut ;
+// - série = du plus ancien mois disponible (ou ancre−(windowSize−1) si pas
+//   d'historique antérieur) jusqu'à l'ancre, sans trou ;
+// - defaultWindow = derniers `windowSize` mois pour cadrer l'affichage initial,
+//   le reste reste accessible via le slider ECharts.
 export const buildMonthlySeries = ({
   valeurs,
   windowSize,

--- a/apps/mb-webapp/src/components/indicateurs/MonthlySeries.ts
+++ b/apps/mb-webapp/src/components/indicateurs/MonthlySeries.ts
@@ -48,9 +48,7 @@ const currentMonth = (): Month => {
 
 // Un même mois peut contenir plusieurs valeurs ; on conserve celle dont la date
 // est la plus récente dans le mois.
-const latestValueByMonthKey = (
-  valeurs: ReadonlyArray<ValeurDateApiModel>,
-): Map<string, number> => {
+const latestValueByMonthKey = (valeurs: ReadonlyArray<ValeurDateApiModel>): Map<string, number> => {
   const latestDateByKey = new Map<string, string>()
   const valueByKey = new Map<string, number>()
   for (const { date, valeur } of valeurs) {
@@ -109,9 +107,7 @@ export const buildMonthlySeries = ({
   const { earliest, latest } = monthBounds(valeurs)
   const anchor = latest ?? currentMonth()
   const minStartOrdinal = ordinalOf(anchor) - (windowSize - 1)
-  const startOrdinal = earliest
-    ? Math.min(ordinalOf(earliest), minStartOrdinal)
-    : minStartOrdinal
+  const startOrdinal = earliest ? Math.min(ordinalOf(earliest), minStartOrdinal) : minStartOrdinal
   const months = enumerateMonths({ start: monthFromOrdinal(startOrdinal), end: anchor })
   const values = months.map((month): number | null => valueByKey.get(month.key) ?? null)
   const lastIndex = months.length - 1

--- a/apps/mb-webapp/src/components/indicateurs/MonthlySeries.ts
+++ b/apps/mb-webapp/src/components/indicateurs/MonthlySeries.ts
@@ -1,0 +1,108 @@
+import type { ValeurDateApiModel } from '@pilote/mb-shared/valeurAvancement'
+
+export type Month = {
+  year: number
+  monthIndex: number
+  date: Date
+  key: string
+}
+
+export type MonthlySeries = {
+  months: ReadonlyArray<Month>
+  values: ReadonlyArray<number | null>
+  defaultWindow: { startIndex: number; endIndex: number }
+}
+
+const ordinalOf = ({ year, monthIndex }: { year: number; monthIndex: number }): number =>
+  year * 12 + monthIndex
+
+const monthFromOrdinal = (ordinal: number): Month => {
+  const year = Math.floor(ordinal / 12)
+  const monthIndex = ((ordinal % 12) + 12) % 12
+  return {
+    year,
+    monthIndex,
+    date: new Date(Date.UTC(year, monthIndex, 1)),
+    key: `${year}-${String(monthIndex + 1).padStart(2, '0')}`,
+  }
+}
+
+const monthFromIsoDate = (isoDate: string): Month => {
+  const parsed = new Date(isoDate)
+  return monthFromOrdinal(
+    ordinalOf({ year: parsed.getUTCFullYear(), monthIndex: parsed.getUTCMonth() }),
+  )
+}
+
+const currentMonth = (): Month => {
+  const now = new Date()
+  return monthFromOrdinal(ordinalOf({ year: now.getUTCFullYear(), monthIndex: now.getUTCMonth() }))
+}
+
+const latestValueByMonthKey = (
+  valeurs: ReadonlyArray<ValeurDateApiModel>,
+): Map<string, number> => {
+  const latestDateByKey = new Map<string, string>()
+  const valueByKey = new Map<string, number>()
+  for (const { date, valeur } of valeurs) {
+    const key = date.slice(0, 7)
+    const previous = latestDateByKey.get(key)
+    if (!previous || date > previous) {
+      latestDateByKey.set(key, date)
+      valueByKey.set(key, valeur)
+    }
+  }
+  return valueByKey
+}
+
+const monthBounds = (
+  valeurs: ReadonlyArray<ValeurDateApiModel>,
+): { earliest: Month | undefined; latest: Month | undefined } => {
+  let earliestDate: string | undefined
+  let latestDate: string | undefined
+  for (const { date } of valeurs) {
+    if (!earliestDate || date < earliestDate) earliestDate = date
+    if (!latestDate || date > latestDate) latestDate = date
+  }
+  return {
+    earliest: earliestDate ? monthFromIsoDate(earliestDate) : undefined,
+    latest: latestDate ? monthFromIsoDate(latestDate) : undefined,
+  }
+}
+
+const enumerateMonths = ({ start, end }: { start: Month; end: Month }): Month[] => {
+  const startOrdinal = ordinalOf(start)
+  const endOrdinal = ordinalOf(end)
+  const months: Month[] = []
+  for (let ordinal = startOrdinal; ordinal <= endOrdinal; ordinal++) {
+    months.push(monthFromOrdinal(ordinal))
+  }
+  return months
+}
+
+export const buildMonthlySeries = ({
+  valeurs,
+  windowSize,
+}: {
+  valeurs: ReadonlyArray<ValeurDateApiModel>
+  windowSize: number
+}): MonthlySeries => {
+  const valueByKey = latestValueByMonthKey(valeurs)
+  const { earliest, latest } = monthBounds(valeurs)
+  const anchor = latest ?? currentMonth()
+  const minStartOrdinal = ordinalOf(anchor) - (windowSize - 1)
+  const startOrdinal = earliest
+    ? Math.min(ordinalOf(earliest), minStartOrdinal)
+    : minStartOrdinal
+  const months = enumerateMonths({ start: monthFromOrdinal(startOrdinal), end: anchor })
+  const values = months.map((month): number | null => valueByKey.get(month.key) ?? null)
+  const lastIndex = months.length - 1
+  return {
+    months,
+    values,
+    defaultWindow: {
+      startIndex: Math.max(0, lastIndex - (windowSize - 1)),
+      endIndex: lastIndex,
+    },
+  }
+}

--- a/apps/mb-webapp/src/lib/format.ts
+++ b/apps/mb-webapp/src/lib/format.ts
@@ -1,0 +1,26 @@
+const numberFr = new Intl.NumberFormat('fr-FR')
+const variationFr = new Intl.NumberFormat('fr-FR', { signDisplay: 'exceptZero' })
+const dateFr = new Intl.DateTimeFormat('fr-FR')
+const monthYearShortFr = new Intl.DateTimeFormat('fr-FR', { month: 'short', year: '2-digit' })
+const monthYearNumericFr = new Intl.DateTimeFormat('fr-FR', {
+  month: '2-digit',
+  year: 'numeric',
+})
+
+const toDate = (value: Date | string): Date =>
+  typeof value === 'string' ? new Date(value) : value
+
+export const formatNumberFr = (value: number): string => numberFr.format(value)
+
+export const formatVariationFr = (value: number): string => variationFr.format(value)
+
+export const formatDateFr = (value: Date | string): string => dateFr.format(toDate(value))
+
+export const formatDateTimeFr = (value: Date | string): string =>
+  toDate(value).toLocaleString('fr-FR')
+
+export const formatMonthYearShortFr = (value: Date | string): string =>
+  monthYearShortFr.format(toDate(value))
+
+export const formatMonthYearNumericFr = (value: Date | string): string =>
+  monthYearNumericFr.format(toDate(value))

--- a/apps/mb-webapp/src/lib/format.ts
+++ b/apps/mb-webapp/src/lib/format.ts
@@ -7,8 +7,7 @@ const monthYearNumericFr = new Intl.DateTimeFormat('fr-FR', {
   year: 'numeric',
 })
 
-const toDate = (value: Date | string): Date =>
-  typeof value === 'string' ? new Date(value) : value
+const toDate = (value: Date | string): Date => (typeof value === 'string' ? new Date(value) : value)
 
 export const formatNumberFr = (value: number): string => numberFr.format(value)
 

--- a/apps/mb-webapp/src/routes/_authenticated/indicateurs/$id.tsx
+++ b/apps/mb-webapp/src/routes/_authenticated/indicateurs/$id.tsx
@@ -10,6 +10,7 @@ import { RouteError } from '@/components/RouteError'
 import { RouteLoading } from '@/components/RouteLoading'
 import { IndicateurMetadonnees } from '@/components/indicateurs/IndicateurMetadonnees'
 import { IndicateurStatsPanel } from '@/components/indicateurs/IndicateurStatsPanel'
+import { IndicateurValeursChart } from '@/components/indicateurs/IndicateurValeursChart'
 import { IndicateurValeursRemarquables } from '@/components/indicateurs/IndicateurValeursRemarquables'
 import { IndicateurValeursTable } from '@/components/indicateurs/IndicateurValeursTable'
 import { IndividuSelect } from '@/components/indicateurs/IndividuSelect'
@@ -147,7 +148,10 @@ function IndicateurDetailComponent() {
           </TabsList>
 
           <TabsContent value="valeurs">
-            <IndicateurValeursTable indicateurId={id} individuId={individuId} />
+            <div className="space-y-6">
+              <IndicateurValeursChart indicateurId={id} individuId={individuId} />
+              <IndicateurValeursTable indicateurId={id} individuId={individuId} />
+            </div>
           </TabsContent>
 
           <TabsContent value="metadonnees">

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -154,6 +154,9 @@ importers:
       dotenv:
         specifier: 16.4.5
         version: 16.4.5
+      echarts-for-react:
+        specifier: 3.0.6
+        version: 3.0.6(echarts@6.0.0)(react@19.2.5)
       hono:
         specifier: '>=4.12.18'
         version: 4.12.19
@@ -5127,6 +5130,12 @@ packages:
   duplexer@0.1.2:
     resolution: {integrity: sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==}
 
+  echarts-for-react@3.0.6:
+    resolution: {integrity: sha512-4zqLgTGWS3JvkQDXjzkR1k1CHRdpd6by0988TWMJgnvDytegWLbeP/VNZmMa+0VJx2eD7Y632bi2JquXDgiGJg==}
+    peerDependencies:
+      echarts: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0
+      react: ^15.0.0 || >=16.0.0
+
   echarts@6.0.0:
     resolution: {integrity: sha512-Tte/grDQRiETQP4xz3iZWSvoHrkCQtwqd6hs+mifXcjrCuo2iKWbajFObuLJVBlDIJlOzgQPd1hsaKt/3+OMkQ==}
 
@@ -8209,6 +8218,9 @@ packages:
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
+
+  size-sensor@1.0.3:
+    resolution: {integrity: sha512-+k9mJ2/rQMiRmQUcjn+qznch260leIXY8r4FyYKKyRBO/s5UoeMAHGkCJyE1R/4wrIhTJONfyloY55SkE7ve3A==}
 
   slash@5.1.0:
     resolution: {integrity: sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==}
@@ -12867,7 +12879,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@opentelemetry/api@1.9.0)(@types/node@22.19.17)(@vitest/coverage-v8@4.1.4)(jsdom@29.1.0(@noble/hashes@1.8.0))(msw@2.14.2(@types/node@22.19.17)(typescript@5.9.3))(vite@8.0.10(@types/node@22.19.17)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.78.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.4(@opentelemetry/api@1.9.0)(@types/node@22.19.17)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.2(@noble/hashes@1.8.0))(msw@2.14.2(@types/node@22.19.17)(typescript@5.9.3))(vite@8.0.10(@types/node@22.19.17)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.78.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
 
   '@vitest/eslint-plugin@1.6.15(@typescript-eslint/eslint-plugin@8.58.2(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.4)':
     dependencies:
@@ -13974,6 +13986,13 @@ snapshots:
       gopd: 1.2.0
 
   duplexer@0.1.2: {}
+
+  echarts-for-react@3.0.6(echarts@6.0.0)(react@19.2.5):
+    dependencies:
+      echarts: 6.0.0
+      fast-deep-equal: 3.1.3
+      react: 19.2.5
+      size-sensor: 1.0.3
 
   echarts@6.0.0:
     dependencies:
@@ -17989,6 +18008,8 @@ snapshots:
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
+
+  size-sensor@1.0.3: {}
 
   slash@5.1.0: {}
 


### PR DESCRIPTION
## Summary
- Ajoute un line chart ECharts (via `echarts-for-react`) au-dessus de la table de valeurs dans la page d'un indicateur.
- Préparation des données : groupement par mois, valeur la plus récente conservée par mois.
- Fenêtre par défaut de 13 mois (et non 12, pour faire apparaître deux occurrences du même mois sur les indicateurs annuels), ancrée sur le mois de la dernière valeur (ou mois courant à défaut).
- Slider `dataZoom` + zoom `inside` activés dès que l'historique dépasse la fenêtre par défaut, pour naviguer dans le temps.

## Test plan
- [ ] Indicateur avec valeurs mensuelles → courbe continue sur les 13 derniers mois
- [ ] Indicateur avec valeurs trimestrielles → points reliés (connectNulls)
- [ ] Indicateur avec valeurs annuelles → 2 points visibles dans la fenêtre de 13 mois
- [ ] Indicateur avec >13 mois d'historique → slider visible, drag pour remonter dans le temps
- [ ] Indicateur sans valeur → axe affiché, pas de courbe

🤖 Generated with [Claude Code](https://claude.com/claude-code)