### PR TITLE
feat(mb-api): fonction d'agrégation par lien indicateur-référentiel

### DIFF
--- a/apps/mb-api/prisma/migrations/20260520144904_add_fonction_agregation_indicateur_referentiel/migration.sql
+++ b/apps/mb-api/prisma/migrations/20260520144904_add_fonction_agregation_indicateur_referentiel/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - Added the required column `fonction_agregation` to the `indicateur_referentiel` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- CreateEnum
+CREATE TYPE "fonction_agregation_enum" AS ENUM ('SUM', 'NONE');
+
+-- AlterTable
+ALTER TABLE "indicateur_referentiel" ADD COLUMN     "fonction_agregation" "fonction_agregation_enum" NOT NULL;

--- a/apps/mb-api/prisma/schema.prisma
+++ b/apps/mb-api/prisma/schema.prisma
@@ -63,10 +63,18 @@ model Indicateur {
   @@map("indicateur")
 }
 
+enum FonctionAgregation {
+  SUM
+  NONE
+
+  @@map("fonction_agregation_enum")
+}
+
 model IndicateurReferentiel {
-  indicateurId  String   @map("indicateur_id")  @db.Uuid
-  referentielId String   @map("referentiel_id") @db.Uuid
-  createdAt     DateTime @default(now())        @map("created_at")
+  indicateurId       String             @map("indicateur_id")  @db.Uuid
+  referentielId      String             @map("referentiel_id") @db.Uuid
+  fonctionAgregation FonctionAgregation @map("fonction_agregation")
+  createdAt          DateTime           @default(now())        @map("created_at")
 
   indicateur  Indicateur  @relation(fields: [indicateurId],  references: [id], onDelete: Cascade)
   referentiel Referentiel @relation(fields: [referentielId], references: [id], onDelete: Cascade)

--- a/apps/mb-api/prisma/seed.ts
+++ b/apps/mb-api/prisma/seed.ts
@@ -2,6 +2,7 @@ import { PrismaPg } from '@prisma/adapter-pg'
 import { uuidv7 } from 'uuidv7'
 
 import { Prisma, PrismaClient } from '../src/generated/prisma/client.js'
+import { type FonctionAgregation } from '../src/generated/prisma/enums.js'
 
 import {
   individusSeed,
@@ -180,51 +181,54 @@ const main = async () => {
 
   const indicateurReferentielsSeed: ReadonlyArray<{
     indicateurPublicId: string
-    liens: ReadonlyArray<{ referentielPublicId: string; fonctionAgregation: 'SUM' | 'NONE' }>
+    referentiels: ReadonlyArray<{
+      referentielPublicId: string
+      fonctionAgregation: FonctionAgregation
+    }>
   }> = [
     {
       indicateurPublicId: 'IND-001',
-      liens: [
+      referentiels: [
         { referentielPublicId: 'REF-DEPT', fonctionAgregation: 'NONE' },
         { referentielPublicId: 'REF-NAT', fonctionAgregation: 'NONE' },
       ],
     },
     {
       indicateurPublicId: 'IND-002',
-      liens: [
+      referentiels: [
         { referentielPublicId: 'REF-DEPT', fonctionAgregation: 'SUM' },
         { referentielPublicId: 'REF-REG', fonctionAgregation: 'SUM' },
       ],
     },
     {
       indicateurPublicId: 'IND-003',
-      liens: [
+      referentiels: [
         { referentielPublicId: 'REF-REG', fonctionAgregation: 'NONE' },
         { referentielPublicId: 'REF-DEPT', fonctionAgregation: 'NONE' },
       ],
     },
     {
       indicateurPublicId: 'IND-004',
-      liens: [{ referentielPublicId: 'REF-DEPT', fonctionAgregation: 'NONE' }],
+      referentiels: [{ referentielPublicId: 'REF-DEPT', fonctionAgregation: 'NONE' }],
     },
     {
       indicateurPublicId: 'IND-005',
-      liens: [
+      referentiels: [
         { referentielPublicId: 'REF-REG', fonctionAgregation: 'SUM' },
         { referentielPublicId: 'REF-NAT', fonctionAgregation: 'SUM' },
       ],
     },
     {
       indicateurPublicId: 'IND-006',
-      liens: [{ referentielPublicId: 'REF-EMPTY', fonctionAgregation: 'NONE' }],
+      referentiels: [{ referentielPublicId: 'REF-EMPTY', fonctionAgregation: 'NONE' }],
     },
     {
       indicateurPublicId: 'IND-007',
-      liens: [{ referentielPublicId: 'REF-EMPTY', fonctionAgregation: 'NONE' }],
+      referentiels: [{ referentielPublicId: 'REF-EMPTY', fonctionAgregation: 'NONE' }],
     },
     {
       indicateurPublicId: 'IND-008',
-      liens: [{ referentielPublicId: 'REF-EMPTY', fonctionAgregation: 'NONE' }],
+      referentiels: [{ referentielPublicId: 'REF-EMPTY', fonctionAgregation: 'NONE' }],
     },
   ]
 
@@ -233,9 +237,9 @@ const main = async () => {
       where: { publicId: item.indicateurPublicId },
       select: { id: true },
     })
-    for (const lien of item.liens) {
+    for (const configuration of item.referentiels) {
       const referentiel = await prisma.referentiel.findUniqueOrThrow({
-        where: { publicId: lien.referentielPublicId },
+        where: { publicId: configuration.referentielPublicId },
         select: { id: true },
       })
       await prisma.indicateurReferentiel.upsert({
@@ -245,17 +249,20 @@ const main = async () => {
             referentielId: referentiel.id,
           },
         },
-        update: { fonctionAgregation: lien.fonctionAgregation },
+        update: { fonctionAgregation: configuration.fonctionAgregation },
         create: {
           indicateurId: indicateur.id,
           referentielId: referentiel.id,
-          fonctionAgregation: lien.fonctionAgregation,
+          fonctionAgregation: configuration.fonctionAgregation,
         },
       })
     }
   }
 
-  const liaisonsCount = indicateurReferentielsSeed.reduce((acc, item) => acc + item.liens.length, 0)
+  const liaisonsCount = indicateurReferentielsSeed.reduce(
+    (acc, item) => acc + item.referentiels.length,
+    0,
+  )
 
   for (const item of relationsSeed) {
     const parent = await prisma.individu.findUniqueOrThrow({

--- a/apps/mb-api/prisma/seed.ts
+++ b/apps/mb-api/prisma/seed.ts
@@ -180,17 +180,52 @@ const main = async () => {
 
   const indicateurReferentielsSeed: ReadonlyArray<{
     indicateurPublicId: string
-    referentielPublicIds: ReadonlyArray<string>
+    liens: ReadonlyArray<{ referentielPublicId: string; fonctionAgregation: 'SUM' | 'NONE' }>
   }> = [
-    { indicateurPublicId: 'IND-001', referentielPublicIds: ['REF-DEPT', 'REF-NAT'] },
-    { indicateurPublicId: 'IND-002', referentielPublicIds: ['REF-DEPT', 'REF-REG'] },
-    { indicateurPublicId: 'IND-003', referentielPublicIds: ['REF-REG', 'REF-DEPT'] },
-    { indicateurPublicId: 'IND-004', referentielPublicIds: ['REF-DEPT'] },
-    { indicateurPublicId: 'IND-005', referentielPublicIds: ['REF-REG', 'REF-NAT'] },
-    // Indicateurs liés à REF-EMPTY pour exercer le fallback "aucun individu disponible".
-    { indicateurPublicId: 'IND-006', referentielPublicIds: ['REF-EMPTY'] },
-    { indicateurPublicId: 'IND-007', referentielPublicIds: ['REF-EMPTY'] },
-    { indicateurPublicId: 'IND-008', referentielPublicIds: ['REF-EMPTY'] },
+    {
+      indicateurPublicId: 'IND-001',
+      liens: [
+        { referentielPublicId: 'REF-DEPT', fonctionAgregation: 'NONE' },
+        { referentielPublicId: 'REF-NAT', fonctionAgregation: 'NONE' },
+      ],
+    },
+    {
+      indicateurPublicId: 'IND-002',
+      liens: [
+        { referentielPublicId: 'REF-DEPT', fonctionAgregation: 'SUM' },
+        { referentielPublicId: 'REF-REG', fonctionAgregation: 'SUM' },
+      ],
+    },
+    {
+      indicateurPublicId: 'IND-003',
+      liens: [
+        { referentielPublicId: 'REF-REG', fonctionAgregation: 'NONE' },
+        { referentielPublicId: 'REF-DEPT', fonctionAgregation: 'NONE' },
+      ],
+    },
+    {
+      indicateurPublicId: 'IND-004',
+      liens: [{ referentielPublicId: 'REF-DEPT', fonctionAgregation: 'NONE' }],
+    },
+    {
+      indicateurPublicId: 'IND-005',
+      liens: [
+        { referentielPublicId: 'REF-REG', fonctionAgregation: 'SUM' },
+        { referentielPublicId: 'REF-NAT', fonctionAgregation: 'SUM' },
+      ],
+    },
+    {
+      indicateurPublicId: 'IND-006',
+      liens: [{ referentielPublicId: 'REF-EMPTY', fonctionAgregation: 'NONE' }],
+    },
+    {
+      indicateurPublicId: 'IND-007',
+      liens: [{ referentielPublicId: 'REF-EMPTY', fonctionAgregation: 'NONE' }],
+    },
+    {
+      indicateurPublicId: 'IND-008',
+      liens: [{ referentielPublicId: 'REF-EMPTY', fonctionAgregation: 'NONE' }],
+    },
   ]
 
   for (const item of indicateurReferentielsSeed) {
@@ -198,9 +233,9 @@ const main = async () => {
       where: { publicId: item.indicateurPublicId },
       select: { id: true },
     })
-    for (const referentielPublicId of item.referentielPublicIds) {
+    for (const lien of item.liens) {
       const referentiel = await prisma.referentiel.findUniqueOrThrow({
-        where: { publicId: referentielPublicId },
+        where: { publicId: lien.referentielPublicId },
         select: { id: true },
       })
       await prisma.indicateurReferentiel.upsert({
@@ -210,14 +245,18 @@ const main = async () => {
             referentielId: referentiel.id,
           },
         },
-        update: {},
-        create: { indicateurId: indicateur.id, referentielId: referentiel.id },
+        update: { fonctionAgregation: lien.fonctionAgregation },
+        create: {
+          indicateurId: indicateur.id,
+          referentielId: referentiel.id,
+          fonctionAgregation: lien.fonctionAgregation,
+        },
       })
     }
   }
 
   const liaisonsCount = indicateurReferentielsSeed.reduce(
-    (acc, item) => acc + item.referentielPublicIds.length,
+    (acc, item) => acc + item.liens.length,
     0,
   )
 

--- a/apps/mb-api/prisma/seed.ts
+++ b/apps/mb-api/prisma/seed.ts
@@ -255,10 +255,7 @@ const main = async () => {
     }
   }
 
-  const liaisonsCount = indicateurReferentielsSeed.reduce(
-    (acc, item) => acc + item.liens.length,
-    0,
-  )
+  const liaisonsCount = indicateurReferentielsSeed.reduce((acc, item) => acc + item.liens.length, 0)
 
   for (const item of relationsSeed) {
     const parent = await prisma.individu.findUniqueOrThrow({

--- a/apps/mb-api/src/indicateur/commands/upsertIndicateur.test.ts
+++ b/apps/mb-api/src/indicateur/commands/upsertIndicateur.test.ts
@@ -8,29 +8,22 @@ import { integrationTest } from '@/test/integrationTest'
 import { testIndicateurId } from '@/test/randomIds'
 import { runAsPrincipal } from '@/test/runAsPrincipal'
 
-const getReferentielLinks = async (publicId: string) => {
+const getConfigurationsReferentiels = async (publicId: string) => {
   const indicateur = await db().indicateur.findUniqueOrThrow({
     where: { publicId },
-    include: {
-      referentiels: {
-        select: {
-          fonctionAgregation: true,
-          referentiel: { select: { publicId: true } },
-        },
-      },
-    },
+    include: { referentiels: { include: { referentiel: true } } },
   })
   return indicateur.referentiels
-    .map((link) => ({
-      referentielId: link.referentiel.publicId,
-      fonctionAgregation: link.fonctionAgregation,
+    .map((configuration) => ({
+      referentielPublicId: configuration.referentiel.publicId,
+      fonctionAgregation: configuration.fonctionAgregation,
     }))
-    .sort((a, b) => a.referentielId.localeCompare(b.referentielId))
+    .sort((a, b) => a.referentielPublicId.localeCompare(b.referentielPublicId))
 }
 
 describe.concurrent('upsertIndicateur', () => {
   it(
-    'crée un indicateur avec ses référentiels liés et auto-grant READ+WRITE au créateur',
+    'crée un indicateur avec ses référentiels configurés et auto-grant READ+WRITE au créateur',
     integrationTest(async () => {
       const indId = testIndicateurId()
       const apiKey = await fixtures.apiKey()
@@ -38,22 +31,19 @@ describe.concurrent('upsertIndicateur', () => {
       const refB = await fixtures.referentiel({ publicId: 'REF-CREATE-B' })
 
       const result = await runAsPrincipal(apiKey.id, () =>
-        upsertIndicateur({
-          publicId: indId,
-          body: {
-            nom: 'Nouvel indicateur',
-            referentiels: [
-              { referentielId: refA.publicId, fonctionAgregation: 'SUM' },
-              { referentielId: refB.publicId, fonctionAgregation: 'NONE' },
-            ],
-          },
+        upsertIndicateur(indId, {
+          nom: 'Nouvel indicateur',
+          referentiels: [
+            { referentielPublicId: refA.publicId, fonctionAgregation: 'SUM' },
+            { referentielPublicId: refB.publicId, fonctionAgregation: 'NONE' },
+          ],
         }),
       )
 
       expect(result.isOk()).toBe(true)
-      expect(await getReferentielLinks(indId)).toEqual([
-        { referentielId: 'REF-CREATE-A', fonctionAgregation: 'SUM' },
-        { referentielId: 'REF-CREATE-B', fonctionAgregation: 'NONE' },
+      expect(await getConfigurationsReferentiels(indId)).toEqual([
+        { referentielPublicId: 'REF-CREATE-A', fonctionAgregation: 'SUM' },
+        { referentielPublicId: 'REF-CREATE-B', fonctionAgregation: 'NONE' },
       ])
       const grants = await db().indicateurPermission.findMany({
         where: { principalId: apiKey.id, indicateur: { publicId: indId } },
@@ -64,7 +54,7 @@ describe.concurrent('upsertIndicateur', () => {
   )
 
   it(
-    "remplace l'ensemble des liens à chaque PUT (ajout + suppression)",
+    "remplace l'ensemble des configurations à chaque PUT (ajout + suppression)",
     integrationTest(async () => {
       const indId = testIndicateurId()
       await fixtures.referentiel(
@@ -74,91 +64,77 @@ describe.concurrent('upsertIndicateur', () => {
       )
       const apiKey = await fixtures.apiKey()
       await runAsPrincipal(apiKey.id, () =>
-        upsertIndicateur({
-          publicId: indId,
-          body: {
-            nom: 'I',
-            referentiels: [
-              { referentielId: 'REF-REPLACE-A', fonctionAgregation: 'SUM' },
-              { referentielId: 'REF-REPLACE-B', fonctionAgregation: 'SUM' },
-            ],
-          },
+        upsertIndicateur(indId, {
+          nom: 'I',
+          referentiels: [
+            { referentielPublicId: 'REF-REPLACE-A', fonctionAgregation: 'SUM' },
+            { referentielPublicId: 'REF-REPLACE-B', fonctionAgregation: 'SUM' },
+          ],
         }),
       )
 
       await runAsPrincipal(apiKey.id, () =>
-        upsertIndicateur({
-          publicId: indId,
-          body: {
-            nom: 'I',
-            referentiels: [
-              { referentielId: 'REF-REPLACE-B', fonctionAgregation: 'SUM' },
-              { referentielId: 'REF-REPLACE-C', fonctionAgregation: 'SUM' },
-            ],
-          },
+        upsertIndicateur(indId, {
+          nom: 'I',
+          referentiels: [
+            { referentielPublicId: 'REF-REPLACE-B', fonctionAgregation: 'SUM' },
+            { referentielPublicId: 'REF-REPLACE-C', fonctionAgregation: 'SUM' },
+          ],
         }),
       )
 
-      expect(await getReferentielLinks(indId)).toEqual([
-        { referentielId: 'REF-REPLACE-B', fonctionAgregation: 'SUM' },
-        { referentielId: 'REF-REPLACE-C', fonctionAgregation: 'SUM' },
+      expect(await getConfigurationsReferentiels(indId)).toEqual([
+        { referentielPublicId: 'REF-REPLACE-B', fonctionAgregation: 'SUM' },
+        { referentielPublicId: 'REF-REPLACE-C', fonctionAgregation: 'SUM' },
       ])
     }),
   )
 
   it(
-    'accepte un tableau vide (supprime tous les liens)',
+    'accepte un tableau vide (supprime toutes les configurations)',
     integrationTest(async () => {
       const indId = testIndicateurId()
       await fixtures.referentiel({ publicId: 'REF-EMPTY-A' })
       const apiKey = await fixtures.apiKey()
       await runAsPrincipal(apiKey.id, () =>
-        upsertIndicateur({
-          publicId: indId,
-          body: {
-            nom: 'I',
-            referentiels: [{ referentielId: 'REF-EMPTY-A', fonctionAgregation: 'SUM' }],
-          },
+        upsertIndicateur(indId, {
+          nom: 'I',
+          referentiels: [{ referentielPublicId: 'REF-EMPTY-A', fonctionAgregation: 'SUM' }],
         }),
       )
 
-      await runAsPrincipal(apiKey.id, () =>
-        upsertIndicateur({ publicId: indId, body: { nom: 'I', referentiels: [] } }),
-      )
+      await runAsPrincipal(apiKey.id, () => upsertIndicateur(indId, { nom: 'I', referentiels: [] }))
 
-      expect(await getReferentielLinks(indId)).toEqual([])
+      expect(await getConfigurationsReferentiels(indId)).toEqual([])
     }),
   )
 
   it(
-    'dédoublonne silencieusement les referentielIds en double',
+    'dédoublonne silencieusement les referentielPublicId en double',
     integrationTest(async () => {
       const indId = testIndicateurId()
       await fixtures.referentiel({ publicId: 'REF-DEDUP-A' })
       const apiKey = await fixtures.apiKey()
 
       const result = await runAsPrincipal(apiKey.id, () =>
-        upsertIndicateur({
-          publicId: indId,
-          body: {
-            nom: 'I',
-            referentiels: [
-              { referentielId: 'REF-DEDUP-A', fonctionAgregation: 'SUM' },
-              { referentielId: 'REF-DEDUP-A', fonctionAgregation: 'SUM' },
-            ],
-          },
+        upsertIndicateur(indId, {
+          nom: 'I',
+          referentiels: [
+            { referentielPublicId: 'REF-DEDUP-A', fonctionAgregation: 'SUM' },
+            { referentielPublicId: 'REF-DEDUP-A', fonctionAgregation: 'SUM' },
+          ],
         }),
       )
 
       expect(result.isOk()).toBe(true)
-      expect(await getReferentielLinks(indId)).toEqual([
-        { referentielId: 'REF-DEDUP-A', fonctionAgregation: 'SUM' },
+      expect(await getConfigurationsReferentiels(indId)).toEqual([
+        { referentielPublicId: 'REF-DEDUP-A', fonctionAgregation: 'SUM' },
       ])
     }),
   )
 
   it(
-    'rejette quand un referentielId est inconnu, avec la liste des IDs manquants',
+    'rejette quand un referentielPublicId est inconnu, avec la liste des IDs manquants',
     integrationTest(async () => {
       const indId = testIndicateurId()
       await fixtures.referentiel({ publicId: 'REF-UNKNOWN-A' })
@@ -166,16 +142,13 @@ describe.concurrent('upsertIndicateur', () => {
 
       await expect(
         runAsPrincipal(apiKey.id, () =>
-          upsertIndicateur({
-            publicId: indId,
-            body: {
-              nom: 'I',
-              referentiels: [
-                { referentielId: 'REF-UNKNOWN-A', fonctionAgregation: 'SUM' },
-                { referentielId: 'REF-UNKNOWN-X', fonctionAgregation: 'SUM' },
-                { referentielId: 'REF-UNKNOWN-Y', fonctionAgregation: 'SUM' },
-              ],
-            },
+          upsertIndicateur(indId, {
+            nom: 'I',
+            referentiels: [
+              { referentielPublicId: 'REF-UNKNOWN-A', fonctionAgregation: 'SUM' },
+              { referentielPublicId: 'REF-UNKNOWN-X', fonctionAgregation: 'SUM' },
+              { referentielPublicId: 'REF-UNKNOWN-Y', fonctionAgregation: 'SUM' },
+            ],
           }),
         ),
       ).rejects.toMatchObject({
@@ -198,69 +171,58 @@ describe.concurrent('upsertIndicateur', () => {
       })
 
       await expect(
-        runAsPrincipal(apiKey.id, () =>
-          upsertIndicateur({ publicId: indId, body: { nom: 'X', referentiels: [] } }),
-        ),
+        runAsPrincipal(apiKey.id, () => upsertIndicateur(indId, { nom: 'X', referentiels: [] })),
       ).rejects.toThrow(/permission/i)
     }),
   )
 
   it(
-    'met à jour la fonctionAgregation pour un lien existant',
+    'met à jour la fonctionAgregation pour une configuration existante',
     integrationTest(async () => {
       const indId = testIndicateurId()
       await fixtures.referentiel({ publicId: 'REF-UPDATE-A' })
       const apiKey = await fixtures.apiKey()
 
       await runAsPrincipal(apiKey.id, () =>
-        upsertIndicateur({
-          publicId: indId,
-          body: {
-            nom: 'I',
-            referentiels: [{ referentielId: 'REF-UPDATE-A', fonctionAgregation: 'SUM' }],
-          },
+        upsertIndicateur(indId, {
+          nom: 'I',
+          referentiels: [{ referentielPublicId: 'REF-UPDATE-A', fonctionAgregation: 'SUM' }],
         }),
       )
 
       await runAsPrincipal(apiKey.id, () =>
-        upsertIndicateur({
-          publicId: indId,
-          body: {
-            nom: 'I',
-            referentiels: [{ referentielId: 'REF-UPDATE-A', fonctionAgregation: 'NONE' }],
-          },
+        upsertIndicateur(indId, {
+          nom: 'I',
+          referentiels: [{ referentielPublicId: 'REF-UPDATE-A', fonctionAgregation: 'NONE' }],
         }),
       )
 
-      expect(await getReferentielLinks(indId)).toEqual([
-        { referentielId: 'REF-UPDATE-A', fonctionAgregation: 'NONE' },
+      expect(await getConfigurationsReferentiels(indId)).toEqual([
+        { referentielPublicId: 'REF-UPDATE-A', fonctionAgregation: 'NONE' },
       ])
     }),
   )
 
   it(
-    "dédoublonne sur referentielId : en cas de fonctions différentes, la dernière l'emporte",
+    "dédoublonne sur referentielPublicId : en cas de fonctions différentes, la dernière l'emporte",
     integrationTest(async () => {
       const indId = testIndicateurId()
       await fixtures.referentiel({ publicId: 'REF-DEDUP-FN' })
       const apiKey = await fixtures.apiKey()
 
       const result = await runAsPrincipal(apiKey.id, () =>
-        upsertIndicateur({
-          publicId: indId,
-          body: {
-            nom: 'I',
-            referentiels: [
-              { referentielId: 'REF-DEDUP-FN', fonctionAgregation: 'SUM' },
-              { referentielId: 'REF-DEDUP-FN', fonctionAgregation: 'NONE' },
-            ],
-          },
+        upsertIndicateur(indId, {
+          nom: 'I',
+          referentiels: [
+            { referentielPublicId: 'REF-DEDUP-FN', fonctionAgregation: 'SUM' },
+            { referentielPublicId: 'REF-DEDUP-FN', fonctionAgregation: 'NONE' },
+          ],
         }),
       )
 
       expect(result.isOk()).toBe(true)
-      expect(await getReferentielLinks(indId)).toEqual([
-        { referentielId: 'REF-DEDUP-FN', fonctionAgregation: 'NONE' },
+      expect(await getConfigurationsReferentiels(indId)).toEqual([
+        { referentielPublicId: 'REF-DEDUP-FN', fonctionAgregation: 'NONE' },
       ])
     }),
   )

--- a/apps/mb-api/src/indicateur/commands/upsertIndicateur.test.ts
+++ b/apps/mb-api/src/indicateur/commands/upsertIndicateur.test.ts
@@ -8,12 +8,24 @@ import { integrationTest } from '@/test/integrationTest'
 import { testIndicateurId } from '@/test/randomIds'
 import { runAsPrincipal } from '@/test/runAsPrincipal'
 
-const getReferentielPublicIds = async (publicId: string): Promise<string[]> => {
+const getReferentielLinks = async (publicId: string) => {
   const indicateur = await db().indicateur.findUniqueOrThrow({
     where: { publicId },
-    include: { referentiels: { include: { referentiel: { select: { publicId: true } } } } },
+    include: {
+      referentiels: {
+        select: {
+          fonctionAgregation: true,
+          referentiel: { select: { publicId: true } },
+        },
+      },
+    },
   })
-  return indicateur.referentiels.map((link) => link.referentiel.publicId).sort()
+  return indicateur.referentiels
+    .map((link) => ({
+      referentielId: link.referentiel.publicId,
+      fonctionAgregation: link.fonctionAgregation,
+    }))
+    .sort((a, b) => a.referentielId.localeCompare(b.referentielId))
 }
 
 describe.concurrent('upsertIndicateur', () => {
@@ -28,12 +40,21 @@ describe.concurrent('upsertIndicateur', () => {
       const result = await runAsPrincipal(apiKey.id, () =>
         upsertIndicateur({
           publicId: indId,
-          body: { nom: 'Nouvel indicateur', referentielIds: [refA.publicId, refB.publicId] },
+          body: {
+            nom: 'Nouvel indicateur',
+            referentiels: [
+              { referentielId: refA.publicId, fonctionAgregation: 'SUM' },
+              { referentielId: refB.publicId, fonctionAgregation: 'NONE' },
+            ],
+          },
         }),
       )
 
       expect(result.isOk()).toBe(true)
-      expect(await getReferentielPublicIds(indId)).toEqual(['REF-CREATE-A', 'REF-CREATE-B'])
+      expect(await getReferentielLinks(indId)).toEqual([
+        { referentielId: 'REF-CREATE-A', fonctionAgregation: 'SUM' },
+        { referentielId: 'REF-CREATE-B', fonctionAgregation: 'NONE' },
+      ])
       const grants = await db().indicateurPermission.findMany({
         where: { principalId: apiKey.id, indicateur: { publicId: indId } },
         orderBy: { action: 'asc' },
@@ -55,18 +76,33 @@ describe.concurrent('upsertIndicateur', () => {
       await runAsPrincipal(apiKey.id, () =>
         upsertIndicateur({
           publicId: indId,
-          body: { nom: 'I', referentielIds: ['REF-REPLACE-A', 'REF-REPLACE-B'] },
+          body: {
+            nom: 'I',
+            referentiels: [
+              { referentielId: 'REF-REPLACE-A', fonctionAgregation: 'SUM' },
+              { referentielId: 'REF-REPLACE-B', fonctionAgregation: 'SUM' },
+            ],
+          },
         }),
       )
 
       await runAsPrincipal(apiKey.id, () =>
         upsertIndicateur({
           publicId: indId,
-          body: { nom: 'I', referentielIds: ['REF-REPLACE-B', 'REF-REPLACE-C'] },
+          body: {
+            nom: 'I',
+            referentiels: [
+              { referentielId: 'REF-REPLACE-B', fonctionAgregation: 'SUM' },
+              { referentielId: 'REF-REPLACE-C', fonctionAgregation: 'SUM' },
+            ],
+          },
         }),
       )
 
-      expect(await getReferentielPublicIds(indId)).toEqual(['REF-REPLACE-B', 'REF-REPLACE-C'])
+      expect(await getReferentielLinks(indId)).toEqual([
+        { referentielId: 'REF-REPLACE-B', fonctionAgregation: 'SUM' },
+        { referentielId: 'REF-REPLACE-C', fonctionAgregation: 'SUM' },
+      ])
     }),
   )
 
@@ -79,15 +115,18 @@ describe.concurrent('upsertIndicateur', () => {
       await runAsPrincipal(apiKey.id, () =>
         upsertIndicateur({
           publicId: indId,
-          body: { nom: 'I', referentielIds: ['REF-EMPTY-A'] },
+          body: {
+            nom: 'I',
+            referentiels: [{ referentielId: 'REF-EMPTY-A', fonctionAgregation: 'SUM' }],
+          },
         }),
       )
 
       await runAsPrincipal(apiKey.id, () =>
-        upsertIndicateur({ publicId: indId, body: { nom: 'I', referentielIds: [] } }),
+        upsertIndicateur({ publicId: indId, body: { nom: 'I', referentiels: [] } }),
       )
 
-      expect(await getReferentielPublicIds(indId)).toEqual([])
+      expect(await getReferentielLinks(indId)).toEqual([])
     }),
   )
 
@@ -101,12 +140,20 @@ describe.concurrent('upsertIndicateur', () => {
       const result = await runAsPrincipal(apiKey.id, () =>
         upsertIndicateur({
           publicId: indId,
-          body: { nom: 'I', referentielIds: ['REF-DEDUP-A', 'REF-DEDUP-A'] },
+          body: {
+            nom: 'I',
+            referentiels: [
+              { referentielId: 'REF-DEDUP-A', fonctionAgregation: 'SUM' },
+              { referentielId: 'REF-DEDUP-A', fonctionAgregation: 'SUM' },
+            ],
+          },
         }),
       )
 
       expect(result.isOk()).toBe(true)
-      expect(await getReferentielPublicIds(indId)).toEqual(['REF-DEDUP-A'])
+      expect(await getReferentielLinks(indId)).toEqual([
+        { referentielId: 'REF-DEDUP-A', fonctionAgregation: 'SUM' },
+      ])
     }),
   )
 
@@ -123,7 +170,11 @@ describe.concurrent('upsertIndicateur', () => {
             publicId: indId,
             body: {
               nom: 'I',
-              referentielIds: ['REF-UNKNOWN-A', 'REF-UNKNOWN-X', 'REF-UNKNOWN-Y'],
+              referentiels: [
+                { referentielId: 'REF-UNKNOWN-A', fonctionAgregation: 'SUM' },
+                { referentielId: 'REF-UNKNOWN-X', fonctionAgregation: 'SUM' },
+                { referentielId: 'REF-UNKNOWN-Y', fonctionAgregation: 'SUM' },
+              ],
             },
           }),
         ),
@@ -148,9 +199,69 @@ describe.concurrent('upsertIndicateur', () => {
 
       await expect(
         runAsPrincipal(apiKey.id, () =>
-          upsertIndicateur({ publicId: indId, body: { nom: 'X', referentielIds: [] } }),
+          upsertIndicateur({ publicId: indId, body: { nom: 'X', referentiels: [] } }),
         ),
       ).rejects.toThrow(/permission/i)
+    }),
+  )
+
+  it(
+    'met à jour la fonctionAgregation pour un lien existant',
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      await fixtures.referentiel({ publicId: 'REF-UPDATE-A' })
+      const apiKey = await fixtures.apiKey()
+
+      await runAsPrincipal(apiKey.id, () =>
+        upsertIndicateur({
+          publicId: indId,
+          body: {
+            nom: 'I',
+            referentiels: [{ referentielId: 'REF-UPDATE-A', fonctionAgregation: 'SUM' }],
+          },
+        }),
+      )
+
+      await runAsPrincipal(apiKey.id, () =>
+        upsertIndicateur({
+          publicId: indId,
+          body: {
+            nom: 'I',
+            referentiels: [{ referentielId: 'REF-UPDATE-A', fonctionAgregation: 'NONE' }],
+          },
+        }),
+      )
+
+      expect(await getReferentielLinks(indId)).toEqual([
+        { referentielId: 'REF-UPDATE-A', fonctionAgregation: 'NONE' },
+      ])
+    }),
+  )
+
+  it(
+    "dédoublonne sur referentielId : en cas de fonctions différentes, la dernière l'emporte",
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      await fixtures.referentiel({ publicId: 'REF-DEDUP-FN' })
+      const apiKey = await fixtures.apiKey()
+
+      const result = await runAsPrincipal(apiKey.id, () =>
+        upsertIndicateur({
+          publicId: indId,
+          body: {
+            nom: 'I',
+            referentiels: [
+              { referentielId: 'REF-DEDUP-FN', fonctionAgregation: 'SUM' },
+              { referentielId: 'REF-DEDUP-FN', fonctionAgregation: 'NONE' },
+            ],
+          },
+        }),
+      )
+
+      expect(result.isOk()).toBe(true)
+      expect(await getReferentielLinks(indId)).toEqual([
+        { referentielId: 'REF-DEDUP-FN', fonctionAgregation: 'NONE' },
+      ])
     }),
   )
 })

--- a/apps/mb-api/src/indicateur/commands/upsertIndicateur.ts
+++ b/apps/mb-api/src/indicateur/commands/upsertIndicateur.ts
@@ -1,47 +1,73 @@
-import { type UpsertIndicateurBody } from '@pilote/mb-shared/indicateur'
+import { type IndicateurReferentielLink, type UpsertIndicateurBody } from '@pilote/mb-shared/indicateur'
 import { ResultAsync } from 'neverthrow'
 import { uuidv7 } from 'uuidv7'
 
 import { requireCurrentPrincipalId } from '@/framework/auth/userContext'
-import { diff } from '@/framework/collections/diff'
 import { ForbiddenError, ValidationError } from '@/framework/errors/AppError'
 import { db } from '@/framework/persistence/dbStore'
-import { PermissionAction } from '@/generated/prisma/enums'
+import { type FonctionAgregation, PermissionAction } from '@/generated/prisma/enums'
 
 type UpsertIndicateurParams = {
   publicId: string
   body: UpsertIndicateurBody
 }
 
-const resolveReferentielIds = async (publicIds: readonly string[]): Promise<string[]> => {
-  const unique = [...new Set(publicIds)]
-  if (unique.length === 0) return []
+type ResolvedLink = { referentielId: string; fonctionAgregation: FonctionAgregation }
+
+const resolveReferentielLinks = async (
+  links: ReadonlyArray<IndicateurReferentielLink>,
+): Promise<ResolvedLink[]> => {
+  const dedupedByPublicId = new Map<string, FonctionAgregation>()
+  for (const link of links) {
+    dedupedByPublicId.set(link.referentielId, link.fonctionAgregation)
+  }
+  const publicIds = [...dedupedByPublicId.keys()]
+  if (publicIds.length === 0) return []
+
   const found = await db().referentiel.findMany({
-    where: { publicId: { in: unique } },
+    where: { publicId: { in: publicIds } },
     select: { id: true, publicId: true },
   })
   const foundPublicIds = new Set(found.map((r) => r.publicId))
-  const unknownIds = unique.filter((id) => !foundPublicIds.has(id))
+  const unknownIds = publicIds.filter((id) => !foundPublicIds.has(id))
   if (unknownIds.length > 0) {
     throw new ValidationError('Référentiels inconnus', {
       unknownReferentielIds: unknownIds.sort(),
     })
   }
-  return found.map((r) => r.id)
+  return found.map((r) => ({
+    referentielId: r.id,
+    fonctionAgregation: dedupedByPublicId.get(r.publicId)!,
+  }))
 }
 
 const replaceReferentielLinks = async (
   indicateurId: string,
-  referentielIds: string[],
+  links: ResolvedLink[],
 ): Promise<void> => {
   const existing = await db().indicateurReferentiel.findMany({
     where: { indicateurId },
-    select: { referentielId: true },
+    select: { referentielId: true, fonctionAgregation: true },
   })
-  const { toAdd, toRemove } = diff(
-    referentielIds,
-    existing.map((link) => link.referentielId),
+  const existingByReferentielId = new Map(
+    existing.map((row) => [row.referentielId, row.fonctionAgregation]),
   )
+  const targetReferentielIds = new Set(links.map((l) => l.referentielId))
+
+  const toRemove = existing
+    .filter((row) => !targetReferentielIds.has(row.referentielId))
+    .map((row) => row.referentielId)
+
+  const toAdd: ResolvedLink[] = []
+  const toUpdate: ResolvedLink[] = []
+  for (const link of links) {
+    const existingFonction = existingByReferentielId.get(link.referentielId)
+    if (existingFonction === undefined) {
+      toAdd.push(link)
+    } else if (existingFonction !== link.fonctionAgregation) {
+      toUpdate.push(link)
+    }
+  }
 
   if (toRemove.length > 0) {
     await db().indicateurReferentiel.deleteMany({
@@ -50,7 +76,22 @@ const replaceReferentielLinks = async (
   }
   if (toAdd.length > 0) {
     await db().indicateurReferentiel.createMany({
-      data: toAdd.map((referentielId) => ({ indicateurId, referentielId })),
+      data: toAdd.map((link) => ({
+        indicateurId,
+        referentielId: link.referentielId,
+        fonctionAgregation: link.fonctionAgregation,
+      })),
+    })
+  }
+  for (const link of toUpdate) {
+    await db().indicateurReferentiel.update({
+      where: {
+        indicateurId_referentielId: {
+          indicateurId,
+          referentielId: link.referentielId,
+        },
+      },
+      data: { fonctionAgregation: link.fonctionAgregation },
     })
   }
 }
@@ -88,9 +129,9 @@ const updateExisting = async ({
   principalId: string
 }): Promise<void> => {
   await assertWritePermission({ indicateurId, principalId })
-  const referentielIds = await resolveReferentielIds(body.referentielIds)
+  const links = await resolveReferentielLinks(body.referentiels)
   await db().indicateur.update({ where: { publicId }, data: { nom: body.nom } })
-  await replaceReferentielLinks(indicateurId, referentielIds)
+  await replaceReferentielLinks(indicateurId, links)
 }
 
 const createWithGrants = async ({
@@ -102,7 +143,7 @@ const createWithGrants = async ({
   body: UpsertIndicateurBody
   principalId: string
 }): Promise<void> => {
-  const referentielIds = await resolveReferentielIds(body.referentielIds)
+  const links = await resolveReferentielLinks(body.referentiels)
   const id = uuidv7()
   await db().indicateur.create({ data: { id, publicId, nom: body.nom } })
   await db().indicateurPermission.createMany({
@@ -111,9 +152,13 @@ const createWithGrants = async ({
       { principalId, indicateurId: id, action: PermissionAction.WRITE },
     ],
   })
-  if (referentielIds.length > 0) {
+  if (links.length > 0) {
     await db().indicateurReferentiel.createMany({
-      data: referentielIds.map((referentielId) => ({ indicateurId: id, referentielId })),
+      data: links.map((link) => ({
+        indicateurId: id,
+        referentielId: link.referentielId,
+        fonctionAgregation: link.fonctionAgregation,
+      })),
     })
   }
 }

--- a/apps/mb-api/src/indicateur/commands/upsertIndicateur.ts
+++ b/apps/mb-api/src/indicateur/commands/upsertIndicateur.ts
@@ -1,4 +1,7 @@
-import { type IndicateurReferentielLink, type UpsertIndicateurBody } from '@pilote/mb-shared/indicateur'
+import {
+  type IndicateurReferentielLink,
+  type UpsertIndicateurBody,
+} from '@pilote/mb-shared/indicateur'
 import { ResultAsync } from 'neverthrow'
 import { uuidv7 } from 'uuidv7'
 

--- a/apps/mb-api/src/indicateur/commands/upsertIndicateur.ts
+++ b/apps/mb-api/src/indicateur/commands/upsertIndicateur.ts
@@ -1,5 +1,5 @@
 import {
-  type IndicateurReferentielLink,
+  type ConfigurationIndicateurReferentiel,
   type UpsertIndicateurBody,
 } from '@pilote/mb-shared/indicateur'
 import { ResultAsync } from 'neverthrow'
@@ -10,102 +10,92 @@ import { ForbiddenError, ValidationError } from '@/framework/errors/AppError'
 import { db } from '@/framework/persistence/dbStore'
 import { type FonctionAgregation, PermissionAction } from '@/generated/prisma/enums'
 
-type UpsertIndicateurParams = {
-  publicId: string
-  body: UpsertIndicateurBody
+type ConfigurationResolue = {
+  referentielId: string
+  fonctionAgregation: FonctionAgregation
 }
 
-type ResolvedLink = { referentielId: string; fonctionAgregation: FonctionAgregation }
-
-const resolveReferentielLinks = async (
-  links: ReadonlyArray<IndicateurReferentielLink>,
-): Promise<ResolvedLink[]> => {
-  const dedupedByPublicId = new Map<string, FonctionAgregation>()
-  for (const link of links) {
-    dedupedByPublicId.set(link.referentielId, link.fonctionAgregation)
+const dedupeConfigurations = (
+  configurations: ReadonlyArray<ConfigurationIndicateurReferentiel>,
+): Map<string, FonctionAgregation> => {
+  const parPublicId = new Map<string, FonctionAgregation>()
+  for (const configuration of configurations) {
+    parPublicId.set(configuration.referentielPublicId, configuration.fonctionAgregation)
   }
-  const publicIds = [...dedupedByPublicId.keys()]
+  return parPublicId
+}
+
+const resoudreConfigurationsReferentiels = async (
+  configurations: ReadonlyArray<ConfigurationIndicateurReferentiel>,
+): Promise<ConfigurationResolue[]> => {
+  const fonctionParPublicId = dedupeConfigurations(configurations)
+  const publicIds = [...fonctionParPublicId.keys()]
   if (publicIds.length === 0) return []
 
-  const found = await db().referentiel.findMany({
+  const referentiels = await db().referentiel.findMany({
     where: { publicId: { in: publicIds } },
-    select: { id: true, publicId: true },
   })
-  const foundPublicIds = new Set(found.map((r) => r.publicId))
-  const unknownIds = publicIds.filter((id) => !foundPublicIds.has(id))
-  if (unknownIds.length > 0) {
+  const publicIdsTrouves = new Set(referentiels.map((referentiel) => referentiel.publicId))
+  const publicIdsInconnus = publicIds.filter((id) => !publicIdsTrouves.has(id))
+  if (publicIdsInconnus.length > 0) {
     throw new ValidationError('Référentiels inconnus', {
-      unknownReferentielIds: unknownIds.sort(),
+      unknownReferentielIds: publicIdsInconnus.sort(),
     })
   }
-  return found.map((r) => ({
-    referentielId: r.id,
-    fonctionAgregation: dedupedByPublicId.get(r.publicId)!,
+  return referentiels.map((referentiel) => ({
+    referentielId: referentiel.id,
+    fonctionAgregation: fonctionParPublicId.get(referentiel.publicId)!,
   }))
 }
 
-const replaceReferentielLinks = async (
+const supprimerConfigurationsRetirees = async (
   indicateurId: string,
-  links: ResolvedLink[],
+  referentielIdsCibles: Set<string>,
 ): Promise<void> => {
-  const existing = await db().indicateurReferentiel.findMany({
-    where: { indicateurId },
-    select: { referentielId: true, fonctionAgregation: true },
+  const existantes = await db().indicateurReferentiel.findMany({ where: { indicateurId } })
+  const aSupprimer = existantes
+    .filter((configuration) => !referentielIdsCibles.has(configuration.referentielId))
+    .map((configuration) => configuration.referentielId)
+  if (aSupprimer.length === 0) return
+  await db().indicateurReferentiel.deleteMany({
+    where: { indicateurId, referentielId: { in: aSupprimer } },
   })
-  const existingByReferentielId = new Map(
-    existing.map((row) => [row.referentielId, row.fonctionAgregation]),
-  )
-  const targetReferentielIds = new Set(links.map((l) => l.referentielId))
+}
 
-  const toRemove = existing
-    .filter((row) => !targetReferentielIds.has(row.referentielId))
-    .map((row) => row.referentielId)
-
-  const toAdd: ResolvedLink[] = []
-  const toUpdate: ResolvedLink[] = []
-  for (const link of links) {
-    const existingFonction = existingByReferentielId.get(link.referentielId)
-    if (existingFonction === undefined) {
-      toAdd.push(link)
-    } else if (existingFonction !== link.fonctionAgregation) {
-      toUpdate.push(link)
-    }
-  }
-
-  if (toRemove.length > 0) {
-    await db().indicateurReferentiel.deleteMany({
-      where: { indicateurId, referentielId: { in: toRemove } },
-    })
-  }
-  if (toAdd.length > 0) {
-    await db().indicateurReferentiel.createMany({
-      data: toAdd.map((link) => ({
-        indicateurId,
-        referentielId: link.referentielId,
-        fonctionAgregation: link.fonctionAgregation,
-      })),
-    })
-  }
-  for (const link of toUpdate) {
-    await db().indicateurReferentiel.update({
+const upsertConfigurationsCibles = async (
+  indicateurId: string,
+  configurations: ConfigurationResolue[],
+): Promise<void> => {
+  for (const configuration of configurations) {
+    await db().indicateurReferentiel.upsert({
       where: {
         indicateurId_referentielId: {
           indicateurId,
-          referentielId: link.referentielId,
+          referentielId: configuration.referentielId,
         },
       },
-      data: { fonctionAgregation: link.fonctionAgregation },
+      update: { fonctionAgregation: configuration.fonctionAgregation },
+      create: {
+        indicateurId,
+        referentielId: configuration.referentielId,
+        fonctionAgregation: configuration.fonctionAgregation,
+      },
     })
   }
 }
 
-const assertWritePermission = async ({
-  indicateurId,
-  principalId,
-}: {
-  indicateurId: string
-  principalId: string
-}): Promise<void> => {
+const remplacerConfigurationsReferentiels = async (
+  indicateurId: string,
+  configurations: ConfigurationResolue[],
+): Promise<void> => {
+  const referentielIdsCibles = new Set(
+    configurations.map((configuration) => configuration.referentielId),
+  )
+  await supprimerConfigurationsRetirees(indicateurId, referentielIdsCibles)
+  await upsertConfigurationsCibles(indicateurId, configurations)
+}
+
+const assertWritePermission = async (indicateurId: string, principalId: string): Promise<void> => {
   const hasWrite = await db().indicateurPermission.findUnique({
     where: {
       principalId_indicateurId_action: {
@@ -120,61 +110,58 @@ const assertWritePermission = async ({
   }
 }
 
-const updateExisting = async ({
-  publicId,
-  indicateurId,
-  body,
-  principalId,
-}: {
-  publicId: string
-  indicateurId: string
-  body: UpsertIndicateurBody
-  principalId: string
-}): Promise<void> => {
-  await assertWritePermission({ indicateurId, principalId })
-  const links = await resolveReferentielLinks(body.referentiels)
+const updateIndicateurExistant = async (
+  publicId: string,
+  indicateurId: string,
+  body: UpsertIndicateurBody,
+  principalId: string,
+): Promise<void> => {
+  await assertWritePermission(indicateurId, principalId)
+  const configurations = await resoudreConfigurationsReferentiels(body.referentiels)
   await db().indicateur.update({ where: { publicId }, data: { nom: body.nom } })
-  await replaceReferentielLinks(indicateurId, links)
+  await remplacerConfigurationsReferentiels(indicateurId, configurations)
 }
 
-const createWithGrants = async ({
-  publicId,
-  body,
-  principalId,
-}: {
-  publicId: string
-  body: UpsertIndicateurBody
-  principalId: string
-}): Promise<void> => {
-  const links = await resolveReferentielLinks(body.referentiels)
-  const id = uuidv7()
-  await db().indicateur.create({ data: { id, publicId, nom: body.nom } })
+const grantOwnerPermissions = async (principalId: string, indicateurId: string): Promise<void> => {
   await db().indicateurPermission.createMany({
     data: [
-      { principalId, indicateurId: id, action: PermissionAction.READ },
-      { principalId, indicateurId: id, action: PermissionAction.WRITE },
+      { principalId, indicateurId, action: PermissionAction.READ },
+      { principalId, indicateurId, action: PermissionAction.WRITE },
     ],
   })
-  if (links.length > 0) {
+}
+
+const createIndicateurAvecGrants = async (
+  publicId: string,
+  body: UpsertIndicateurBody,
+  principalId: string,
+): Promise<void> => {
+  const configurations = await resoudreConfigurationsReferentiels(body.referentiels)
+  const indicateurId = uuidv7()
+  await db().indicateur.create({ data: { id: indicateurId, publicId, nom: body.nom } })
+  await grantOwnerPermissions(principalId, indicateurId)
+  if (configurations.length > 0) {
     await db().indicateurReferentiel.createMany({
-      data: links.map((link) => ({
-        indicateurId: id,
-        referentielId: link.referentielId,
-        fonctionAgregation: link.fonctionAgregation,
+      data: configurations.map((configuration) => ({
+        indicateurId,
+        referentielId: configuration.referentielId,
+        fonctionAgregation: configuration.fonctionAgregation,
       })),
     })
   }
 }
 
-const performUpsert = async ({ publicId, body }: UpsertIndicateurParams): Promise<void> => {
+const performUpsert = async (publicId: string, body: UpsertIndicateurBody): Promise<void> => {
   const principalId = requireCurrentPrincipalId()
-  const existing = await db().indicateur.findUnique({ where: { publicId } })
-  if (existing) {
-    await updateExisting({ publicId, indicateurId: existing.id, body, principalId })
+  const existant = await db().indicateur.findUnique({ where: { publicId } })
+  if (existant) {
+    await updateIndicateurExistant(publicId, existant.id, body, principalId)
     return
   }
-  await createWithGrants({ publicId, body, principalId })
+  await createIndicateurAvecGrants(publicId, body, principalId)
 }
 
-export const upsertIndicateur = (params: UpsertIndicateurParams): ResultAsync<void, never> =>
-  ResultAsync.fromSafePromise(performUpsert(params))
+export const upsertIndicateur = (
+  publicId: string,
+  body: UpsertIndicateurBody,
+): ResultAsync<void, never> => ResultAsync.fromSafePromise(performUpsert(publicId, body))

--- a/apps/mb-api/src/indicateur/queries/getIndicateurByPublicId.test.ts
+++ b/apps/mb-api/src/indicateur/queries/getIndicateurByPublicId.test.ts
@@ -19,8 +19,8 @@ describe.concurrent('getIndicateurByPublicId', () => {
       )
       await db().indicateurReferentiel.createMany({
         data: [
-          { indicateurId: indicateur.id, referentielId: refA!.id },
-          { indicateurId: indicateur.id, referentielId: refB!.id },
+          { indicateurId: indicateur.id, referentielId: refA!.id, fonctionAgregation: 'SUM' },
+          { indicateurId: indicateur.id, referentielId: refB!.id, fonctionAgregation: 'SUM' },
         ],
       })
       const apiKey = await fixtures.apiKey({
@@ -33,7 +33,10 @@ describe.concurrent('getIndicateurByPublicId', () => {
       expect(result._unsafeUnwrap()).toEqual({
         id: indId,
         nom: 'Indicateur de test',
-        referentielIds: ['REF-DETAIL-A', 'REF-DETAIL-B'],
+        referentiels: [
+          { referentielId: 'REF-DETAIL-A', fonctionAgregation: 'SUM' },
+          { referentielId: 'REF-DETAIL-B', fonctionAgregation: 'SUM' },
+        ],
         createdAt: indicateur.createdAt.toISOString(),
         updatedAt: indicateur.updatedAt.toISOString(),
       })
@@ -52,7 +55,7 @@ describe.concurrent('getIndicateurByPublicId', () => {
       const result = await runAsPrincipal(apiKey.id, () => getIndicateurByPublicId(indId))
 
       expect(result.isOk()).toBe(true)
-      expect(result._unsafeUnwrap().referentielIds).toEqual([])
+      expect(result._unsafeUnwrap().referentiels).toEqual([])
     }),
   )
 

--- a/apps/mb-api/src/indicateur/queries/getIndicateurByPublicId.test.ts
+++ b/apps/mb-api/src/indicateur/queries/getIndicateurByPublicId.test.ts
@@ -34,8 +34,8 @@ describe.concurrent('getIndicateurByPublicId', () => {
         id: indId,
         nom: 'Indicateur de test',
         referentiels: [
-          { referentielId: 'REF-DETAIL-A', fonctionAgregation: 'SUM' },
-          { referentielId: 'REF-DETAIL-B', fonctionAgregation: 'SUM' },
+          { referentielPublicId: 'REF-DETAIL-A', fonctionAgregation: 'SUM' },
+          { referentielPublicId: 'REF-DETAIL-B', fonctionAgregation: 'SUM' },
         ],
         createdAt: indicateur.createdAt.toISOString(),
         updatedAt: indicateur.updatedAt.toISOString(),

--- a/apps/mb-api/src/indicateur/queries/getIndicateurByPublicId.ts
+++ b/apps/mb-api/src/indicateur/queries/getIndicateurByPublicId.ts
@@ -13,14 +13,7 @@ export const getIndicateurByPublicId = (
   return ResultAsync.fromSafePromise(
     db().indicateur.findFirstOrThrow({
       where: withIndicateurReadPermission({ publicId }, principalId),
-      include: {
-        referentiels: {
-          select: {
-            fonctionAgregation: true,
-            referentiel: { select: { publicId: true } },
-          },
-        },
-      },
+      include: { referentiels: { include: { referentiel: true } } },
     }),
   ).map(toIndicateurApiModel)
 }

--- a/apps/mb-api/src/indicateur/queries/getIndicateurByPublicId.ts
+++ b/apps/mb-api/src/indicateur/queries/getIndicateurByPublicId.ts
@@ -15,7 +15,10 @@ export const getIndicateurByPublicId = (
       where: withIndicateurReadPermission({ publicId }, principalId),
       include: {
         referentiels: {
-          include: { referentiel: { select: { publicId: true } } },
+          select: {
+            fonctionAgregation: true,
+            referentiel: { select: { publicId: true } },
+          },
         },
       },
     }),

--- a/apps/mb-api/src/indicateur/queries/listIndicateurs.test.ts
+++ b/apps/mb-api/src/indicateur/queries/listIndicateurs.test.ts
@@ -185,7 +185,7 @@ describe.concurrent('listIndicateurs', () => {
   )
 
   it(
-    'expose referentielIds triés par publicId ASC sur chaque item',
+    'expose referentiels triés par publicId ASC sur chaque item',
     integrationTest(async () => {
       const [accessible] = testIndicateurIds(1)
       const indicateur = await fixtures.indicateur({ publicId: accessible })
@@ -195,8 +195,8 @@ describe.concurrent('listIndicateurs', () => {
       )
       await db().indicateurReferentiel.createMany({
         data: [
-          { indicateurId: indicateur.id, referentielId: refA!.id },
-          { indicateurId: indicateur.id, referentielId: refB!.id },
+          { indicateurId: indicateur.id, referentielId: refA!.id, fonctionAgregation: 'SUM' },
+          { indicateurId: indicateur.id, referentielId: refB!.id, fonctionAgregation: 'SUM' },
         ],
       })
       const apiKey = await fixtures.apiKey({
@@ -206,9 +206,9 @@ describe.concurrent('listIndicateurs', () => {
       const result = await runAsPrincipal(apiKey.id, () => listIndicateurs({}))
 
       const value = result._unsafeUnwrap()
-      expect(value.items.find((i) => i.id === accessible)?.referentielIds).toEqual([
-        'REF-LIST-M',
-        'REF-LIST-Z',
+      expect(value.items.find((i) => i.id === accessible)?.referentiels).toEqual([
+        { referentielId: 'REF-LIST-M', fonctionAgregation: 'SUM' },
+        { referentielId: 'REF-LIST-Z', fonctionAgregation: 'SUM' },
       ])
     }),
   )

--- a/apps/mb-api/src/indicateur/queries/listIndicateurs.test.ts
+++ b/apps/mb-api/src/indicateur/queries/listIndicateurs.test.ts
@@ -207,8 +207,8 @@ describe.concurrent('listIndicateurs', () => {
 
       const value = result._unsafeUnwrap()
       expect(value.items.find((i) => i.id === accessible)?.referentiels).toEqual([
-        { referentielId: 'REF-LIST-M', fonctionAgregation: 'SUM' },
-        { referentielId: 'REF-LIST-Z', fonctionAgregation: 'SUM' },
+        { referentielPublicId: 'REF-LIST-M', fonctionAgregation: 'SUM' },
+        { referentielPublicId: 'REF-LIST-Z', fonctionAgregation: 'SUM' },
       ])
     }),
   )

--- a/apps/mb-api/src/indicateur/queries/listIndicateurs.ts
+++ b/apps/mb-api/src/indicateur/queries/listIndicateurs.ts
@@ -22,14 +22,7 @@ export const listIndicateurs = (
   const fetchPage = db().indicateur.findMany({
     where,
     orderBy: { id: 'asc' },
-    include: {
-      referentiels: {
-        select: {
-          fonctionAgregation: true,
-          referentiel: { select: { publicId: true } },
-        },
-      },
-    },
+    include: { referentiels: { include: { referentiel: true } } },
     ...buildPaginationArgs(params.cursor, params.pageSize),
   })
   const fetchTotal = db().indicateur.count({ where })

--- a/apps/mb-api/src/indicateur/queries/listIndicateurs.ts
+++ b/apps/mb-api/src/indicateur/queries/listIndicateurs.ts
@@ -24,7 +24,10 @@ export const listIndicateurs = (
     orderBy: { id: 'asc' },
     include: {
       referentiels: {
-        include: { referentiel: { select: { publicId: true } } },
+        select: {
+          fonctionAgregation: true,
+          referentiel: { select: { publicId: true } },
+        },
       },
     },
     ...buildPaginationArgs(params.cursor, params.pageSize),

--- a/apps/mb-api/src/indicateur/routes.ts
+++ b/apps/mb-api/src/indicateur/routes.ts
@@ -140,7 +140,7 @@ indicateurRoutes.openapi(upsertIndicateurRoute, async (context) => {
   const body = context.req.valid('json')
 
   const result = await withTransaction(async () => {
-    await upsertIndicateur({ publicId: id, body })
+    await upsertIndicateur(id, body)
     return getIndicateurByPublicId(id)
   })
 

--- a/apps/mb-api/src/indicateur/utils.ts
+++ b/apps/mb-api/src/indicateur/utils.ts
@@ -6,7 +6,7 @@ import { type IndicateurModel, type ReferentielModel } from '@/generated/prisma/
 export type IndicateurWithReferentiels = IndicateurModel & {
   referentiels: Array<{
     fonctionAgregation: FonctionAgregation
-    referentiel: Pick<ReferentielModel, 'publicId'>
+    referentiel: ReferentielModel
   }>
 }
 
@@ -16,11 +16,11 @@ export const toIndicateurApiModel = (
   id: indicateur.publicId,
   nom: indicateur.nom,
   referentiels: indicateur.referentiels
-    .map((link) => ({
-      referentielId: link.referentiel.publicId,
-      fonctionAgregation: link.fonctionAgregation,
+    .map((configuration) => ({
+      referentielPublicId: configuration.referentiel.publicId,
+      fonctionAgregation: configuration.fonctionAgregation,
     }))
-    .sort((a, b) => a.referentielId.localeCompare(b.referentielId)),
+    .sort((a, b) => a.referentielPublicId.localeCompare(b.referentielPublicId)),
   createdAt: indicateur.createdAt.toISOString(),
   updatedAt: indicateur.updatedAt.toISOString(),
 })

--- a/apps/mb-api/src/indicateur/utils.ts
+++ b/apps/mb-api/src/indicateur/utils.ts
@@ -1,9 +1,13 @@
 import { type IndicateurApiModel } from '@pilote/mb-shared/indicateur'
 
+import { type FonctionAgregation } from '@/generated/prisma/enums'
 import { type IndicateurModel, type ReferentielModel } from '@/generated/prisma/models'
 
 export type IndicateurWithReferentiels = IndicateurModel & {
-  referentiels: Array<{ referentiel: Pick<ReferentielModel, 'publicId'> }>
+  referentiels: Array<{
+    fonctionAgregation: FonctionAgregation
+    referentiel: Pick<ReferentielModel, 'publicId'>
+  }>
 }
 
 export const toIndicateurApiModel = (
@@ -11,7 +15,12 @@ export const toIndicateurApiModel = (
 ): IndicateurApiModel => ({
   id: indicateur.publicId,
   nom: indicateur.nom,
-  referentielIds: [...indicateur.referentiels.map((link) => link.referentiel.publicId)].sort(),
+  referentiels: indicateur.referentiels
+    .map((link) => ({
+      referentielId: link.referentiel.publicId,
+      fonctionAgregation: link.fonctionAgregation,
+    }))
+    .sort((a, b) => a.referentielId.localeCompare(b.referentielId)),
   createdAt: indicateur.createdAt.toISOString(),
   updatedAt: indicateur.updatedAt.toISOString(),
 })

--- a/apps/mb-api/src/test/fixtures.ts
+++ b/apps/mb-api/src/test/fixtures.ts
@@ -21,7 +21,7 @@ import {
   type UtilisateurModel,
   type ValeurAvancementModel,
 } from '@/generated/prisma/models'
-import { PermissionAction } from '@/generated/prisma/enums'
+import { PermissionAction, type FonctionAgregation } from '@/generated/prisma/enums'
 
 // --- Indicateur --------------------------------------------------------------
 
@@ -163,11 +163,13 @@ async function individu(
 type IndicateurReferentielOverrides = {
   indicateur: IndicateurOverrides
   referentiel: ReferentielOverrides
+  fonctionAgregation?: FonctionAgregation
 }
 
 const upsertIndicateurReferentiel = async (o: IndicateurReferentielOverrides) => {
   const indicateurRow = await upsertIndicateur(o.indicateur)
   const referentielRow = await upsertReferentiel(o.referentiel)
+  const fonctionAgregation = o.fonctionAgregation ?? 'SUM'
   return db().indicateurReferentiel.upsert({
     where: {
       indicateurId_referentielId: {
@@ -175,8 +177,12 @@ const upsertIndicateurReferentiel = async (o: IndicateurReferentielOverrides) =>
         referentielId: referentielRow.id,
       },
     },
-    update: {},
-    create: { indicateurId: indicateurRow.id, referentielId: referentielRow.id },
+    update: { fonctionAgregation },
+    create: {
+      indicateurId: indicateurRow.id,
+      referentielId: referentielRow.id,
+      fonctionAgregation,
+    },
   })
 }
 

--- a/apps/mb-api/src/valeurAvancement/queries/getValeurDerivee.test.ts
+++ b/apps/mb-api/src/valeurAvancement/queries/getValeurDerivee.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
+import { ValidationError } from '@/framework/errors/AppError'
 import { fixtures } from '@/test/fixtures'
 import { integrationTest } from '@/test/integrationTest'
 import {
@@ -24,6 +25,10 @@ describe.concurrent('getValeurDerivee', () => {
         publicId: deptId,
         referentiel: { publicId: refDept, nom: 'Dept' },
       })
+      await fixtures.indicateurReferentiel({
+        indicateur: { publicId: indId },
+        referentiel: { publicId: refDept },
+      })
       const apiKey = await fixtures.apiKey({
         permissions: [{ indicateur: { publicId: indId }, action: 'READ' }],
       })
@@ -33,7 +38,7 @@ describe.concurrent('getValeurDerivee', () => {
       expect(result._unsafeUnwrap()).toEqual({
         indicateur: indId,
         individu: deptId,
-        agregateur: 'SUM',
+        fonctionAgregation: 'SUM',
         valeurDerivee: null,
         contributions: [],
         couverture: { nbEnfantsAvecValeur: 0, nbEnfantsTotal: 0 },
@@ -59,6 +64,10 @@ describe.concurrent('getValeurDerivee', () => {
           child: { publicId: dept2, referentiel: { publicId: refDept } },
         },
       )
+      await fixtures.indicateurReferentiel({
+        indicateur: { publicId: indId },
+        referentiel: { publicId: refReg },
+      })
       await fixtures.valeurAvancement(
         {
           indicateur: { publicId: indId, nom: 'T' },
@@ -120,6 +129,10 @@ describe.concurrent('getValeurDerivee', () => {
           child: { publicId: dept3, referentiel: { publicId: refDept } },
         },
       )
+      await fixtures.indicateurReferentiel({
+        indicateur: { publicId: indId },
+        referentiel: { publicId: refReg },
+      })
       await fixtures.valeurAvancement({
         indicateur: { publicId: indId, nom: 'T' },
         individu: { publicId: dept1 },
@@ -179,6 +192,10 @@ describe.concurrent('getValeurDerivee', () => {
           child: { publicId: deptS2, referentiel: { publicId: refDept } },
         },
       )
+      await fixtures.indicateurReferentiel({
+        indicateur: { publicId: indId },
+        referentiel: { publicId: refPays },
+      })
       await fixtures.valeurAvancement(
         {
           indicateur: { publicId: indId, nom: 'T' },
@@ -249,6 +266,10 @@ describe.concurrent('getValeurDerivee', () => {
           child: { publicId: dept2, referentiel: { publicId: refDept } },
         },
       )
+      await fixtures.indicateurReferentiel({
+        indicateur: { publicId: indId },
+        referentiel: { publicId: refPays },
+      })
       await fixtures.valeurAvancement(
         {
           indicateur: { publicId: indId, nom: 'T' },
@@ -317,6 +338,60 @@ describe.concurrent('getValeurDerivee', () => {
       await expect(
         runAsPrincipal(apiKey.id, () => getValeurDerivee(indId, testDeptId())),
       ).rejects.toThrow()
+    }),
+  )
+
+  it(
+    "rejette avec ValidationError quand l'indicateur n'est pas configuré pour le référentiel de l'individu",
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const deptId = testDeptId()
+      const refDept = testReferentielId()
+      await fixtures.indicateur({ publicId: indId })
+      await fixtures.individu({
+        publicId: deptId,
+        referentiel: { publicId: refDept, nom: 'Dept' },
+      })
+      // Volontairement : aucun fixtures.indicateurReferentiel(...)
+      const apiKey = await fixtures.apiKey({
+        permissions: [{ indicateur: { publicId: indId }, action: 'READ' }],
+      })
+
+      await expect(
+        runAsPrincipal(apiKey.id, () => getValeurDerivee(indId, deptId)),
+      ).rejects.toMatchObject({
+        constructor: ValidationError,
+        message: expect.stringContaining("n'est pas configuré"),
+      })
+    }),
+  )
+
+  it(
+    'rejette avec ValidationError quand fonctionAgregation vaut NONE',
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const deptId = testDeptId()
+      const refDept = testReferentielId()
+      await fixtures.indicateur({ publicId: indId })
+      await fixtures.individu({
+        publicId: deptId,
+        referentiel: { publicId: refDept, nom: 'Dept' },
+      })
+      await fixtures.indicateurReferentiel({
+        indicateur: { publicId: indId },
+        referentiel: { publicId: refDept },
+        fonctionAgregation: 'NONE',
+      })
+      const apiKey = await fixtures.apiKey({
+        permissions: [{ indicateur: { publicId: indId }, action: 'READ' }],
+      })
+
+      await expect(
+        runAsPrincipal(apiKey.id, () => getValeurDerivee(indId, deptId)),
+      ).rejects.toMatchObject({
+        constructor: ValidationError,
+        message: expect.stringContaining('NONE'),
+      })
     }),
   )
 })

--- a/apps/mb-api/src/valeurAvancement/queries/getValeurDerivee.test.ts
+++ b/apps/mb-api/src/valeurAvancement/queries/getValeurDerivee.test.ts
@@ -28,6 +28,7 @@ describe.concurrent('getValeurDerivee', () => {
       await fixtures.indicateurReferentiel({
         indicateur: { publicId: indId },
         referentiel: { publicId: refDept },
+        fonctionAgregation: 'SUM',
       })
       const apiKey = await fixtures.apiKey({
         permissions: [{ indicateur: { publicId: indId }, action: 'READ' }],
@@ -67,6 +68,7 @@ describe.concurrent('getValeurDerivee', () => {
       await fixtures.indicateurReferentiel({
         indicateur: { publicId: indId },
         referentiel: { publicId: refReg },
+        fonctionAgregation: 'SUM',
       })
       await fixtures.valeurAvancement(
         {
@@ -132,6 +134,7 @@ describe.concurrent('getValeurDerivee', () => {
       await fixtures.indicateurReferentiel({
         indicateur: { publicId: indId },
         referentiel: { publicId: refReg },
+        fonctionAgregation: 'SUM',
       })
       await fixtures.valeurAvancement({
         indicateur: { publicId: indId, nom: 'T' },
@@ -195,6 +198,7 @@ describe.concurrent('getValeurDerivee', () => {
       await fixtures.indicateurReferentiel({
         indicateur: { publicId: indId },
         referentiel: { publicId: refPays },
+        fonctionAgregation: 'SUM',
       })
       await fixtures.valeurAvancement(
         {
@@ -269,6 +273,7 @@ describe.concurrent('getValeurDerivee', () => {
       await fixtures.indicateurReferentiel({
         indicateur: { publicId: indId },
         referentiel: { publicId: refPays },
+        fonctionAgregation: 'SUM',
       })
       await fixtures.valeurAvancement(
         {
@@ -390,7 +395,7 @@ describe.concurrent('getValeurDerivee', () => {
         runAsPrincipal(apiKey.id, () => getValeurDerivee(indId, deptId)),
       ).rejects.toMatchObject({
         constructor: ValidationError,
-        message: expect.stringContaining('NONE'),
+        message: expect.stringContaining('saisie directement'),
       })
     }),
   )

--- a/apps/mb-api/src/valeurAvancement/queries/getValeurDerivee.test.ts
+++ b/apps/mb-api/src/valeurAvancement/queries/getValeurDerivee.test.ts
@@ -9,6 +9,7 @@ import {
   testIndicateurId,
   testReferentielId,
   testRegId,
+  testRegIds,
 } from '@/test/randomIds'
 import { runAsPrincipal } from '@/test/runAsPrincipal'
 import { getValeurDerivee } from '@/valeurAvancement/queries/getValeurDerivee'
@@ -161,8 +162,7 @@ describe.concurrent('getValeurDerivee', () => {
     'dérive le niveau intermédiaire à partir des feuilles (grand-parent, 2 niveaux)',
     integrationTest(async () => {
       const indId = testIndicateurId()
-      const franceId = testRegId()
-      const [regN, regS] = [testRegId(), testRegId()]
+      const [franceId, regN, regS] = testRegIds(3)
       const [deptN1, deptN2, deptS1, deptS2] = testDeptIds(4)
       const refPays = testReferentielId()
       const refReg = testReferentielId()
@@ -250,8 +250,7 @@ describe.concurrent('getValeurDerivee', () => {
     'priorise la saisie sur un nœud intermédiaire (D1 : saisie ≻ dérivée pour la contribution au parent)',
     integrationTest(async () => {
       const indId = testIndicateurId()
-      const franceId = testRegId()
-      const reg = testRegId()
+      const [franceId, reg] = testRegIds(2)
       const [dept1, dept2] = testDeptIds(2)
       const refPays = testReferentielId()
       const refReg = testReferentielId()

--- a/apps/mb-api/src/valeurAvancement/queries/getValeurDerivee.ts
+++ b/apps/mb-api/src/valeurAvancement/queries/getValeurDerivee.ts
@@ -57,26 +57,26 @@ const buildResult = async (
     where: { publicId: individuPublicId },
   })
 
-  const lien = await db().indicateurReferentiel.findUnique({
+  const configurationIndicateurReferentiel = await db().indicateurReferentiel.findUnique({
     where: {
       indicateurId_referentielId: {
         indicateurId: indicateur.id,
         referentielId: cible.referentielId,
       },
     },
-    select: { fonctionAgregation: true },
   })
 
-  if (!lien) {
+  if (!configurationIndicateurReferentiel) {
     throw new ValidationError(
       "L'indicateur n'est pas configuré pour le référentiel de cet individu",
       { indicateur: indicateur.publicId, individu: cible.publicId },
     )
   }
 
-  if (lien.fonctionAgregation === 'NONE') {
+  if (configurationIndicateurReferentiel.fonctionAgregation === 'NONE') {
     throw new ValidationError(
-      "Cet indicateur n'est pas dérivable pour ce référentiel (fonction d'agrégation NONE)",
+      'Cet indicateur ne se dérive pas depuis ses enfants pour ce référentiel : ' +
+        'la valeur doit être saisie directement.',
       { indicateur: indicateur.publicId, individu: cible.publicId },
     )
   }
@@ -101,7 +101,7 @@ const buildResult = async (
   return {
     indicateur: indicateur.publicId,
     individu: cible.publicId,
-    fonctionAgregation: lien.fonctionAgregation,
+    fonctionAgregation: configurationIndicateurReferentiel.fonctionAgregation,
     valeurDerivee,
     contributions,
     couverture,

--- a/apps/mb-api/src/valeurAvancement/queries/getValeurDerivee.ts
+++ b/apps/mb-api/src/valeurAvancement/queries/getValeurDerivee.ts
@@ -2,6 +2,7 @@ import { type ValeurDeriveeApiModel } from '@pilote/mb-shared/valeurAvancement'
 import { ResultAsync } from 'neverthrow'
 
 import { requireCurrentPrincipalId } from '@/framework/auth/userContext'
+import { ValidationError } from '@/framework/errors/AppError'
 import { db } from '@/framework/persistence/dbStore'
 import { getDernieresValeursPourIndividus } from '@/generated/prisma/sql'
 import { withIndicateurReadPermission } from '@/indicateur/permissions'
@@ -56,6 +57,30 @@ const buildResult = async (
     where: { publicId: individuPublicId },
   })
 
+  const lien = await db().indicateurReferentiel.findUnique({
+    where: {
+      indicateurId_referentielId: {
+        indicateurId: indicateur.id,
+        referentielId: cible.referentielId,
+      },
+    },
+    select: { fonctionAgregation: true },
+  })
+
+  if (!lien) {
+    throw new ValidationError(
+      "L'indicateur n'est pas configuré pour le référentiel de cet individu",
+      { indicateur: indicateur.publicId, individu: cible.publicId },
+    )
+  }
+
+  if (lien.fonctionAgregation === 'NONE') {
+    throw new ValidationError(
+      "Cet indicateur n'est pas dérivable pour ce référentiel (fonction d'agrégation NONE)",
+      { indicateur: indicateur.publicId, individu: cible.publicId },
+    )
+  }
+
   const { allIds, enfantsParParent } = await loadIndividuTree(cible.id)
 
   const rows = await db().$queryRawTyped(getDernieresValeursPourIndividus(indicateur.id, allIds))
@@ -76,7 +101,7 @@ const buildResult = async (
   return {
     indicateur: indicateur.publicId,
     individu: cible.publicId,
-    agregateur: 'SUM',
+    fonctionAgregation: lien.fonctionAgregation,
     valeurDerivee,
     contributions,
     couverture,

--- a/apps/mb-webapp/src/components/indicateurs/IndividuSelect.tsx
+++ b/apps/mb-webapp/src/components/indicateurs/IndividuSelect.tsx
@@ -33,15 +33,16 @@ type IndividuSelectProps = {
 
 export function IndividuSelect({ id, indicateurId, value, onChange }: IndividuSelectProps) {
   const { data: indicateur } = useSuspenseQuery(indicateurQueryOptions(indicateurId))
+  const referentielIds = indicateur.referentiels.map((link) => link.referentielId)
   const referentiels = useSuspenseQueries({
-    queries: indicateur.referentielIds.map((refId) => referentielQueryOptions(refId)),
+    queries: referentielIds.map((refId) => referentielQueryOptions(refId)),
     combine: (results) => results.map((r) => r.data),
   })
   const individusByReferentiel = useSuspenseQueries({
-    queries: indicateur.referentielIds.map((refId) => referentielIndividusQueryOptions(refId)),
+    queries: referentielIds.map((refId) => referentielIndividusQueryOptions(refId)),
     combine: (results) => results.map((r) => r.data),
   })
-  const groupes: Groupe[] = indicateur.referentielIds.map((_, i) => ({
+  const groupes: Groupe[] = referentielIds.map((_, i) => ({
     referentiel: referentiels[i]!,
     individus: individusByReferentiel[i]!,
   }))

--- a/apps/mb-webapp/src/components/indicateurs/IndividuSelect.tsx
+++ b/apps/mb-webapp/src/components/indicateurs/IndividuSelect.tsx
@@ -33,7 +33,9 @@ type IndividuSelectProps = {
 
 export function IndividuSelect({ id, indicateurId, value, onChange }: IndividuSelectProps) {
   const { data: indicateur } = useSuspenseQuery(indicateurQueryOptions(indicateurId))
-  const referentielIds = indicateur.referentiels.map((link) => link.referentielId)
+  const referentielIds = indicateur.referentiels.map(
+    (configuration) => configuration.referentielPublicId,
+  )
   const referentiels = useSuspenseQueries({
     queries: referentielIds.map((refId) => referentielQueryOptions(refId)),
     combine: (results) => results.map((r) => r.data),

--- a/apps/mb-webapp/src/routes/_authenticated/indicateurs/$id.tsx
+++ b/apps/mb-webapp/src/routes/_authenticated/indicateurs/$id.tsx
@@ -46,7 +46,9 @@ export const Route = createFileRoute('/_authenticated/indicateurs/$id')({
     const { queryClient } = context
     const indicateur = await loadIndicateur({ queryClient, indicateurId: params.id })
 
-    const referentielIds = indicateur.referentiels.map((link) => link.referentielId)
+    const referentielIds = indicateur.referentiels.map(
+      (configuration) => configuration.referentielPublicId,
+    )
     if (referentielIds.length === 0) return { indicateur }
 
     const individus = await loadIndividusFromReferentiels({

--- a/apps/mb-webapp/src/routes/_authenticated/indicateurs/$id.tsx
+++ b/apps/mb-webapp/src/routes/_authenticated/indicateurs/$id.tsx
@@ -46,11 +46,12 @@ export const Route = createFileRoute('/_authenticated/indicateurs/$id')({
     const { queryClient } = context
     const indicateur = await loadIndicateur({ queryClient, indicateurId: params.id })
 
-    if (indicateur.referentielIds.length === 0) return { indicateur }
+    const referentielIds = indicateur.referentiels.map((link) => link.referentielId)
+    if (referentielIds.length === 0) return { indicateur }
 
     const individus = await loadIndividusFromReferentiels({
       queryClient,
-      referentielIds: indicateur.referentielIds,
+      referentielIds,
     })
     if (individus.length === 0) return { indicateur }
 
@@ -95,7 +96,7 @@ function IndicateurDetailComponent() {
     </BackLink>
   )
 
-  if (indicateur.referentielIds.length === 0) {
+  if (indicateur.referentiels.length === 0) {
     return (
       <Page title={indicateur.nom} back={back}>
         <Section>

--- a/packages/mb-shared/src/indicateur.ts
+++ b/packages/mb-shared/src/indicateur.ts
@@ -11,26 +11,31 @@ export const indicateurPublicIdSchema = z
 export const fonctionAgregationSchema = z
   .enum(['SUM', 'NONE'])
   .describe(
-    "Fonction d'agrégation appliquée pour dériver la valeur d'un parent depuis ses enfants. " +
-      "`SUM` = somme des contributions ; `NONE` = indicateur non dérivable pour ce référentiel.",
+    "Fonction d'agrégation appliquée pour calculer la valeur d'un parent à partir des valeurs " +
+      "de ses enfants. `SUM` = somme des contributions des enfants. `NONE` = pas d'agrégation : " +
+      "la valeur doit être saisie directement pour ce référentiel, elle n'est jamais dérivée depuis " +
+      'les enfants.',
   )
 export type FonctionAgregation = z.infer<typeof fonctionAgregationSchema>
 
-export const indicateurReferentielLinkSchema = z
+export const configurationIndicateurReferentielSchema = z
   .object({
-    referentielId: referentielPublicIdSchema,
+    referentielPublicId: referentielPublicIdSchema,
     fonctionAgregation: fonctionAgregationSchema,
   })
-  .describe("Lien indicateur-référentiel avec sa fonction d'agrégation.")
-export type IndicateurReferentielLink = z.infer<typeof indicateurReferentielLinkSchema>
+  .describe("Configuration d'un indicateur sur un référentiel donné.")
+export type ConfigurationIndicateurReferentiel = z.infer<
+  typeof configurationIndicateurReferentielSchema
+>
 
 export const indicateurApiModelSchema = z.object({
   id: indicateurPublicIdSchema,
   nom: z.string().describe("Nom lisible de l'indicateur."),
   referentiels: z
-    .array(indicateurReferentielLinkSchema)
+    .array(configurationIndicateurReferentielSchema)
     .describe(
-      "Liens vers les référentiels associés, triés par `referentielId` ASC. Tableau vide si aucun lien.",
+      'Configurations de cet indicateur sur chaque référentiel associé, triées par ' +
+        '`referentielPublicId` ASC. Tableau vide si aucun référentiel.',
     ),
   createdAt: z.string().datetime().describe('Date ISO 8601 de création.'),
   updatedAt: z.string().datetime().describe('Date ISO 8601 de dernière mise à jour.'),
@@ -46,10 +51,11 @@ export type ListIndicateursQuery = z.infer<typeof listIndicateursQuerySchema>
 export const upsertIndicateurBodySchema = z.object({
   nom: z.string().min(1).describe("Nom lisible de l'indicateur."),
   referentiels: z
-    .array(indicateurReferentielLinkSchema)
+    .array(configurationIndicateurReferentielSchema)
     .describe(
-      'Liste complète des liens à appliquer (replace-all à chaque PUT). Tableau vide pour aucun lien. ' +
-        "Doublons silencieusement dédupliqués sur `referentielId` ; en cas de fonctions différentes, la dernière occurrence l'emporte.",
+      'Liste complète des référentiels configurés pour cet indicateur (replace-all à chaque PUT). ' +
+        'Tableau vide pour aucun référentiel. Doublons silencieusement dédupliqués sur ' +
+        "`referentielPublicId` ; en cas de fonctions différentes, la dernière occurrence l'emporte.",
     ),
 })
 export type UpsertIndicateurBody = z.infer<typeof upsertIndicateurBodySchema>

--- a/packages/mb-shared/src/indicateur.ts
+++ b/packages/mb-shared/src/indicateur.ts
@@ -8,12 +8,30 @@ export const indicateurPublicIdSchema = z
   .regex(/^IND-\d+$/, 'Identifiant public attendu au format IND-XXX')
   .describe("Identifiant public de l'indicateur (format IND-XXX).")
 
+export const fonctionAgregationSchema = z
+  .enum(['SUM', 'NONE'])
+  .describe(
+    "Fonction d'agrégation appliquée pour dériver la valeur d'un parent depuis ses enfants. " +
+      "`SUM` = somme des contributions ; `NONE` = indicateur non dérivable pour ce référentiel.",
+  )
+export type FonctionAgregation = z.infer<typeof fonctionAgregationSchema>
+
+export const indicateurReferentielLinkSchema = z
+  .object({
+    referentielId: referentielPublicIdSchema,
+    fonctionAgregation: fonctionAgregationSchema,
+  })
+  .describe("Lien indicateur-référentiel avec sa fonction d'agrégation.")
+export type IndicateurReferentielLink = z.infer<typeof indicateurReferentielLinkSchema>
+
 export const indicateurApiModelSchema = z.object({
   id: indicateurPublicIdSchema,
   nom: z.string().describe("Nom lisible de l'indicateur."),
-  referentielIds: z
-    .array(referentielPublicIdSchema)
-    .describe('Référentiels liés à l\'indicateur, triés par identifiant public ASC. Tableau vide si aucun lien.'),
+  referentiels: z
+    .array(indicateurReferentielLinkSchema)
+    .describe(
+      "Liens vers les référentiels associés, triés par `referentielId` ASC. Tableau vide si aucun lien.",
+    ),
   createdAt: z.string().datetime().describe('Date ISO 8601 de création.'),
   updatedAt: z.string().datetime().describe('Date ISO 8601 de dernière mise à jour.'),
 })
@@ -27,11 +45,11 @@ export type ListIndicateursQuery = z.infer<typeof listIndicateursQuerySchema>
 
 export const upsertIndicateurBodySchema = z.object({
   nom: z.string().min(1).describe("Nom lisible de l'indicateur."),
-  referentielIds: z
-    .array(referentielPublicIdSchema)
+  referentiels: z
+    .array(indicateurReferentielLinkSchema)
     .describe(
-      'Liste complète des référentiels à lier à l\'indicateur (replace-all à chaque PUT). ' +
-        'Tableau vide pour ne lier aucun référentiel. Doublons silencieusement dédupliqués.',
+      'Liste complète des liens à appliquer (replace-all à chaque PUT). Tableau vide pour aucun lien. ' +
+        "Doublons silencieusement dédupliqués sur `referentielId` ; en cas de fonctions différentes, la dernière occurrence l'emporte.",
     ),
 })
 export type UpsertIndicateurBody = z.infer<typeof upsertIndicateurBodySchema>

--- a/packages/mb-shared/src/valeurAvancement.ts
+++ b/packages/mb-shared/src/valeurAvancement.ts
@@ -275,7 +275,8 @@ export const valeurDeriveeApiModelSchema = z.object({
   individu: individuPublicIdSchema,
   fonctionAgregation: fonctionAgregationSchema.describe(
     "Fonction d'agrégation appliquée pour ce couple (indicateur, référentiel de l'individu). " +
-      "Toujours `SUM` quand le calcul a abouti ; un retour 400 est renvoyé si la fonction vaut `NONE`.",
+      "Toujours `SUM` quand le calcul a abouti ; un retour 400 est renvoyé si la fonction vaut " +
+      '`NONE` (la valeur doit alors être saisie directement, pas dérivée).',
   ),
   valeurDerivee: z
     .number()

--- a/packages/mb-shared/src/valeurAvancement.ts
+++ b/packages/mb-shared/src/valeurAvancement.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod'
 
-import { indicateurPublicIdSchema } from './indicateur'
+import { fonctionAgregationSchema, indicateurPublicIdSchema } from './indicateur'
 import { individuApiModelSchema, individuPublicIdSchema } from './individu'
 import {
   createPaginatedApiListSchema,
@@ -273,12 +273,15 @@ export type CouvertureApiModel = z.infer<typeof couvertureApiModelSchema>
 export const valeurDeriveeApiModelSchema = z.object({
   indicateur: indicateurPublicIdSchema,
   individu: individuPublicIdSchema,
-  agregateur: z.literal('SUM').describe('Agrégateur appliqué (SUM uniquement pour le moment).'),
+  fonctionAgregation: fonctionAgregationSchema.describe(
+    "Fonction d'agrégation appliquée pour ce couple (indicateur, référentiel de l'individu). " +
+      "Toujours `SUM` quand le calcul a abouti ; un retour 400 est renvoyé si la fonction vaut `NONE`.",
+  ),
   valeurDerivee: z
     .number()
     .nullable()
     .describe(
-      "Somme des valeurs retenues parmi les enfants directs. null si aucun enfant n'a de valeur.",
+      "Résultat de l'agrégation appliquée aux valeurs retenues parmi les enfants directs. null si aucun enfant n'a de valeur.",
     ),
   contributions: z
     .array(contributionApiModelSchema)


### PR DESCRIPTION
## Summary

Rend explicite et configurable la fonction d'agrégation utilisée lors du calcul de la valeur dérivée d'un indicateur, en l'attachant au lien `IndicateurReferentiel`.

- Nouvelle enum Prisma `FonctionAgregation { SUM, NONE }` + colonne NOT NULL `fonctionAgregation` sur `IndicateurReferentiel`
- API `PUT /indicateurs/{id}` : body évolue de `referentielIds: string[]` à `referentiels: Array<{ referentielId, fonctionAgregation }>` (idem en sortie GET)
- `getValeurDerivee` : lookup obligatoire du lien `(indicateur, référentiel de l'individu)`, **400 VALIDATION_ERROR** si lien absent ou fonction `NONE`
- Renommage du champ `agregateur` (literal `'SUM'` hardcodé) → `fonctionAgregation` (enum partagé)
- Seed mixé : 4 liens `SUM` (CO2, effectif police) / 8 liens `NONE` (taux, délais, REF-EMPTY)

## Why

Tous les indicateurs ne sont pas dérivables (taux, moyennes pondérées…). L'API `agregateur: 'SUM'` actuelle est un mensonge — on appliquait toujours une somme sans savoir si elle avait un sens. La colonne `fonctionAgregation` rend ce choix explicite, contrôlé par le créateur de l'indicateur, et permet d'ajouter d'autres fonctions (AVG, MIN…) sans refacto structurelle.

## Breaking changes

- `IndicateurApiModel.referentielIds: string[]` → `referentiels: Array<{ referentielId, fonctionAgregation }>` (GET + body PUT)
- `ValeurDeriveeApiModel.agregateur: 'SUM'` → `fonctionAgregation: FonctionAgregation`
- Nouveau code d'erreur 400 sur `GET /indicateurs/:id/individus/:individuId/valeur-derivee` : `VALIDATION_ERROR` quand l'indicateur n'a pas de lien sur le référentiel de l'individu cible, ou quand `fonctionAgregation === 'NONE'`.

Le frontend `mb-webapp` consommant l'API a été adapté (dérivation locale de `referentielIds` depuis `referentiels`).

## DB

Migration `20260520144904_add_fonction_agregation_indicateur_referentiel` :
- `CREATE TYPE "fonction_agregation_enum" AS ENUM ('SUM', 'NONE')`
- `ALTER TABLE "indicateur_referentiel" ADD COLUMN "fonction_agregation" "fonction_agregation_enum" NOT NULL`

Reset de la DB de dev nécessaire (NOT NULL sans default). Aucune donnée à migrer en prod (feature en cours).

## Test plan

- [x] `pnpm --filter @pilote/mb-api lint` (eslint + tsc + prettier)
- [x] `pnpm --filter @pilote/mb-webapp lint`
- [x] `pnpm --filter @pilote/mb-api test` : 191/191 verts (8 tests `upsertIndicateur`, 9 tests `getValeurDerivee`)
- [x] Nouveaux cas couverts :
  - `upsertIndicateur` met à jour la `fonctionAgregation` d'un lien existant
  - dédup sur `referentielId` : la dernière `fonctionAgregation` l'emporte si différente
  - `getValeurDerivee` 400 si lien absent
  - `getValeurDerivee` 400 si `fonctionAgregation === 'NONE'`
- [ ] Smoke test manuel via Swagger UI sur l'environnement de dev

## Refs

- Spec : `docs/superpowers/specs/2026-05-20-fonction-agregation-indicateur-referentiel-design.md` (local)
- Plan d'exécution : `docs/superpowers/plans/2026-05-20-fonction-agregation-indicateur-referentiel.md` (local)