### PR TITLE
feat(mb-api): synthèse individus étendue aux valeurs dérivées

### DIFF
--- a/apps/mb-api/docs/architecture/synthese-individus-derives.md
+++ b/apps/mb-api/docs/architecture/synthese-individus-derives.md
@@ -1,0 +1,82 @@
+# Synthèse individus — extension aux valeurs dérivées
+
+Date : 2026-05-22
+Statut : accepté
+
+## Contexte
+
+`GET /indicateurs/:id/synthese-individus` calcule `variation` et `ecartMediane` par individu en
+lisant uniquement les saisies directes (`ValeurAvancement`). Les individus agrégés (régions,
+France…) n'ont pas de saisies directes exploitables : leurs valeurs sont calculées par dérivation
+hiérarchique (`resolveSerieDerivee`, cf. `indicateur-derives.md`). Ce design étend la synthèse pour
+supporter ces individus.
+
+## Décisions
+
+### D1. Mode par individu : saisie vs dérivée
+
+Pour chaque individu demandé, on vérifie `IndicateurReferentiel(indicateurId, referentielId)
+.fonctionAgregation` :
+
+- `fonctionAgregation != NONE` → mode **dérivé** : série calculée via `resolveSerieIndividu`
+- `fonctionAgregation = NONE` ou absence de lien → mode **saisie** : comportement actuel inchangé
+
+Cohérent avec D6 de `indicateur-derives.md` (saisie ignorée sur indicateur agrégé).
+
+### D2. Variation pour un individu agrégé
+
+On appelle `resolveSerieIndividu(individuId, ctx, cache)` → série ASC complète avec
+`dateTrunc='month'`. On prend les **2 derniers points** (les plus récents), on les passe en ordre
+DESC à `computeVariation` (convention existante : `[recente, precedente]`).
+
+Pas de filtre sur la couverture : un point à `1/18` contribue comme un point à `18/18`.
+
+### D3. Médiane pour un référentiel agrégé
+
+Pour chaque référentiel distinct parmi les individus demandés :
+
+- `fonctionAgregation != NONE` → médiane calculée sur la **dernière valeur dérivée** de chaque
+  individu de ce référentiel (tous, pas seulement les cibles)
+- `fonctionAgregation = NONE` → médiane sur les dernières saisies (comportement actuel)
+
+Individus sans aucune valeur dérivée (série vide) sont exclus de la médiane — même comportement
+que le filtre existant `valeurs: { some: { indicateurId } }`.
+
+### D4. Memoïsation partagée
+
+Un unique `Map<individuId, PointInterne[]>` est instancié au niveau du use case et partagé entre :
+- Le calcul des séries des individus demandés (D2)
+- Le calcul des séries de tous les individus des référentiels agrégés (D3)
+
+Si un individu intermédiaire est à la fois cible et membre du groupe de médiane, sa série n'est
+calculée qu'une fois.
+
+### D5. Chargement DB
+
+Un seul appel `getValeursTronqueesPourIndividus` (`dateTrunc='month'`) pour toutes les saisies
+feuilles nécessaires — descendants des cibles agrégées + descendants de tous les individus des
+référentiels agrégés. Dédoublonnage des `individuIds` avant la requête.
+
+### D6. Extraction des helpers partagés
+
+`loadSousArbre`, `loadFonctionsAgregation` et `loadSaisiesTronquees` sont extraits de
+`listValeursForIndicateur.ts` dans un module partagé `loadSerieContext.ts`. Les deux use cases
+importent depuis ce module.
+
+### D7. Output inchangé
+
+Le schéma `SyntheseIndividusListApiModel` ne change pas. `variation` et `ecartMediane` restent
+`number | null`. La source (saisie vs dérivée) n'est pas exposée dans la synthèse.
+
+## Tests
+
+### Nouveaux cas d'intégration
+
+- Individu agrégé sans saisies directes → variation et ecartMediane calculées sur série dérivée
+- Individu agrégé avec une seule valeur → variation = valeur, ecartMediane calculée
+- Individu agrégé seul dans son référentiel → ecartMediane = 0
+- Référentiel avec `fonctionAgregation != NONE` → médiane calculée sur valeurs dérivées de tous
+  ses membres
+- Référentiel avec `fonctionAgregation = NONE` → médiane sur saisies (comportement actuel conservé)
+- Mix `individus=[FRANCE, DEPT-13]` — FRANCE en mode dérivé, DEPT-13 en mode saisie dans le même appel
+- Individu agrégé sans aucune descendance avec saisie → variation null, ecartMediane null

--- a/apps/mb-api/src/valeurAvancement/loadSerieContext.ts
+++ b/apps/mb-api/src/valeurAvancement/loadSerieContext.ts
@@ -1,0 +1,78 @@
+import { type FonctionAgregation } from '@pilote/mb-shared/indicateur'
+import { type DateTrunc } from '@pilote/mb-shared/valeurAvancement'
+
+import { db } from '@/framework/persistence/dbStore'
+import { getValeursTronqueesPourIndividus } from '@/generated/prisma/sql'
+import { type IndividuRef, type SaisieTronquee } from '@/valeurAvancement/resolveSerieDerivee'
+
+export const loadSousArbre = async (
+  cibles: ReadonlyArray<IndividuRef>,
+): Promise<{
+  allNodes: Map<string, IndividuRef>
+  enfantsParParent: Map<string, IndividuRef[]>
+}> => {
+  const allNodes = new Map<string, IndividuRef>()
+  for (const cible of cibles) allNodes.set(cible.id, cible)
+  const enfantsParParent = new Map<string, IndividuRef[]>()
+  let currentLevel = cibles.map((c) => c.id)
+
+  while (currentLevel.length > 0) {
+    const relations = await db().relation.findMany({
+      where: { parentId: { in: currentLevel } },
+      include: { child: true },
+    })
+    if (relations.length === 0) break
+
+    const nextLevelSet = new Set<string>()
+    for (const relation of relations) {
+      const childRef: IndividuRef = {
+        id: relation.child.id,
+        publicId: relation.child.publicId,
+        referentielId: relation.child.referentielId,
+      }
+      if (!allNodes.has(childRef.id)) {
+        allNodes.set(childRef.id, childRef)
+        nextLevelSet.add(childRef.id)
+      }
+      const liste = enfantsParParent.get(relation.parentId) ?? []
+      liste.push(childRef)
+      enfantsParParent.set(relation.parentId, liste)
+    }
+    currentLevel = [...nextLevelSet]
+  }
+
+  return { allNodes, enfantsParParent }
+}
+
+export const loadFonctionsAgregation = async (
+  indicateurId: string,
+): Promise<Map<string, FonctionAgregation>> => {
+  const liens = await db().indicateurReferentiel.findMany({
+    where: { indicateurId },
+    select: { referentielId: true, fonctionAgregation: true },
+  })
+  return new Map(liens.map((lien) => [lien.referentielId, lien.fonctionAgregation]))
+}
+
+export const loadSaisiesTronquees = async ({
+  indicateurId,
+  individuIds,
+  dateTrunc,
+}: {
+  indicateurId: string
+  individuIds: ReadonlyArray<string>
+  dateTrunc: DateTrunc
+}): Promise<Map<string, SaisieTronquee[]>> => {
+  if (individuIds.length === 0) return new Map()
+  const rows = await db().$queryRawTyped(
+    getValeursTronqueesPourIndividus(indicateurId, [...individuIds], dateTrunc),
+  )
+  const serieFeuilleParIndividu = new Map<string, SaisieTronquee[]>()
+  for (const row of rows) {
+    if (!row.bucket) continue
+    const liste = serieFeuilleParIndividu.get(row.individuId) ?? []
+    liste.push({ bucket: row.bucket, dateOrigine: row.dateOrigine, valeur: row.valeur })
+    serieFeuilleParIndividu.set(row.individuId, liste)
+  }
+  return serieFeuilleParIndividu
+}

--- a/apps/mb-api/src/valeurAvancement/queries/listSyntheseIndividus.test.ts
+++ b/apps/mb-api/src/valeurAvancement/queries/listSyntheseIndividus.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import { fixtures } from '@/test/fixtures'
 import { integrationTest } from '@/test/integrationTest'
-import { testDeptId, testDeptIds, testIndicateurId } from '@/test/randomIds'
+import { testDeptId, testDeptIds, testIndicateurId, testIndividuId } from '@/test/randomIds'
 import { runAsPrincipal } from '@/test/runAsPrincipal'
 import { listSyntheseIndividus } from '@/valeurAvancement/queries/listSyntheseIndividus'
 
@@ -487,6 +487,238 @@ describe.concurrent('listSyntheseIndividus', () => {
       await expect(
         runAsPrincipal(apiKey.id, () => listSyntheseIndividus(indId, { individus: [deptId] })),
       ).rejects.toThrow()
+    }),
+  )
+
+  // --- Cas dérivés ---
+
+  it(
+    'retourne variation et ecartMediane dérivées pour un individu agrégé (2 buckets)',
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const refRegId = `REF-${testIndicateurId()}`
+      const refDeptId = `REF-${testIndicateurId()}`
+      const regId = testIndividuId()
+      const deptId = testIndividuId()
+      await fixtures.indicateurReferentiel({
+        indicateur: { publicId: indId, nom: 'T', visibilite: 'PUBLIC' },
+        referentiel: { publicId: refRegId, nom: 'Régions' },
+        fonctionAgregation: 'SUM',
+      })
+      await fixtures.relation({
+        parent: { publicId: regId, referentiel: { publicId: refRegId } },
+        child: { publicId: deptId, referentiel: { publicId: refDeptId, nom: 'Depts' } },
+      })
+      await fixtures.valeurAvancement(
+        {
+          indicateur: { publicId: indId },
+          individu: { publicId: deptId },
+          date: '2026-01-15',
+          valeur: 100,
+        },
+        {
+          indicateur: { publicId: indId },
+          individu: { publicId: deptId },
+          date: '2026-02-10',
+          valeur: 200,
+        },
+      )
+      const apiKey = await fixtures.apiKey()
+
+      // Buckets mensuels : 2026-01 → 100, 2026-02 → 200
+      // derniers2Desc = [200, 100] → variation = 100
+      // mediane = 200 (seule région), ecartMediane = 0
+      const result = await runAsPrincipal(apiKey.id, () =>
+        listSyntheseIndividus(indId, { individus: [regId] }),
+      )
+
+      expect(result._unsafeUnwrap()).toEqual({
+        items: [{ individu: regId, variation: 100, ecartMediane: 0 }],
+      })
+    }),
+  )
+
+  it(
+    'retourne variation = valeur dérivée et ecartMediane pour un individu agrégé avec un seul bucket',
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const refRegId = `REF-${testIndicateurId()}`
+      const refDeptId = `REF-${testIndicateurId()}`
+      const regId = testIndividuId()
+      const deptId = testIndividuId()
+      await fixtures.indicateurReferentiel({
+        indicateur: { publicId: indId, nom: 'T', visibilite: 'PUBLIC' },
+        referentiel: { publicId: refRegId, nom: 'Régions' },
+        fonctionAgregation: 'SUM',
+      })
+      await fixtures.relation({
+        parent: { publicId: regId, referentiel: { publicId: refRegId } },
+        child: { publicId: deptId, referentiel: { publicId: refDeptId, nom: 'Depts' } },
+      })
+      await fixtures.valeurAvancement({
+        indicateur: { publicId: indId },
+        individu: { publicId: deptId },
+        date: '2026-01-15',
+        valeur: 50,
+      })
+      const apiKey = await fixtures.apiKey()
+
+      // 1 seul bucket → variation = 50 (pas de précédent, équivalent saisie)
+      const result = await runAsPrincipal(apiKey.id, () =>
+        listSyntheseIndividus(indId, { individus: [regId] }),
+      )
+
+      expect(result._unsafeUnwrap()).toEqual({
+        items: [{ individu: regId, variation: 50, ecartMediane: 0 }],
+      })
+    }),
+  )
+
+  it(
+    'retourne variation null et ecartMediane null pour un individu agrégé sans descendant avec saisie',
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const refRegId = `REF-${testIndicateurId()}`
+      const refDeptId = `REF-${testIndicateurId()}`
+      const regId = testIndividuId()
+      const deptId = testIndividuId()
+      await fixtures.indicateurReferentiel({
+        indicateur: { publicId: indId, nom: 'T', visibilite: 'PUBLIC' },
+        referentiel: { publicId: refRegId, nom: 'Régions' },
+        fonctionAgregation: 'SUM',
+      })
+      await fixtures.relation({
+        parent: { publicId: regId, referentiel: { publicId: refRegId } },
+        child: { publicId: deptId, referentiel: { publicId: refDeptId, nom: 'Depts' } },
+      })
+      const apiKey = await fixtures.apiKey()
+
+      const result = await runAsPrincipal(apiKey.id, () =>
+        listSyntheseIndividus(indId, { individus: [regId] }),
+      )
+
+      expect(result._unsafeUnwrap()).toEqual({
+        items: [{ individu: regId, variation: null, ecartMediane: null }],
+      })
+    }),
+  )
+
+  it(
+    'calcule la médiane sur les valeurs dérivées de tous les membres du référentiel agrégé',
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const refRegId = `REF-${testIndicateurId()}`
+      const refDeptId = `REF-${testIndicateurId()}`
+      const [reg1, reg2] = [testIndividuId(), testIndividuId()]
+      const [dept1, dept2] = [testIndividuId(), testIndividuId()]
+      await fixtures.indicateurReferentiel({
+        indicateur: { publicId: indId, nom: 'T', visibilite: 'PUBLIC' },
+        referentiel: { publicId: refRegId, nom: 'Régions' },
+        fonctionAgregation: 'SUM',
+      })
+      await fixtures.relation(
+        {
+          parent: { publicId: reg1, referentiel: { publicId: refRegId } },
+          child: { publicId: dept1, referentiel: { publicId: refDeptId, nom: 'Depts' } },
+        },
+        {
+          parent: { publicId: reg2, referentiel: { publicId: refRegId } },
+          child: { publicId: dept2, referentiel: { publicId: refDeptId } },
+        },
+      )
+      await fixtures.valeurAvancement(
+        {
+          indicateur: { publicId: indId },
+          individu: { publicId: dept1 },
+          date: '2026-01-01',
+          valeur: 100,
+        },
+        {
+          indicateur: { publicId: indId },
+          individu: { publicId: dept2 },
+          date: '2026-01-01',
+          valeur: 300,
+        },
+      )
+      const apiKey = await fixtures.apiKey()
+
+      // reg1 derivée = 100, reg2 derivée = 300
+      // mediane = (100+300)/2 = 200
+      // reg1.ecartMediane = 100-200 = -100, reg2.ecartMediane = 300-200 = 100
+      const result = await runAsPrincipal(apiKey.id, () =>
+        listSyntheseIndividus(indId, { individus: [reg1, reg2] }),
+      )
+
+      const items = result._unsafeUnwrap().items
+      expect(items.find((i) => i.individu === reg1)).toEqual({
+        individu: reg1,
+        variation: 100,
+        ecartMediane: -100,
+      })
+      expect(items.find((i) => i.individu === reg2)).toEqual({
+        individu: reg2,
+        variation: 300,
+        ecartMediane: 100,
+      })
+    }),
+  )
+
+  it(
+    'gère un mix individu agrégé (dérivé) et individu feuille (saisie) dans le même appel',
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const refRegId = `REF-${testIndicateurId()}`
+      const refDeptId = `REF-${testIndicateurId()}`
+      const regId = testIndividuId()
+      const deptEnfantId = testIndividuId()
+      const deptFeuilleId = testIndividuId()
+      await fixtures.indicateurReferentiel({
+        indicateur: { publicId: indId, nom: 'T', visibilite: 'PUBLIC' },
+        referentiel: { publicId: refRegId, nom: 'Régions' },
+        fonctionAgregation: 'SUM',
+      })
+      await fixtures.relation({
+        parent: { publicId: regId, referentiel: { publicId: refRegId } },
+        child: { publicId: deptEnfantId, referentiel: { publicId: refDeptId, nom: 'Depts' } },
+      })
+      // deptFeuilleId est dans refDeptId sans lien d'agrégation : mode saisie
+      await fixtures.individu({
+        publicId: deptFeuilleId,
+        referentiel: { publicId: refDeptId },
+      })
+      await fixtures.valeurAvancement(
+        {
+          indicateur: { publicId: indId },
+          individu: { publicId: deptEnfantId },
+          date: '2026-01-01',
+          valeur: 120,
+        },
+        {
+          indicateur: { publicId: indId },
+          individu: { publicId: deptFeuilleId },
+          date: '2026-01-01',
+          valeur: 80,
+        },
+      )
+      const apiKey = await fixtures.apiKey()
+
+      // reg: dérivée = 120, mediane régions = 120, ecartMediane = 0
+      // deptFeuille: saisie = 80, mediane depts (80, 120) = 100, ecartMediane = -20
+      const result = await runAsPrincipal(apiKey.id, () =>
+        listSyntheseIndividus(indId, { individus: [regId, deptFeuilleId] }),
+      )
+
+      const items = result._unsafeUnwrap().items
+      expect(items.find((i) => i.individu === regId)).toEqual({
+        individu: regId,
+        variation: 120,
+        ecartMediane: 0,
+      })
+      expect(items.find((i) => i.individu === deptFeuilleId)).toEqual({
+        individu: deptFeuilleId,
+        variation: 80,
+        ecartMediane: -20,
+      })
     }),
   )
 })

--- a/apps/mb-api/src/valeurAvancement/queries/listSyntheseIndividus.ts
+++ b/apps/mb-api/src/valeurAvancement/queries/listSyntheseIndividus.ts
@@ -9,8 +9,20 @@ import { requireCurrentPrincipalId } from '@/framework/auth/userContext'
 import { db } from '@/framework/persistence/dbStore'
 import { withIndicateurReadPermission } from '@/indicateur/permissions'
 import { computeEcartMediane } from '@/valeurAvancement/computeEcartMediane'
-import { groupMedianesByKey } from '@/valeurAvancement/computeMediane'
+import { groupMedianesByKey, computeMediane } from '@/valeurAvancement/computeMediane'
 import { computeVariation } from '@/valeurAvancement/computeVariation'
+import {
+  loadFonctionsAgregation,
+  loadSaisiesTronquees,
+  loadSousArbre,
+} from '@/valeurAvancement/loadSerieContext'
+import {
+  type IndividuRef,
+  type PointInterne,
+  resolveSerieIndividu,
+  type ResolveSerieContext,
+} from '@/valeurAvancement/resolveSerieDerivee'
+import { Decimal } from '@/framework/decimal'
 
 const fetchLatestValeursIndividus = ({
   indicateurId,
@@ -61,32 +73,149 @@ const buildSynthese = async (
     where: withIndicateurReadPermission({ publicId: indicateurPublicId }, principalId),
     select: { id: true },
   })
-  const itemsRows = await fetchLatestValeursIndividus({
-    indicateurId: indicateur.id,
-    individuPublicIds: params.individus,
+
+  const cibles = await db().individu.findMany({
+    where: { publicId: { in: [...params.individus] } },
+    select: { id: true, publicId: true, referentielId: true },
+    orderBy: { publicId: 'asc' },
   })
-  const referentielIds = unique(itemsRows.map((row) => row.referentielId))
-  const populationRows = referentielIds.length
-    ? await fetchLatestValeursParReferentiel({ indicateurId: indicateur.id, referentielIds })
-    : []
-  const valeursParRef = populationRows.flatMap((row) =>
-    row.valeurs.map((v) => ({ referentielId: row.referentielId, valeur: v.valeur })),
-  )
-  const medianeParRef = groupMedianesByKey(
-    valeursParRef,
-    (row) => row.referentielId,
-    (row) => row.valeur,
-  )
+  if (cibles.length === 0) return { items: [] }
+
+  const fonctionAgregationParReferentiel = await loadFonctionsAgregation(indicateur.id)
+
+  const isAgregePourReferentiel = (referentielId: string): boolean => {
+    const fn = fonctionAgregationParReferentiel.get(referentielId)
+    return fn !== undefined && fn !== 'NONE'
+  }
+
+  const ciblesAgregees = cibles.filter((c) => isAgregePourReferentiel(c.referentielId))
+  const ciblesSaisie = cibles.filter((c) => !isAgregePourReferentiel(c.referentielId))
+
+  // --- Mode saisie : comportement actuel ---
+
+  const saisieRowsByPublicId = new Map<string, { valeurs: { valeur: Decimal }[] }>()
+  const medianeParRefSaisie = new Map<string, number | null>()
+
+  if (ciblesSaisie.length > 0) {
+    const saisieRows = await fetchLatestValeursIndividus({
+      indicateurId: indicateur.id,
+      individuPublicIds: ciblesSaisie.map((c) => c.publicId),
+    })
+    for (const row of saisieRows) {
+      saisieRowsByPublicId.set(row.publicId, { valeurs: row.valeurs })
+    }
+
+    const referentielIdsSaisie = unique(ciblesSaisie.map((c) => c.referentielId))
+    const populationRows = await fetchLatestValeursParReferentiel({
+      indicateurId: indicateur.id,
+      referentielIds: referentielIdsSaisie,
+    })
+    const valeursParRef = populationRows.flatMap((row) =>
+      row.valeurs.map((v) => ({ referentielId: row.referentielId, valeur: v.valeur })),
+    )
+    const medianes = groupMedianesByKey(
+      valeursParRef,
+      (row) => row.referentielId,
+      (row) => row.valeur,
+    )
+    for (const [refId, mediane] of medianes) {
+      medianeParRefSaisie.set(refId, mediane)
+    }
+  }
+
+  // --- Mode dérivé ---
+
+  const seriesParIndividuId = new Map<string, ReadonlyArray<PointInterne>>()
+  const medianeParRefDerivee = new Map<string, number | null>()
+
+  if (ciblesAgregees.length > 0) {
+    const aggrRefIds = unique(ciblesAgregees.map((c) => c.referentielId))
+
+    // Tous les individus des référentiels agrégés (pour la médiane).
+    const medianeIndividus = await db().individu.findMany({
+      where: { referentielId: { in: aggrRefIds } },
+      select: { id: true, publicId: true, referentielId: true },
+    })
+
+    // Dédoublonnage : union cibles agrégées + individus pour la médiane.
+    const toutesCiblesAgregees = new Map<string, IndividuRef>()
+    for (const c of ciblesAgregees) toutesCiblesAgregees.set(c.id, c)
+    for (const m of medianeIndividus) toutesCiblesAgregees.set(m.id, m)
+
+    const [{ allNodes, enfantsParParent }] = await Promise.all([
+      loadSousArbre([...toutesCiblesAgregees.values()]),
+    ])
+
+    const serieFeuilleParIndividu = await loadSaisiesTronquees({
+      indicateurId: indicateur.id,
+      individuIds: [...allNodes.keys()],
+      dateTrunc: 'month',
+    })
+
+    const ctx: ResolveSerieContext = {
+      enfantsParParent,
+      fonctionAgregationParReferentiel,
+      serieFeuilleParIndividu,
+      referentielParIndividu: new Map(
+        [...allNodes.values()].map((individu) => [individu.id, individu.referentielId]),
+      ),
+    }
+    const cache = new Map<string, ReadonlyArray<PointInterne>>()
+
+    // Calcul des séries pour les cibles agrégées (cache partagé avec médiane).
+    for (const cible of ciblesAgregees) {
+      seriesParIndividuId.set(cible.id, resolveSerieIndividu(cible.id, ctx, cache))
+    }
+
+    // Calcul de la médiane par référentiel agrégé.
+    const valeursParRef = new Map<string, Decimal[]>()
+    for (const individu of medianeIndividus) {
+      const serie = resolveSerieIndividu(individu.id, ctx, cache)
+      if (serie.length === 0) continue
+      const dernierPoint = serie[serie.length - 1]!
+      const liste = valeursParRef.get(individu.referentielId) ?? []
+      liste.push(dernierPoint.valeur)
+      valeursParRef.set(individu.referentielId, liste)
+    }
+    for (const [refId, valeurs] of valeursParRef) {
+      medianeParRefDerivee.set(refId, computeMediane(valeurs))
+    }
+  }
+
+  // --- Construction de la réponse (ordre publicId ASC conservé) ---
 
   return {
-    items: itemsRows.map((row) => ({
-      individu: row.publicId,
-      variation: computeVariation(row.valeurs),
-      ecartMediane: computeEcartMediane(
-        row.valeurs[0]?.valeur,
-        medianeParRef.get(row.referentielId) ?? null,
-      ),
-    })),
+    items: cibles.map((cible) => {
+      if (isAgregePourReferentiel(cible.referentielId)) {
+        const serie = seriesParIndividuId.get(cible.id) ?? []
+        // Les 2 derniers points en ordre DESC (recente, precedente) pour computeVariation.
+        const derniers2Desc =
+          serie.length >= 2
+            ? [serie[serie.length - 1]!, serie[serie.length - 2]!]
+            : serie.length === 1
+              ? [serie[0]!]
+              : []
+        const variation = computeVariation(derniers2Desc)
+        const dernierPoint = serie.length > 0 ? serie[serie.length - 1] : undefined
+        const mediane = medianeParRefDerivee.get(cible.referentielId) ?? null
+        return {
+          individu: cible.publicId,
+          variation,
+          ecartMediane: computeEcartMediane(dernierPoint?.valeur, mediane),
+        }
+      }
+
+      const row = saisieRowsByPublicId.get(cible.publicId)
+      const valeurs = row?.valeurs ?? []
+      return {
+        individu: cible.publicId,
+        variation: computeVariation(valeurs),
+        ecartMediane: computeEcartMediane(
+          valeurs[0]?.valeur,
+          medianeParRefSaisie.get(cible.referentielId) ?? null,
+        ),
+      }
+    }),
   }
 }
 

--- a/apps/mb-api/src/valeurAvancement/queries/listValeursForIndicateur.ts
+++ b/apps/mb-api/src/valeurAvancement/queries/listValeursForIndicateur.ts
@@ -1,4 +1,3 @@
-import { type FonctionAgregation } from '@pilote/mb-shared/indicateur'
 import {
   type ContributionApiModel,
   type DateTrunc,
@@ -10,14 +9,17 @@ import { ResultAsync } from 'neverthrow'
 
 import { requireCurrentPrincipalId } from '@/framework/auth/userContext'
 import { db } from '@/framework/persistence/dbStore'
-import { getValeursTronqueesPourIndividus } from '@/generated/prisma/sql'
 import { withIndicateurReadPermission } from '@/indicateur/permissions'
+import {
+  loadFonctionsAgregation,
+  loadSaisiesTronquees,
+  loadSousArbre,
+} from '@/valeurAvancement/loadSerieContext'
 import {
   type IndividuRef,
   type PointInterne,
   resolveSerieIndividu,
   type ResolveSerieContext,
-  type SaisieTronquee,
 } from '@/valeurAvancement/resolveSerieDerivee'
 
 // Cap par défaut à la granularité mensuelle : sans troncature, une série France
@@ -98,82 +100,6 @@ const loadCibles = (individus: ReadonlyArray<string>): Promise<IndividuRef[]> =>
     select: { id: true, publicId: true, referentielId: true },
     orderBy: { publicId: 'asc' },
   })
-
-// BFS itératif niveau par niveau plutôt qu'une CTE récursive PostgreSQL :
-// l'arbre est typiquement peu profond (3-4 niveaux France→Région→Département)
-// et garder le calcul en JS reste plus simple à lire et à débugger que du SQL
-// récursif. Détection naïve des cycles : on ne retraite pas un nœud déjà vu.
-const loadSousArbre = async (
-  cibles: ReadonlyArray<IndividuRef>,
-): Promise<{
-  allNodes: Map<string, IndividuRef>
-  enfantsParParent: Map<string, IndividuRef[]>
-}> => {
-  const allNodes = new Map<string, IndividuRef>()
-  for (const cible of cibles) allNodes.set(cible.id, cible)
-  const enfantsParParent = new Map<string, IndividuRef[]>()
-  let currentLevel = cibles.map((c) => c.id)
-
-  while (currentLevel.length > 0) {
-    const relations = await db().relation.findMany({
-      where: { parentId: { in: currentLevel } },
-      include: { child: true },
-    })
-    if (relations.length === 0) break
-
-    const nextLevelSet = new Set<string>()
-    for (const relation of relations) {
-      const childRef: IndividuRef = {
-        id: relation.child.id,
-        publicId: relation.child.publicId,
-        referentielId: relation.child.referentielId,
-      }
-      if (!allNodes.has(childRef.id)) {
-        allNodes.set(childRef.id, childRef)
-        nextLevelSet.add(childRef.id)
-      }
-      const liste = enfantsParParent.get(relation.parentId) ?? []
-      liste.push(childRef)
-      enfantsParParent.set(relation.parentId, liste)
-    }
-    currentLevel = [...nextLevelSet]
-  }
-
-  return { allNodes, enfantsParParent }
-}
-
-const loadFonctionsAgregation = async (
-  indicateurId: string,
-): Promise<Map<string, FonctionAgregation>> => {
-  const liens = await db().indicateurReferentiel.findMany({
-    where: { indicateurId },
-    select: { referentielId: true, fonctionAgregation: true },
-  })
-  return new Map(liens.map((lien) => [lien.referentielId, lien.fonctionAgregation]))
-}
-
-const loadSaisiesTronquees = async ({
-  indicateurId,
-  individuIds,
-  dateTrunc,
-}: {
-  indicateurId: string
-  individuIds: ReadonlyArray<string>
-  dateTrunc: DateTrunc
-}): Promise<Map<string, SaisieTronquee[]>> => {
-  if (individuIds.length === 0) return new Map()
-  const rows = await db().$queryRawTyped(
-    getValeursTronqueesPourIndividus(indicateurId, [...individuIds], dateTrunc),
-  )
-  const serieFeuilleParIndividu = new Map<string, SaisieTronquee[]>()
-  for (const row of rows) {
-    if (!row.bucket) continue
-    const liste = serieFeuilleParIndividu.get(row.individuId) ?? []
-    liste.push({ bucket: row.bucket, dateOrigine: row.dateOrigine, valeur: row.valeur })
-    serieFeuilleParIndividu.set(row.individuId, liste)
-  }
-  return serieFeuilleParIndividu
-}
 
 const toApiModel = ({
   indicateurPublicId,


### PR DESCRIPTION
Pour les indicateurs avec fonctionAgregation != NONE, variation et ecartMediane sont calculées via resolveSerieIndividu (série dérivée, dateTrunc=month) plutôt que depuis les saisies directes. La médiane du référentiel est également calculée sur les valeurs dérivées de tous ses membres. Les helpers de chargement BFS/saisies sont extraits dans loadSerieContext.ts et partagés avec listValeursForIndicateur.