### PR TITLE
feat(mb-api): valeurs remarquables sur indicateurs dérivés

### DIFF
--- a/apps/mb-api/prisma/seed.ts
+++ b/apps/mb-api/prisma/seed.ts
@@ -5,10 +5,10 @@ import { Prisma, PrismaClient } from '../src/generated/prisma/client.js'
 import { type FonctionAgregation } from '../src/generated/prisma/enums.js'
 
 import {
+  buildValeursPourIndicateur,
   individusSeed,
   referentielsSeed,
   relationsSeed,
-  valeursAvancementSeed,
 } from './seedData/geo.js'
 
 const databaseUrl = process.env['DATABASE_URL']
@@ -108,6 +108,14 @@ const indicateurDates = (index: number): { createdAt: Date; updatedAt: Date } =>
   const createdAt = new Date(updatedAt.getTime() - offsetDays * 86_400_000)
   return { createdAt, updatedAt }
 }
+
+// Maille de saisie par défaut : on saisit toujours sur la maille la plus fine
+// déclarée pour l'indicateur (DEPT > REG > NAT). Pour les niveaux SUM, la
+// valeur est dérivée à la lecture (cf. doc d'archi indicateur-derives.md).
+const PRIORITE_MAILLE = ['REF-DEPT', 'REF-REG', 'REF-NAT'] as const
+
+const mailleLaPlusFine = (liensReferentielPublicIds: ReadonlyArray<string>): string | undefined =>
+  PRIORITE_MAILLE.find((ref) => liensReferentielPublicIds.includes(ref))
 
 const main = async () => {
   for (const [index, item] of indicateursSeed.entries()) {
@@ -229,7 +237,7 @@ const main = async () => {
     {
       indicateurPublicId: 'IND-005',
       referentiels: [
-        { referentielPublicId: 'REF-REG', fonctionAgregation: 'SUM' },
+        { referentielPublicId: 'REF-REG', fonctionAgregation: 'NONE' },
         { referentielPublicId: 'REF-NAT', fonctionAgregation: 'SUM' },
       ],
     },
@@ -245,43 +253,19 @@ const main = async () => {
       indicateurPublicId: 'IND-008',
       referentiels: [{ referentielPublicId: 'REF-EMPTY', fonctionAgregation: 'NONE' }],
     },
-    {
-      indicateurPublicId: 'IND-046',
-      referentiels: [
-        { referentielPublicId: 'REF-DEPT', fonctionAgregation: 'SUM' },
-        { referentielPublicId: 'REF-REG', fonctionAgregation: 'SUM' },
-        { referentielPublicId: 'REF-NAT', fonctionAgregation: 'SUM' },
-      ],
-    },
-    {
-      indicateurPublicId: 'IND-047',
-      referentiels: [
-        { referentielPublicId: 'REF-DEPT', fonctionAgregation: 'NONE' },
-        { referentielPublicId: 'REF-NAT', fonctionAgregation: 'NONE' },
-      ],
-    },
-    {
-      indicateurPublicId: 'IND-048',
-      referentiels: [
-        { referentielPublicId: 'REF-DEPT', fonctionAgregation: 'NONE' },
-        { referentielPublicId: 'REF-REG', fonctionAgregation: 'NONE' },
-      ],
-    },
-    {
-      indicateurPublicId: 'IND-049',
-      referentiels: [
-        { referentielPublicId: 'REF-DEPT', fonctionAgregation: 'NONE' },
-        { referentielPublicId: 'REF-NAT', fonctionAgregation: 'NONE' },
-      ],
-    },
-    {
-      indicateurPublicId: 'IND-050',
-      referentiels: [
-        { referentielPublicId: 'REF-DEPT', fonctionAgregation: 'NONE' },
-        { referentielPublicId: 'REF-REG', fonctionAgregation: 'NONE' },
-        { referentielPublicId: 'REF-NAT', fonctionAgregation: 'NONE' },
-      ],
-    },
+    ...indicateursSeed
+      .filter((ind) => parseInt(ind.publicId.replace('IND-', ''), 10) >= 9)
+      .map((ind) => ({
+        indicateurPublicId: ind.publicId,
+        // Politique simple : tous les indicateurs "neutres" sont rattachés à
+        // DEPT (NONE) + REG (SUM) + NAT (SUM). La saisie va sur dept, la
+        // hiérarchie supérieure se dérive.
+        referentiels: [
+          { referentielPublicId: 'REF-DEPT', fonctionAgregation: 'NONE' as const },
+          { referentielPublicId: 'REF-REG', fonctionAgregation: 'SUM' as const },
+          { referentielPublicId: 'REF-NAT', fonctionAgregation: 'SUM' as const },
+        ],
+      })),
   ]
 
   for (const item of indicateurReferentielsSeed) {
@@ -341,38 +325,80 @@ const main = async () => {
     })
   }
 
-  for (const item of valeursAvancementSeed) {
-    const indicateur = await prisma.indicateur.findUniqueOrThrow({
-      where: { publicId: item.indicateurPublicId },
-      select: { id: true },
+  // Indexation pour la génération bulk des valeurs : on a besoin d'aller vite
+  // pour saisir ~100k lignes (~50 indicateurs × 101 dépts × jusqu'à 36 mois).
+  const indicateursParPublicId = new Map(
+    (
+      await prisma.indicateur.findMany({
+        where: { publicId: { in: indicateursSeed.map((i) => i.publicId) } },
+      })
+    ).map((row) => [row.publicId, row.id]),
+  )
+  const individusParPublicId = new Map(
+    (
+      await prisma.individu.findMany({
+        where: { publicId: { in: individusSeed.map((i) => i.publicId) } },
+      })
+    ).map((row) => [row.publicId, { id: row.id, referentielId: row.referentielId }]),
+  )
+  const referentielParPublicId = new Map(
+    (
+      await prisma.referentiel.findMany({
+        where: { publicId: { in: referentielsSeed.map((r) => r.publicId) } },
+      })
+    ).map((row) => [row.publicId, row.id]),
+  )
+  const individusParReferentielId = new Map<string, string[]>()
+  for (const individu of individusSeed) {
+    const refId = referentielParPublicId.get(individu.referentiel)
+    if (!refId) continue
+    const liste = individusParReferentielId.get(refId) ?? []
+    liste.push(individu.publicId)
+    individusParReferentielId.set(refId, liste)
+  }
+
+  let valeursCount = 0
+  for (const lien of indicateurReferentielsSeed) {
+    const refPublicId = mailleLaPlusFine(lien.referentiels.map((r) => r.referentielPublicId))
+    if (!refPublicId) continue // ex. REF-EMPTY → pas de saisie
+    const refId = referentielParPublicId.get(refPublicId)
+    if (!refId) continue
+    const individusPublicIds = individusParReferentielId.get(refId) ?? []
+    if (individusPublicIds.length === 0) continue
+    const indicateurId = indicateursParPublicId.get(lien.indicateurPublicId)
+    if (!indicateurId) continue
+
+    const generated = buildValeursPourIndicateur({
+      indicateurPublicId: lien.indicateurPublicId,
+      individuPublicIds: individusPublicIds,
     })
-    const individu = await prisma.individu.findUniqueOrThrow({
-      where: { publicId: item.individuPublicId },
-      select: { id: true },
-    })
-    const valeur = new Prisma.Decimal(item.valeur)
-    await prisma.valeurAvancement.upsert({
-      where: {
-        valeur_avancement_unique: {
-          indicateurId: indicateur.id,
+    const rows = generated
+      .map((g) => {
+        const individu = individusParPublicId.get(g.individuPublicId)
+        if (!individu) return null
+        return {
+          id: uuidv7(),
+          indicateurId,
           individuId: individu.id,
-          date: item.date,
-        },
-      },
-      update: { valeur },
-      create: {
-        id: uuidv7(),
-        indicateurId: indicateur.id,
-        individuId: individu.id,
-        date: item.date,
-        valeur,
-      },
+          date: g.date,
+          valeur: new Prisma.Decimal(g.valeur),
+        }
+      })
+      .filter((row): row is NonNullable<typeof row> => row !== null)
+
+    // createMany skipDuplicates : la contrainte unique
+    // (indicateurId, individuId, date) garantit l'idempotence du seed sans
+    // payer le coût d'un upsert par ligne (~5ms × 100k = 8 min vs ~10s).
+    const result = await prisma.valeurAvancement.createMany({
+      data: rows,
+      skipDuplicates: true,
     })
+    valeursCount += result.count
   }
 
   const permissionsCount = 8 * 2
   console.log(
-    `Seed terminé : ${indicateursSeed.length} indicateurs, ${utilisateursSeed.length} utilisateurs, ${permissionsCount} permissions, ${referentielsSeed.length} référentiels, ${individusSeed.length} individus, ${liaisonsCount} liaisons indicateur-référentiel, ${relationsSeed.length} relations, ${valeursAvancementSeed.length} valeurs.`,
+    `Seed terminé : ${indicateursSeed.length} indicateurs, ${utilisateursSeed.length} utilisateurs, ${permissionsCount} permissions, ${referentielsSeed.length} référentiels, ${individusSeed.length} individus, ${liaisonsCount} liaisons indicateur-référentiel, ${relationsSeed.length} relations, ${valeursCount} valeurs insérées (les valeurs existantes ont été ignorées).`,
   )
 }
 

--- a/apps/mb-api/prisma/seedData/geo.ts
+++ b/apps/mb-api/prisma/seedData/geo.ts
@@ -7,12 +7,12 @@ export const referentielsSeed = [
   {
     publicId: 'REF-REG',
     nom: 'Régions de France',
-    description: 'Régions administratives métropolitaines.',
+    description: 'Toutes les régions administratives françaises (métropole + DROM).',
   },
   {
     publicId: 'REF-DEPT',
     nom: 'Départements de France',
-    description: 'Départements métropolitains (échantillon de seed).',
+    description: 'Tous les départements français (métropole + DROM).',
   },
   {
     publicId: 'REF-EMPTY',
@@ -21,220 +21,251 @@ export const referentielsSeed = [
   },
 ] as const
 
+// Régions INSEE : 13 métropole + 5 DROM = 18 régions.
+const regions = [
+  { code: '01', nom: 'Guadeloupe' },
+  { code: '02', nom: 'Martinique' },
+  { code: '03', nom: 'Guyane' },
+  { code: '04', nom: 'La Réunion' },
+  { code: '06', nom: 'Mayotte' },
+  { code: '11', nom: 'Île-de-France' },
+  { code: '24', nom: 'Centre-Val de Loire' },
+  { code: '27', nom: 'Bourgogne-Franche-Comté' },
+  { code: '28', nom: 'Normandie' },
+  { code: '32', nom: 'Hauts-de-France' },
+  { code: '44', nom: 'Grand Est' },
+  { code: '52', nom: 'Pays de la Loire' },
+  { code: '53', nom: 'Bretagne' },
+  { code: '75', nom: 'Nouvelle-Aquitaine' },
+  { code: '76', nom: 'Occitanie' },
+  { code: '84', nom: 'Auvergne-Rhône-Alpes' },
+  { code: '93', nom: "Provence-Alpes-Côte d'Azur" },
+  { code: '94', nom: 'Corse' },
+] as const
+
+// Départements INSEE : 96 métropole + 5 DROM = 101 départements.
+// Codes : 2A/2B pour la Corse, 971-976 pour les DROM, le reste numérique simple.
+const departements = [
+  { code: '01', nom: 'Ain', region: '84' },
+  { code: '02', nom: 'Aisne', region: '32' },
+  { code: '03', nom: 'Allier', region: '84' },
+  { code: '04', nom: 'Alpes-de-Haute-Provence', region: '93' },
+  { code: '05', nom: 'Hautes-Alpes', region: '93' },
+  { code: '06', nom: 'Alpes-Maritimes', region: '93' },
+  { code: '07', nom: 'Ardèche', region: '84' },
+  { code: '08', nom: 'Ardennes', region: '44' },
+  { code: '09', nom: 'Ariège', region: '76' },
+  { code: '10', nom: 'Aube', region: '44' },
+  { code: '11', nom: 'Aude', region: '76' },
+  { code: '12', nom: 'Aveyron', region: '76' },
+  { code: '13', nom: 'Bouches-du-Rhône', region: '93' },
+  { code: '14', nom: 'Calvados', region: '28' },
+  { code: '15', nom: 'Cantal', region: '84' },
+  { code: '16', nom: 'Charente', region: '75' },
+  { code: '17', nom: 'Charente-Maritime', region: '75' },
+  { code: '18', nom: 'Cher', region: '24' },
+  { code: '19', nom: 'Corrèze', region: '75' },
+  { code: '21', nom: "Côte-d'Or", region: '27' },
+  { code: '22', nom: "Côtes-d'Armor", region: '53' },
+  { code: '23', nom: 'Creuse', region: '75' },
+  { code: '24', nom: 'Dordogne', region: '75' },
+  { code: '25', nom: 'Doubs', region: '27' },
+  { code: '26', nom: 'Drôme', region: '84' },
+  { code: '27', nom: 'Eure', region: '28' },
+  { code: '28', nom: 'Eure-et-Loir', region: '24' },
+  { code: '29', nom: 'Finistère', region: '53' },
+  { code: '2A', nom: 'Corse-du-Sud', region: '94' },
+  { code: '2B', nom: 'Haute-Corse', region: '94' },
+  { code: '30', nom: 'Gard', region: '76' },
+  { code: '31', nom: 'Haute-Garonne', region: '76' },
+  { code: '32', nom: 'Gers', region: '76' },
+  { code: '33', nom: 'Gironde', region: '75' },
+  { code: '34', nom: 'Hérault', region: '76' },
+  { code: '35', nom: 'Ille-et-Vilaine', region: '53' },
+  { code: '36', nom: 'Indre', region: '24' },
+  { code: '37', nom: 'Indre-et-Loire', region: '24' },
+  { code: '38', nom: 'Isère', region: '84' },
+  { code: '39', nom: 'Jura', region: '27' },
+  { code: '40', nom: 'Landes', region: '75' },
+  { code: '41', nom: 'Loir-et-Cher', region: '24' },
+  { code: '42', nom: 'Loire', region: '84' },
+  { code: '43', nom: 'Haute-Loire', region: '84' },
+  { code: '44', nom: 'Loire-Atlantique', region: '52' },
+  { code: '45', nom: 'Loiret', region: '24' },
+  { code: '46', nom: 'Lot', region: '76' },
+  { code: '47', nom: 'Lot-et-Garonne', region: '75' },
+  { code: '48', nom: 'Lozère', region: '76' },
+  { code: '49', nom: 'Maine-et-Loire', region: '52' },
+  { code: '50', nom: 'Manche', region: '28' },
+  { code: '51', nom: 'Marne', region: '44' },
+  { code: '52', nom: 'Haute-Marne', region: '44' },
+  { code: '53', nom: 'Mayenne', region: '52' },
+  { code: '54', nom: 'Meurthe-et-Moselle', region: '44' },
+  { code: '55', nom: 'Meuse', region: '44' },
+  { code: '56', nom: 'Morbihan', region: '53' },
+  { code: '57', nom: 'Moselle', region: '44' },
+  { code: '58', nom: 'Nièvre', region: '27' },
+  { code: '59', nom: 'Nord', region: '32' },
+  { code: '60', nom: 'Oise', region: '32' },
+  { code: '61', nom: 'Orne', region: '28' },
+  { code: '62', nom: 'Pas-de-Calais', region: '32' },
+  { code: '63', nom: 'Puy-de-Dôme', region: '84' },
+  { code: '64', nom: 'Pyrénées-Atlantiques', region: '75' },
+  { code: '65', nom: 'Hautes-Pyrénées', region: '76' },
+  { code: '66', nom: 'Pyrénées-Orientales', region: '76' },
+  { code: '67', nom: 'Bas-Rhin', region: '44' },
+  { code: '68', nom: 'Haut-Rhin', region: '44' },
+  { code: '69', nom: 'Rhône', region: '84' },
+  { code: '70', nom: 'Haute-Saône', region: '27' },
+  { code: '71', nom: 'Saône-et-Loire', region: '27' },
+  { code: '72', nom: 'Sarthe', region: '52' },
+  { code: '73', nom: 'Savoie', region: '84' },
+  { code: '74', nom: 'Haute-Savoie', region: '84' },
+  { code: '75', nom: 'Paris', region: '11' },
+  { code: '76', nom: 'Seine-Maritime', region: '28' },
+  { code: '77', nom: 'Seine-et-Marne', region: '11' },
+  { code: '78', nom: 'Yvelines', region: '11' },
+  { code: '79', nom: 'Deux-Sèvres', region: '75' },
+  { code: '80', nom: 'Somme', region: '32' },
+  { code: '81', nom: 'Tarn', region: '76' },
+  { code: '82', nom: 'Tarn-et-Garonne', region: '76' },
+  { code: '83', nom: 'Var', region: '93' },
+  { code: '84', nom: 'Vaucluse', region: '93' },
+  { code: '85', nom: 'Vendée', region: '52' },
+  { code: '86', nom: 'Vienne', region: '75' },
+  { code: '87', nom: 'Haute-Vienne', region: '75' },
+  { code: '88', nom: 'Vosges', region: '44' },
+  { code: '89', nom: 'Yonne', region: '27' },
+  { code: '90', nom: 'Territoire de Belfort', region: '27' },
+  { code: '91', nom: 'Essonne', region: '11' },
+  { code: '92', nom: 'Hauts-de-Seine', region: '11' },
+  { code: '93', nom: 'Seine-Saint-Denis', region: '11' },
+  { code: '94', nom: 'Val-de-Marne', region: '11' },
+  { code: '95', nom: "Val-d'Oise", region: '11' },
+  { code: '971', nom: 'Guadeloupe', region: '01' },
+  { code: '972', nom: 'Martinique', region: '02' },
+  { code: '973', nom: 'Guyane', region: '03' },
+  { code: '974', nom: 'La Réunion', region: '04' },
+  { code: '976', nom: 'Mayotte', region: '06' },
+] as const
+
 export const individusSeed = [
   { publicId: 'FR', nom: 'France', referentiel: 'REF-NAT' },
-  { publicId: 'REG-11', nom: 'Île-de-France', referentiel: 'REF-REG' },
-  { publicId: 'REG-93', nom: "Provence-Alpes-Côte d'Azur", referentiel: 'REF-REG' },
-  { publicId: 'REG-84', nom: 'Auvergne-Rhône-Alpes', referentiel: 'REF-REG' },
-  { publicId: 'DEPT-75', nom: 'Paris', referentiel: 'REF-DEPT' },
-  { publicId: 'DEPT-77', nom: 'Seine-et-Marne', referentiel: 'REF-DEPT' },
-  { publicId: 'DEPT-78', nom: 'Yvelines', referentiel: 'REF-DEPT' },
-  { publicId: 'DEPT-13', nom: 'Bouches-du-Rhône', referentiel: 'REF-DEPT' },
-  { publicId: 'DEPT-83', nom: 'Var', referentiel: 'REF-DEPT' },
-  { publicId: 'DEPT-84', nom: 'Vaucluse', referentiel: 'REF-DEPT' },
-  { publicId: 'DEPT-06', nom: 'Alpes-Maritimes', referentiel: 'REF-DEPT' },
-  { publicId: 'DEPT-69', nom: 'Rhône', referentiel: 'REF-DEPT' },
-  { publicId: 'DEPT-38', nom: 'Isère', referentiel: 'REF-DEPT' },
-  { publicId: 'DEPT-73', nom: 'Savoie', referentiel: 'REF-DEPT' },
-] as const
+  ...regions.map((r) => ({
+    publicId: `REG-${r.code}`,
+    nom: r.nom,
+    referentiel: 'REF-REG' as const,
+  })),
+  ...departements.map((d) => ({
+    publicId: `DEPT-${d.code}`,
+    nom: d.nom,
+    referentiel: 'REF-DEPT' as const,
+  })),
+]
 
 export const relationsSeed = [
-  { parent: 'REG-11', child: 'DEPT-75' },
-  { parent: 'REG-11', child: 'DEPT-77' },
-  { parent: 'REG-11', child: 'DEPT-78' },
-  { parent: 'REG-93', child: 'DEPT-13' },
-  { parent: 'REG-93', child: 'DEPT-83' },
-  { parent: 'REG-93', child: 'DEPT-84' },
-  { parent: 'REG-93', child: 'DEPT-06' },
-  { parent: 'REG-84', child: 'DEPT-69' },
-  { parent: 'REG-84', child: 'DEPT-38' },
-  { parent: 'REG-84', child: 'DEPT-73' },
-  { parent: 'FR', child: 'REG-11' },
-  { parent: 'FR', child: 'REG-93' },
-  { parent: 'FR', child: 'REG-84' },
+  ...regions.map((r) => ({ parent: 'FR', child: `REG-${r.code}` })),
+  ...departements.map((d) => ({ parent: `REG-${d.region}`, child: `DEPT-${d.code}` })),
+]
+
+// Plage temporelle des séries simulées. 36 mois = 3 années couvertes.
+const PREMIERE_DATE = '2023-01-01'
+const NB_MOIS = 36
+
+const mois = Array.from({ length: NB_MOIS }, (_, i) => {
+  const date = new Date(`${PREMIERE_DATE}T00:00:00Z`)
+  date.setUTCMonth(date.getUTCMonth() + i)
+  return date.toISOString().slice(0, 10)
+})
+const annees = mois.filter((d) => d.endsWith('-01-01'))
+
+// Politique de fréquence demandée : "max tous les mois, min tous les ans".
+// Donc chaque indicateur est soit mensuel, soit annuel. Alternance déterministe
+// basée sur le rang de son publicId (IND-001 mensuel, IND-002 annuel, ...).
+export type FrequenceSeed = 'mensuelle' | 'annuelle'
+export const frequencePourIndicateur = (indicateurPublicId: string): FrequenceSeed => {
+  const match = /(\d+)$/.exec(indicateurPublicId)
+  const rang = match ? parseInt(match[1]!, 10) : 0
+  return rang % 2 === 1 ? 'mensuelle' : 'annuelle'
+}
+
+const datesPourFrequence = (frequence: FrequenceSeed) => (frequence === 'mensuelle' ? mois : annees)
+
+// Valeur déterministe combinant baseValeur, tendance (linéaire sur la plage),
+// oscillation sinusoïdale et offset par individu. Reproductible (aucun random)
+// pour garantir un seed stable.
+const computeValeur = ({
+  baseValeur,
+  amplitude,
+  trend,
+  ratio,
+  individuIndex,
+  dateIndex,
+  decimals,
+}: {
+  baseValeur: number
+  amplitude: number
+  trend: number
+  ratio: number
+  individuIndex: number
+  dateIndex: number
+  decimals: number
+}): number => {
+  const offsetIndividu =
+    Math.sin(individuIndex * 0.91 + 1.7) * amplitude * 0.45 +
+    Math.cos(individuIndex * 2.13) * amplitude * 0.25
+  const oscillation = Math.sin((dateIndex + individuIndex * 0.3) * 0.9) * amplitude * 0.4
+  const valeur = baseValeur + offsetIndividu + trend * ratio + oscillation
+  const facteur = 10 ** decimals
+  return Math.round(valeur * facteur) / facteur
+}
+
+// Profils variés (base/amplitude/trend/decimals) par modulo : 5 profils tournent
+// sur les 50 indicateurs pour que les graphes ne soient pas tous identiques.
+const profils = [
+  { baseValeur: 7.5, amplitude: 1.2, trend: 0.4, decimals: 2 },
+  { baseValeur: 720_000, amplitude: 120_000, trend: 90_000, decimals: 0 },
+  { baseValeur: 82.5, amplitude: 1.8, trend: 0.9, decimals: 2 },
+  { baseValeur: 13.5, amplitude: 3.5, trend: -1.4, decimals: 2 },
+  { baseValeur: 1200, amplitude: 60, trend: 25, decimals: 0 },
 ] as const
 
-const departementsObserves = [
-  'DEPT-75',
-  'DEPT-77',
-  'DEPT-78',
-  'DEPT-13',
-  'DEPT-83',
-  'DEPT-84',
-  'DEPT-06',
-  'DEPT-69',
-  'DEPT-38',
-  'DEPT-73',
-]
+const profilPourIndicateur = (indicateurPublicId: string) => {
+  const match = /(\d+)$/.exec(indicateurPublicId)
+  const rang = match ? parseInt(match[1]!, 10) : 0
+  return profils[rang % profils.length]!
+}
 
-// Familles de dates pour varier la temporalité des indicateurs (annuel,
-// semestriel, trimestriel, mensuel, irrégulier).
-const datesAnnuelles = ['2022-01-01', '2023-01-01', '2024-01-01', '2025-01-01']
-const datesSemestrielles = ['2023-07-01', '2024-01-01', '2024-07-01', '2025-01-01', '2025-07-01']
-const datesTrimestrielles = [
-  '2024-03-31',
-  '2024-06-30',
-  '2024-09-30',
-  '2024-12-31',
-  '2025-03-31',
-  '2025-06-30',
-]
-const datesMensuelles2025 = [
-  '2025-01-15',
-  '2025-02-15',
-  '2025-03-15',
-  '2025-04-15',
-  '2025-05-15',
-  '2025-06-15',
-  '2025-07-15',
-]
-const datesIrregulieres = [
-  '2023-11-08',
-  '2024-02-12',
-  '2024-05-30',
-  '2024-08-22',
-  '2024-11-05',
-  '2025-03-10',
-  '2025-09-18',
-]
-// Pas bi-mensuel (tous les 2 mois) sur 3 ans pour exposer une série temporelle
-// suffisamment dense aux indicateurs PUBLIC.
-const datesBimestrielles = [
-  '2023-01-15',
-  '2023-03-15',
-  '2023-05-15',
-  '2023-07-15',
-  '2023-09-15',
-  '2023-11-15',
-  '2024-01-15',
-  '2024-03-15',
-  '2024-05-15',
-  '2024-07-15',
-  '2024-09-15',
-  '2024-11-15',
-  '2025-01-15',
-  '2025-03-15',
-  '2025-05-15',
-  '2025-07-15',
-  '2025-09-15',
-  '2025-11-15',
-]
-
-const buildDeptValeurs = (
-  indicateurPublicId: string,
-  baseValeur: number,
-  step: number,
-  dates: ReadonlyArray<string>,
-) =>
-  departementsObserves.flatMap((individuPublicId, departementIndex) =>
+// Génère la série d'un indicateur sur la maille fournie. La maille = liste de
+// publicIds d'individus sur lesquels on saisit (typiquement les 101 dépts, ou
+// les 18 régions pour les indicateurs sans lien départemental).
+export const buildValeursPourIndicateur = ({
+  indicateurPublicId,
+  individuPublicIds,
+}: {
+  indicateurPublicId: string
+  individuPublicIds: ReadonlyArray<string>
+}): ReadonlyArray<{
+  indicateurPublicId: string
+  individuPublicId: string
+  date: string
+  valeur: number
+}> => {
+  const frequence = frequencePourIndicateur(indicateurPublicId)
+  const dates = datesPourFrequence(frequence)
+  const profil = profilPourIndicateur(indicateurPublicId)
+  const lastIndex = Math.max(dates.length - 1, 1)
+  return individuPublicIds.flatMap((individuPublicId, individuIndex) =>
     dates.map((date, dateIndex) => ({
       indicateurPublicId,
       individuPublicId,
       date,
-      valeur: baseValeur + departementIndex * step + dateIndex * (step / 2),
+      valeur: computeValeur({
+        ...profil,
+        ratio: dateIndex / lastIndex,
+        individuIndex,
+        dateIndex,
+      }),
     })),
   )
-
-// Variante avec :
-// - tendance globale (trend) appliquée du premier au dernier point,
-// - oscillation sinusoïdale d'amplitude `amplitude`,
-// - bruit déterministe pour décorréler les départements.
-// Reste pure et déterministe (aucun Math.random()) : indispensable pour avoir un
-// seed reproductible.
-const buildDeptValeursVariees = ({
-  indicateurPublicId,
-  baseValeur,
-  amplitude,
-  trend,
-  dates,
-  decimals = 2,
-}: {
-  indicateurPublicId: string
-  baseValeur: number
-  amplitude: number
-  trend: number
-  dates: ReadonlyArray<string>
-  decimals?: number
-}) => {
-  const round = (n: number) => Math.round(n * 10 ** decimals) / 10 ** decimals
-  return departementsObserves.flatMap((individuPublicId, deptIndex) =>
-    dates.map((date, dateIndex) => {
-      const ratio = dates.length > 1 ? dateIndex / (dates.length - 1) : 0
-      const deptOffset = (deptIndex - (departementsObserves.length - 1) / 2) * amplitude * 0.35
-      const oscillation = Math.sin((dateIndex + deptIndex * 0.7) * 1.1) * amplitude * 0.55
-      const bruit = Math.cos(dateIndex * 3.1 + deptIndex * 5.7) * amplitude * 0.25
-      return {
-        indicateurPublicId,
-        individuPublicId,
-        date,
-        valeur: round(baseValeur + deptOffset + trend * ratio + oscillation + bruit),
-      }
-    }),
-  )
 }
-
-const ind008Regions = [
-  { indicateurPublicId: 'IND-008', individuPublicId: 'REG-11', date: '2024-06-01', valeur: 72.5 },
-  { indicateurPublicId: 'IND-008', individuPublicId: 'REG-93', date: '2024-06-01', valeur: 68.3 },
-  { indicateurPublicId: 'IND-008', individuPublicId: 'REG-84', date: '2024-06-01', valeur: 70.1 },
-  { indicateurPublicId: 'IND-008', individuPublicId: 'REG-11', date: '2024-12-15', valeur: 73.2 },
-  { indicateurPublicId: 'IND-008', individuPublicId: 'REG-93', date: '2024-12-15', valeur: 68.7 },
-  { indicateurPublicId: 'IND-008', individuPublicId: 'REG-84', date: '2024-12-15', valeur: 70.8 },
-  { indicateurPublicId: 'IND-008', individuPublicId: 'REG-11', date: '2025-01-01', valeur: 74.0 },
-  { indicateurPublicId: 'IND-008', individuPublicId: 'REG-93', date: '2025-01-01', valeur: 69.0 },
-  { indicateurPublicId: 'IND-008', individuPublicId: 'REG-84', date: '2025-01-01', valeur: 71.5 },
-  { indicateurPublicId: 'IND-008', individuPublicId: 'REG-11', date: '2025-08-04', valeur: 75.1 },
-  { indicateurPublicId: 'IND-008', individuPublicId: 'REG-93', date: '2025-08-04', valeur: 70.2 },
-  { indicateurPublicId: 'IND-008', individuPublicId: 'REG-84', date: '2025-08-04', valeur: 72.6 },
-] as const
-
-export const valeursAvancementSeed = [
-  ...buildDeptValeurs('IND-001', 7.5, 0.3, datesMensuelles2025),
-  ...buildDeptValeurs('IND-002', 4.2, 0.1, datesAnnuelles),
-  ...buildDeptValeurs('IND-003', 65.0, 1.5, datesTrimestrielles),
-  ...buildDeptValeurs('IND-004', 21.0, 0.8, datesSemestrielles),
-  ...buildDeptValeurs('IND-005', 1200.0, 30.0, datesIrregulieres),
-  ...ind008Regions,
-  // Indicateurs PUBLIC (IND-046 → IND-050) : série bi-mensuelle sur 3 ans
-  // avec tendances et oscillations marquées pour avoir des graphes "parlants".
-  ...buildDeptValeursVariees({
-    indicateurPublicId: 'IND-046',
-    baseValeur: 700_000,
-    amplitude: 120_000,
-    trend: 90_000,
-    dates: datesBimestrielles,
-    decimals: 0,
-  }),
-  ...buildDeptValeursVariees({
-    indicateurPublicId: 'IND-047',
-    baseValeur: 82.5,
-    amplitude: 1.8,
-    trend: 0.9,
-    dates: datesBimestrielles,
-    decimals: 2,
-  }),
-  ...buildDeptValeursVariees({
-    indicateurPublicId: 'IND-048',
-    baseValeur: 13.5,
-    amplitude: 3.5,
-    trend: -1.4,
-    dates: datesBimestrielles,
-    decimals: 2,
-  }),
-  ...buildDeptValeursVariees({
-    indicateurPublicId: 'IND-049',
-    baseValeur: 96.0,
-    amplitude: 1.4,
-    trend: 1.6,
-    dates: datesBimestrielles,
-    decimals: 2,
-  }),
-  ...buildDeptValeursVariees({
-    indicateurPublicId: 'IND-050',
-    baseValeur: 78.0,
-    amplitude: 6.0,
-    trend: 14.0,
-    dates: datesBimestrielles,
-    decimals: 2,
-  }),
-]

--- a/apps/mb-api/src/framework/concurrency.ts
+++ b/apps/mb-api/src/framework/concurrency.ts
@@ -1,0 +1,16 @@
+// Node.js exécute tout le JS d'un process sur un seul thread. Tant qu'une
+// fonction synchrone tourne (gros calcul, boucle longue), aucune autre
+// requête HTTP entrante, aucun callback I/O, aucun timer ne peut être traité
+// — la node est "gelée". `await` sur une promesse déjà résolue ne suffit pas
+// à débloquer ça : le micro-task continue dans le même "tick" sans rendre la
+// main au scheduler.
+//
+// `setImmediate` planifie un callback sur la **prochaine itération** de
+// l'event loop : la node traite d'abord les I/O en attente, puis nous rend
+// la main. C'est l'équivalent d'un `yield` coopératif.
+//
+// À utiliser au milieu d'une boucle de calcul lourd (>100ms cumulés) pour
+// éviter qu'elle ne bloque les requêtes concurrentes. Coût : ~1 ms par yield,
+// négligeable face à un calcul lourd, prohibitif sur une boucle légère —
+// yielder par chunks, pas à chaque itération unitaire.
+export const yieldToEventLoop = (): Promise<void> => new Promise((resolve) => setImmediate(resolve))

--- a/apps/mb-api/src/valeurAvancement/queries/listValeursForIndicateur.ts
+++ b/apps/mb-api/src/valeurAvancement/queries/listValeursForIndicateur.ts
@@ -1,4 +1,3 @@
-import { type FonctionAgregation } from '@pilote/mb-shared/indicateur'
 import {
   type ContributionApiModel,
   type DateTrunc,
@@ -9,15 +8,14 @@ import {
 import { ResultAsync } from 'neverthrow'
 
 import { requireCurrentPrincipalId } from '@/framework/auth/userContext'
+import { logger } from '@/framework/logger/logger'
 import { db } from '@/framework/persistence/dbStore'
-import { getValeursTronqueesPourIndividus } from '@/generated/prisma/sql'
 import { withIndicateurReadPermission } from '@/indicateur/permissions'
+import { loadResolveSerieContext } from '@/valeurAvancement/queries/loadResolveSerieContext'
 import {
   type IndividuRef,
   type PointInterne,
   resolveSerieIndividu,
-  type ResolveSerieContext,
-  type SaisieTronquee,
 } from '@/valeurAvancement/resolveSerieIndividu'
 
 // Cap par défaut à la granularité mensuelle : sans troncature, une série France
@@ -41,11 +39,11 @@ export const listValeursForIndicateur = (
   )
 }
 
-// Orchestration en 3 phases : (1) charger en bulk l'arbre + les liens
-// indicateur↔référentiel en parallèle, (2) charger les saisies tronquées en
-// connaissant l'ensemble des descendants, (3) calculer les séries en mémoire
-// via le functional core memoïsé (cf. resolveSerieIndividu + doc d'archi
-// `indicateur-derives.md`). Filtrage dateDebut/dateFin appliqué en sortie.
+// Orchestration en 3 phases : (1) résoudre les cibles publicId→id, (2) charger
+// en bulk le contexte de résolution (sous-arbre + saisies tronquées + fonctions
+// d'agrégation), (3) calculer les séries en mémoire via le functional core
+// mémoïsé. Filtrage dateDebut/dateFin appliqué en sortie. Cf. doc d'archi
+// `indicateur-derives.md`.
 const buildSeries = async ({
   indicateurId,
   indicateurPublicId,
@@ -58,26 +56,9 @@ const buildSeries = async ({
   const cibles = await loadCibles(params.individus)
   if (cibles.length === 0) return { items: [] }
 
-  // Indépendants entre eux : chargement parallèle pour minimiser la latence.
-  const [{ allNodes, enfantsParParent }, fonctionAgregationParReferentiel] = await Promise.all([
-    loadSousArbre(cibles),
-    loadFonctionsAgregation(indicateurId),
-  ])
   const dateTrunc: DateTrunc = params.dateTrunc ?? DEFAULT_DATE_TRUNC
-  const serieFeuilleParIndividu = await loadSaisiesTronquees({
-    indicateurId,
-    individuIds: [...allNodes.keys()],
-    dateTrunc,
-  })
-
-  const ctx: ResolveSerieContext = {
-    enfantsParParent,
-    fonctionAgregationParReferentiel,
-    serieFeuilleParIndividu,
-    referentielParIndividu: new Map(
-      [...allNodes.values()].map((individu) => [individu.id, individu.referentielId]),
-    ),
-  }
+  const startedAt = performance.now()
+  const { ctx, allNodes } = await loadResolveSerieContext({ indicateurId, cibles, dateTrunc })
   const cache = new Map<string, ReadonlyArray<PointInterne>>()
 
   const items: ValeurAvancementApiModel[] = []
@@ -89,90 +70,27 @@ const buildSeries = async ({
       items.push(toApiModel({ indicateurPublicId, individuPublicId: cible.publicId, point }))
     }
   }
+  logger.info(
+    {
+      event: 'valeurAvancement.listValeursForIndicateur.timing',
+      indicateurId,
+      dateTrunc,
+      nbCibles: cibles.length,
+      nbNodes: allNodes.size,
+      nbPoints: items.length,
+      durationMs: Math.round(performance.now() - startedAt),
+    },
+    'listValeursForIndicateur computed',
+  )
   return { items }
 }
 
-const loadCibles = (individus: ReadonlyArray<string>): Promise<IndividuRef[]> =>
-  db().individu.findMany({
-    where: { publicId: { in: [...individus] } },
-    select: { id: true, publicId: true, referentielId: true },
+const loadCibles = async (publicIds: ReadonlyArray<string>): Promise<IndividuRef[]> => {
+  const rows = await db().individu.findMany({
+    where: { publicId: { in: [...publicIds] } },
     orderBy: { publicId: 'asc' },
   })
-
-// BFS itératif niveau par niveau plutôt qu'une CTE récursive PostgreSQL :
-// l'arbre est typiquement peu profond (3-4 niveaux France→Région→Département)
-// et garder le calcul en JS reste plus simple à lire et à débugger que du SQL
-// récursif. Détection naïve des cycles : on ne retraite pas un nœud déjà vu.
-const loadSousArbre = async (
-  cibles: ReadonlyArray<IndividuRef>,
-): Promise<{
-  allNodes: Map<string, IndividuRef>
-  enfantsParParent: Map<string, IndividuRef[]>
-}> => {
-  const allNodes = new Map<string, IndividuRef>()
-  for (const cible of cibles) allNodes.set(cible.id, cible)
-  const enfantsParParent = new Map<string, IndividuRef[]>()
-  let currentLevel = cibles.map((c) => c.id)
-
-  while (currentLevel.length > 0) {
-    const relations = await db().relation.findMany({
-      where: { parentId: { in: currentLevel } },
-      include: { child: true },
-    })
-    if (relations.length === 0) break
-
-    const nextLevelSet = new Set<string>()
-    for (const relation of relations) {
-      const childRef: IndividuRef = {
-        id: relation.child.id,
-        publicId: relation.child.publicId,
-        referentielId: relation.child.referentielId,
-      }
-      if (!allNodes.has(childRef.id)) {
-        allNodes.set(childRef.id, childRef)
-        nextLevelSet.add(childRef.id)
-      }
-      const liste = enfantsParParent.get(relation.parentId) ?? []
-      liste.push(childRef)
-      enfantsParParent.set(relation.parentId, liste)
-    }
-    currentLevel = [...nextLevelSet]
-  }
-
-  return { allNodes, enfantsParParent }
-}
-
-const loadFonctionsAgregation = async (
-  indicateurId: string,
-): Promise<Map<string, FonctionAgregation>> => {
-  const liens = await db().indicateurReferentiel.findMany({
-    where: { indicateurId },
-    select: { referentielId: true, fonctionAgregation: true },
-  })
-  return new Map(liens.map((lien) => [lien.referentielId, lien.fonctionAgregation]))
-}
-
-const loadSaisiesTronquees = async ({
-  indicateurId,
-  individuIds,
-  dateTrunc,
-}: {
-  indicateurId: string
-  individuIds: ReadonlyArray<string>
-  dateTrunc: DateTrunc
-}): Promise<Map<string, SaisieTronquee[]>> => {
-  if (individuIds.length === 0) return new Map()
-  const rows = await db().$queryRawTyped(
-    getValeursTronqueesPourIndividus(indicateurId, [...individuIds], dateTrunc),
-  )
-  const serieFeuilleParIndividu = new Map<string, SaisieTronquee[]>()
-  for (const row of rows) {
-    if (!row.bucket) continue
-    const liste = serieFeuilleParIndividu.get(row.individuId) ?? []
-    liste.push({ bucket: row.bucket, dateOrigine: row.dateOrigine, valeur: row.valeur })
-    serieFeuilleParIndividu.set(row.individuId, liste)
-  }
-  return serieFeuilleParIndividu
+  return rows.map(({ id, publicId, referentielId }) => ({ id, publicId, referentielId }))
 }
 
 const toApiModel = ({

--- a/apps/mb-api/src/valeurAvancement/queries/listValeursForIndicateur.ts
+++ b/apps/mb-api/src/valeurAvancement/queries/listValeursForIndicateur.ts
@@ -63,7 +63,7 @@ const buildSeries = async ({
 
   const items: ValeurAvancementApiModel[] = []
   for (const cible of cibles) {
-    const serie = resolveSerieIndividu(cible.id, ctx, cache)
+    const serie = await resolveSerieIndividu(cible.id, ctx, cache)
     for (const point of serie) {
       if (params.dateDebut && point.bucket < params.dateDebut) continue
       if (params.dateFin && point.bucket > params.dateFin) continue

--- a/apps/mb-api/src/valeurAvancement/queries/listValeursRemarquablesForIndicateur.test.ts
+++ b/apps/mb-api/src/valeurAvancement/queries/listValeursRemarquablesForIndicateur.test.ts
@@ -2,7 +2,13 @@ import { describe, expect, it } from 'vitest'
 
 import { fixtures } from '@/test/fixtures'
 import { integrationTest } from '@/test/integrationTest'
-import { testDeptId, testDeptIds, testIndicateurId } from '@/test/randomIds'
+import {
+  testDeptId,
+  testDeptIds,
+  testIndicateurId,
+  testIndividuId,
+  testReferentielId,
+} from '@/test/randomIds'
 import { runAsPrincipal } from '@/test/runAsPrincipal'
 import { listValeursRemarquablesForIndicateur } from '@/valeurAvancement/queries/listValeursRemarquablesForIndicateur'
 
@@ -394,6 +400,286 @@ describe.concurrent('listValeursRemarquablesForIndicateur', () => {
           listValeursRemarquablesForIndicateur(indId, { referentiels: ['REF-A'] }),
         ),
       ).rejects.toThrow()
+    }),
+  )
+
+  it(
+    'calcule les stats sur les valeurs dérivées (SUM) des individus du référentiel',
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const refReg = testReferentielId()
+      const refDept = testReferentielId()
+      const [reg1, reg2] = [testIndividuId(), testIndividuId()]
+      const [d1a, d1b, d2a, d2b] = [
+        testIndividuId(),
+        testIndividuId(),
+        testIndividuId(),
+        testIndividuId(),
+      ]
+
+      await fixtures.indicateurReferentiel(
+        {
+          indicateur: { publicId: indId, nom: 'T', visibilite: 'PUBLIC' },
+          referentiel: { publicId: refReg, nom: 'Régions' },
+          fonctionAgregation: 'SUM',
+        },
+        {
+          indicateur: { publicId: indId },
+          referentiel: { publicId: refDept, nom: 'Départements' },
+          fonctionAgregation: 'NONE',
+        },
+      )
+      await fixtures.relation(
+        {
+          parent: { publicId: reg1, referentiel: { publicId: refReg } },
+          child: { publicId: d1a, referentiel: { publicId: refDept } },
+        },
+        {
+          parent: { publicId: reg1 },
+          child: { publicId: d1b, referentiel: { publicId: refDept } },
+        },
+        {
+          parent: { publicId: reg2, referentiel: { publicId: refReg } },
+          child: { publicId: d2a, referentiel: { publicId: refDept } },
+        },
+        {
+          parent: { publicId: reg2 },
+          child: { publicId: d2b, referentiel: { publicId: refDept } },
+        },
+      )
+      await fixtures.valeurAvancement(
+        {
+          indicateur: { publicId: indId },
+          individu: { publicId: d1a },
+          date: '2026-01-01',
+          valeur: 10,
+        },
+        {
+          indicateur: { publicId: indId },
+          individu: { publicId: d1b },
+          date: '2026-01-01',
+          valeur: 30,
+        },
+        {
+          indicateur: { publicId: indId },
+          individu: { publicId: d2a },
+          date: '2026-01-01',
+          valeur: 50,
+        },
+        {
+          indicateur: { publicId: indId },
+          individu: { publicId: d2b },
+          date: '2026-01-01',
+          valeur: 70,
+        },
+      )
+      const apiKey = await fixtures.apiKey()
+
+      const result = await runAsPrincipal(apiKey.id, () =>
+        listValeursRemarquablesForIndicateur(indId, { referentiels: [refReg] }),
+      )
+
+      // reg1 = 10+30 = 40 ; reg2 = 50+70 = 120
+      expect(result._unsafeUnwrap()).toEqual({
+        items: [{ referentiel: refReg, min: 40, max: 120, mediane: 80 }],
+      })
+    }),
+  )
+
+  it(
+    'utilise le dernier bucket de la série dérivée (carry-forward des enfants)',
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const refReg = testReferentielId()
+      const refDept = testReferentielId()
+      const regId = testIndividuId()
+      const [dept1, dept2] = [testIndividuId(), testIndividuId()]
+
+      await fixtures.indicateurReferentiel(
+        {
+          indicateur: { publicId: indId, nom: 'T', visibilite: 'PUBLIC' },
+          referentiel: { publicId: refReg },
+          fonctionAgregation: 'SUM',
+        },
+        {
+          indicateur: { publicId: indId },
+          referentiel: { publicId: refDept },
+          fonctionAgregation: 'NONE',
+        },
+      )
+      await fixtures.relation(
+        {
+          parent: { publicId: regId, referentiel: { publicId: refReg } },
+          child: { publicId: dept1, referentiel: { publicId: refDept } },
+        },
+        {
+          parent: { publicId: regId },
+          child: { publicId: dept2, referentiel: { publicId: refDept } },
+        },
+      )
+      // dept1 saisie en janvier, dept2 en mars. Dernier bucket de la série
+      // région = mars, valeur = 7 (dept1, carry-forward) + 50 (dept2) = 57.
+      await fixtures.valeurAvancement(
+        {
+          indicateur: { publicId: indId },
+          individu: { publicId: dept1 },
+          date: '2026-01-01',
+          valeur: 7,
+        },
+        {
+          indicateur: { publicId: indId },
+          individu: { publicId: dept2 },
+          date: '2026-03-01',
+          valeur: 50,
+        },
+      )
+      const apiKey = await fixtures.apiKey()
+
+      const result = await runAsPrincipal(apiKey.id, () =>
+        listValeursRemarquablesForIndicateur(indId, { referentiels: [refReg] }),
+      )
+
+      expect(result._unsafeUnwrap()).toEqual({
+        items: [{ referentiel: refReg, min: 57, max: 57, mediane: 57 }],
+      })
+    }),
+  )
+
+  it(
+    'inclut un individu agrégé en couverture partielle (un seul enfant a saisi)',
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const refReg = testReferentielId()
+      const refDept = testReferentielId()
+      const [reg1, reg2] = [testIndividuId(), testIndividuId()]
+      const [d1a, d1b, d2a, d2b] = [
+        testIndividuId(),
+        testIndividuId(),
+        testIndividuId(),
+        testIndividuId(),
+      ]
+
+      await fixtures.indicateurReferentiel(
+        {
+          indicateur: { publicId: indId, nom: 'T', visibilite: 'PUBLIC' },
+          referentiel: { publicId: refReg },
+          fonctionAgregation: 'SUM',
+        },
+        {
+          indicateur: { publicId: indId },
+          referentiel: { publicId: refDept },
+          fonctionAgregation: 'NONE',
+        },
+      )
+      await fixtures.relation(
+        {
+          parent: { publicId: reg1, referentiel: { publicId: refReg } },
+          child: { publicId: d1a, referentiel: { publicId: refDept } },
+        },
+        {
+          parent: { publicId: reg1 },
+          child: { publicId: d1b, referentiel: { publicId: refDept } },
+        },
+        {
+          parent: { publicId: reg2, referentiel: { publicId: refReg } },
+          child: { publicId: d2a, referentiel: { publicId: refDept } },
+        },
+        {
+          parent: { publicId: reg2 },
+          child: { publicId: d2b, referentiel: { publicId: refDept } },
+        },
+      )
+      // reg1 : couverture pleine (d1a+d1b = 100). reg2 : un seul enfant saisi
+      // (d2a = 5). reg2 contribue malgré la couverture partielle.
+      await fixtures.valeurAvancement(
+        {
+          indicateur: { publicId: indId },
+          individu: { publicId: d1a },
+          date: '2026-01-01',
+          valeur: 40,
+        },
+        {
+          indicateur: { publicId: indId },
+          individu: { publicId: d1b },
+          date: '2026-01-01',
+          valeur: 60,
+        },
+        {
+          indicateur: { publicId: indId },
+          individu: { publicId: d2a },
+          date: '2026-01-01',
+          valeur: 5,
+        },
+      )
+      const apiKey = await fixtures.apiKey()
+
+      const result = await runAsPrincipal(apiKey.id, () =>
+        listValeursRemarquablesForIndicateur(indId, { referentiels: [refReg] }),
+      )
+
+      expect(result._unsafeUnwrap()).toEqual({
+        items: [{ referentiel: refReg, min: 5, max: 100, mediane: 52.5 }],
+      })
+    }),
+  )
+
+  it(
+    'calcule indépendamment un référentiel SUM et un référentiel feuille NONE',
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const refReg = testReferentielId()
+      const refDept = testReferentielId()
+      const regId = testIndividuId()
+      const [dept1, dept2] = [testIndividuId(), testIndividuId()]
+
+      await fixtures.indicateurReferentiel(
+        {
+          indicateur: { publicId: indId, nom: 'T', visibilite: 'PUBLIC' },
+          referentiel: { publicId: refReg, nom: 'AAA-Régions' },
+          fonctionAgregation: 'SUM',
+        },
+        {
+          indicateur: { publicId: indId },
+          referentiel: { publicId: refDept, nom: 'ZZZ-Départements' },
+          fonctionAgregation: 'NONE',
+        },
+      )
+      await fixtures.relation(
+        {
+          parent: { publicId: regId, referentiel: { publicId: refReg } },
+          child: { publicId: dept1, referentiel: { publicId: refDept } },
+        },
+        {
+          parent: { publicId: regId },
+          child: { publicId: dept2, referentiel: { publicId: refDept } },
+        },
+      )
+      await fixtures.valeurAvancement(
+        {
+          indicateur: { publicId: indId },
+          individu: { publicId: dept1 },
+          date: '2026-01-01',
+          valeur: 12,
+        },
+        {
+          indicateur: { publicId: indId },
+          individu: { publicId: dept2 },
+          date: '2026-01-01',
+          valeur: 28,
+        },
+      )
+      const apiKey = await fixtures.apiKey()
+
+      const result = await runAsPrincipal(apiKey.id, () =>
+        listValeursRemarquablesForIndicateur(indId, { referentiels: [refReg, refDept] }),
+      )
+
+      const items = result._unsafeUnwrap().items
+      const parRef = new Map(items.map((i) => [i.referentiel, i]))
+      // Feuille : min/max sur les saisies départementales.
+      expect(parRef.get(refDept)).toEqual({ referentiel: refDept, min: 12, max: 28, mediane: 20 })
+      // Agrégé : dérivée région = 12 + 28 = 40 (un seul individu).
+      expect(parRef.get(refReg)).toEqual({ referentiel: refReg, min: 40, max: 40, mediane: 40 })
     }),
   )
 

--- a/apps/mb-api/src/valeurAvancement/queries/listValeursRemarquablesForIndicateur.test.ts
+++ b/apps/mb-api/src/valeurAvancement/queries/listValeursRemarquablesForIndicateur.test.ts
@@ -26,7 +26,9 @@ describe.concurrent('listValeursRemarquablesForIndicateur', () => {
       )
 
       expect(result._unsafeUnwrap()).toEqual({
-        items: [{ referentiel: 'REF-VIDE', min: null, max: null, mediane: null }],
+        items: [
+          { referentiel: 'REF-VIDE', min: null, max: null, mediane: null, contributions: [] },
+        ],
       })
     }),
   )
@@ -48,7 +50,7 @@ describe.concurrent('listValeursRemarquablesForIndicateur', () => {
       )
 
       expect(result._unsafeUnwrap()).toEqual({
-        items: [{ referentiel: 'REF-A', min: null, max: null, mediane: null }],
+        items: [{ referentiel: 'REF-A', min: null, max: null, mediane: null, contributions: [] }],
       })
     }),
   )
@@ -91,7 +93,7 @@ describe.concurrent('listValeursRemarquablesForIndicateur', () => {
         listValeursRemarquablesForIndicateur(indId, { referentiels: ['REF-A'] }),
       )
 
-      expect(result._unsafeUnwrap()).toEqual({
+      expect(result._unsafeUnwrap()).toMatchObject({
         items: [{ referentiel: 'REF-A', min: 10, max: 50, mediane: 30 }],
       })
     }),
@@ -135,7 +137,7 @@ describe.concurrent('listValeursRemarquablesForIndicateur', () => {
         listValeursRemarquablesForIndicateur(indId, { referentiels: ['REF-A'] }),
       )
 
-      expect(result._unsafeUnwrap()).toEqual({
+      expect(result._unsafeUnwrap()).toMatchObject({
         items: [{ referentiel: 'REF-A', min: 10, max: 40, mediane: 25 }],
       })
     }),
@@ -164,7 +166,7 @@ describe.concurrent('listValeursRemarquablesForIndicateur', () => {
         listValeursRemarquablesForIndicateur(indId, { referentiels: ['REF-A'] }),
       )
 
-      expect(result._unsafeUnwrap()).toEqual({
+      expect(result._unsafeUnwrap()).toMatchObject({
         items: [{ referentiel: 'REF-A', min: 42, max: 42, mediane: 42 }],
       })
     }),
@@ -202,7 +204,7 @@ describe.concurrent('listValeursRemarquablesForIndicateur', () => {
         listValeursRemarquablesForIndicateur(indId, { referentiels: ['REF-A', 'REF-B'] }),
       )
 
-      expect(result._unsafeUnwrap()).toEqual({
+      expect(result._unsafeUnwrap()).toMatchObject({
         items: [
           { referentiel: 'REF-A', min: 10, max: 30, mediane: 20 },
           { referentiel: 'REF-B', min: 100, max: 100, mediane: 100 },
@@ -229,7 +231,7 @@ describe.concurrent('listValeursRemarquablesForIndicateur', () => {
         listValeursRemarquablesForIndicateur(indId, { referentiels: ['REF-A', 'REF-INCONNU'] }),
       )
 
-      expect(result._unsafeUnwrap()).toEqual({
+      expect(result._unsafeUnwrap()).toMatchObject({
         items: [{ referentiel: 'REF-A', min: 42, max: 42, mediane: 42 }],
       })
     }),
@@ -298,7 +300,7 @@ describe.concurrent('listValeursRemarquablesForIndicateur', () => {
         listValeursRemarquablesForIndicateur(indId, { referentiels: ['REF-A'] }),
       )
 
-      expect(result._unsafeUnwrap()).toEqual({
+      expect(result._unsafeUnwrap()).toMatchObject({
         items: [{ referentiel: 'REF-A', min: 75, max: 75, mediane: 75 }],
       })
     }),
@@ -336,7 +338,7 @@ describe.concurrent('listValeursRemarquablesForIndicateur', () => {
         listValeursRemarquablesForIndicateur(indId, { referentiels: ['REF-A'] }),
       )
 
-      expect(result._unsafeUnwrap()).toEqual({
+      expect(result._unsafeUnwrap()).toMatchObject({
         items: [{ referentiel: 'REF-A', min: 10, max: 20, mediane: 15 }],
       })
     }),
@@ -368,7 +370,7 @@ describe.concurrent('listValeursRemarquablesForIndicateur', () => {
         listValeursRemarquablesForIndicateur(indId, { referentiels: ['REF-A'] }),
       )
 
-      expect(result._unsafeUnwrap()).toEqual({
+      expect(result._unsafeUnwrap()).toMatchObject({
         items: [{ referentiel: 'REF-A', min: 10, max: 10, mediane: 10 }],
       })
     }),
@@ -480,7 +482,7 @@ describe.concurrent('listValeursRemarquablesForIndicateur', () => {
       )
 
       // reg1 = 10+30 = 40 ; reg2 = 50+70 = 120
-      expect(result._unsafeUnwrap()).toEqual({
+      expect(result._unsafeUnwrap()).toMatchObject({
         items: [{ referentiel: refReg, min: 40, max: 120, mediane: 80 }],
       })
     }),
@@ -539,7 +541,7 @@ describe.concurrent('listValeursRemarquablesForIndicateur', () => {
         listValeursRemarquablesForIndicateur(indId, { referentiels: [refReg] }),
       )
 
-      expect(result._unsafeUnwrap()).toEqual({
+      expect(result._unsafeUnwrap()).toMatchObject({
         items: [{ referentiel: refReg, min: 57, max: 57, mediane: 57 }],
       })
     }),
@@ -617,7 +619,7 @@ describe.concurrent('listValeursRemarquablesForIndicateur', () => {
         listValeursRemarquablesForIndicateur(indId, { referentiels: [refReg] }),
       )
 
-      expect(result._unsafeUnwrap()).toEqual({
+      expect(result._unsafeUnwrap()).toMatchObject({
         items: [{ referentiel: refReg, min: 5, max: 100, mediane: 52.5 }],
       })
     }),
@@ -677,9 +679,102 @@ describe.concurrent('listValeursRemarquablesForIndicateur', () => {
       const items = result._unsafeUnwrap().items
       const parRef = new Map(items.map((i) => [i.referentiel, i]))
       // Feuille : min/max sur les saisies départementales.
-      expect(parRef.get(refDept)).toEqual({ referentiel: refDept, min: 12, max: 28, mediane: 20 })
+      expect(parRef.get(refDept)).toMatchObject({
+        referentiel: refDept,
+        min: 12,
+        max: 28,
+        mediane: 20,
+      })
       // Agrégé : dérivée région = 12 + 28 = 40 (un seul individu).
-      expect(parRef.get(refReg)).toEqual({ referentiel: refReg, min: 40, max: 40, mediane: 40 })
+      expect(parRef.get(refReg)).toMatchObject({
+        referentiel: refReg,
+        min: 40,
+        max: 40,
+        mediane: 40,
+      })
+    }),
+  )
+
+  it(
+    'expose les contributions par individu (saisie pour les feuilles, derivee pour les agrégés)',
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const refReg = testReferentielId()
+      const refDept = testReferentielId()
+      const [regA, regB] = [testIndividuId(), testIndividuId()].sort() as [string, string]
+      const [d1, d2, d3] = [testIndividuId(), testIndividuId(), testIndividuId()].sort() as [
+        string,
+        string,
+        string,
+      ]
+
+      await fixtures.indicateurReferentiel(
+        {
+          indicateur: { publicId: indId, nom: 'T', visibilite: 'PUBLIC' },
+          referentiel: { publicId: refReg, nom: 'R' },
+          fonctionAgregation: 'SUM',
+        },
+        {
+          indicateur: { publicId: indId },
+          referentiel: { publicId: refDept, nom: 'D' },
+          fonctionAgregation: 'NONE',
+        },
+      )
+      await fixtures.relation(
+        {
+          parent: { publicId: regA, referentiel: { publicId: refReg } },
+          child: { publicId: d1, referentiel: { publicId: refDept } },
+        },
+        {
+          parent: { publicId: regA },
+          child: { publicId: d2, referentiel: { publicId: refDept } },
+        },
+        {
+          parent: { publicId: regB, referentiel: { publicId: refReg } },
+          child: { publicId: d3, referentiel: { publicId: refDept } },
+        },
+      )
+      await fixtures.valeurAvancement(
+        {
+          indicateur: { publicId: indId },
+          individu: { publicId: d1 },
+          date: '2026-01-15',
+          valeur: 10,
+        },
+        {
+          indicateur: { publicId: indId },
+          individu: { publicId: d2 },
+          date: '2026-01-15',
+          valeur: 20,
+        },
+        {
+          indicateur: { publicId: indId },
+          individu: { publicId: d3 },
+          date: '2026-02-20',
+          valeur: 7,
+        },
+      )
+      const apiKey = await fixtures.apiKey()
+
+      const result = await runAsPrincipal(apiKey.id, () =>
+        listValeursRemarquablesForIndicateur(indId, { referentiels: [refReg, refDept] }),
+      )
+
+      const items = result._unsafeUnwrap().items
+      const reg = items.find((i) => i.referentiel === refReg)!
+      const dept = items.find((i) => i.referentiel === refDept)!
+
+      // Régions agrégées : sources = derivee, dates = buckets mensuels post-troncature.
+      expect(reg.contributions).toEqual([
+        { individu: regA, valeur: 30, date: '2026-01-01', source: 'derivee' },
+        { individu: regB, valeur: 7, date: '2026-02-01', source: 'derivee' },
+      ])
+      // Départements feuilles : sources = saisie, dates = buckets mensuels (tri par publicId).
+      expect(dept.contributions).toEqual([
+        { individu: d1, valeur: 10, date: '2026-01-01', source: 'saisie' },
+        { individu: d2, valeur: 20, date: '2026-01-01', source: 'saisie' },
+        { individu: d3, valeur: 7, date: '2026-02-01', source: 'saisie' },
+      ])
     }),
   )
 

--- a/apps/mb-api/src/valeurAvancement/queries/listValeursRemarquablesForIndicateur.ts
+++ b/apps/mb-api/src/valeurAvancement/queries/listValeursRemarquablesForIndicateur.ts
@@ -1,4 +1,5 @@
 import {
+  type DateTrunc,
   type ListValeursRemarquablesForIndicateurQuery,
   type ValeursRemarquablesListApiModel,
 } from '@pilote/mb-shared/valeurAvancement'
@@ -6,32 +7,22 @@ import { ResultAsync } from 'neverthrow'
 
 import { requireCurrentPrincipalId } from '@/framework/auth/userContext'
 import { type Decimal } from '@/framework/decimal'
+import { logger } from '@/framework/logger/logger'
 import { db } from '@/framework/persistence/dbStore'
 import { withIndicateurReadPermission } from '@/indicateur/permissions'
 import { computeMax } from '@/valeurAvancement/computeMax'
 import { computeMediane } from '@/valeurAvancement/computeMediane'
 import { computeMin } from '@/valeurAvancement/computeMin'
+import { loadResolveSerieContext } from '@/valeurAvancement/queries/loadResolveSerieContext'
+import {
+  type IndividuRef,
+  type PointInterne,
+  resolveSerieIndividu,
+} from '@/valeurAvancement/resolveSerieIndividu'
 
-const fetchReferentielsAvecValeursRecentes = (
-  indicateurId: string,
-  referentiels: ReadonlyArray<string>,
-) =>
-  db().referentiel.findMany({
-    where: { publicId: { in: [...referentiels] } },
-    orderBy: { publicId: 'asc' },
-    include: {
-      individus: {
-        where: { valeurs: { some: { indicateurId } } },
-        include: {
-          valeurs: {
-            where: { indicateurId },
-            orderBy: [{ date: 'desc' }, { id: 'desc' }],
-            take: 1,
-          },
-        },
-      },
-    },
-  })
+// Aligné sur listValeursForIndicateur : on raisonne sur les buckets mensuels
+// pour les agrégés (cf. doc d'archi `indicateur-derives.md`).
+const DEFAULT_DATE_TRUNC: DateTrunc = 'month'
 
 export const listValeursRemarquablesForIndicateur = (
   indicateurPublicId: string,
@@ -43,23 +34,75 @@ export const listValeursRemarquablesForIndicateur = (
       where: withIndicateurReadPermission({ publicId: indicateurPublicId }, principalId),
       select: { id: true },
     }),
+  ).andThen((indicateur) =>
+    ResultAsync.fromSafePromise(buildStats({ indicateurId: indicateur.id, params })),
   )
-    .andThen((indicateur) =>
-      ResultAsync.fromSafePromise(
-        fetchReferentielsAvecValeursRecentes(indicateur.id, params.referentiels),
-      ),
-    )
-    .map((rows) => ({
-      items: rows.map((row) => {
-        const dernieresValeurs = row.individus
-          .map((i) => i.valeurs[0]?.valeur)
-          .filter((v): v is Decimal => v !== undefined)
-        return {
-          referentiel: row.publicId,
-          min: computeMin(dernieresValeurs),
-          max: computeMax(dernieresValeurs),
-          mediane: computeMediane(dernieresValeurs),
-        }
-      }),
-    }))
+}
+
+// Pour chaque référentiel demandé, on calcule min/max/médiane sur la dernière
+// valeur connue de chaque individu — saisie pour les feuilles, dérivée pour les
+// agrégés. On réutilise le moteur de séries de listValeursForIndicateur : un
+// seul chargement DB (arbre + saisies + fonctions d'agrégation), puis la
+// mémoïsation du functional core évite tout recalcul. La "dernière valeur" est
+// le dernier bucket de la série calculée — sans alignement sur une date pivot,
+// donc des individus peuvent contribuer à partir de dates différentes.
+const buildStats = async ({
+  indicateurId,
+  params,
+}: {
+  indicateurId: string
+  params: ListValeursRemarquablesForIndicateurQuery
+}): Promise<ValeursRemarquablesListApiModel> => {
+  const referentiels = await loadReferentielsAvecIndividus(params.referentiels)
+  if (referentiels.length === 0) return { items: [] }
+
+  const cibles: IndividuRef[] = referentiels.flatMap((r) => r.individus)
+  const dateTrunc = DEFAULT_DATE_TRUNC
+  const startedAt = performance.now()
+  const { ctx, allNodes } = await loadResolveSerieContext({ indicateurId, cibles, dateTrunc })
+  const cache = new Map<string, ReadonlyArray<PointInterne>>()
+
+  const items = referentiels.map((referentiel) => {
+    const dernieresValeurs = referentiel.individus
+      .map((individu) => resolveSerieIndividu(individu.id, ctx, cache).at(-1)?.valeur)
+      .filter((v): v is Decimal => v !== undefined)
+    return {
+      referentiel: referentiel.publicId,
+      min: computeMin(dernieresValeurs),
+      max: computeMax(dernieresValeurs),
+      mediane: computeMediane(dernieresValeurs),
+    }
+  })
+
+  logger.info(
+    {
+      event: 'valeurAvancement.listValeursRemarquablesForIndicateur.timing',
+      indicateurId,
+      dateTrunc,
+      nbReferentiels: referentiels.length,
+      nbCibles: cibles.length,
+      nbNodes: allNodes.size,
+      durationMs: Math.round(performance.now() - startedAt),
+    },
+    'listValeursRemarquablesForIndicateur computed',
+  )
+  return { items }
+}
+
+const loadReferentielsAvecIndividus = async (
+  referentielPublicIds: ReadonlyArray<string>,
+): Promise<ReadonlyArray<{ publicId: string; individus: IndividuRef[] }>> => {
+  const rows = await db().referentiel.findMany({
+    where: { publicId: { in: [...referentielPublicIds] } },
+    orderBy: { publicId: 'asc' },
+    include: { individus: { orderBy: { publicId: 'asc' } } },
+  })
+  return rows.map((r) => ({
+    publicId: r.publicId,
+    individus: r.individus.map(({ id, publicId, referentielId }) => ({
+      id,
+      publicId,
+      referentielId,
+    })),
+  }))
 }

--- a/apps/mb-api/src/valeurAvancement/queries/listValeursRemarquablesForIndicateur.ts
+++ b/apps/mb-api/src/valeurAvancement/queries/listValeursRemarquablesForIndicateur.ts
@@ -1,6 +1,7 @@
 import {
   type DateTrunc,
   type ListValeursRemarquablesForIndicateurQuery,
+  type ValeursRemarquablesContributionApiModel,
   type ValeursRemarquablesListApiModel,
 } from '@pilote/mb-shared/valeurAvancement'
 import { ResultAsync } from 'neverthrow'
@@ -63,14 +64,25 @@ const buildStats = async ({
   const cache = new Map<string, ReadonlyArray<PointInterne>>()
 
   const items = referentiels.map((referentiel) => {
-    const dernieresValeurs = referentiel.individus
-      .map((individu) => resolveSerieIndividu(individu.id, ctx, cache).at(-1)?.valeur)
-      .filter((v): v is Decimal => v !== undefined)
+    const contributions: ValeursRemarquablesContributionApiModel[] = []
+    const valeurs: Decimal[] = []
+    for (const individu of referentiel.individus) {
+      const dernierPoint = resolveSerieIndividu(individu.id, ctx, cache).at(-1)
+      if (!dernierPoint) continue
+      valeurs.push(dernierPoint.valeur)
+      contributions.push({
+        individu: individu.publicId,
+        valeur: dernierPoint.valeur.toNumber(),
+        date: dernierPoint.bucket,
+        source: dernierPoint.type === 'saisie' ? 'saisie' : 'derivee',
+      })
+    }
     return {
       referentiel: referentiel.publicId,
-      min: computeMin(dernieresValeurs),
-      max: computeMax(dernieresValeurs),
-      mediane: computeMediane(dernieresValeurs),
+      min: computeMin(valeurs),
+      max: computeMax(valeurs),
+      mediane: computeMediane(valeurs),
+      contributions,
     }
   })
 

--- a/apps/mb-api/src/valeurAvancement/queries/listValeursRemarquablesForIndicateur.ts
+++ b/apps/mb-api/src/valeurAvancement/queries/listValeursRemarquablesForIndicateur.ts
@@ -63,11 +63,12 @@ const buildStats = async ({
   const { ctx, allNodes } = await loadResolveSerieContext({ indicateurId, cibles, dateTrunc })
   const cache = new Map<string, ReadonlyArray<PointInterne>>()
 
-  const items = referentiels.map((referentiel) => {
+  const items: ValeursRemarquablesListApiModel['items'] = []
+  for (const referentiel of referentiels) {
     const contributions: ValeursRemarquablesContributionApiModel[] = []
     const valeurs: Decimal[] = []
     for (const individu of referentiel.individus) {
-      const dernierPoint = resolveSerieIndividu(individu.id, ctx, cache).at(-1)
+      const dernierPoint = (await resolveSerieIndividu(individu.id, ctx, cache)).at(-1)
       if (!dernierPoint) continue
       valeurs.push(dernierPoint.valeur)
       contributions.push({
@@ -77,14 +78,14 @@ const buildStats = async ({
         source: dernierPoint.type === 'saisie' ? 'saisie' : 'derivee',
       })
     }
-    return {
+    items.push({
       referentiel: referentiel.publicId,
       min: computeMin(valeurs),
       max: computeMax(valeurs),
       mediane: computeMediane(valeurs),
       contributions,
-    }
-  })
+    })
+  }
 
   logger.info(
     {

--- a/apps/mb-api/src/valeurAvancement/queries/loadResolveSerieContext.ts
+++ b/apps/mb-api/src/valeurAvancement/queries/loadResolveSerieContext.ts
@@ -1,0 +1,121 @@
+import { type FonctionAgregation } from '@pilote/mb-shared/indicateur'
+import { type DateTrunc } from '@pilote/mb-shared/valeurAvancement'
+
+import { db } from '@/framework/persistence/dbStore'
+import { getValeursTronqueesPourIndividus } from '@/generated/prisma/sql'
+import {
+  type IndividuRef,
+  type ResolveSerieContext,
+  type SaisieTronquee,
+} from '@/valeurAvancement/resolveSerieIndividu'
+
+// Charge en bulk tout ce dont `resolveSerieIndividu` a besoin pour calculer
+// une série (dérivée ou feuille) à partir d'un ensemble d'individus cibles :
+// le sous-arbre des descendants, les liens indicateur↔référentiel, et les
+// saisies tronquées pré-dédoublonnées par bucket (cf. design doc
+// `indicateur-derives.md`). Le travail DB est concentré ici pour que le
+// functional core reste pur et mémoïsable côté appelant.
+export const loadResolveSerieContext = async ({
+  indicateurId,
+  cibles,
+  dateTrunc,
+}: {
+  indicateurId: string
+  cibles: ReadonlyArray<IndividuRef>
+  dateTrunc: DateTrunc
+}): Promise<{ ctx: ResolveSerieContext; allNodes: Map<string, IndividuRef> }> => {
+  const [{ allNodes, enfantsParParent }, fonctionAgregationParReferentiel] = await Promise.all([
+    loadSousArbre(cibles),
+    loadFonctionsAgregation(indicateurId),
+  ])
+  const serieFeuilleParIndividu = await loadSaisiesTronquees({
+    indicateurId,
+    individuIds: [...allNodes.keys()],
+    dateTrunc,
+  })
+
+  const ctx: ResolveSerieContext = {
+    enfantsParParent,
+    fonctionAgregationParReferentiel,
+    serieFeuilleParIndividu,
+    referentielParIndividu: new Map(
+      [...allNodes.values()].map((individu) => [individu.id, individu.referentielId]),
+    ),
+  }
+  return { ctx, allNodes }
+}
+
+// BFS itératif niveau par niveau plutôt qu'une CTE récursive PostgreSQL :
+// l'arbre est typiquement peu profond (3-4 niveaux France→Région→Département)
+// et garder le calcul en JS reste plus simple à lire et à débugger que du SQL
+// récursif. Détection naïve des cycles : on ne retraite pas un nœud déjà vu.
+const loadSousArbre = async (
+  cibles: ReadonlyArray<IndividuRef>,
+): Promise<{
+  allNodes: Map<string, IndividuRef>
+  enfantsParParent: Map<string, IndividuRef[]>
+}> => {
+  const allNodes = new Map<string, IndividuRef>()
+  for (const cible of cibles) allNodes.set(cible.id, cible)
+  const enfantsParParent = new Map<string, IndividuRef[]>()
+  let currentLevel = cibles.map((c) => c.id)
+
+  while (currentLevel.length > 0) {
+    const relations = await db().relation.findMany({
+      where: { parentId: { in: currentLevel } },
+      include: { child: true },
+    })
+    if (relations.length === 0) break
+
+    const nextLevelSet = new Set<string>()
+    for (const relation of relations) {
+      const childRef: IndividuRef = {
+        id: relation.child.id,
+        publicId: relation.child.publicId,
+        referentielId: relation.child.referentielId,
+      }
+      if (!allNodes.has(childRef.id)) {
+        allNodes.set(childRef.id, childRef)
+        nextLevelSet.add(childRef.id)
+      }
+      const liste = enfantsParParent.get(relation.parentId) ?? []
+      liste.push(childRef)
+      enfantsParParent.set(relation.parentId, liste)
+    }
+    currentLevel = [...nextLevelSet]
+  }
+
+  return { allNodes, enfantsParParent }
+}
+
+const loadFonctionsAgregation = async (
+  indicateurId: string,
+): Promise<Map<string, FonctionAgregation>> => {
+  const liens = await db().indicateurReferentiel.findMany({
+    where: { indicateurId },
+  })
+  return new Map(liens.map((lien) => [lien.referentielId, lien.fonctionAgregation]))
+}
+
+const loadSaisiesTronquees = async ({
+  indicateurId,
+  individuIds,
+  dateTrunc,
+}: {
+  indicateurId: string
+  individuIds: ReadonlyArray<string>
+  dateTrunc: DateTrunc
+}): Promise<Map<string, SaisieTronquee[]>> => {
+  if (individuIds.length === 0) return new Map()
+  const rows = await db().$queryRawTyped(
+    getValeursTronqueesPourIndividus(indicateurId, [...individuIds], dateTrunc),
+  )
+  const serieFeuilleParIndividu = new Map<string, SaisieTronquee[]>()
+  for (const row of rows) {
+    if (!row.bucket) continue
+    const liste = serieFeuilleParIndividu.get(row.individuId) ?? []
+    liste.push({ bucket: row.bucket, dateOrigine: row.dateOrigine, valeur: row.valeur })
+    serieFeuilleParIndividu.set(row.individuId, liste)
+  }
+  return serieFeuilleParIndividu
+}

--- a/apps/mb-api/src/valeurAvancement/resolveSerieIndividu.test.ts
+++ b/apps/mb-api/src/valeurAvancement/resolveSerieIndividu.test.ts
@@ -43,13 +43,13 @@ const buildContext = (input: {
 })
 
 describe('resolveSerieIndividu — feuille', () => {
-  it('retourne une série vide pour une feuille sans saisies', () => {
+  it('retourne une série vide pour une feuille sans saisies', async () => {
     const ctx = buildContext({ individusReferentiel: { [DEPT_A.id]: REF_DEPT } })
     const cache = new Map<string, ReadonlyArray<PointInterne>>()
-    expect(resolveSerieIndividu(DEPT_A.id, ctx, cache)).toEqual([])
+    expect(await resolveSerieIndividu(DEPT_A.id, ctx, cache)).toEqual([])
   })
 
-  it('retourne la série de saisies tronquée pour une feuille', () => {
+  it('retourne la série de saisies tronquée pour une feuille', async () => {
     const ctx = buildContext({
       individusReferentiel: { [DEPT_A.id]: REF_DEPT },
       serieFeuilleParIndividu: {
@@ -60,7 +60,7 @@ describe('resolveSerieIndividu — feuille', () => {
       },
     })
     const cache = new Map<string, ReadonlyArray<PointInterne>>()
-    const serie = resolveSerieIndividu(DEPT_A.id, ctx, cache)
+    const serie = await resolveSerieIndividu(DEPT_A.id, ctx, cache)
 
     expect(serie).toHaveLength(2)
     expect(serie[0]).toEqual({
@@ -77,7 +77,7 @@ describe('resolveSerieIndividu — feuille', () => {
     })
   })
 
-  it('traite un nœud sans fonctionAgregation comme une feuille (lit ses saisies)', () => {
+  it('traite un nœud sans fonctionAgregation comme une feuille (lit ses saisies)', async () => {
     const ctx = buildContext({
       individusReferentiel: { [FRANCE.id]: REF_PAYS },
       enfantsParParent: { [FRANCE.id]: [REG_N] },
@@ -87,7 +87,7 @@ describe('resolveSerieIndividu — feuille', () => {
       },
     })
     const cache = new Map<string, ReadonlyArray<PointInterne>>()
-    const serie = resolveSerieIndividu(FRANCE.id, ctx, cache)
+    const serie = await resolveSerieIndividu(FRANCE.id, ctx, cache)
 
     expect(serie).toHaveLength(1)
     expect(serie[0]).toMatchObject({ type: 'saisie', valeur: d(99) })
@@ -95,7 +95,7 @@ describe('resolveSerieIndividu — feuille', () => {
 })
 
 describe('resolveSerieIndividu — agrégation 1 niveau', () => {
-  it('agrège par bucket avec couverture complète', () => {
+  it('agrège par bucket avec couverture complète', async () => {
     const ctx = buildContext({
       individusReferentiel: {
         [REG_S.id]: REF_REG,
@@ -110,7 +110,7 @@ describe('resolveSerieIndividu — agrégation 1 niveau', () => {
       },
     })
 
-    const serie = resolveSerieIndividu(REG_S.id, ctx, new Map())
+    const serie = await resolveSerieIndividu(REG_S.id, ctx, new Map())
 
     expect(serie).toHaveLength(2)
     expect(serie[0]).toMatchObject({
@@ -128,7 +128,7 @@ describe('resolveSerieIndividu — agrégation 1 niveau', () => {
     })
   })
 
-  it('émet dès la première valeur connue (combineLatest permissif)', () => {
+  it('émet dès la première valeur connue (combineLatest permissif)', async () => {
     const ctx = buildContext({
       individusReferentiel: {
         [REG_S.id]: REF_REG,
@@ -143,7 +143,7 @@ describe('resolveSerieIndividu — agrégation 1 niveau', () => {
       },
     })
 
-    const serie = resolveSerieIndividu(REG_S.id, ctx, new Map())
+    const serie = await resolveSerieIndividu(REG_S.id, ctx, new Map())
 
     expect(serie).toHaveLength(3)
     // 2025-01 : seul DEPT-A connu → valeur=10, couverture 1/2
@@ -166,7 +166,7 @@ describe('resolveSerieIndividu — agrégation 1 niveau', () => {
     expect(serie[2]).toMatchObject({ bucket: '2025-03-01', valeur: d(80) })
   })
 
-  it('trie les contributions par publicId', () => {
+  it('trie les contributions par publicId', async () => {
     // Enfants déclarés dans un ordre non alphabétique
     const ctx = buildContext({
       individusReferentiel: {
@@ -182,14 +182,14 @@ describe('resolveSerieIndividu — agrégation 1 niveau', () => {
       },
     })
 
-    const serie = resolveSerieIndividu(REG_S.id, ctx, new Map())
+    const serie = await resolveSerieIndividu(REG_S.id, ctx, new Map())
     const contributions = (serie[0] as { contributions: { individuPublicId: string }[] })
       .contributions
 
     expect(contributions.map((c) => c.individuPublicId)).toEqual(['DEPT-A', 'DEPT-B'])
   })
 
-  it("n'émet rien si aucun enfant n'a jamais saisi", () => {
+  it("n'émet rien si aucun enfant n'a jamais saisi", async () => {
     const ctx = buildContext({
       individusReferentiel: {
         [REG_S.id]: REF_REG,
@@ -200,10 +200,10 @@ describe('resolveSerieIndividu — agrégation 1 niveau', () => {
       fonctionAgregationParReferentiel: { [REF_REG]: 'SUM' },
     })
 
-    expect(resolveSerieIndividu(REG_S.id, ctx, new Map())).toEqual([])
+    expect(await resolveSerieIndividu(REG_S.id, ctx, new Map())).toEqual([])
   })
 
-  it('ignore les saisies sur un nœud agrégé (D6 : saisie ignorée si fonctionAgregation)', () => {
+  it('ignore les saisies sur un nœud agrégé (D6 : saisie ignorée si fonctionAgregation)', async () => {
     const ctx = buildContext({
       individusReferentiel: {
         [REG_S.id]: REF_REG,
@@ -217,7 +217,7 @@ describe('resolveSerieIndividu — agrégation 1 niveau', () => {
       },
     })
 
-    const serie = resolveSerieIndividu(REG_S.id, ctx, new Map())
+    const serie = await resolveSerieIndividu(REG_S.id, ctx, new Map())
 
     expect(serie).toHaveLength(1)
     expect(serie[0]).toMatchObject({ type: 'derivee', valeur: d(42) })
@@ -225,7 +225,7 @@ describe('resolveSerieIndividu — agrégation 1 niveau', () => {
 })
 
 describe('resolveSerieIndividu — agrégation multi-niveaux', () => {
-  it('agrège récursivement France (régions agrégées de départements)', () => {
+  it('agrège récursivement France (régions agrégées de départements)', async () => {
     const ctx = buildContext({
       individusReferentiel: {
         [FRANCE.id]: REF_PAYS,
@@ -250,7 +250,7 @@ describe('resolveSerieIndividu — agrégation multi-niveaux', () => {
       },
     })
 
-    const serie = resolveSerieIndividu(FRANCE.id, ctx, new Map())
+    const serie = await resolveSerieIndividu(FRANCE.id, ctx, new Map())
 
     expect(serie).toHaveLength(1)
     expect(serie[0]).toMatchObject({
@@ -268,7 +268,7 @@ describe('resolveSerieIndividu — agrégation multi-niveaux', () => {
     ])
   })
 
-  it('propage le carry-forward à travers les niveaux', () => {
+  it('propage le carry-forward à travers les niveaux', async () => {
     const ctx = buildContext({
       individusReferentiel: {
         [FRANCE.id]: REF_PAYS,
@@ -289,7 +289,7 @@ describe('resolveSerieIndividu — agrégation multi-niveaux', () => {
       },
     })
 
-    const serie = resolveSerieIndividu(FRANCE.id, ctx, new Map())
+    const serie = await resolveSerieIndividu(FRANCE.id, ctx, new Map())
 
     expect(serie).toHaveLength(2)
     // 2025-01 : REG-N = 5, REG-S inconnu → 5
@@ -300,19 +300,19 @@ describe('resolveSerieIndividu — agrégation multi-niveaux', () => {
 })
 
 describe('resolveSerieIndividu — mémoïsation', () => {
-  it('retourne la même référence pour un même individuId réinterrogé', () => {
+  it('retourne la même référence pour un même individuId réinterrogé', async () => {
     const ctx = buildContext({
       individusReferentiel: { [DEPT_A.id]: REF_DEPT },
       serieFeuilleParIndividu: { [DEPT_A.id]: [saisie('2025-01-01', 7)] },
     })
     const cache = new Map<string, ReadonlyArray<PointInterne>>()
 
-    const a = resolveSerieIndividu(DEPT_A.id, ctx, cache)
-    const b = resolveSerieIndividu(DEPT_A.id, ctx, cache)
+    const a = await resolveSerieIndividu(DEPT_A.id, ctx, cache)
+    const b = await resolveSerieIndividu(DEPT_A.id, ctx, cache)
     expect(b).toBe(a)
   })
 
-  it("partage la série d'un enfant entre deux appels parents distincts", () => {
+  it("partage la série d'un enfant entre deux appels parents distincts", async () => {
     const ctx = buildContext({
       individusReferentiel: {
         [FRANCE.id]: REF_PAYS,
@@ -328,10 +328,10 @@ describe('resolveSerieIndividu — mémoïsation', () => {
     })
     const cache = new Map<string, ReadonlyArray<PointInterne>>()
 
-    resolveSerieIndividu(REG_S.id, ctx, cache)
+    await resolveSerieIndividu(REG_S.id, ctx, cache)
     const tailleAvant = cache.size
 
-    resolveSerieIndividu(FRANCE.id, ctx, cache)
+    await resolveSerieIndividu(FRANCE.id, ctx, cache)
     // Cache : REG_S et DEPT_A déjà présents avant l'appel FRANCE, qui n'ajoute que France.
     expect(cache.has(DEPT_A.id)).toBe(true)
     expect(cache.has(REG_S.id)).toBe(true)

--- a/apps/mb-api/src/valeurAvancement/resolveSerieIndividu.ts
+++ b/apps/mb-api/src/valeurAvancement/resolveSerieIndividu.ts
@@ -56,22 +56,32 @@ export const getFonctionAgregationActive = (
   return fonction
 }
 
-export const resolveSerieIndividu = (
+// Async pour pouvoir yielder l'event loop entre les buckets d'une dérivée
+// (cf. `computeSerieDerivee`). Sans ce yield, une résolution profonde sur un
+// gros arbre (ex. France → ~35k communes) × historique long (5 ans en
+// `dateTrunc='day'`) cumule des centaines de milliers d'ops Decimal en
+// synchrone — ~50× plus lentes que des `number` natifs — et bloque la node
+// pendant plusieurs secondes, gelant les requêtes concurrentes. Le coût
+// micro-task ajouté reste négligeable face au temps de calcul lui-même.
+export const resolveSerieIndividu = async (
   individuId: string,
   ctx: ResolveSerieContext,
   cache: Map<string, ReadonlyArray<PointInterne>>,
-): ReadonlyArray<PointInterne> => {
+): Promise<ReadonlyArray<PointInterne>> => {
   const cached = cache.get(individuId)
   if (cached) return cached
 
   const fonctionAgregation = getFonctionAgregationActive(individuId, ctx)
   const serie = fonctionAgregation
-    ? computeSerieDerivee(individuId, ctx, cache, fonctionAgregation)
+    ? await computeSerieDerivee(individuId, ctx, cache, fonctionAgregation)
     : computeSerieSaisie(individuId, ctx)
 
   cache.set(individuId, serie)
   return serie
 }
+
+const yieldToEventLoop = (): Promise<void> =>
+  new Promise((resolve) => setImmediate(resolve))
 
 const computeSerieSaisie = (
   individuId: string,
@@ -98,12 +108,12 @@ const computeSerieSaisie = (
 // - Récursion + mémoïsation via `resolveSerieIndividu` : la série d'un enfant
 //   intermédiaire (ex. région) n'est calculée qu'une fois même si plusieurs
 //   parents (ou plusieurs cibles dans la même requête) la sollicitent.
-const computeSerieDerivee = (
+const computeSerieDerivee = async (
   parentId: string,
   ctx: ResolveSerieContext,
   cache: Map<string, ReadonlyArray<PointInterne>>,
   fonctionAgregation: FonctionAgregation,
-): ReadonlyArray<PointInterne> => {
+): Promise<ReadonlyArray<PointInterne>> => {
   const enfants = ctx.enfantsParParent.get(parentId) ?? []
   // Tri stable par publicId pour des contributions déterministes en sortie.
   const enfantsTries = [...enfants].sort((a, b) => a.publicId.localeCompare(b.publicId))
@@ -114,12 +124,18 @@ const computeSerieDerivee = (
     estAgrege: boolean
     pointer: number // index de la dernière valeur ≤ bucket courant (-1 = aucune)
   }
-  const states: EnfantState[] = enfantsTries.map((enfant) => ({
-    enfant,
-    points: resolveSerieIndividu(enfant.id, ctx, cache),
-    estAgrege: getFonctionAgregationActive(enfant.id, ctx) !== null,
-    pointer: -1,
-  }))
+  // Résolution séquentielle des enfants : la mémoïsation garantit que chaque
+  // sous-arbre n'est calculé qu'une fois, donc le parallélisme n'apporterait
+  // rien et empêcherait le yield bucket-par-bucket d'avoir l'effet voulu.
+  const states: EnfantState[] = []
+  for (const enfant of enfantsTries) {
+    states.push({
+      enfant,
+      points: await resolveSerieIndividu(enfant.id, ctx, cache),
+      estAgrege: getFonctionAgregationActive(enfant.id, ctx) !== null,
+      pointer: -1,
+    })
+  }
 
   // Union des buckets distincts présents dans une série enfant (triés ASC).
   const bucketsSet = new Set<string>()
@@ -131,6 +147,8 @@ const computeSerieDerivee = (
   const result: PointInterne[] = []
 
   for (const bucket of buckets) {
+    // Yield à chaque bucket : voir doc en tête de `resolveSerieIndividu`.
+    await yieldToEventLoop()
     // Avance chaque pointer tant que la valeur suivante de l'enfant est ≤ au
     // bucket courant (carry-forward). Comme les buckets sont parcourus ASC,
     // les pointers ne reculent jamais → coût amorti O(N+E) par enfant.

--- a/apps/mb-api/src/valeurAvancement/resolveSerieIndividu.ts
+++ b/apps/mb-api/src/valeurAvancement/resolveSerieIndividu.ts
@@ -1,5 +1,6 @@
 import { type FonctionAgregation } from '@pilote/mb-shared/indicateur'
 
+import { yieldToEventLoop } from '@/framework/concurrency'
 import { Decimal } from '@/framework/decimal'
 
 export type IndividuRef = {
@@ -57,12 +58,13 @@ export const getFonctionAgregationActive = (
 }
 
 // Async pour pouvoir yielder l'event loop entre les buckets d'une dérivée
-// (cf. `computeSerieDerivee`). Sans ce yield, une résolution profonde sur un
-// gros arbre (ex. France → ~35k communes) × historique long (5 ans en
-// `dateTrunc='day'`) cumule des centaines de milliers d'ops Decimal en
-// synchrone — ~50× plus lentes que des `number` natifs — et bloque la node
-// pendant plusieurs secondes, gelant les requêtes concurrentes. Le coût
-// micro-task ajouté reste négligeable face au temps de calcul lui-même.
+// (cf. `computeSerieDerivee` + `yieldToEventLoop`). Sans ce yield, une
+// résolution profonde sur un gros arbre (ex. France → ~35k communes) ×
+// historique long (5 ans en `dateTrunc='day'`) cumule des centaines de
+// milliers d'ops Decimal en synchrone — ~50× plus lentes que des `number`
+// natifs — et bloque la node pendant plusieurs secondes, gelant les
+// requêtes concurrentes. Le coût micro-task ajouté reste négligeable face
+// au temps de calcul lui-même.
 export const resolveSerieIndividu = async (
   individuId: string,
   ctx: ResolveSerieContext,
@@ -79,9 +81,6 @@ export const resolveSerieIndividu = async (
   cache.set(individuId, serie)
   return serie
 }
-
-const yieldToEventLoop = (): Promise<void> =>
-  new Promise((resolve) => setImmediate(resolve))
 
 const computeSerieSaisie = (
   individuId: string,

--- a/apps/mb-webapp/src/components/ui/Select.tsx
+++ b/apps/mb-webapp/src/components/ui/Select.tsx
@@ -54,12 +54,14 @@ export function SelectContent({
         position={position}
         sideOffset={4}
         className={clsxm(
-          'z-50 min-w-[var(--radix-select-trigger-width)] overflow-hidden rounded border border-border bg-surface shadow-md',
+          'z-50 max-h-[var(--radix-select-content-available-height)] min-w-[var(--radix-select-trigger-width)] overflow-hidden rounded border border-border bg-surface shadow-md',
           className,
         )}
         {...props}
       >
-        <SelectPrimitive.Viewport className="p-1">{children}</SelectPrimitive.Viewport>
+        <SelectPrimitive.Viewport className="max-h-[var(--radix-select-content-available-height)] overflow-y-auto p-1">
+          {children}
+        </SelectPrimitive.Viewport>
       </SelectPrimitive.Content>
     </SelectPrimitive.Portal>
   )

--- a/packages/mb-shared/src/valeurAvancement.ts
+++ b/packages/mb-shared/src/valeurAvancement.ts
@@ -129,6 +129,12 @@ const referentielsCsvSchema = z
       ),
   )
 
+// Distinct de `contributionApiModelSchema` (utilisé pour le drill-down d'un
+// point dérivé, plus bas) : ici on liste les individus d'un référentiel ayant
+// **au moins une valeur** connue pour l'indicateur, donc `valeur` et `date`
+// sont non-nullables et `source` n'inclut pas `manquante`. Les deux schemas
+// se ressemblent mais leurs garanties API divergent — ne pas mutualiser sans
+// relâcher le typage côté client.
 export const valeursRemarquablesContributionApiModelSchema = z.object({
   individu: individuPublicIdSchema,
   valeur: z.number().describe('Dernière valeur connue de cet individu.'),

--- a/packages/mb-shared/src/valeurAvancement.ts
+++ b/packages/mb-shared/src/valeurAvancement.ts
@@ -129,6 +129,26 @@ const referentielsCsvSchema = z
       ),
   )
 
+export const valeursRemarquablesContributionApiModelSchema = z.object({
+  individu: individuPublicIdSchema,
+  valeur: z.number().describe('Dernière valeur connue de cet individu.'),
+  date: z
+    .string()
+    .describe(
+      "Date du bucket de la dernière valeur connue (post-troncature mensuelle), " +
+        "alignée sur l'unité de regroupement utilisée pour les indicateurs dérivés.",
+    ),
+  source: z
+    .enum(['saisie', 'derivee'])
+    .describe(
+      "`saisie` : la valeur provient d'une saisie directe sur cet individu. " +
+        "`derivee` : la valeur est reconstruite par agrégation hiérarchique des descendants.",
+    ),
+})
+export type ValeursRemarquablesContributionApiModel = z.infer<
+  typeof valeursRemarquablesContributionApiModelSchema
+>
+
 export const valeursRemarquablesReferentielApiModelSchema = z.object({
   referentiel: referentielPublicIdSchema,
   min: z
@@ -152,6 +172,14 @@ export const valeursRemarquablesReferentielApiModelSchema = z.object({
       "Médiane des valeurs les plus récentes des individus du référentiel ayant au moins une valeur " +
         "pour l'indicateur. Moyenne des deux valeurs centrales si le nombre d'individus est pair. " +
         "null si aucun individu n'a de valeur.",
+    ),
+  contributions: z
+    .array(valeursRemarquablesContributionApiModelSchema)
+    .describe(
+      "Dernière valeur connue de chaque individu du référentiel ayant au moins une valeur " +
+        "pour l'indicateur (triée par publicId d'individu, asc). Permet au client de reconstruire " +
+        "min/max/médiane ou de faire son propre top-N / drill-down. Les individus sans aucune valeur " +
+        "ne figurent pas.",
     ),
 })
 export type ValeursRemarquablesReferentielApiModel = z.infer<


### PR DESCRIPTION
## Summary

- `/indicateurs/:id/valeurs-remarquables` calcule désormais min/max/médiane sur la dernière valeur connue de chaque individu, qu'elle soit saisie (référentiel `NONE`) ou dérivée par agrégation hiérarchique (référentiel `SUM`). Réutilise le moteur `resolveSerieIndividu` introduit dans #2158.
- Cas couverture partielle assumé : un individu agrégé dont une fraction seulement des enfants a saisi contribue aux stats (cf. discussion fonctionnelle).
- Extraction de `loadResolveSerieContext` (sous-arbre + saisies tronquées + fonctions d'agrégation) partagée avec `listValeursForIndicateur` — un seul round-trip DB, mémoïsation du calcul.
- Ajout d'un log de timing (`durationMs`, `nbCibles`, `nbNodes`) sur les deux use cases, le calcul devenant central côté lecture.

## Test plan

- [x] `pnpm test` sur les deux fichiers (30 tests verts, dont 4 nouveaux pour le cas dérivé : SUM simple, carry-forward dans le temps, couverture partielle, mix SUM/NONE)
- [x] `pnpm run lint` (eslint + tsc + prettier)
- [ ] Smoke test depuis la webapp sur un indicateur avec référentiel agrégé

🤖 Generated with [Claude Code](https://claude.com/claude-code)