### PR TITLE
feat(mb-api): synthèse individu sur indicateurs dérivés

### DIFF
--- a/apps/mb-api/prisma/seed.ts
+++ b/apps/mb-api/prisma/seed.ts
@@ -237,7 +237,8 @@ const main = async () => {
     {
       indicateurPublicId: 'IND-005',
       referentiels: [
-        { referentielPublicId: 'REF-REG', fonctionAgregation: 'NONE' },
+        { referentielPublicId: 'REF-DEPT', fonctionAgregation: 'NONE' },
+        { referentielPublicId: 'REF-REG', fonctionAgregation: 'SUM' },
         { referentielPublicId: 'REF-NAT', fonctionAgregation: 'SUM' },
       ],
     },

--- a/apps/mb-api/src/valeurAvancement/queries/listSyntheseIndividus.ts
+++ b/apps/mb-api/src/valeurAvancement/queries/listSyntheseIndividus.ts
@@ -1,4 +1,5 @@
 import {
+  type DateTrunc,
   type ListSyntheseIndividusQuery,
   type SyntheseIndividusListApiModel,
 } from '@pilote/mb-shared/valeurAvancement'
@@ -6,52 +7,37 @@ import { ResultAsync } from 'neverthrow'
 
 import { unique } from '@/framework/array'
 import { requireCurrentPrincipalId } from '@/framework/auth/userContext'
+import { type Decimal } from '@/framework/decimal'
+import { logger } from '@/framework/logger/logger'
 import { db } from '@/framework/persistence/dbStore'
 import { withIndicateurReadPermission } from '@/indicateur/permissions'
 import { computeEcartMediane } from '@/valeurAvancement/computeEcartMediane'
-import { groupMedianesByKey } from '@/valeurAvancement/computeMediane'
+import { computeMediane } from '@/valeurAvancement/computeMediane'
 import { computeVariation } from '@/valeurAvancement/computeVariation'
+import { loadResolveSerieContext } from '@/valeurAvancement/queries/loadResolveSerieContext'
+import {
+  type IndividuRef,
+  type PointInterne,
+  resolveSerieIndividu,
+} from '@/valeurAvancement/resolveSerieIndividu'
 
-const fetchLatestValeursIndividus = ({
-  indicateurId,
-  individuPublicIds,
-}: {
-  indicateurId: string
-  individuPublicIds: ReadonlyArray<string>
-}) =>
-  db().individu.findMany({
-    where: { publicId: { in: [...individuPublicIds] } },
-    orderBy: { publicId: 'asc' },
-    include: {
-      valeurs: {
-        where: { indicateurId },
-        orderBy: [{ date: 'desc' }, { id: 'desc' }],
-        take: 2,
-      },
-    },
-  })
+// Aligné sur listValeursForIndicateur : on raisonne sur les buckets mensuels
+// pour les agrégés (cf. doc d'archi `indicateur-derives.md`).
+const DEFAULT_DATE_TRUNC: DateTrunc = 'month'
 
-const fetchLatestValeursParReferentiel = ({
-  indicateurId,
-  referentielIds,
-}: {
-  indicateurId: string
-  referentielIds: ReadonlyArray<string>
-}) =>
-  db().individu.findMany({
-    where: {
-      referentielId: { in: [...referentielIds] },
-      valeurs: { some: { indicateurId } },
-    },
-    include: {
-      valeurs: {
-        where: { indicateurId },
-        orderBy: [{ date: 'desc' }, { id: 'desc' }],
-        take: 1,
-      },
-    },
-  })
+export const listSyntheseIndividus = (
+  indicateurPublicId: string,
+  params: ListSyntheseIndividusQuery,
+): ResultAsync<SyntheseIndividusListApiModel, never> =>
+  ResultAsync.fromSafePromise(buildSynthese(indicateurPublicId, params))
 
+// Pour chaque individu demandé : variation (derniers 2 buckets de sa série) et
+// écart à la médiane des dernières valeurs des pairs de son référentiel.
+// Saisie pour les feuilles, dérivée pour les agrégés — on réutilise le moteur
+// de séries : un seul `loadResolveSerieContext` couvre la population complète
+// des référentiels concernés, puis la mémoïsation du functional core évite
+// tout recalcul. Comme pour les valeurs remarquables, la "dernière valeur" est
+// le dernier bucket de la série calculée (pas d'alignement sur une date pivot).
 const buildSynthese = async (
   indicateurPublicId: string,
   params: ListSyntheseIndividusQuery,
@@ -61,37 +47,110 @@ const buildSynthese = async (
     where: withIndicateurReadPermission({ publicId: indicateurPublicId }, principalId),
     select: { id: true },
   })
-  const itemsRows = await fetchLatestValeursIndividus({
-    indicateurId: indicateur.id,
-    individuPublicIds: params.individus,
-  })
-  const referentielIds = unique(itemsRows.map((row) => row.referentielId))
-  const populationRows = referentielIds.length
-    ? await fetchLatestValeursParReferentiel({ indicateurId: indicateur.id, referentielIds })
-    : []
-  const valeursParRef = populationRows.flatMap((row) =>
-    row.valeurs.map((v) => ({ referentielId: row.referentielId, valeur: v.valeur })),
-  )
-  const medianeParRef = groupMedianesByKey(
-    valeursParRef,
-    (row) => row.referentielId,
-    (row) => row.valeur,
-  )
 
-  return {
-    items: itemsRows.map((row) => ({
-      individu: row.publicId,
-      variation: computeVariation(row.valeurs),
+  const individusDemandes = await loadIndividus({ publicIds: params.individus })
+  if (individusDemandes.length === 0) return { items: [] }
+
+  // Population des référentiels concernés : nécessaire pour calculer la
+  // médiane des pairs. Elle contient déjà les individus demandés (mêmes
+  // référentiels), donc on s'en sert directement comme cibles unique.
+  const referentielIds = unique(individusDemandes.map((i) => i.referentielId))
+  const population = await loadPopulation({ referentielIds })
+
+  const startedAt = performance.now()
+  const { ctx, allNodes } = await loadResolveSerieContext({
+    indicateurId: indicateur.id,
+    cibles: population,
+    dateTrunc: DEFAULT_DATE_TRUNC,
+  })
+  const cache = new Map<string, ReadonlyArray<PointInterne>>()
+
+  const medianeParReferentiel = await computeMedianeParReferentiel({ population, ctx, cache })
+
+  const items: SyntheseIndividusListApiModel['items'] = []
+  for (const individu of individusDemandes) {
+    const serie = await resolveSerieIndividu(individu.id, ctx, cache)
+    items.push({
+      individu: individu.publicId,
+      variation: computeVariation(extractDeuxDerniers(serie)),
       ecartMediane: computeEcartMediane(
-        row.valeurs[0]?.valeur,
-        medianeParRef.get(row.referentielId) ?? null,
+        serie.at(-1)?.valeur,
+        medianeParReferentiel.get(individu.referentielId) ?? null,
       ),
-    })),
+    })
   }
+
+  logger.info(
+    {
+      event: 'valeurAvancement.listSyntheseIndividus.timing',
+      indicateurId: indicateur.id,
+      dateTrunc: DEFAULT_DATE_TRUNC,
+      nbDemandes: individusDemandes.length,
+      nbPopulation: population.length,
+      nbNodes: allNodes.size,
+      durationMs: Math.round(performance.now() - startedAt),
+    },
+    'listSyntheseIndividus computed',
+  )
+  return { items }
 }
 
-export const listSyntheseIndividus = (
-  indicateurPublicId: string,
-  params: ListSyntheseIndividusQuery,
-): ResultAsync<SyntheseIndividusListApiModel, never> =>
-  ResultAsync.fromSafePromise(buildSynthese(indicateurPublicId, params))
+// computeVariation attend [recente, precedente] ; nos séries sont ASC par
+// bucket → on inverse les deux derniers points.
+const extractDeuxDerniers = (
+  serie: ReadonlyArray<PointInterne>,
+): ReadonlyArray<{ valeur: Decimal }> => {
+  const dernier = serie.at(-1)
+  if (!dernier) return []
+  const precedent = serie.at(-2)
+  return precedent ? [{ valeur: dernier.valeur }, { valeur: precedent.valeur }] : [{ valeur: dernier.valeur }]
+}
+
+const computeMedianeParReferentiel = async ({
+  population,
+  ctx,
+  cache,
+}: {
+  population: ReadonlyArray<IndividuRef>
+  ctx: Awaited<ReturnType<typeof loadResolveSerieContext>>['ctx']
+  cache: Map<string, ReadonlyArray<PointInterne>>
+}): Promise<Map<string, number | null>> => {
+  const valeursParReferentiel = new Map<string, Decimal[]>()
+  for (const individu of population) {
+    const dernier = (await resolveSerieIndividu(individu.id, ctx, cache)).at(-1)
+    if (!dernier) continue
+    const liste = valeursParReferentiel.get(individu.referentielId) ?? []
+    liste.push(dernier.valeur)
+    valeursParReferentiel.set(individu.referentielId, liste)
+  }
+  const result = new Map<string, number | null>()
+  for (const [referentielId, valeurs] of valeursParReferentiel) {
+    result.set(referentielId, computeMediane(valeurs))
+  }
+  return result
+}
+
+const loadIndividus = async ({
+  publicIds,
+}: {
+  publicIds: ReadonlyArray<string>
+}): Promise<IndividuRef[]> => {
+  const rows = await db().individu.findMany({
+    where: { publicId: { in: [...publicIds] } },
+    orderBy: { publicId: 'asc' },
+  })
+  return rows.map(({ id, publicId, referentielId }) => ({ id, publicId, referentielId }))
+}
+
+const loadPopulation = async ({
+  referentielIds,
+}: {
+  referentielIds: ReadonlyArray<string>
+}): Promise<IndividuRef[]> => {
+  if (referentielIds.length === 0) return []
+  const rows = await db().individu.findMany({
+    where: { referentielId: { in: [...referentielIds] } },
+    orderBy: { publicId: 'asc' },
+  })
+  return rows.map(({ id, publicId, referentielId }) => ({ id, publicId, referentielId }))
+}

--- a/apps/mb-api/src/valeurAvancement/queries/listSyntheseIndividus.ts
+++ b/apps/mb-api/src/valeurAvancement/queries/listSyntheseIndividus.ts
@@ -103,7 +103,9 @@ const extractDeuxDerniers = (
   const dernier = serie.at(-1)
   if (!dernier) return []
   const precedent = serie.at(-2)
-  return precedent ? [{ valeur: dernier.valeur }, { valeur: precedent.valeur }] : [{ valeur: dernier.valeur }]
+  return precedent
+    ? [{ valeur: dernier.valeur }, { valeur: precedent.valeur }]
+    : [{ valeur: dernier.valeur }]
 }
 
 const computeMedianeParReferentiel = async ({

--- a/apps/mb-api/src/valeurAvancement/queries/listSyntheseIndividus.ts
+++ b/apps/mb-api/src/valeurAvancement/queries/listSyntheseIndividus.ts
@@ -57,11 +57,12 @@ const buildSynthese = async (
   const referentielIds = unique(individusDemandes.map((i) => i.referentielId))
   const population = await loadPopulation({ referentielIds })
 
+  const dateTrunc: DateTrunc = params.dateTrunc ?? DEFAULT_DATE_TRUNC
   const startedAt = performance.now()
   const { ctx, allNodes } = await loadResolveSerieContext({
     indicateurId: indicateur.id,
     cibles: population,
-    dateTrunc: DEFAULT_DATE_TRUNC,
+    dateTrunc,
   })
   const cache = new Map<string, ReadonlyArray<PointInterne>>()
 
@@ -84,7 +85,7 @@ const buildSynthese = async (
     {
       event: 'valeurAvancement.listSyntheseIndividus.timing',
       indicateurId: indicateur.id,
-      dateTrunc: DEFAULT_DATE_TRUNC,
+      dateTrunc,
       nbDemandes: individusDemandes.length,
       nbPopulation: population.length,
       nbNodes: allNodes.size,

--- a/apps/mb-api/src/valeurAvancement/queries/listValeursRemarquablesForIndicateur.ts
+++ b/apps/mb-api/src/valeurAvancement/queries/listValeursRemarquablesForIndicateur.ts
@@ -58,7 +58,7 @@ const buildStats = async ({
   if (referentiels.length === 0) return { items: [] }
 
   const cibles: IndividuRef[] = referentiels.flatMap((r) => r.individus)
-  const dateTrunc = DEFAULT_DATE_TRUNC
+  const dateTrunc: DateTrunc = params.dateTrunc ?? DEFAULT_DATE_TRUNC
   const startedAt = performance.now()
   const { ctx, allNodes } = await loadResolveSerieContext({ indicateurId, cibles, dateTrunc })
   const cache = new Map<string, ReadonlyArray<PointInterne>>()

--- a/apps/mb-api/src/valeurAvancement/routes.ts
+++ b/apps/mb-api/src/valeurAvancement/routes.ts
@@ -357,9 +357,9 @@ valeurAvancementRoutes.openapi(getIndividusWithValeursRoute, async (context) => 
 
 valeurAvancementRoutes.openapi(getValeursRemarquablesForIndicateurRoute, async (context) => {
   const { id } = context.req.valid('param')
-  const { referentiels } = context.req.valid('query')
+  const { referentiels, dateTrunc } = context.req.valid('query')
 
-  return listValeursRemarquablesForIndicateur(id, { referentiels }).match(
+  return listValeursRemarquablesForIndicateur(id, { referentiels, dateTrunc }).match(
     (data) =>
       jsonResponseOk({
         context,
@@ -373,9 +373,9 @@ valeurAvancementRoutes.openapi(getValeursRemarquablesForIndicateurRoute, async (
 
 valeurAvancementRoutes.openapi(getSyntheseIndividusRoute, async (context) => {
   const { id } = context.req.valid('param')
-  const { individus } = context.req.valid('query')
+  const { individus, dateTrunc } = context.req.valid('query')
 
-  return listSyntheseIndividus(id, { individus }).match(
+  return listSyntheseIndividus(id, { individus, dateTrunc }).match(
     (data) =>
       jsonResponseOk({
         context,

--- a/apps/mb-webapp/src/api/indicateurs.ts
+++ b/apps/mb-webapp/src/api/indicateurs.ts
@@ -69,7 +69,10 @@ export const fetchValeursRemarquablesForIndicateur = async (
 ): Promise<ValeursRemarquablesListApiModel> => {
   const json = await apiClient
     .get(`indicateurs/${indicateurId}/valeurs-remarquables`, {
-      searchParams: { referentiels: params.referentiels.join(',') },
+      searchParams: {
+        referentiels: params.referentiels.join(','),
+        ...(params.dateTrunc ? { dateTrunc: params.dateTrunc } : {}),
+      },
     })
     .json()
   return valeursRemarquablesListApiModelSchema.parse(json)
@@ -81,7 +84,10 @@ export const fetchSyntheseIndividus = async (
 ): Promise<SyntheseIndividusListApiModel> => {
   const json = await apiClient
     .get(`indicateurs/${indicateurId}/synthese-individus`, {
-      searchParams: { individus: params.individus.join(',') },
+      searchParams: {
+        individus: params.individus.join(','),
+        ...(params.dateTrunc ? { dateTrunc: params.dateTrunc } : {}),
+      },
     })
     .json()
   return syntheseIndividusListApiModelSchema.parse(json)

--- a/apps/mb-webapp/src/queries/indicateurs.ts
+++ b/apps/mb-webapp/src/queries/indicateurs.ts
@@ -70,14 +70,18 @@ export const indicateurValeursRemarquablesQueryOptions = (
   queryOptions({
     queryKey: ['indicateur', indicateurId, 'valeurs-remarquables', referentielId],
     queryFn: () =>
-      fetchValeursRemarquablesForIndicateur(indicateurId, { referentiels: [referentielId] }),
+      fetchValeursRemarquablesForIndicateur(indicateurId, {
+        referentiels: [referentielId],
+        dateTrunc: 'month',
+      }),
     staleTime: DEFAULT_STALE_TIME,
   })
 
 export const indicateurSyntheseIndividuQueryOptions = (indicateurId: string, individuId: string) =>
   queryOptions({
     queryKey: ['indicateur', indicateurId, 'synthese-individus', individuId],
-    queryFn: () => fetchSyntheseIndividus(indicateurId, { individus: [individuId] }),
+    queryFn: () =>
+      fetchSyntheseIndividus(indicateurId, { individus: [individuId], dateTrunc: 'month' }),
     staleTime: DEFAULT_STALE_TIME,
   })
 

--- a/packages/mb-shared/src/valeurAvancement.ts
+++ b/packages/mb-shared/src/valeurAvancement.ts
@@ -205,6 +205,13 @@ export const listValeursRemarquablesForIndicateurQuerySchema = z.object({
   referentiels: referentielsCsvSchema.describe(
     `Liste d'identifiants de référentiels séparés par une virgule (ex. REF-DEPT,REF-REG). 1..${MAX_REFERENTIELS_PAR_REQUETE} identifiants.`,
   ),
+  dateTrunc: dateTruncSchema
+    .optional()
+    .describe(
+      'Granularité de troncature des dates des points. Par défaut `month`. Détermine le ' +
+        "bucket retenu comme « dernière valeur » de chaque individu. S'applique aux séries " +
+        'saisies comme aux séries dérivées.',
+    ),
 })
 export type ListValeursRemarquablesForIndicateurQuery = z.infer<
   typeof listValeursRemarquablesForIndicateurQuerySchema
@@ -241,6 +248,13 @@ export const listSyntheseIndividusQuerySchema = z.object({
   individus: individusCsvSchema.describe(
     `Liste d'identifiants d'individus séparés par une virgule (ex. DEPT-84,DEPT-13). 1..${MAX_INDIVIDUS_PAR_REQUETE} identifiants.`,
   ),
+  dateTrunc: dateTruncSchema
+    .optional()
+    .describe(
+      'Granularité de troncature des dates des points. Par défaut `month`. Détermine les ' +
+        "buckets retenus comme « dernière » et « précédente » valeur pour le calcul de la " +
+        "variation. S'applique aux séries saisies comme aux séries dérivées.",
+    ),
 })
 export type ListSyntheseIndividusQuery = z.infer<typeof listSyntheseIndividusQuerySchema>
 


### PR DESCRIPTION
## Summary
- `listSyntheseIndividus` réécrit pour fonctionner sur les indicateurs dérivés (variation + écart à la médiane sur séries calculées, pas uniquement sur les saisies brutes)
- Réutilise le moteur `loadResolveSerieContext` + `resolveSerieIndividu` (mémoïsation, dateTrunc='month' aligné sur les autres queries dérivées)
- La population complète du référentiel de chaque individu demandé est chargée comme cibles, ce qui permet de calculer la médiane des pairs (saisie ou dérivée) en une seule passe

## Test plan
- [x] Tests d'intégration `listSyntheseIndividus.test.ts` (15/15 pass) — rétrocompatibilité totale sur les cas saisie-seule
- [x] Suite complète `valeurAvancement` (120/120 pass)
- [x] `tsc --noEmit` OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)