### PR TITLE
feat(mb-api): fonction d'agrégation AVG sur les indicateurs dérivés

### DIFF
--- a/apps/mb-api/prisma/migrations/20260526120000_add_avg_to_fonction_agregation/migration.sql
+++ b/apps/mb-api/prisma/migrations/20260526120000_add_avg_to_fonction_agregation/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "fonction_agregation_enum" ADD VALUE 'AVG';

--- a/apps/mb-api/prisma/schema.prisma
+++ b/apps/mb-api/prisma/schema.prisma
@@ -66,6 +66,7 @@ model Indicateur {
 
 enum FonctionAgregation {
   SUM
+  AVG
   NONE
 
   @@map("fonction_agregation_enum")

--- a/apps/mb-api/prisma/seed.ts
+++ b/apps/mb-api/prisma/seed.ts
@@ -117,6 +117,42 @@ const PRIORITE_MAILLE = ['REF-DEPT', 'REF-REG', 'REF-NAT'] as const
 const mailleLaPlusFine = (liensReferentielPublicIds: ReadonlyArray<string>): string | undefined =>
   PRIORITE_MAILLE.find((ref) => liensReferentielPublicIds.includes(ref))
 
+// Indicateurs qui représentent des taux, délais, indices ou ratios : agrégés
+// par moyenne arithmétique (non pondérée) à la remontée hiérarchique, plutôt
+// que par somme. Classification indicative de seed ; le métier reste seul
+// juge sur chaque indicateur réel.
+const INDICATEURS_EN_MOYENNE = new Set<string>([
+  'IND-009', // Délai moyen de prise en charge urgences
+  'IND-010', // Taux de vaccination infantile
+  'IND-011', // Accès aux soins de proximité
+  'IND-012', // Couverture des services France Santé
+  'IND-014', // Amélioration de l'orientation des élèves (indice)
+  'IND-015', // Taux de réussite au baccalauréat
+  'IND-020', // Qualité de l'air en zones urbaines (indice)
+  'IND-023', // Délai de traitement CAF
+  'IND-024', // Délai de traitement Pôle emploi
+  'IND-025', // Délai de délivrance des titres d'identité
+  'IND-026', // Présence postale en zone rurale (couverture)
+  'IND-028', // Désertification médicale (taux)
+  'IND-030', // Élucidation des cambriolages (taux)
+  'IND-032', // Délai de jugement civil
+  'IND-033', // Délai de jugement pénal
+  'IND-035', // Dette publique / PIB (ratio)
+  'IND-036', // Croissance du PIB (taux)
+  'IND-037', // Inflation (IPC, taux)
+  'IND-038', // Taux d'emploi des seniors
+  'IND-039', // Taux d'emploi des jeunes
+  'IND-043', // Couverture 5G du territoire
+  'IND-044', // Dématérialisation des démarches (taux)
+  'IND-047', // Espérance de vie (moyenne)
+  'IND-048', // Pauvreté (taux)
+  'IND-049', // Taux d'alphabétisation
+  'IND-050', // Accès à internet haut débit (couverture)
+])
+
+const fonctionAgregationGenerique = (publicId: string): FonctionAgregation =>
+  INDICATEURS_EN_MOYENNE.has(publicId) ? 'AVG' : 'SUM'
+
 const main = async () => {
   for (const [index, item] of indicateursSeed.entries()) {
     const { createdAt, updatedAt } = indicateurDates(index)
@@ -255,17 +291,21 @@ const main = async () => {
     },
     ...indicateursSeed
       .filter((ind) => parseInt(ind.publicId.replace('IND-', ''), 10) >= 9)
-      .map((ind) => ({
-        indicateurPublicId: ind.publicId,
+      .map((ind) => {
         // Politique simple : tous les indicateurs "neutres" sont rattachés à
-        // DEPT (NONE) + REG (SUM) + NAT (SUM). La saisie va sur dept, la
-        // hiérarchie supérieure se dérive.
-        referentiels: [
-          { referentielPublicId: 'REF-DEPT', fonctionAgregation: 'NONE' as const },
-          { referentielPublicId: 'REF-REG', fonctionAgregation: 'SUM' as const },
-          { referentielPublicId: 'REF-NAT', fonctionAgregation: 'SUM' as const },
-        ],
-      })),
+        // DEPT (NONE) + REG + NAT. La saisie va sur dept, la hiérarchie
+        // supérieure se dérive — par somme pour les volumes/cumuls, par
+        // moyenne pour les taux/délais/indices (cf. INDICATEURS_EN_MOYENNE).
+        const fonction = fonctionAgregationGenerique(ind.publicId)
+        return {
+          indicateurPublicId: ind.publicId,
+          referentiels: [
+            { referentielPublicId: 'REF-DEPT', fonctionAgregation: 'NONE' as const },
+            { referentielPublicId: 'REF-REG', fonctionAgregation: fonction },
+            { referentielPublicId: 'REF-NAT', fonctionAgregation: fonction },
+          ],
+        }
+      }),
   ]
 
   for (const item of indicateurReferentielsSeed) {

--- a/apps/mb-api/prisma/seedData/geo.ts
+++ b/apps/mb-api/prisma/seedData/geo.ts
@@ -230,11 +230,47 @@ const profils = [
   { baseValeur: 1200, amplitude: 60, trend: 25, decimals: 0 },
 ] as const
 
+// Profil dédié pour les indicateurs en pourcentage : borné par construction
+// dans [0, 100] (base 70, amplitudes choisies pour ne pas déborder).
+const PROFIL_TAUX_POURCENTAGE = {
+  baseValeur: 70,
+  amplitude: 12,
+  trend: 4,
+  decimals: 1,
+} as const
+
+// Indicateurs dont la valeur représente un pourcentage : on force un profil
+// borné 0-100 plutôt qu'un profil cyclique générique (où IND-001 / IND-049
+// auraient hérité de bases à 720k / 1200 — non sensé pour un taux).
+const INDICATEURS_TAUX_POURCENTAGE = new Set<string>([
+  'IND-001', // Taux de chômage
+  'IND-010', // Taux de vaccination infantile
+  'IND-011', // Accès aux soins de proximité
+  'IND-012', // Couverture des services France Santé
+  'IND-014', // Amélioration de l'orientation des élèves (indice 0-100)
+  'IND-015', // Taux de réussite au baccalauréat
+  'IND-020', // Qualité de l'air en zones urbaines (indice 0-100)
+  'IND-026', // Présence postale en zone rurale (couverture %)
+  'IND-028', // Désertification médicale
+  'IND-030', // Élucidation des cambriolages
+  'IND-038', // Taux d'emploi des seniors
+  'IND-039', // Taux d'emploi des jeunes
+  'IND-043', // Couverture 5G du territoire
+  'IND-044', // Dématérialisation des démarches
+  'IND-048', // Pauvreté
+  'IND-049', // Taux d'alphabétisation
+  'IND-050', // Accès à internet haut débit
+])
+
 const profilPourIndicateur = (indicateurPublicId: string) => {
+  if (INDICATEURS_TAUX_POURCENTAGE.has(indicateurPublicId)) return PROFIL_TAUX_POURCENTAGE
   const match = /(\d+)$/.exec(indicateurPublicId)
   const rang = match ? parseInt(match[1]!, 10) : 0
   return profils[rang % profils.length]!
 }
+
+const clamp = (valeur: number, min: number, max: number): number =>
+  Math.min(Math.max(valeur, min), max)
 
 // Génère la série d'un indicateur sur la maille fournie. La maille = liste de
 // publicIds d'individus sur lesquels on saisit (typiquement les 101 dépts, ou
@@ -254,18 +290,20 @@ export const buildValeursPourIndicateur = ({
   const frequence = frequencePourIndicateur(indicateurPublicId)
   const dates = datesPourFrequence(frequence)
   const profil = profilPourIndicateur(indicateurPublicId)
+  const estTauxPourcentage = INDICATEURS_TAUX_POURCENTAGE.has(indicateurPublicId)
   const lastIndex = Math.max(dates.length - 1, 1)
   return individuPublicIds.flatMap((individuPublicId, individuIndex) =>
-    dates.map((date, dateIndex) => ({
-      indicateurPublicId,
-      individuPublicId,
-      date,
-      valeur: computeValeur({
+    dates.map((date, dateIndex) => {
+      const valeurBrute = computeValeur({
         ...profil,
         ratio: dateIndex / lastIndex,
         individuIndex,
         dateIndex,
-      }),
-    })),
+      })
+      // Filet de sécurité : la combinaison oscillation+offset+trend pourrait
+      // théoriquement déborder pour les taux ; on garantit [0, 100].
+      const valeur = estTauxPourcentage ? clamp(valeurBrute, 0, 100) : valeurBrute
+      return { indicateurPublicId, individuPublicId, date, valeur }
+    }),
   )
 }

--- a/apps/mb-api/src/valeurAvancement/resolveSerieIndividu.test.ts
+++ b/apps/mb-api/src/valeurAvancement/resolveSerieIndividu.test.ts
@@ -281,6 +281,20 @@ describe('resolveSerieIndividu — agrégation AVG', () => {
     expect(serie[1]).toMatchObject({ bucket: '2025-02-01', valeur: d(25) })
   })
 
+  it("n'émet rien si aucun enfant n'a jamais saisi (évite la division par zéro)", async () => {
+    const ctx = buildContext({
+      individusReferentiel: {
+        [REG_S.id]: REF_REG,
+        [DEPT_A.id]: REF_DEPT,
+        [DEPT_B.id]: REF_DEPT,
+      },
+      enfantsParParent: { [REG_S.id]: [DEPT_A, DEPT_B] },
+      fonctionAgregationParReferentiel: { [REF_REG]: 'AVG' },
+    })
+
+    expect(await resolveSerieIndividu(REG_S.id, ctx, new Map())).toEqual([])
+  })
+
   it('produit une moyenne décimale exacte sur des entiers non divisibles', async () => {
     const ctx = buildContext({
       individusReferentiel: {

--- a/apps/mb-api/src/valeurAvancement/resolveSerieIndividu.test.ts
+++ b/apps/mb-api/src/valeurAvancement/resolveSerieIndividu.test.ts
@@ -30,7 +30,7 @@ const DEPT_D: IndividuRef = { id: 'i-dept-d', publicId: 'DEPT-D', referentielId:
 
 const buildContext = (input: {
   enfantsParParent?: Record<string, IndividuRef[]>
-  fonctionAgregationParReferentiel?: Record<string, 'SUM' | 'NONE'>
+  fonctionAgregationParReferentiel?: Record<string, 'SUM' | 'AVG' | 'NONE'>
   serieFeuilleParIndividu?: Record<string, SaisieTronquee[]>
   individusReferentiel?: Record<string, string>
 }): ResolveSerieContext => ({
@@ -221,6 +221,88 @@ describe('resolveSerieIndividu — agrégation 1 niveau', () => {
 
     expect(serie).toHaveLength(1)
     expect(serie[0]).toMatchObject({ type: 'derivee', valeur: d(42) })
+  })
+})
+
+describe('resolveSerieIndividu — agrégation AVG', () => {
+  it('calcule la moyenne arithmétique simple sur couverture complète', async () => {
+    const ctx = buildContext({
+      individusReferentiel: {
+        [REG_S.id]: REF_REG,
+        [DEPT_A.id]: REF_DEPT,
+        [DEPT_B.id]: REF_DEPT,
+      },
+      enfantsParParent: { [REG_S.id]: [DEPT_A, DEPT_B] },
+      fonctionAgregationParReferentiel: { [REF_REG]: 'AVG' },
+      serieFeuilleParIndividu: {
+        [DEPT_A.id]: [saisie('2025-01-01', 10), saisie('2025-02-01', 20)],
+        [DEPT_B.id]: [saisie('2025-01-01', 30), saisie('2025-02-01', 40)],
+      },
+    })
+
+    const serie = await resolveSerieIndividu(REG_S.id, ctx, new Map())
+
+    expect(serie).toHaveLength(2)
+    expect(serie[0]).toMatchObject({
+      type: 'derivee',
+      bucket: '2025-01-01',
+      valeur: d(20), // (10 + 30) / 2
+      fonctionAgregation: 'AVG',
+      couverture: { nbEnfantsAvecValeur: 2, nbEnfantsTotal: 2 },
+    })
+    expect(serie[1]).toMatchObject({ bucket: '2025-02-01', valeur: d(30) }) // (20 + 40) / 2
+  })
+
+  it('moyenne sur les enfants connus uniquement (permissif, comme SUM)', async () => {
+    const ctx = buildContext({
+      individusReferentiel: {
+        [REG_S.id]: REF_REG,
+        [DEPT_A.id]: REF_DEPT,
+        [DEPT_B.id]: REF_DEPT,
+      },
+      enfantsParParent: { [REG_S.id]: [DEPT_A, DEPT_B] },
+      fonctionAgregationParReferentiel: { [REF_REG]: 'AVG' },
+      serieFeuilleParIndividu: {
+        [DEPT_A.id]: [saisie('2025-01-01', 10)],
+        [DEPT_B.id]: [saisie('2025-02-01', 40)],
+      },
+    })
+
+    const serie = await resolveSerieIndividu(REG_S.id, ctx, new Map())
+
+    expect(serie).toHaveLength(2)
+    // 2025-01 : seul DEPT-A → moyenne sur 1 = 10, couverture 1/2
+    expect(serie[0]).toMatchObject({
+      bucket: '2025-01-01',
+      valeur: d(10),
+      couverture: { nbEnfantsAvecValeur: 1, nbEnfantsTotal: 2 },
+    })
+    // 2025-02 : DEPT-A carry-forward (10) + DEPT-B (40) → moyenne 25
+    expect(serie[1]).toMatchObject({ bucket: '2025-02-01', valeur: d(25) })
+  })
+
+  it('produit une moyenne décimale exacte sur des entiers non divisibles', async () => {
+    const ctx = buildContext({
+      individusReferentiel: {
+        [REG_S.id]: REF_REG,
+        [DEPT_A.id]: REF_DEPT,
+        [DEPT_B.id]: REF_DEPT,
+        [DEPT_C.id]: REF_DEPT,
+      },
+      enfantsParParent: { [REG_S.id]: [DEPT_A, DEPT_B, DEPT_C] },
+      fonctionAgregationParReferentiel: { [REF_REG]: 'AVG' },
+      serieFeuilleParIndividu: {
+        [DEPT_A.id]: [saisie('2025-01-01', 1)],
+        [DEPT_B.id]: [saisie('2025-01-01', 2)],
+        [DEPT_C.id]: [saisie('2025-01-01', 2)],
+      },
+    })
+
+    const serie = await resolveSerieIndividu(REG_S.id, ctx, new Map())
+
+    // (1 + 2 + 2) / 3 = 1.6666...
+    const valeur = (serie[0] as { valeur: Decimal }).valeur
+    expect(valeur.toFixed(4)).toBe('1.6667')
   })
 })
 

--- a/apps/mb-api/src/valeurAvancement/resolveSerieIndividu.ts
+++ b/apps/mb-api/src/valeurAvancement/resolveSerieIndividu.ts
@@ -161,7 +161,7 @@ const computeSerieDerivee = async (
     }
 
     const contributions: ContributionInterne[] = []
-    const valeursPourSomme: Decimal[] = []
+    const valeursAAgreger: Decimal[] = []
 
     for (const state of states) {
       const courant = state.pointer >= 0 ? state.points[state.pointer] : undefined
@@ -183,26 +183,45 @@ const computeSerieDerivee = async (
         dateOrigine,
         source: state.estAgrege ? 'derivee' : 'saisie',
       })
-      valeursPourSomme.push(courant.valeur)
+      valeursAAgreger.push(courant.valeur)
     }
 
     // Permissif : on n'émet pas tant qu'aucun enfant n'a saisi ; dès la première
     // valeur connue d'un enfant, le point sort avec une couverture < total.
-    if (valeursPourSomme.length === 0) continue
+    if (valeursAAgreger.length === 0) continue
 
-    const somme = valeursPourSomme.reduce((acc, v) => acc.plus(v), new Decimal(0))
+    const valeur = agreger(valeursAAgreger, fonctionAgregation)
     result.push({
       type: 'derivee',
       bucket,
-      valeur: somme,
+      valeur,
       fonctionAgregation,
       contributions,
       couverture: {
-        nbEnfantsAvecValeur: valeursPourSomme.length,
+        nbEnfantsAvecValeur: valeursAAgreger.length,
         nbEnfantsTotal: states.length,
       },
     })
   }
 
   return result
+}
+
+// Précondition : `valeurs` est non vide (filtré en amont sur la couverture > 0)
+// et `fonction` est active (≠ 'NONE', cf. `getFonctionAgregationActive`).
+// `AVG` est une moyenne arithmétique simple non pondérée : chaque enfant connu
+// compte pour 1, les enfants sans valeur sont ignorés (cf. cas permissif amont).
+const agreger = (valeurs: ReadonlyArray<Decimal>, fonction: FonctionAgregation): Decimal => {
+  const somme = valeurs.reduce((acc, v) => acc.plus(v), new Decimal(0))
+  switch (fonction) {
+    case 'SUM':
+      return somme
+    case 'AVG':
+      return somme.dividedBy(valeurs.length)
+    case 'NONE':
+      throw new Error(
+        "agreger appelé avec fonction 'NONE' : une dérivation ne devrait pas être déclenchée " +
+          "lorsque l'agrégation est désactivée.",
+      )
+  }
 }

--- a/packages/mb-shared/src/indicateur.ts
+++ b/packages/mb-shared/src/indicateur.ts
@@ -16,12 +16,12 @@ export const indicateurVisibiliteSchema = z
 export type IndicateurVisibilite = z.infer<typeof indicateurVisibiliteSchema>
 
 export const fonctionAgregationSchema = z
-  .enum(['SUM', 'NONE'])
+  .enum(['SUM', 'AVG', 'NONE'])
   .describe(
     "Fonction d'agrégation appliquée pour calculer la valeur d'un parent à partir des valeurs " +
-      "de ses enfants. `SUM` = somme des contributions des enfants. `NONE` = pas d'agrégation : " +
-      "la valeur doit être saisie directement pour ce référentiel, elle n'est jamais dérivée depuis " +
-      'les enfants.',
+      "de ses enfants. `SUM` = somme des contributions des enfants. `AVG` = moyenne arithmétique " +
+      "simple (non pondérée) des contributions connues. `NONE` = pas d'agrégation : la valeur doit " +
+      "être saisie directement pour ce référentiel, elle n'est jamais dérivée depuis les enfants.",
   )
 export type FonctionAgregation = z.infer<typeof fonctionAgregationSchema>
 


### PR DESCRIPTION
## Summary
- Ajoute `AVG` (moyenne arithmétique simple, non pondérée) en complément de `SUM` dans l'enum `FonctionAgregation` (Prisma + Zod côté `mb-shared`).
- Dispatcher SUM/AVG dans `computeSerieDerivee` (`resolveSerieIndividu.ts`) — le reste de la pipeline (valeurs remarquables, synthèse, médiane/min/max) est déjà function-agnostic et ne change pas.
- Calcul AVG **permissif** sur la couverture, comme SUM : on moyenne sur les enfants connus du bucket, les manquants ne pèsent pas. La couverture exposée (`nbEnfantsAvecValeur / nbEnfantsTotal`) reste l'information de qualité côté client.
- Seed mis à jour : 26 indicateurs de type taux / délai / indice / couverture / ratio passent en `AVG` sur `REF-REG` et `REF-NAT` ; volumes / effectifs / cumuls (CO₂, effectifs gendarmerie, créations d'entreprises, etc.) restent en `SUM`.

## Notes
- Pas de pondération introduite. Si le métier souhaite un AVG pondéré (par population, par surface…), c'est un autre chantier qui nécessite une notion de poids par individu côté référentiel.
- Migration enum simple (`ALTER TYPE ... ADD VALUE 'AVG'`) — pas de DDL sur les tables existantes.

## Test plan
- [x] `tsc --noEmit` sur `mb-api`
- [x] `vitest run src/valeurAvancement` → 123/123 verts (3 nouveaux tests AVG : couverture complète, couverture partielle permissive avec carry-forward, division non entière)
- [x] `prisma migrate deploy` + `prisma db seed` OK sur DB de dev → 52 lignes `indicateur_referentiel` en `AVG` (26 indicateurs × 2 niveaux)
- [ ] Vérification visuelle côté webapp sur quelques indicateurs en AVG (taux de chômage / inflation / délai CAF) après merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)