### PR TITLE
feat: paniers d'indicateurs (modèle, API, navigation)

### DIFF
--- a/apps/mb-api/docs/architecture/paniers-design.md
+++ b/apps/mb-api/docs/architecture/paniers-design.md
@@ -1,0 +1,358 @@
+# Paniers d'indicateurs — design
+
+Date : 2026-05-27
+Statut : proposé
+
+## Contexte
+
+Besoin produit : regrouper des indicateurs en collections nommées (« paniers »)
+pour les exposer côté front, typiquement pour qu'un utilisateur navigue d'une
+sélection thématique vers les indicateurs qui la composent.
+
+Périmètre v0 délibérément minimaliste :
+
+- Pas de création/édition côté API. Les paniers sont **créés par seed**
+  uniquement.
+- Lecture exposée via API publique (liste paginée + détail).
+- Affichage côté front : entrée « Paniers » dans la top bar, page liste,
+  page détail réutilisant la grid d'indicateurs existante.
+
+## État de l'existant
+
+- Modèle Prisma `Indicateur` avec `id` (uuid) + `publicId` lisible (`IND-XXX`).
+  Même pattern sur `Referentiel` (`REF-XXX`), `Widget`, `Individu`.
+- Pattern de N-N déjà utilisé : `IndicateurReferentiel` (join table avec
+  `createdAt`, propriétés portées sur la relation).
+- Routes : Hono + `@hono/zod-openapi`, un fichier `routes.ts` par module
+  contenant les Zod schemas, `createRoute`, handlers.
+- Pagination cursor-based homogène sur tout le repo
+  (`cursor`, `pageSize`, response `{ items, pagination, total }`).
+- Queries en `ResultAsync<T, never>` (neverthrow), accès Prisma direct via
+  `db()`, permissions appliquées via helpers `with*ReadPermission`.
+- Seeds en TS dans `prisma/seed.ts`, idempotent via `upsert`.
+- Côté front : TanStack Router file-based, React Query, fetch via Ky +
+  validation Zod, composant `IndicateurCard` + `CardGrid` réutilisables.
+
+## Décisions
+
+### D1. Paniers globaux, pas de scope
+
+Un panier n'appartient ni à une organisation, ni à un référentiel, ni à un
+principal. Tout principal authentifié peut lister et lire tous les paniers.
+
+### D2. Pas de modèle de permissions sur le panier (v0)
+
+Pas de champ `visibilite`, pas de table `PanierPermission`. Cohérent avec D1
+et avec le fait que la création est aujourd'hui une opération de seed
+contrôlée. Si un besoin de paniers privés / par organisation émerge, on
+introduira un modèle de permissions à ce moment-là.
+
+### D3. Composition N-N via join table, ordre par `createdAt`
+
+Table de jonction `PanierIndicateur(panierId, indicateurId, createdAt)`.
+L'ordre d'affichage des indicateurs dans un panier = `createdAt ASC` de la
+ligne de jonction, c'est-à-dire **l'ordre d'insertion au seed**. Pas de champ
+`position` explicite.
+
+Un même indicateur peut appartenir à plusieurs paniers.
+
+### D4. `publicId` lisible `PAN-XXX`
+
+Format `PAN-001`, `PAN-002`, etc. Généré côté seed (cohérent avec `IND-XXX`,
+`REF-XXX`). Pas de séquence Postgres, pas de trigger.
+
+### D5. Pas de création par API en v0
+
+Pas d'endpoint `POST/PUT/DELETE /paniers`. Cycle de vie 100% via
+`prisma/seed.ts`. À introduire plus tard quand un cas d'usage explicite
+arrive (admin UI, intégration externe).
+
+### D6. Pas de filtrage des indicateurs contenus par les permissions du principal (v0)
+
+`GET /paniers/:publicId` renvoie l'**intégralité** des `indicateurPublicIds`
+de la jonction, sans intersection avec les droits du principal courant.
+
+L'invariant « tous les indicateurs d'un panier sont accessibles au principal »
+est garanti **par le seed** (qui n'y met que des indicateurs PUBLIC), pas par
+le modèle Prisma.
+
+**Évolution prévue** : à terme, intersecter avec
+`withIndicateurReadPermission` dans `getPanierByPublicId` /
+`listPaniers` pour ne renvoyer que les `publicId` visibles. Trivial à
+brancher (helper déjà disponible), mais hors scope v0.
+
+### D7. Recomposition côté front via bulk fetch `GET /indicateurs?ids=...`
+
+Le payload panier ne porte que des `publicId` d'indicateurs. Le front résout
+la donnée des indicateurs via un appel groupé à `GET /indicateurs?ids=PAN-001,IND-XXX,...`.
+
+Conséquence : on **étend `GET /indicateurs`** avec un filtre `ids` optionnel
+(liste de `publicId`). Les permissions y restent appliquées normalement —
+combiné avec D6, un indicateur non visible n'apparaîtra simplement pas dans
+la réponse, et le front doit tolérer que `indicateurs.length <
+indicateurPublicIds.length` (cas qui ne se présente pas en v0, mais qui
+deviendra la norme à terme).
+
+### D8. Pas de recherche, pas de filtre métier en v0
+
+`GET /paniers` n'expose pas de paramètre `recherche` ni de filtre. Volumétrie
+attendue très faible (4-5 paniers seed). À ajouter quand le besoin émerge.
+
+### D9. Pagination cursor-based standard
+
+Cohérence avec les autres listings : `cursor`, `pageSize` (default 20),
+response `{ items, pagination: { cursor, hasMore }, total }`. Même si la
+volumétrie est faible, on garde la forme standard pour éviter une forme
+divergente.
+
+### D10. Même `ApiModel` pour liste et détail
+
+`PanierApiModel` (publicId, nom, description, indicateurPublicIds[],
+createdAt, updatedAt) est renvoyé tel quel par les deux endpoints. Pas de
+shape allégée vs détaillée — le payload est petit, l'unification simplifie
+le typage côté front.
+
+## Conséquences
+
+- Nouveau module `src/panier/` dans mb-api (routes + queries + tests).
+- Migration Prisma : 2 nouvelles tables (`panier`, `panier_indicateur`),
+  relation inverse à ajouter sur `Indicateur`.
+- Extension de `GET /indicateurs` avec param `ids` optionnel.
+- Nouveaux schémas Zod dans `packages/mb-shared/src/panier.ts`.
+- Côté front : nouveau composant `PanierCard`, 2 nouvelles routes
+  (`/paniers`, `/paniers/$publicId`), entrée dans la top bar.
+
+## Plan d'implémentation
+
+### Backend
+
+#### Modèle Prisma
+
+```prisma
+model Panier {
+  id          String   @id @db.Uuid
+  publicId    String   @unique @map("public_id")
+  nom         String
+  description String?
+  createdAt   DateTime @default(now()) @map("created_at")
+  updatedAt   DateTime @updatedAt      @map("updated_at")
+
+  indicateurs PanierIndicateur[]
+
+  @@map("panier")
+}
+
+model PanierIndicateur {
+  panierId     String   @map("panier_id")     @db.Uuid
+  indicateurId String   @map("indicateur_id") @db.Uuid
+  createdAt    DateTime @default(now())       @map("created_at")
+
+  panier     Panier     @relation(fields: [panierId],     references: [id], onDelete: Cascade)
+  indicateur Indicateur @relation(fields: [indicateurId], references: [id], onDelete: Cascade)
+
+  @@id([panierId, indicateurId])
+  @@index([panierId, createdAt])
+  @@map("panier_indicateur")
+}
+```
+
+Ajout sur `Indicateur` : `paniers PanierIndicateur[]` (relation inverse).
+
+#### Schémas Zod partagés (`packages/mb-shared/src/panier.ts`)
+
+```ts
+panierPublicIdSchema      = z.string().regex(/^PAN-\d+$/)
+
+panierApiModelSchema = z.object({
+  publicId: panierPublicIdSchema,
+  nom: z.string(),
+  description: z.string().nullable(),
+  indicateurPublicIds: z.array(indicateurPublicIdSchema),
+  createdAt: z.string().datetime(),
+  updatedAt: z.string().datetime(),
+})
+
+panierListApiModelSchema  = paginatedSchema(panierApiModelSchema)
+listPaniersQuerySchema    = z.object({ cursor: ..., pageSize: ... })
+```
+
+Côté `indicateur.ts` : étendre `listIndicateursQuerySchema` avec un
+`ids?: z.array(indicateurPublicIdSchema).optional()` (CSV en query string,
+décodé via `transform`).
+
+#### Queries
+
+`src/panier/queries/listPaniers.ts` :
+
+```ts
+listPaniers({ cursor, pageSize }): ResultAsync<PanierListApiModel, never>
+  - db().panier.findMany({
+      orderBy: { createdAt: 'asc' },
+      include: { indicateurs: { orderBy: { createdAt: 'asc' },
+                                include: { indicateur: { select: { publicId: true } } } } },
+      ... pagination cursor
+    })
+  - db().panier.count()
+  - toPanierApiModel(row) → ApiModel
+```
+
+`src/panier/queries/getPanierByPublicId.ts` :
+
+```ts
+getPanierByPublicId({ publicId }): ResultAsync<PanierApiModel | null, never>
+  - db().panier.findUnique({ where: { publicId }, include: ... })
+```
+
+Pas de helper de permission (D2).
+
+#### Extension `GET /indicateurs?ids=...`
+
+`src/indicateur/queries/listIndicateurs.ts` : si `params.ids` fourni, ajouter
+`publicId: { in: params.ids }` au `where`. Les permissions
+(`withIndicateurReadPermission`) restent appliquées au-dessus → un id non
+accessible est silencieusement filtré.
+
+Pagination conservée (un client pourrait passer une longue liste).
+
+#### Routes
+
+`src/panier/routes.ts` (un seul fichier, convention mb-api) :
+
+- `GET /paniers` → handler appelle `listPaniers(query).match(...)`
+- `GET /paniers/{publicId}` → `getPanierByPublicId({ publicId })`, 404 si
+  `null`
+
+Enregistrement dans le `app.route(...)` central.
+
+#### Seed
+
+`prisma/seed.ts` : ajout d'un bloc `paniersSeed` avec 4-5 paniers de
+démo, chacun référençant 3-6 indicateurs **PUBLIC existants** dans le seed.
+
+```ts
+const paniersSeed = [
+  { publicId: 'PAN-001', nom: '...', description: '...',
+    indicateurPublicIds: ['IND-001', 'IND-005', ...] },
+  ...
+]
+
+for (const p of paniersSeed) {
+  const panier = await prisma.panier.upsert({
+    where: { publicId: p.publicId },
+    update: { nom: p.nom, description: p.description },
+    create: { id: uuidv7(), publicId: p.publicId, nom: p.nom, description: p.description },
+  })
+  for (const indPublicId of p.indicateurPublicIds) {
+    const ind = await prisma.indicateur.findUniqueOrThrow({ where: { publicId: indPublicId } })
+    await prisma.panierIndicateur.upsert({
+      where: { panierId_indicateurId: { panierId: panier.id, indicateurId: ind.id } },
+      update: {},
+      create: { panierId: panier.id, indicateurId: ind.id },
+    })
+  }
+}
+```
+
+L'ordre du tableau `indicateurPublicIds` détermine l'ordre d'affichage (via
+`createdAt` croissant des upserts).
+
+#### Fixtures de test
+
+`src/test/fixtures.ts` : ajout d'un `fixtures.panier(...)` variadic, mêmes
+conventions que les fixtures existantes (defaults hardcodés, upsert).
+
+```ts
+fixtures.panier({ publicId?, nom?, description?, indicateurPublicIds? })
+```
+
+#### Tests
+
+Queries :
+
+- `listPaniers.test.ts` : liste vide, ordre alphabétique stable, pagination,
+  un panier avec 0 indicateurs, contenu de `indicateurPublicIds` dans l'ordre
+  d'insertion.
+- `getPanierByPublicId.test.ts` : présent, absent (null), ordre des
+  indicateurs respecté.
+
+Routes :
+
+- 200 / 404 / 401 sur les deux endpoints (intégration légère, le gros est sur
+  les queries).
+
+Indicateurs :
+
+- `listIndicateurs.test.ts` : nouveau cas « filtre `ids` retourne le
+  sous-ensemble dans l'ordre par défaut, permissions appliquées ».
+
+### Frontend
+
+#### API client
+
+`src/api/paniers.ts` :
+
+```ts
+fetchPaniers(params)  → panierListApiModelSchema.parse(json)
+fetchPanier(publicId) → panierApiModelSchema.parse(json)
+```
+
+`src/api/indicateurs.ts` : étendre `fetchIndicateurs` pour accepter
+`ids?: string[]` (sérialisé en CSV dans la query string).
+
+`src/queries/paniers.ts` :
+
+```ts
+paniersQueryOptions(params)
+panierQueryOptions(publicId)
+```
+
+#### Routes
+
+`src/routes/_authenticated/paniers/index.tsx` :
+
+- Loader : `queryClient.ensureQueryData(paniersQueryOptions(...))`
+- Composant : `Page` + `Section` + `CardGrid` de `PanierCard`
+- Pagination identique à la page indicateurs
+
+`src/routes/_authenticated/paniers/$publicId.tsx` :
+
+- Loader : chaîne `panierQueryOptions(publicId)` puis (si non-vide)
+  `indicateursQueryOptions({ ids: panier.indicateurPublicIds })`
+- Composant : header (nom + description) + `CardGrid` de `IndicateurCard`
+  (réutilisé tel quel)
+
+#### Composants
+
+`src/components/paniers/PanierCard.tsx` :
+
+```tsx
+type PanierCardProps = {
+  panier: Pick<PanierApiModel, 'publicId' | 'nom' | 'description' | 'updatedAt'>
+}
+```
+
+Calqué sur `IndicateurCard`. Click → navigue vers `/paniers/$publicId`.
+
+#### Navigation
+
+`src/routes/__root.tsx` : ajout d'un `<Link to="/paniers">Paniers</Link>` à
+côté de l'entrée Indicateurs.
+
+## Hors scope (v0)
+
+- Endpoints de création / édition / suppression (POST/PUT/DELETE).
+- Permissions sur le panier lui-même (visibilité, principal-based).
+- Filtrage des `indicateurPublicIds` selon les permissions du principal.
+- Recherche / filtres sur la liste des paniers.
+- Pagination des indicateurs *à l'intérieur* d'un panier (assumé petite
+  collection).
+- Tri / réordonnancement explicite (l'ordre = `createdAt` de la jonction).
+
+## Prochaines étapes
+
+1. Validation de ce design.
+2. Migration Prisma + schémas Zod partagés.
+3. Queries + fixtures + tests + routes panier.
+4. Extension `GET /indicateurs?ids=...` + tests.
+5. Seed (4-5 paniers).
+6. Front : api / queries / page liste + `PanierCard` / page détail / top bar.

--- a/apps/mb-api/prisma/migrations/20260527142319_add_panier/migration.sql
+++ b/apps/mb-api/prisma/migrations/20260527142319_add_panier/migration.sql
@@ -1,0 +1,38 @@
+-- AlterTable
+ALTER TABLE "objectif_indicateur_individu" ALTER COLUMN "id" DROP DEFAULT;
+
+-- CreateTable
+CREATE TABLE "panier" (
+    "id" UUID NOT NULL,
+    "public_id" TEXT NOT NULL,
+    "nom" TEXT NOT NULL,
+    "description" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "panier_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "panier_indicateur" (
+    "panier_id" UUID NOT NULL,
+    "indicateur_id" UUID NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "panier_indicateur_pkey" PRIMARY KEY ("panier_id","indicateur_id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "panier_public_id_key" ON "panier"("public_id");
+
+-- CreateIndex
+CREATE INDEX "panier_indicateur_panier_id_created_at_idx" ON "panier_indicateur"("panier_id", "created_at");
+
+-- AddForeignKey
+ALTER TABLE "panier_indicateur" ADD CONSTRAINT "panier_indicateur_panier_id_fkey" FOREIGN KEY ("panier_id") REFERENCES "panier"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "panier_indicateur" ADD CONSTRAINT "panier_indicateur_indicateur_id_fkey" FOREIGN KEY ("indicateur_id") REFERENCES "indicateur"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- RenameIndex
+ALTER INDEX "objectif_indicateur_individu_indicateur_id_individu_id_date_cib" RENAME TO "objectif_indicateur_individu_indicateur_id_individu_id_date_key";

--- a/apps/mb-api/prisma/schema.prisma
+++ b/apps/mb-api/prisma/schema.prisma
@@ -61,6 +61,7 @@ model Indicateur {
   objectifs    ObjectifIndicateurIndividu[]
   referentiels IndicateurReferentiel[]
   permissions  IndicateurPermission[]
+  paniers      PanierIndicateur[]
 
   @@map("indicateur")
 }
@@ -224,6 +225,32 @@ model ObjectifIndicateurIndividu {
   @@index([indicateurId, individuId])
   @@index([indicateurId, dateCible])
   @@map("objectif_indicateur_individu")
+}
+
+model Panier {
+  id          String   @id @db.Uuid
+  publicId    String   @unique @map("public_id")
+  nom         String
+  description String?
+  createdAt   DateTime @default(now()) @map("created_at")
+  updatedAt   DateTime @updatedAt      @map("updated_at")
+
+  indicateurs PanierIndicateur[]
+
+  @@map("panier")
+}
+
+model PanierIndicateur {
+  panierId     String   @map("panier_id")     @db.Uuid
+  indicateurId String   @map("indicateur_id") @db.Uuid
+  createdAt    DateTime @default(now())       @map("created_at")
+
+  panier     Panier     @relation(fields: [panierId],     references: [id], onDelete: Cascade)
+  indicateur Indicateur @relation(fields: [indicateurId], references: [id], onDelete: Cascade)
+
+  @@id([panierId, indicateurId])
+  @@index([panierId, createdAt])
+  @@map("panier_indicateur")
 }
 
 enum ApplicationLogLevel {

--- a/apps/mb-api/prisma/seed.ts
+++ b/apps/mb-api/prisma/seed.ts
@@ -514,10 +514,80 @@ const main = async () => {
     objectifsCount += result.count
   }
 
+  // Paniers d'indicateurs (v0) : collections thématiques pour le front. L'ordre
+  // du tableau `indicateurPublicIds` détermine l'ordre d'affichage (via createdAt
+  // ASC de la jonction). On ne seede que des indicateurs PUBLIC : tant que le
+  // panier n'applique pas le filtrage par permissions du principal (cf.
+  // docs/architecture/paniers-design.md, D6), l'invariant est porté par le seed.
+  const paniersSeed: ReadonlyArray<{
+    publicId: string
+    nom: string
+    description: string | null
+    indicateurPublicIds: ReadonlyArray<string>
+  }> = [
+    {
+      publicId: 'PAN-001',
+      nom: 'Indicateurs sociaux',
+      description: 'Pauvreté, alphabétisation et accès numérique.',
+      indicateurPublicIds: ['IND-048', 'IND-049', 'IND-050'],
+    },
+    {
+      publicId: 'PAN-002',
+      nom: 'Santé et démographie',
+      description: 'Démographie générale et espérance de vie.',
+      indicateurPublicIds: ['IND-046', 'IND-047'],
+    },
+    {
+      publicId: 'PAN-003',
+      nom: "Vue d'ensemble — indicateurs publics",
+      description: "L'ensemble des indicateurs publics du référentiel mb.",
+      indicateurPublicIds: ['IND-046', 'IND-047', 'IND-048', 'IND-049', 'IND-050'],
+    },
+    {
+      publicId: 'PAN-004',
+      nom: 'Niveau de vie',
+      description: 'Indicateurs de bien-être matériel et de connectivité.',
+      indicateurPublicIds: ['IND-048', 'IND-050'],
+    },
+  ]
+
+  for (const panierItem of paniersSeed) {
+    const panier = await prisma.panier.upsert({
+      where: { publicId: panierItem.publicId },
+      update: { nom: panierItem.nom, description: panierItem.description },
+      create: {
+        id: uuidv7(),
+        publicId: panierItem.publicId,
+        nom: panierItem.nom,
+        description: panierItem.description,
+      },
+    })
+    for (const indicateurPublicId of panierItem.indicateurPublicIds) {
+      const indicateur = await prisma.indicateur.findUniqueOrThrow({
+        where: { publicId: indicateurPublicId },
+        select: { id: true },
+      })
+      await prisma.panierIndicateur.upsert({
+        where: {
+          panierId_indicateurId: {
+            panierId: panier.id,
+            indicateurId: indicateur.id,
+          },
+        },
+        update: {},
+        create: { panierId: panier.id, indicateurId: indicateur.id },
+      })
+    }
+  }
+  const panierLiaisonsCount = paniersSeed.reduce(
+    (acc, item) => acc + item.indicateurPublicIds.length,
+    0,
+  )
+
   const permissionsCount = 8 * 2
   const widgetLiaisonsCount = widgetsSeed.reduce((acc, w) => acc + w.referentielPublicIds.length, 0)
   console.log(
-    `Seed terminé : ${indicateursSeed.length} indicateurs, ${utilisateursSeed.length} utilisateurs, ${permissionsCount} permissions, ${referentielsSeed.length} référentiels, ${individusSeed.length} individus, ${liaisonsCount} liaisons indicateur-référentiel, ${relationsSeed.length} relations, ${valeursCount} valeurs insérées, ${objectifsCount} objectifs insérés (les doublons ont été ignorés), ${widgetsSeed.length} widgets, ${widgetLiaisonsCount} liaisons référentiel-widget.`,
+    `Seed terminé : ${indicateursSeed.length} indicateurs, ${utilisateursSeed.length} utilisateurs, ${permissionsCount} permissions, ${referentielsSeed.length} référentiels, ${individusSeed.length} individus, ${liaisonsCount} liaisons indicateur-référentiel, ${relationsSeed.length} relations, ${valeursCount} valeurs insérées, ${objectifsCount} objectifs insérés (les doublons ont été ignorés), ${widgetsSeed.length} widgets, ${widgetLiaisonsCount} liaisons référentiel-widget, ${paniersSeed.length} paniers (${panierLiaisonsCount} liaisons panier-indicateur).`,
   )
 }
 

--- a/apps/mb-api/src/app.ts
+++ b/apps/mb-api/src/app.ts
@@ -10,6 +10,7 @@ import { databaseContext } from '@/framework/persistence/databaseContext'
 import { health } from '@/healthcheck/routes/health'
 import { indicateurRoutes } from '@/indicateur/routes'
 import { individuRoutes } from '@/individu/routes'
+import { panierRoutes } from '@/panier/routes'
 import { referentielRoutes } from '@/referentiel/routes'
 import { sharedMessage } from '@/shared/routes/sharedMessage'
 import { objectifIndicateurIndividuRoutes } from '@/objectifIndicateurIndividu/routes'
@@ -36,6 +37,7 @@ app.route('/', valeurAvancementRoutes)
 app.route('/', objectifIndicateurIndividuRoutes)
 app.route('/', referentielRoutes)
 app.route('/', individuRoutes)
+app.route('/', panierRoutes)
 app.route('/', me)
 
 app.doc('/openapi.json', {

--- a/apps/mb-api/src/indicateur/queries/listIndicateurs.test.ts
+++ b/apps/mb-api/src/indicateur/queries/listIndicateurs.test.ts
@@ -203,6 +203,46 @@ describe.concurrent('listIndicateurs', () => {
   )
 
   it(
+    'filtre les indicateurs par ids quand le paramètre est fourni',
+    integrationTest(async () => {
+      const [ind1, ind2, ind3] = testIndicateurIds(3)
+      await fixtures.indicateur({ publicId: ind1 }, { publicId: ind2 }, { publicId: ind3 })
+      const apiKey = await fixtures.apiKey({
+        permissions: [
+          { indicateur: { publicId: ind1 }, action: 'READ' },
+          { indicateur: { publicId: ind2 }, action: 'READ' },
+          { indicateur: { publicId: ind3 }, action: 'READ' },
+        ],
+      })
+
+      const result = await runAsPrincipal(apiKey.id, () => listIndicateurs({ ids: [ind1, ind3] }))
+
+      const value = result._unsafeUnwrap()
+      expect(value.items.map((i) => i.id).sort()).toEqual([ind1, ind3].sort())
+      expect(value.total).toBe(2)
+    }),
+  )
+
+  it(
+    'applique les permissions par-dessus le filtre ids (un id non autorisé est silencieusement écarté)',
+    integrationTest(async () => {
+      const [accessible, hidden] = testIndicateurIds(2)
+      await fixtures.indicateur({ publicId: accessible }, { publicId: hidden })
+      const apiKey = await fixtures.apiKey({
+        permissions: [{ indicateur: { publicId: accessible }, action: 'READ' }],
+      })
+
+      const result = await runAsPrincipal(apiKey.id, () =>
+        listIndicateurs({ ids: [accessible, hidden] }),
+      )
+
+      const value = result._unsafeUnwrap()
+      expect(value.items.map((i) => i.id)).toEqual([accessible])
+      expect(value.total).toBe(1)
+    }),
+  )
+
+  it(
     'expose referentiels triés par publicId ASC sur chaque item',
     integrationTest(async () => {
       const [accessible] = testIndicateurIds(1)

--- a/apps/mb-api/src/indicateur/queries/listIndicateurs.ts
+++ b/apps/mb-api/src/indicateur/queries/listIndicateurs.ts
@@ -7,6 +7,7 @@ import { ResultAsync } from 'neverthrow'
 import { requireCurrentPrincipalId } from '@/framework/auth/userContext'
 import { db } from '@/framework/persistence/dbStore'
 import { buildPaginationArgs, toPaginatedResponse } from '@/framework/persistence/paginate'
+import { type Prisma } from '@/generated/prisma/client'
 import { withIndicateurReadPermission } from '@/indicateur/permissions'
 import { toIndicateurApiModel } from '@/indicateur/utils'
 
@@ -14,10 +15,14 @@ export const listIndicateurs = (
   params: ListIndicateursQuery,
 ): ResultAsync<IndicateurListApiModel, never> => {
   const principalId = requireCurrentPrincipalId()
-  const where = withIndicateurReadPermission(
-    params.recherche ? { nom: { contains: params.recherche, mode: 'insensitive' } } : {},
-    principalId,
-  )
+  const filters: Prisma.IndicateurWhereInput = {}
+  if (params.recherche) {
+    filters.nom = { contains: params.recherche, mode: 'insensitive' }
+  }
+  if (params.ids && params.ids.length > 0) {
+    filters.publicId = { in: params.ids }
+  }
+  const where = withIndicateurReadPermission(filters, principalId)
 
   const fetchPage = db().indicateur.findMany({
     where,

--- a/apps/mb-api/src/indicateur/routes.ts
+++ b/apps/mb-api/src/indicateur/routes.ts
@@ -2,11 +2,11 @@ import { createRoute, OpenAPIHono, z } from '@hono/zod-openapi'
 import { errorApiModelSchema } from '@pilote/mb-shared/error'
 import {
   indicateurApiModelSchema,
-  indicateurPublicIdSchema,
   listIndicateursQuerySchema,
   upsertIndicateurBodySchema,
 } from '@pilote/mb-shared/indicateur'
 import { createPaginatedApiListSchema } from '@pilote/mb-shared/pagination'
+import { indicateurPublicIdSchema } from '@pilote/mb-shared/publicIds'
 
 import { requireAuthentication } from '@/framework/auth/requireAuthentication'
 import { never } from '@/framework/errors/never'

--- a/apps/mb-api/src/indicateur/routes.ts
+++ b/apps/mb-api/src/indicateur/routes.ts
@@ -106,9 +106,9 @@ const upsertIndicateurRoute = createRoute({
 export const indicateurRoutes = new OpenAPIHono()
 
 indicateurRoutes.openapi(getIndicateursRoute, async (context) => {
-  const { recherche, cursor, pageSize } = context.req.valid('query')
+  const { recherche, cursor, pageSize, ids } = context.req.valid('query')
 
-  return listIndicateurs({ recherche, cursor, pageSize }).match(
+  return listIndicateurs({ recherche, cursor, pageSize, ids }).match(
     (data) =>
       jsonResponseOk({
         context,

--- a/apps/mb-api/src/objectifIndicateurIndividu/routes.ts
+++ b/apps/mb-api/src/objectifIndicateurIndividu/routes.ts
@@ -1,6 +1,6 @@
 import { createRoute, OpenAPIHono, z } from '@hono/zod-openapi'
 import { errorApiModelSchema } from '@pilote/mb-shared/error'
-import { indicateurPublicIdSchema } from '@pilote/mb-shared/indicateur'
+import { indicateurPublicIdSchema } from '@pilote/mb-shared/publicIds'
 import {
   deleteObjectifIndicateurIndividuBodySchema,
   listObjectifsForIndicateurQuerySchema,

--- a/apps/mb-api/src/panier/queries/getPanierByPublicId.test.ts
+++ b/apps/mb-api/src/panier/queries/getPanierByPublicId.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+
+import { getPanierByPublicId } from '@/panier/queries/getPanierByPublicId'
+import { fixtures } from '@/test/fixtures'
+import { integrationTest } from '@/test/integrationTest'
+import { testIndicateurIds } from '@/test/randomIds'
+
+describe.concurrent('getPanierByPublicId', () => {
+  it(
+    "retourne le panier avec ses indicateurs triés par ordre d'insertion",
+    integrationTest(async () => {
+      const [indA, indB] = testIndicateurIds(2)
+      const panier = await fixtures.panier({
+        publicId: 'PAN-DETAIL-1',
+        nom: 'Panier de détail',
+        description: 'Une description',
+        indicateurs: [{ publicId: indA }, { publicId: indB }],
+      })
+
+      const result = await getPanierByPublicId('PAN-DETAIL-1')
+
+      expect(result.isOk()).toBe(true)
+      expect(result._unsafeUnwrap()).toEqual({
+        id: 'PAN-DETAIL-1',
+        nom: 'Panier de détail',
+        description: 'Une description',
+        indicateurIds: [indA, indB],
+        createdAt: panier.createdAt.toISOString(),
+        updatedAt: panier.updatedAt.toISOString(),
+      })
+    }),
+  )
+
+  it(
+    'retourne un panier sans indicateurs avec un tableau vide',
+    integrationTest(async () => {
+      await fixtures.panier({ publicId: 'PAN-DETAIL-EMPTY', nom: 'Sans indicateurs' })
+
+      const result = await getPanierByPublicId('PAN-DETAIL-EMPTY')
+
+      expect(result._unsafeUnwrap()).toMatchObject({
+        id: 'PAN-DETAIL-EMPTY',
+        indicateurIds: [],
+        description: null,
+      })
+    }),
+  )
+
+  it(
+    'lève une erreur quand aucun panier ne correspond',
+    integrationTest(async () => {
+      await expect(getPanierByPublicId('PAN-NOPE-001')).rejects.toThrow()
+    }),
+  )
+})

--- a/apps/mb-api/src/panier/queries/getPanierByPublicId.ts
+++ b/apps/mb-api/src/panier/queries/getPanierByPublicId.ts
@@ -1,0 +1,19 @@
+import { type PanierApiModel } from '@pilote/mb-shared/panier'
+import { ResultAsync } from 'neverthrow'
+
+import { db } from '@/framework/persistence/dbStore'
+import { toPanierApiModel } from '@/panier/utils'
+
+export const getPanierByPublicId = (publicId: string): ResultAsync<PanierApiModel, never> => {
+  return ResultAsync.fromSafePromise(
+    db().panier.findUniqueOrThrow({
+      where: { publicId },
+      include: {
+        indicateurs: {
+          orderBy: { createdAt: 'asc' },
+          include: { indicateur: { select: { publicId: true } } },
+        },
+      },
+    }),
+  ).map(toPanierApiModel)
+}

--- a/apps/mb-api/src/panier/queries/listPaniers.test.ts
+++ b/apps/mb-api/src/panier/queries/listPaniers.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest'
+
+import { encodeCursor } from '@/framework/persistence/paginate'
+import { listPaniers } from '@/panier/queries/listPaniers'
+import { fixtures } from '@/test/fixtures'
+import { integrationTest } from '@/test/integrationTest'
+import { testIndicateurIds } from '@/test/randomIds'
+
+describe.concurrent('listPaniers', () => {
+  it(
+    "retourne une liste vide quand aucun panier n'existe",
+    integrationTest(async () => {
+      const result = await listPaniers({})
+
+      expect(result.isOk()).toBe(true)
+      expect(result._unsafeUnwrap()).toEqual({
+        items: [],
+        pagination: { cursor: null, hasMore: false },
+        total: 0,
+      })
+    }),
+  )
+
+  it(
+    'retourne tous les paniers quand leur nombre est inférieur à la taille de page',
+    integrationTest(async () => {
+      await fixtures.panier(
+        { publicId: 'PAN-LIST-1', nom: 'Panier 1' },
+        { publicId: 'PAN-LIST-2', nom: 'Panier 2' },
+        { publicId: 'PAN-LIST-3', nom: 'Panier 3' },
+      )
+
+      const result = await listPaniers({})
+
+      const value = result._unsafeUnwrap()
+      expect(value.items.map((p) => p.id)).toEqual(['PAN-LIST-1', 'PAN-LIST-2', 'PAN-LIST-3'])
+      expect(value.pagination).toEqual({ cursor: null, hasMore: false })
+      expect(value.total).toBe(3)
+    }),
+  )
+
+  it(
+    "expose les indicateurs du panier triés par ordre d'insertion (createdAt ASC)",
+    integrationTest(async () => {
+      const [indA, indB, indC] = testIndicateurIds(3)
+      await fixtures.panier({
+        publicId: 'PAN-ORDER-001',
+        indicateurs: [{ publicId: indA }, { publicId: indB }, { publicId: indC }],
+      })
+
+      const result = await listPaniers({})
+
+      const value = result._unsafeUnwrap()
+      const panier = value.items.find((p) => p.id === 'PAN-ORDER-001')
+      expect(panier?.indicateurIds).toEqual([indA, indB, indC])
+    }),
+  )
+
+  it(
+    'retourne un panier sans indicateurs avec un tableau vide',
+    integrationTest(async () => {
+      await fixtures.panier({ publicId: 'PAN-EMPTY-001' })
+
+      const result = await listPaniers({})
+
+      const value = result._unsafeUnwrap()
+      const panier = value.items.find((p) => p.id === 'PAN-EMPTY-001')
+      expect(panier?.indicateurIds).toEqual([])
+    }),
+  )
+
+  it(
+    'pagine quand le nombre de paniers dépasse la taille de page',
+    integrationTest(async () => {
+      const created = await fixtures.panier(
+        { publicId: 'PAN-PAGE-1' },
+        { publicId: 'PAN-PAGE-2' },
+        { publicId: 'PAN-PAGE-3' },
+        { publicId: 'PAN-PAGE-4' },
+        { publicId: 'PAN-PAGE-5' },
+        { publicId: 'PAN-PAGE-6' },
+      )
+
+      const result = await listPaniers({ pageSize: 5 })
+
+      const value = result._unsafeUnwrap()
+      expect(value.items.map((p) => p.id)).toEqual([
+        'PAN-PAGE-1',
+        'PAN-PAGE-2',
+        'PAN-PAGE-3',
+        'PAN-PAGE-4',
+        'PAN-PAGE-5',
+      ])
+      expect(value.pagination).toEqual({ cursor: encodeCursor(created[4]!.id), hasMore: true })
+      expect(value.total).toBe(6)
+    }),
+  )
+
+  it(
+    'retourne la page suivante en utilisant le cursor',
+    integrationTest(async () => {
+      const created = await fixtures.panier(
+        { publicId: 'PAN-CURSOR-1' },
+        { publicId: 'PAN-CURSOR-2' },
+        { publicId: 'PAN-CURSOR-3' },
+        { publicId: 'PAN-CURSOR-4' },
+        { publicId: 'PAN-CURSOR-5' },
+        { publicId: 'PAN-CURSOR-6' },
+      )
+
+      const result = await listPaniers({ cursor: encodeCursor(created[4]!.id) })
+
+      const value = result._unsafeUnwrap()
+      expect(value.items.map((p) => p.id)).toEqual(['PAN-CURSOR-6'])
+      expect(value.pagination).toEqual({ cursor: null, hasMore: false })
+      expect(value.total).toBe(6)
+    }),
+  )
+})

--- a/apps/mb-api/src/panier/queries/listPaniers.ts
+++ b/apps/mb-api/src/panier/queries/listPaniers.ts
@@ -1,0 +1,24 @@
+import { type ListPaniersQuery, type PanierListApiModel } from '@pilote/mb-shared/panier'
+import { ResultAsync } from 'neverthrow'
+
+import { db } from '@/framework/persistence/dbStore'
+import { buildPaginationArgs, toPaginatedResponse } from '@/framework/persistence/paginate'
+import { toPanierApiModel } from '@/panier/utils'
+
+export const listPaniers = (params: ListPaniersQuery): ResultAsync<PanierListApiModel, never> => {
+  const fetchPage = db().panier.findMany({
+    orderBy: { id: 'asc' },
+    include: {
+      indicateurs: {
+        orderBy: { createdAt: 'asc' },
+        include: { indicateur: { select: { publicId: true } } },
+      },
+    },
+    ...buildPaginationArgs(params.cursor, params.pageSize),
+  })
+  const fetchTotal = db().panier.count()
+
+  return ResultAsync.fromSafePromise(Promise.all([fetchPage, fetchTotal])).map(([rows, total]) =>
+    toPaginatedResponse(rows, total, toPanierApiModel, params.pageSize),
+  )
+}

--- a/apps/mb-api/src/panier/routes.ts
+++ b/apps/mb-api/src/panier/routes.ts
@@ -1,0 +1,102 @@
+import { createRoute, OpenAPIHono, z } from '@hono/zod-openapi'
+import { errorApiModelSchema } from '@pilote/mb-shared/error'
+import {
+  listPaniersQuerySchema,
+  panierApiModelSchema,
+  panierListApiModelSchema,
+  panierPublicIdSchema,
+} from '@pilote/mb-shared/panier'
+
+import { requireAuthentication } from '@/framework/auth/requireAuthentication'
+import { never } from '@/framework/errors/never'
+import { jsonResponseOk } from '@/framework/openapi/jsonResponse'
+import { getPanierByPublicId } from '@/panier/queries/getPanierByPublicId'
+import { listPaniers } from '@/panier/queries/listPaniers'
+
+const PanierApiModelSchema = panierApiModelSchema.openapi('PanierApiModel')
+const PanierListApiModelSchema = panierListApiModelSchema.openapi('PanierListApiModel')
+const ErrorApiModelSchema = errorApiModelSchema.openapi('ErrorApiModel')
+
+// --- GET /paniers ------------------------------------------------------------
+
+const getPaniersRoute = createRoute({
+  method: 'get',
+  path: '/paniers',
+  tags: ['Panier'],
+  summary: "Lister les paniers d'indicateurs",
+  description:
+    "Retourne la liste paginée des paniers d'indicateurs. La pagination est cursor-based : passez `cursor` (renvoyé dans la réponse précédente) pour obtenir la page suivante. Chaque item inclut `indicateurIds`, triés par ordre d'insertion dans le panier (createdAt ASC de la jonction).",
+  middleware: [requireAuthentication],
+  request: { query: listPaniersQuerySchema },
+  responses: {
+    200: {
+      content: { 'application/json': { schema: PanierListApiModelSchema } },
+      description: 'Liste paginée des paniers',
+    },
+    400: {
+      content: { 'application/json': { schema: ErrorApiModelSchema } },
+      description: 'Paramètres de requête invalides',
+    },
+  },
+})
+
+// --- GET /paniers/:id --------------------------------------------------------
+
+const detailParamsSchema = z.object({
+  id: panierPublicIdSchema,
+})
+
+const getPanierByIdRoute = createRoute({
+  method: 'get',
+  path: '/paniers/{id}',
+  tags: ['Panier'],
+  summary: 'Récupérer un panier par identifiant public',
+  description:
+    "Retourne un panier identifié par son identifiant public (format `PAN-XXX`). La réponse inclut `indicateurIds` triés par ordre d'insertion (createdAt ASC de la jonction). Renvoie 404 (`ENTITY_NOT_FOUND`) si aucun panier ne correspond.",
+  middleware: [requireAuthentication],
+  request: { params: detailParamsSchema },
+  responses: {
+    200: {
+      content: { 'application/json': { schema: PanierApiModelSchema } },
+      description: 'Panier trouvé',
+    },
+    404: {
+      content: { 'application/json': { schema: ErrorApiModelSchema } },
+      description: 'Panier introuvable',
+    },
+  },
+})
+
+// --- App registration --------------------------------------------------------
+
+export const panierRoutes = new OpenAPIHono()
+
+panierRoutes.openapi(getPaniersRoute, async (context) => {
+  const { cursor, pageSize } = context.req.valid('query')
+
+  return listPaniers({ cursor, pageSize }).match(
+    (data) =>
+      jsonResponseOk({
+        context,
+        data,
+        schema: PanierListApiModelSchema,
+        status: 200,
+      }),
+    never,
+  )
+})
+
+panierRoutes.openapi(getPanierByIdRoute, async (context) => {
+  const { id } = context.req.valid('param')
+
+  return getPanierByPublicId(id).match(
+    (data) =>
+      jsonResponseOk({
+        context,
+        data,
+        schema: PanierApiModelSchema,
+        status: 200,
+      }),
+    never,
+  )
+})

--- a/apps/mb-api/src/panier/routes.ts
+++ b/apps/mb-api/src/panier/routes.ts
@@ -1,11 +1,10 @@
 import { createRoute, OpenAPIHono, z } from '@hono/zod-openapi'
-import { errorApiModelSchema } from '@pilote/mb-shared/error'
 import {
   listPaniersQuerySchema,
   panierApiModelSchema,
   panierListApiModelSchema,
-  panierPublicIdSchema,
 } from '@pilote/mb-shared/panier'
+import { panierPublicIdSchema } from '@pilote/mb-shared/publicIds'
 
 import { requireAuthentication } from '@/framework/auth/requireAuthentication'
 import { never } from '@/framework/errors/never'
@@ -15,7 +14,6 @@ import { listPaniers } from '@/panier/queries/listPaniers'
 
 const PanierApiModelSchema = panierApiModelSchema.openapi('PanierApiModel')
 const PanierListApiModelSchema = panierListApiModelSchema.openapi('PanierListApiModel')
-const ErrorApiModelSchema = errorApiModelSchema.openapi('ErrorApiModel')
 
 // --- GET /paniers ------------------------------------------------------------
 
@@ -25,17 +23,13 @@ const getPaniersRoute = createRoute({
   tags: ['Panier'],
   summary: "Lister les paniers d'indicateurs",
   description:
-    "Retourne la liste paginée des paniers d'indicateurs. La pagination est cursor-based : passez `cursor` (renvoyé dans la réponse précédente) pour obtenir la page suivante. Chaque item inclut `indicateurIds`, triés par ordre d'insertion dans le panier (createdAt ASC de la jonction).",
+    "Chaque item inclut `indicateurIds`, triés par ordre d'insertion dans le panier (createdAt ASC de la jonction).",
   middleware: [requireAuthentication],
   request: { query: listPaniersQuerySchema },
   responses: {
     200: {
       content: { 'application/json': { schema: PanierListApiModelSchema } },
       description: 'Liste paginée des paniers',
-    },
-    400: {
-      content: { 'application/json': { schema: ErrorApiModelSchema } },
-      description: 'Paramètres de requête invalides',
     },
   },
 })
@@ -52,17 +46,13 @@ const getPanierByIdRoute = createRoute({
   tags: ['Panier'],
   summary: 'Récupérer un panier par identifiant public',
   description:
-    "Retourne un panier identifié par son identifiant public (format `PAN-XXX`). La réponse inclut `indicateurIds` triés par ordre d'insertion (createdAt ASC de la jonction). Renvoie 404 (`ENTITY_NOT_FOUND`) si aucun panier ne correspond.",
+    "La réponse inclut `indicateurIds` triés par ordre d'insertion (createdAt ASC de la jonction).",
   middleware: [requireAuthentication],
   request: { params: detailParamsSchema },
   responses: {
     200: {
       content: { 'application/json': { schema: PanierApiModelSchema } },
       description: 'Panier trouvé',
-    },
-    404: {
-      content: { 'application/json': { schema: ErrorApiModelSchema } },
-      description: 'Panier introuvable',
     },
   },
 })

--- a/apps/mb-api/src/panier/utils.ts
+++ b/apps/mb-api/src/panier/utils.ts
@@ -3,20 +3,16 @@ import { type PanierApiModel } from '@pilote/mb-shared/panier'
 import { type IndicateurModel, type PanierModel } from '@/generated/prisma/models'
 
 export type PanierWithIndicateurs = PanierModel & {
-  indicateurs: Array<{
-    createdAt: Date
-    indicateur: Pick<IndicateurModel, 'publicId'>
-  }>
+  indicateurs: Array<{ indicateur: Pick<IndicateurModel, 'publicId'> }>
 }
 
+// L'ordre des `indicateurs` est garanti par la query Prisma
+// (`orderBy: { createdAt: 'asc' }` dans l'include).
 export const toPanierApiModel = (panier: PanierWithIndicateurs): PanierApiModel => ({
   id: panier.publicId,
   nom: panier.nom,
   description: panier.description,
-  indicateurIds: panier.indicateurs
-    .slice()
-    .sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime())
-    .map((lien) => lien.indicateur.publicId),
+  indicateurIds: panier.indicateurs.map((lien) => lien.indicateur.publicId),
   createdAt: panier.createdAt.toISOString(),
   updatedAt: panier.updatedAt.toISOString(),
 })

--- a/apps/mb-api/src/panier/utils.ts
+++ b/apps/mb-api/src/panier/utils.ts
@@ -1,0 +1,22 @@
+import { type PanierApiModel } from '@pilote/mb-shared/panier'
+
+import { type IndicateurModel, type PanierModel } from '@/generated/prisma/models'
+
+export type PanierWithIndicateurs = PanierModel & {
+  indicateurs: Array<{
+    createdAt: Date
+    indicateur: Pick<IndicateurModel, 'publicId'>
+  }>
+}
+
+export const toPanierApiModel = (panier: PanierWithIndicateurs): PanierApiModel => ({
+  id: panier.publicId,
+  nom: panier.nom,
+  description: panier.description,
+  indicateurIds: panier.indicateurs
+    .slice()
+    .sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime())
+    .map((lien) => lien.indicateur.publicId),
+  createdAt: panier.createdAt.toISOString(),
+  updatedAt: panier.updatedAt.toISOString(),
+})

--- a/apps/mb-api/src/test/fixtures.ts
+++ b/apps/mb-api/src/test/fixtures.ts
@@ -9,6 +9,7 @@ import {
   testEmail,
   testIndicateurId,
   testIndividuId,
+  testPanierId,
   testReferentielId,
   testWidgetId,
 } from '@/test/randomIds'
@@ -19,6 +20,7 @@ import {
   type IndicateurReferentielModel,
   type IndividuModel,
   type ObjectifIndicateurIndividuModel,
+  type PanierModel,
   type ReferentielModel,
   type ReferentielWidgetModel,
   type RelationModel,
@@ -443,6 +445,62 @@ async function objectifIndicateurIndividu(
   return results
 }
 
+// --- Panier ------------------------------------------------------------------
+
+type PanierOverrides = Partial<{
+  id: string
+  publicId: string
+  nom: string
+  description: string | null
+  indicateurs: IndicateurOverrides[]
+}>
+
+const upsertPanier = async (o: PanierOverrides = {}) => {
+  const publicId = o.publicId ?? testPanierId()
+  const { indicateurs, id: _id, publicId: _pub, ...rest } = o
+  const create = {
+    id: o.id ?? uuidv7(),
+    publicId,
+    nom: o.nom ?? 'Panier de test',
+    description: o.description ?? null,
+  }
+  const panier = await db().panier.upsert({
+    where: { publicId },
+    update: rest,
+    create,
+  })
+  if (indicateurs) {
+    for (const indicateurOverride of indicateurs) {
+      const indicateurRow = await upsertIndicateur(indicateurOverride)
+      await db().panierIndicateur.upsert({
+        where: {
+          panierId_indicateurId: {
+            panierId: panier.id,
+            indicateurId: indicateurRow.id,
+          },
+        },
+        update: {},
+        create: { panierId: panier.id, indicateurId: indicateurRow.id },
+      })
+    }
+  }
+  return panier
+}
+
+function panier(): Promise<PanierModel>
+function panier(override: PanierOverrides): Promise<PanierModel>
+function panier(
+  o1: PanierOverrides,
+  o2: PanierOverrides,
+  ...rest: PanierOverrides[]
+): Promise<PanierModel[]>
+async function panier(...overrides: PanierOverrides[]): Promise<PanierModel | PanierModel[]> {
+  if (overrides.length <= 1) return upsertPanier(overrides[0])
+  const results: PanierModel[] = []
+  for (const o of overrides) results.push(await upsertPanier(o))
+  return results
+}
+
 // --- ApiKey ------------------------------------------------------------------
 
 type PrincipalIndicateurPermissionOverrides = {
@@ -610,6 +668,7 @@ export const fixtures = {
   relation,
   valeurAvancement,
   objectifIndicateurIndividu,
+  panier,
   apiKey,
   utilisateur,
   indicateurPermission,

--- a/apps/mb-api/src/test/randomIds.ts
+++ b/apps/mb-api/src/test/randomIds.ts
@@ -155,6 +155,8 @@ export const testIndividuId = (): string => `TEST-${randomToken(12)}`
 
 export const testWidgetId = (): string => `WID-${randomToken(12).toUpperCase()}`
 
+export const testPanierId = (): string => `PAN-${randomToken(12)}`
+
 export const testDeptId = (): string => `DEPT-${pickRandom(DEPT_CODES)}`
 
 export const testRegId = (): string => `REG-${pickRandom(REG_CODES)}`

--- a/apps/mb-api/src/valeurAvancement/routes.ts
+++ b/apps/mb-api/src/valeurAvancement/routes.ts
@@ -1,6 +1,6 @@
 import { createRoute, OpenAPIHono, z } from '@hono/zod-openapi'
 import { errorApiModelSchema } from '@pilote/mb-shared/error'
-import { indicateurPublicIdSchema } from '@pilote/mb-shared/indicateur'
+import { indicateurPublicIdSchema } from '@pilote/mb-shared/publicIds'
 import { createPaginatedApiListSchema } from '@pilote/mb-shared/pagination'
 import {
   deleteValeurAvancementBodySchema,

--- a/apps/mb-api/tsconfig.json
+++ b/apps/mb-api/tsconfig.json
@@ -22,6 +22,7 @@
       "@/valeurAvancement/*": ["./src/valeurAvancement/*"],
       "@/objectifIndicateurIndividu/*": ["./src/objectifIndicateurIndividu/*"],
       "@/widget/*": ["./src/widget/*"],
+      "@/panier/*": ["./src/panier/*"],
       "@/shared/*": ["./src/shared/*"],
       "@/generated/*": ["./src/generated/*"],
       "@/test/*": ["./src/test/*"],

--- a/apps/mb-webapp/src/api/indicateurs.ts
+++ b/apps/mb-webapp/src/api/indicateurs.ts
@@ -26,8 +26,14 @@ export const fetchIndicateurs = async (
   params: ListIndicateursQuery,
 ): Promise<IndicateurListApiModel> => {
   // ky filters out `undefined` values from object-form searchParams (see
-  // Ky.#normalizeSearchParams), so we can pass `params` directly.
-  const json = await apiClient.get('indicateurs', { searchParams: params }).json()
+  // Ky.#normalizeSearchParams). Le filtre `ids` est CSV côté API : on le
+  // sérialise explicitement, sinon ky le rendrait en multi-value `?ids=a&ids=b`.
+  const { ids, ...rest } = params
+  const searchParams = {
+    ...rest,
+    ...(ids && ids.length > 0 ? { ids: ids.join(',') } : {}),
+  }
+  const json = await apiClient.get('indicateurs', { searchParams }).json()
   return indicateurListApiModelSchema.parse(json)
 }
 

--- a/apps/mb-webapp/src/api/paniers.ts
+++ b/apps/mb-webapp/src/api/paniers.ts
@@ -1,0 +1,19 @@
+import {
+  type ListPaniersQuery,
+  type PanierApiModel,
+  panierApiModelSchema,
+  type PanierListApiModel,
+  panierListApiModelSchema,
+} from '@pilote/mb-shared/panier'
+
+import { apiClient } from '@/api/client'
+
+export const fetchPaniers = async (params: ListPaniersQuery): Promise<PanierListApiModel> => {
+  const json = await apiClient.get('paniers', { searchParams: params }).json()
+  return panierListApiModelSchema.parse(json)
+}
+
+export const fetchPanierById = async (id: string): Promise<PanierApiModel> => {
+  const json = await apiClient.get(`paniers/${id}`).json()
+  return panierApiModelSchema.parse(json)
+}

--- a/apps/mb-webapp/src/components/indicateurs/IndicateurCard.tsx
+++ b/apps/mb-webapp/src/components/indicateurs/IndicateurCard.tsx
@@ -10,11 +10,11 @@ function formatMiseAJour(iso: string): string {
   return formatMonthYearNumericFr(date)
 }
 
-type IndicateurCardProps = {
+export function IndicateurCard({
+  indicateur,
+}: {
   indicateur: Pick<IndicateurApiModel, 'id' | 'nom' | 'updatedAt'>
-}
-
-export function IndicateurCard({ indicateur }: IndicateurCardProps) {
+}) {
   return (
     <EntityCard
       asChild

--- a/apps/mb-webapp/src/components/paniers/PanierCard.tsx
+++ b/apps/mb-webapp/src/components/paniers/PanierCard.tsx
@@ -3,11 +3,11 @@ import { Link } from '@tanstack/react-router'
 
 import { EntityCard } from '@/components/ui/EntityCard'
 
-type PanierCardProps = {
+export function PanierCard({
+  panier,
+}: {
   panier: Pick<PanierApiModel, 'id' | 'nom' | 'description' | 'indicateurIds'>
-}
-
-export function PanierCard({ panier }: PanierCardProps) {
+}) {
   const nb = panier.indicateurIds.length
   return (
     <EntityCard

--- a/apps/mb-webapp/src/components/paniers/PanierCard.tsx
+++ b/apps/mb-webapp/src/components/paniers/PanierCard.tsx
@@ -1,0 +1,27 @@
+import type { PanierApiModel } from '@pilote/mb-shared/panier'
+import { Link } from '@tanstack/react-router'
+
+import { EntityCard } from '@/components/ui/EntityCard'
+
+type PanierCardProps = {
+  panier: Pick<PanierApiModel, 'id' | 'nom' | 'description' | 'indicateurIds'>
+}
+
+export function PanierCard({ panier }: PanierCardProps) {
+  const nb = panier.indicateurIds.length
+  return (
+    <EntityCard
+      asChild
+      kicker={panier.id}
+      title={panier.nom}
+      footer={
+        <>
+          {nb} indicateur{nb > 1 ? 's' : ''}
+          {panier.description ? ` — ${panier.description}` : ''}
+        </>
+      }
+    >
+      <Link to="/paniers/$id" params={{ id: panier.id }} />
+    </EntityCard>
+  )
+}

--- a/apps/mb-webapp/src/queries/paniers.ts
+++ b/apps/mb-webapp/src/queries/paniers.ts
@@ -1,0 +1,36 @@
+import { type ListPaniersQuery } from '@pilote/mb-shared/panier'
+import { type QueryClient, queryOptions } from '@tanstack/react-query'
+
+import { fetchPanierById, fetchPaniers } from '@/api/paniers'
+
+import { DEFAULT_STALE_TIME } from './utils'
+
+export const paniersQueryOptions = (params: ListPaniersQuery) =>
+  queryOptions({
+    queryKey: ['paniers', params],
+    queryFn: () => fetchPaniers(params),
+    staleTime: DEFAULT_STALE_TIME,
+  })
+
+export const loadPaniers = ({
+  queryClient,
+  query,
+}: {
+  queryClient: QueryClient
+  query: ListPaniersQuery
+}) => queryClient.fetchQuery(paniersQueryOptions(query))
+
+export const panierQueryOptions = (id: string) =>
+  queryOptions({
+    queryKey: ['panier', id],
+    queryFn: () => fetchPanierById(id),
+    staleTime: DEFAULT_STALE_TIME,
+  })
+
+export const loadPanier = ({
+  queryClient,
+  panierId,
+}: {
+  queryClient: QueryClient
+  panierId: string
+}) => queryClient.fetchQuery(panierQueryOptions(panierId))

--- a/apps/mb-webapp/src/routes/__root.tsx
+++ b/apps/mb-webapp/src/routes/__root.tsx
@@ -33,6 +33,9 @@ function RootComponent() {
             >
               Indicateurs
             </Link>
+            <Link to="/paniers" search={{}} className="text-secondary-foreground hover:text-text">
+              Paniers
+            </Link>
             {auth.isAuthenticated ? (
               <span className="flex items-center gap-2">
                 <span className="text-text-muted">

--- a/apps/mb-webapp/src/routes/_authenticated/indicateurs/$id.tsx
+++ b/apps/mb-webapp/src/routes/_authenticated/indicateurs/$id.tsx
@@ -1,4 +1,4 @@
-import { indicateurPublicIdSchema } from '@pilote/mb-shared/indicateur'
+import { indicateurPublicIdSchema } from '@pilote/mb-shared/publicIds'
 import { individuPublicIdSchema } from '@pilote/mb-shared/individu'
 import { referentielPublicIdSchema } from '@pilote/mb-shared/referentiel'
 import { useSuspenseQuery } from '@tanstack/react-query'

--- a/apps/mb-webapp/src/routes/_authenticated/paniers/$id.tsx
+++ b/apps/mb-webapp/src/routes/_authenticated/paniers/$id.tsx
@@ -1,4 +1,4 @@
-import { panierPublicIdSchema } from '@pilote/mb-shared/panier'
+import { panierPublicIdSchema } from '@pilote/mb-shared/publicIds'
 import { useSuspenseQuery } from '@tanstack/react-query'
 import { createFileRoute, Link } from '@tanstack/react-router'
 import { z } from 'zod'

--- a/apps/mb-webapp/src/routes/_authenticated/paniers/$id.tsx
+++ b/apps/mb-webapp/src/routes/_authenticated/paniers/$id.tsx
@@ -1,0 +1,83 @@
+import { panierPublicIdSchema } from '@pilote/mb-shared/panier'
+import { useSuspenseQuery } from '@tanstack/react-query'
+import { createFileRoute, Link } from '@tanstack/react-router'
+import { z } from 'zod'
+
+import { RouteError } from '@/components/RouteError'
+import { RouteLoading } from '@/components/RouteLoading'
+import { IndicateurCard } from '@/components/indicateurs/IndicateurCard'
+import { BackLink } from '@/components/ui/BackLink'
+import { CardGrid } from '@/components/ui/CardGrid'
+import { EmptyState } from '@/components/ui/EmptyState'
+import { Page } from '@/components/ui/Page'
+import { Section } from '@/components/ui/Section'
+import { Text } from '@/components/ui/Typography'
+import { indicateursQueryOptions } from '@/queries/indicateurs'
+import { loadPanier, panierQueryOptions } from '@/queries/paniers'
+
+const paramsSchema = z.object({
+  id: panierPublicIdSchema,
+})
+
+export const Route = createFileRoute('/_authenticated/paniers/$id')({
+  params: {
+    parse: (raw) => paramsSchema.parse(raw),
+    stringify: ({ id }) => ({ id }),
+  },
+  loader: async ({ context, params }) => {
+    const { queryClient } = context
+    const panier = await loadPanier({ queryClient, panierId: params.id })
+    if (panier.indicateurIds.length > 0) {
+      await queryClient.ensureQueryData(indicateursQueryOptions({ ids: panier.indicateurIds }))
+    }
+    return { panier }
+  },
+  pendingComponent: () => <RouteLoading message="Chargement du panier…" />,
+  errorComponent: RouteError,
+  component: PanierDetailComponent,
+})
+
+function PanierDetailComponent() {
+  const { id } = Route.useParams()
+  const { data: panier } = useSuspenseQuery(panierQueryOptions(id))
+  const { data: indicateurs } = useSuspenseQuery(
+    indicateursQueryOptions({ ids: panier.indicateurIds }),
+  )
+
+  // Re-tri selon l'ordre du panier : la query indicateurs ne garantit pas
+  // l'ordre du filtre `ids`.
+  const indicateurById = new Map(indicateurs.items.map((i) => [i.id, i]))
+  const orderedIndicateurs = panier.indicateurIds
+    .map((indicateurId) => indicateurById.get(indicateurId))
+    .filter((i): i is NonNullable<typeof i> => i !== undefined)
+
+  const back = (
+    <BackLink asChild>
+      <Link to="/paniers" search={{}}>
+        Retour aux paniers
+      </Link>
+    </BackLink>
+  )
+
+  return (
+    <Page title={panier.nom} description={panier.description ?? undefined} back={back}>
+      <Section
+        toolbar={
+          <Text tone="muted">
+            {orderedIndicateurs.length} indicateur{orderedIndicateurs.length > 1 ? 's' : ''}
+          </Text>
+        }
+      >
+        {orderedIndicateurs.length === 0 ? (
+          <EmptyState title="Ce panier ne contient aucun indicateur." />
+        ) : (
+          <CardGrid>
+            {orderedIndicateurs.map((indicateur) => (
+              <IndicateurCard key={indicateur.id} indicateur={indicateur} />
+            ))}
+          </CardGrid>
+        )}
+      </Section>
+    </Page>
+  )
+}

--- a/apps/mb-webapp/src/routes/_authenticated/paniers/index.tsx
+++ b/apps/mb-webapp/src/routes/_authenticated/paniers/index.tsx
@@ -1,0 +1,70 @@
+import { useSuspenseQuery } from '@tanstack/react-query'
+import { createFileRoute, useNavigate } from '@tanstack/react-router'
+import { z } from 'zod'
+
+import { RouteError } from '@/components/RouteError'
+import { RouteLoading } from '@/components/RouteLoading'
+import { PanierCard } from '@/components/paniers/PanierCard'
+import { CardGrid } from '@/components/ui/CardGrid'
+import { EmptyState } from '@/components/ui/EmptyState'
+import { Page } from '@/components/ui/Page'
+import { DEFAULT_PAGE_SIZE_OPTIONS, Pagination } from '@/components/ui/Pagination'
+import { Section } from '@/components/ui/Section'
+import { Text } from '@/components/ui/Typography'
+import { loadPaniers, paniersQueryOptions } from '@/queries/paniers'
+
+const paniersSearchSchema = z.object({
+  cursor: z.string().optional(),
+  pageSize: z.coerce.number().int().min(1).max(100).optional(),
+})
+
+export const Route = createFileRoute('/_authenticated/paniers/')({
+  validateSearch: paniersSearchSchema,
+  loaderDeps: ({ search }) => search,
+  loader: ({ context, deps }) => loadPaniers({ queryClient: context.queryClient, query: deps }),
+  pendingComponent: () => <RouteLoading message="Chargement des paniers…" />,
+  errorComponent: RouteError,
+  component: PaniersListComponent,
+})
+
+function PaniersListComponent() {
+  const search = Route.useSearch()
+  const navigate = useNavigate({ from: Route.fullPath })
+  const { data } = useSuspenseQuery(paniersQueryOptions(search))
+
+  return (
+    <Page title="Paniers d'indicateurs" description="Collections thématiques d'indicateurs.">
+      <Section
+        toolbar={
+          <Text tone="muted">
+            {data.total} panier{data.total > 1 ? 's' : ''}
+          </Text>
+        }
+      >
+        {data.items.length === 0 ? (
+          <EmptyState title="Aucun panier disponible." />
+        ) : (
+          <CardGrid>
+            {data.items.map((panier) => (
+              <PanierCard key={panier.id} panier={panier} />
+            ))}
+          </CardGrid>
+        )}
+
+        <div className="mt-6">
+          <Pagination
+            hasNext={data.pagination.hasMore}
+            onNext={() => {
+              const next = data.pagination.cursor
+              if (next) void navigate({ search: (prev) => ({ ...prev, cursor: next }) })
+            }}
+            pageSize={search.pageSize ?? DEFAULT_PAGE_SIZE_OPTIONS[0]}
+            onPageSizeChange={(pageSize) => {
+              void navigate({ search: (prev) => ({ ...prev, pageSize, cursor: undefined }) })
+            }}
+          />
+        </div>
+      </Section>
+    </Page>
+  )
+}

--- a/packages/mb-shared/package.json
+++ b/packages/mb-shared/package.json
@@ -28,6 +28,10 @@
       "types": "./src/pagination.ts",
       "default": "./src/pagination.ts"
     },
+    "./publicIds": {
+      "types": "./src/publicIds.ts",
+      "default": "./src/publicIds.ts"
+    },
     "./referentiel": {
       "types": "./src/referentiel.ts",
       "default": "./src/referentiel.ts"

--- a/packages/mb-shared/package.json
+++ b/packages/mb-shared/package.json
@@ -43,6 +43,10 @@
     "./widget": {
       "types": "./src/widget.ts",
       "default": "./src/widget.ts"
+    },
+    "./panier": {
+      "types": "./src/panier.ts",
+      "default": "./src/panier.ts"
     }
   },
   "files": [

--- a/packages/mb-shared/src/indicateur.ts
+++ b/packages/mb-shared/src/indicateur.ts
@@ -19,7 +19,7 @@ export const fonctionAgregationSchema = z
   .enum(['SUM', 'AVG', 'NONE'])
   .describe(
     "Fonction d'agrégation appliquée pour calculer la valeur d'un parent à partir des valeurs " +
-      "de ses enfants. `SUM` = somme des contributions des enfants. `AVG` = moyenne arithmétique " +
+      'de ses enfants. `SUM` = somme des contributions des enfants. `AVG` = moyenne arithmétique ' +
       "simple (non pondérée) des contributions connues. `NONE` = pas d'agrégation : la valeur doit " +
       "être saisie directement pour ce référentiel, elle n'est jamais dérivée depuis les enfants.",
   )
@@ -53,7 +53,20 @@ export type IndicateurApiModel = z.infer<typeof indicateurApiModelSchema>
 export const indicateurListApiModelSchema = createPaginatedApiListSchema(indicateurApiModelSchema)
 export type IndicateurListApiModel = z.infer<typeof indicateurListApiModelSchema>
 
-export const listIndicateursQuerySchema = listQuerySchema
+export const listIndicateursQuerySchema = listQuerySchema.extend({
+  ids: z
+    .preprocess((val) => {
+      if (typeof val !== 'string') return val
+      const parts = val
+        .split(',')
+        .map((p) => p.trim())
+        .filter(Boolean)
+      return parts.length === 0 ? undefined : parts
+    }, z.array(indicateurPublicIdSchema).optional())
+    .describe(
+      'Filtre par identifiants publics (CSV, ex. `IND-001,IND-002`). Vide ou absent = aucun filtre.',
+    ),
+})
 export type ListIndicateursQuery = z.infer<typeof listIndicateursQuerySchema>
 
 export const upsertIndicateurBodySchema = z.object({

--- a/packages/mb-shared/src/indicateur.ts
+++ b/packages/mb-shared/src/indicateur.ts
@@ -1,12 +1,7 @@
 import { z } from 'zod'
 
 import { createPaginatedApiListSchema, listQuerySchema } from './pagination'
-import { referentielPublicIdSchema } from './publicIds'
-
-export const indicateurPublicIdSchema = z
-  .string()
-  .regex(/^IND-\d+$/, 'Identifiant public attendu au format IND-XXX')
-  .describe("Identifiant public de l'indicateur (format IND-XXX).")
+import { indicateurPublicIdSchema, referentielPublicIdSchema } from './publicIds'
 
 export const indicateurVisibiliteSchema = z
   .enum(['PUBLIC', 'PRIVE'])

--- a/packages/mb-shared/src/objectifIndicateurIndividu.ts
+++ b/packages/mb-shared/src/objectifIndicateurIndividu.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod'
 
-import { indicateurPublicIdSchema } from './indicateur'
+import { indicateurPublicIdSchema } from './publicIds'
 import { individuPublicIdSchema } from './individu'
 import { individusCsvSchema, MAX_INDIVIDUS_PAR_REQUETE } from './individusCsv'
 import { dateSchema } from './valeurAvancement'

--- a/packages/mb-shared/src/panier.ts
+++ b/packages/mb-shared/src/panier.ts
@@ -1,12 +1,7 @@
 import { z } from 'zod'
 
-import { indicateurPublicIdSchema } from './indicateur'
 import { createPaginatedApiListSchema, paginationCursorSchema, pageSizeSchema } from './pagination'
-
-export const panierPublicIdSchema = z
-  .string()
-  .regex(/^PAN-\d+$/, 'Identifiant public attendu au format PAN-XXX')
-  .describe('Identifiant public du panier (format PAN-XXX).')
+import { indicateurPublicIdSchema, panierPublicIdSchema } from './publicIds'
 
 export const panierApiModelSchema = z.object({
   id: panierPublicIdSchema,

--- a/packages/mb-shared/src/panier.ts
+++ b/packages/mb-shared/src/panier.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod'
+
+import { indicateurPublicIdSchema } from './indicateur'
+import { createPaginatedApiListSchema, paginationCursorSchema, pageSizeSchema } from './pagination'
+
+export const panierPublicIdSchema = z
+  .string()
+  .regex(/^PAN-\d+$/, 'Identifiant public attendu au format PAN-XXX')
+  .describe('Identifiant public du panier (format PAN-XXX).')
+
+export const panierApiModelSchema = z.object({
+  id: panierPublicIdSchema,
+  nom: z.string().describe('Nom lisible du panier.'),
+  description: z.string().nullable().describe('Description libre du panier.'),
+  indicateurIds: z
+    .array(indicateurPublicIdSchema)
+    .describe(
+      "Identifiants publics des indicateurs composant le panier, triés par ordre d'insertion (createdAt ASC).",
+    ),
+  createdAt: z.string().datetime().describe('Date ISO 8601 de création.'),
+  updatedAt: z.string().datetime().describe('Date ISO 8601 de dernière mise à jour.'),
+})
+export type PanierApiModel = z.infer<typeof panierApiModelSchema>
+
+export const panierListApiModelSchema = createPaginatedApiListSchema(panierApiModelSchema)
+export type PanierListApiModel = z.infer<typeof panierListApiModelSchema>
+
+export const listPaniersQuerySchema = z.object({
+  cursor: paginationCursorSchema.optional(),
+  pageSize: pageSizeSchema,
+})
+export type ListPaniersQuery = z.infer<typeof listPaniersQuerySchema>

--- a/packages/mb-shared/src/publicIds.ts
+++ b/packages/mb-shared/src/publicIds.ts
@@ -1,5 +1,15 @@
 import { z } from 'zod'
 
+export const indicateurPublicIdSchema = z
+  .string()
+  .regex(/^IND-\d+$/, 'Identifiant public attendu au format IND-XXX')
+  .describe("Identifiant public de l'indicateur (format IND-XXX).")
+
+export const panierPublicIdSchema = z
+  .string()
+  .regex(/^PAN-\d+$/, 'Identifiant public attendu au format PAN-XXX')
+  .describe('Identifiant public du panier (format PAN-XXX).')
+
 export const referentielPublicIdSchema = z
   .string()
   .regex(

--- a/packages/mb-shared/src/valeurAvancement.ts
+++ b/packages/mb-shared/src/valeurAvancement.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod'
 
-import { fonctionAgregationSchema, indicateurPublicIdSchema } from './indicateur'
+import { fonctionAgregationSchema } from './indicateur'
+import { indicateurPublicIdSchema } from './publicIds'
 import { individuApiModelSchema, individuPublicIdSchema } from './individu'
 import { individusCsvSchema, MAX_INDIVIDUS_PAR_REQUETE } from './individusCsv'
 import {


### PR DESCRIPTION
## Summary
- Nouveau concept de **panier d'indicateurs** : collection nommée, relation N-N avec indicateurs (ordre = `createdAt` de la jonction)
- **API** : `GET /paniers` (paginé cursor) + `GET /paniers/{id}` — pas de POST/PUT/DELETE en v0 (création via seed uniquement)
- **Front** : entrée « Paniers » dans la top bar, page liste, page détail réutilisant la grid `IndicateurCard`
- **Seed** : 4 paniers thématiques sur les indicateurs publics (PAN-001 à PAN-004)
- **Design doc** : `apps/mb-api/docs/architecture/paniers-design.md` détaille les 10 décisions (permissions, ordre, format `PAN-XXX`, etc.)
- Extension `GET /indicateurs` avec filtre `ids` (CSV) pour la recomposition côté front

## Notes
- PR basée sur `mb-widgets-carto`. À rebase `--onto dev` une fois widgets-carto mergée.
- v0 : pas de permissions sur le panier, pas de filtrage des indicateurs contenus par le principal (invariant porté par le seed → tous PUBLIC). Cf. décision D6 du design doc.

## Test plan
- [ ] `pnpm test` mb-api : 244/244 passent (dont 12 nouveaux cas paniers/filtre ids)
- [ ] `pnpm lint` mb-api + mb-webapp passent (les fichiers paniers, pas les warnings préexistants `carteFranceData.ts`)
- [ ] Page `/paniers` : voir 4 cartes
- [ ] Détail d'un panier → grid d'indicateurs dans l'ordre du seed
- [ ] Swagger UI : `GET /paniers` et `GET /paniers/PAN-001` répondent
- [ ] `GET /indicateurs?ids=IND-046,IND-048` renvoie 2 items

🤖 Generated with [Claude Code](https://claude.com/claude-code)