### PR TITLE
feat(mb-api): batch upsert transactionnel des valeurs d'avancement

### DIFF
--- a/apps/mb-api/prisma/sql/upsertValeursAvancementBatch.sql
+++ b/apps/mb-api/prisma/sql/upsertValeursAvancementBatch.sql
@@ -1,0 +1,21 @@
+-- Upsert atomique d'un batch de valeurs d'avancement pour un indicateur donné.
+-- `payload.items` est un tableau JSON d'objets `{id, individuId, date, valeur}` (valeur
+-- exprimée en chaîne pour préserver la précision décimale).
+-- Retourne, pour chaque ligne dans l'ordre du payload, si elle vient d'être créée
+-- (`xmax = 0`) ou si elle a remplacé une valeur préexistante.
+-- @param {String} $1:indicateurId
+-- @param {Json} $2:payload
+INSERT INTO valeur_avancement (id, indicateur_id, individu_id, date, valeur, created_at, updated_at)
+SELECT
+  (input->>'id')::uuid,
+  $1::uuid,
+  (input->>'individuId')::uuid,
+  input->>'date',
+  (input->>'valeur')::numeric,
+  NOW(),
+  NOW()
+FROM jsonb_array_elements(($2::jsonb)->'items') AS input
+ON CONFLICT (indicateur_id, individu_id, date) DO UPDATE
+SET valeur = EXCLUDED.valeur,
+    updated_at = NOW()
+RETURNING (xmax = 0) AS created;

--- a/apps/mb-api/src/indicateur/resolveIndicateurAndIndividuForWrite.ts
+++ b/apps/mb-api/src/indicateur/resolveIndicateurAndIndividuForWrite.ts
@@ -1,10 +1,8 @@
-import { ResultAsync } from 'neverthrow'
+import { type ResultAsync } from 'neverthrow'
 
-import { requireCurrentPrincipalId } from '@/framework/auth/userContext'
-import { db } from '@/framework/persistence/dbStore'
 import { type IndividuInconnuError, resolveAuthorizedIndividu } from '@/individu/permission'
 
-import { ensureIndicateurWritePermission, withIndicateurReadPermission } from './permissions'
+import { resolveIndicateurForWrite } from './resolveIndicateurForWrite'
 
 type ResolvedContext = {
   indicateur: { id: string; publicId: string }
@@ -18,22 +16,9 @@ export const resolveIndicateurAndIndividuForWrite = ({
 }: {
   indicateurPublicId: string
   individuPublicId: string
-}): ResultAsync<ResolvedContext, IndividuInconnuError> => {
-  const principalId = requireCurrentPrincipalId()
-  return ResultAsync.fromSafePromise(
-    db().indicateur.findFirstOrThrow({
-      where: withIndicateurReadPermission({ publicId: indicateurPublicId }, principalId),
-      select: { id: true, publicId: true },
-    }),
+}): ResultAsync<ResolvedContext, IndividuInconnuError> =>
+  resolveIndicateurForWrite({ indicateurPublicId }).andThen(({ indicateur, principalId }) =>
+    resolveAuthorizedIndividu({ individuPublicId, indicateurId: indicateur.id }).map(
+      (individu) => ({ indicateur, individu, principalId }),
+    ),
   )
-    .andThen((indicateur) =>
-      ensureIndicateurWritePermission({ indicateurId: indicateur.id, principalId }).map(
-        () => indicateur,
-      ),
-    )
-    .andThen((indicateur) =>
-      resolveAuthorizedIndividu({ individuPublicId, indicateurId: indicateur.id }).map(
-        (individu) => ({ indicateur, individu, principalId }),
-      ),
-    )
-}

--- a/apps/mb-api/src/indicateur/resolveIndicateurForWrite.ts
+++ b/apps/mb-api/src/indicateur/resolveIndicateurForWrite.ts
@@ -1,0 +1,30 @@
+import { ResultAsync } from 'neverthrow'
+
+import { requireCurrentPrincipalId } from '@/framework/auth/userContext'
+import { db } from '@/framework/persistence/dbStore'
+
+import { ensureIndicateurWritePermission, withIndicateurReadPermission } from './permissions'
+
+type ResolvedIndicateur = {
+  indicateur: { id: string; publicId: string }
+  principalId: string
+}
+
+export const resolveIndicateurForWrite = ({
+  indicateurPublicId,
+}: {
+  indicateurPublicId: string
+}): ResultAsync<ResolvedIndicateur, never> => {
+  const principalId = requireCurrentPrincipalId()
+  return ResultAsync.fromSafePromise(
+    db().indicateur.findFirstOrThrow({
+      where: withIndicateurReadPermission({ publicId: indicateurPublicId }, principalId),
+      select: { id: true, publicId: true },
+    }),
+  ).andThen((indicateur) =>
+    ensureIndicateurWritePermission({ indicateurId: indicateur.id, principalId }).map(() => ({
+      indicateur,
+      principalId,
+    })),
+  )
+}

--- a/apps/mb-api/src/valeurAvancement/commands/upsertValeursAvancementBatch.test.ts
+++ b/apps/mb-api/src/valeurAvancement/commands/upsertValeursAvancementBatch.test.ts
@@ -36,15 +36,12 @@ describe.concurrent('upsertValeursAvancementBatch', () => {
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>
-        upsertValeursAvancementBatch({
-          indicateurPublicId: indId,
-          body: {
-            items: [
-              { individu: deptA, date: '2025-03-01', valeur: 10 },
-              { individu: deptB, date: '2025-03-01', valeur: 20 },
-              { individu: deptC, date: '2025-03-01', valeur: 30 },
-            ],
-          },
+        upsertValeursAvancementBatch(indId, {
+          items: [
+            { individu: deptA, date: '2025-03-01', valeur: 10 },
+            { individu: deptB, date: '2025-03-01', valeur: 20 },
+            { individu: deptC, date: '2025-03-01', valeur: 30 },
+          ],
         }),
       )
 
@@ -52,20 +49,18 @@ describe.concurrent('upsertValeursAvancementBatch', () => {
       expect(result._unsafeUnwrap()).toEqual({ total: 3, created: 2, updated: 1 })
       const rows = await db().valeurAvancement.findMany({
         where: { indicateur: { publicId: indId } },
-        orderBy: [{ individu: { publicId: 'asc' } }],
+        include: { individu: { select: { publicId: true } } },
       })
-      expect(rows).toHaveLength(3)
-      const valeurParPublicId = new Map<string, number>()
-      for (const row of rows) {
-        const individu = await db().individu.findUniqueOrThrow({
-          where: { id: row.individuId },
-          select: { publicId: true },
-        })
-        valeurParPublicId.set(individu.publicId, row.valeur.toNumber())
-      }
-      expect(valeurParPublicId.get(deptA)).toBe(10)
-      expect(valeurParPublicId.get(deptB)).toBe(20)
-      expect(valeurParPublicId.get(deptC)).toBe(30)
+      const valeurParPublicId = new Map(
+        rows.map((row) => [row.individu.publicId, row.valeur.toNumber()]),
+      )
+      expect(valeurParPublicId).toEqual(
+        new Map([
+          [deptA, 10],
+          [deptB, 20],
+          [deptC, 30],
+        ]),
+      )
     }),
   )
 
@@ -88,15 +83,12 @@ describe.concurrent('upsertValeursAvancementBatch', () => {
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>
-        upsertValeursAvancementBatch({
-          indicateurPublicId: indId,
-          body: {
-            items: [
-              { individu: deptA, date: '2025-03-01', valeur: 10 },
-              { individu: deptB, date: '2025-03-01', valeur: 20 },
-              { individu: deptA, date: '2025-03-01', valeur: 99 },
-            ],
-          },
+        upsertValeursAvancementBatch(indId, {
+          items: [
+            { individu: deptA, date: '2025-03-01', valeur: 10 },
+            { individu: deptB, date: '2025-03-01', valeur: 20 },
+            { individu: deptA, date: '2025-03-01', valeur: 99 },
+          ],
         }),
       )
 
@@ -114,37 +106,36 @@ describe.concurrent('upsertValeursAvancementBatch', () => {
   )
 
   it(
-    'remonte INDIVIDU_INCONNU agrégé par individu et n\'applique rien',
+    "remonte INDIVIDU_INCONNU agrégé par individu et n'applique rien",
     integrationTest(async () => {
       const indId = testIndicateurId()
-      const refId = testReferentielId()
-      const refOrphelin = testReferentielId()
-      const [deptA, deptOrphelin] = testDeptIds(2)
-      const inconnu = `DEPT-XX`
+      const refLie = testReferentielId()
+      // Référentiel qui existe mais n'a pas de lien IndicateurReferentiel avec `indId` :
+      // les individus rattachés à ce référentiel doivent donc être rejetés en INDIVIDU_INCONNU.
+      const refNonLieAIndicateur = testReferentielId()
+      const [deptLie, deptDansRefNonLie] = testDeptIds(2)
+      const deptInconnu = 'DEPT-XX'
       await fixtures.indicateurReferentiel({
         indicateur: { publicId: indId },
-        referentiel: { publicId: refId },
+        referentiel: { publicId: refLie },
       })
-      await fixtures.individu({ publicId: deptA, referentiel: { publicId: refId } })
+      await fixtures.individu({ publicId: deptLie, referentiel: { publicId: refLie } })
       await fixtures.individu({
-        publicId: deptOrphelin,
-        referentiel: { publicId: refOrphelin },
+        publicId: deptDansRefNonLie,
+        referentiel: { publicId: refNonLieAIndicateur },
       })
       const apiKey = await fixtures.apiKey({
         permissions: [{ indicateur: { publicId: indId }, action: 'WRITE' }],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>
-        upsertValeursAvancementBatch({
-          indicateurPublicId: indId,
-          body: {
-            items: [
-              { individu: deptA, date: '2025-03-01', valeur: 1 },
-              { individu: inconnu, date: '2025-03-01', valeur: 2 },
-              { individu: deptOrphelin, date: '2025-03-01', valeur: 3 },
-              { individu: inconnu, date: '2025-04-01', valeur: 4 },
-            ],
-          },
+        upsertValeursAvancementBatch(indId, {
+          items: [
+            { individu: deptLie, date: '2025-03-01', valeur: 1 },
+            { individu: deptInconnu, date: '2025-03-01', valeur: 2 },
+            { individu: deptDansRefNonLie, date: '2025-03-01', valeur: 3 },
+            { individu: deptInconnu, date: '2025-04-01', valeur: 4 },
+          ],
         }),
       )
 
@@ -153,8 +144,8 @@ describe.concurrent('upsertValeursAvancementBatch', () => {
       expect(err.type).toBe('BATCH_INVALID')
       expect(err.errors).toEqual(
         expect.arrayContaining([
-          { code: 'INDIVIDU_INCONNU', individu: inconnu, indices: [1, 3] },
-          { code: 'INDIVIDU_INCONNU', individu: deptOrphelin, indices: [2] },
+          { code: 'INDIVIDU_INCONNU', individu: deptInconnu, indices: [1, 3] },
+          { code: 'INDIVIDU_INCONNU', individu: deptDansRefNonLie, indices: [2] },
         ]),
       )
       expect(err.errors).toHaveLength(2)
@@ -171,7 +162,7 @@ describe.concurrent('upsertValeursAvancementBatch', () => {
       const indId = testIndicateurId()
       const refId = testReferentielId()
       const [deptA, deptB] = testDeptIds(2)
-      const inconnu = `DEPT-YY`
+      const deptInconnu = 'DEPT-YY'
       await fixtures.indicateurReferentiel({
         indicateur: { publicId: indId },
         referentiel: { publicId: refId },
@@ -185,16 +176,13 @@ describe.concurrent('upsertValeursAvancementBatch', () => {
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>
-        upsertValeursAvancementBatch({
-          indicateurPublicId: indId,
-          body: {
-            items: [
-              { individu: deptA, date: '2025-03-01', valeur: 1 },
-              { individu: deptA, date: '2025-03-01', valeur: 2 },
-              { individu: inconnu, date: '2025-04-01', valeur: 3 },
-              { individu: deptB, date: '2025-04-01', valeur: 4 },
-            ],
-          },
+        upsertValeursAvancementBatch(indId, {
+          items: [
+            { individu: deptA, date: '2025-03-01', valeur: 1 },
+            { individu: deptA, date: '2025-03-01', valeur: 2 },
+            { individu: deptInconnu, date: '2025-04-01', valeur: 3 },
+            { individu: deptB, date: '2025-04-01', valeur: 4 },
+          ],
         }),
       )
 
@@ -203,7 +191,7 @@ describe.concurrent('upsertValeursAvancementBatch', () => {
       expect(err.errors).toEqual(
         expect.arrayContaining([
           { code: 'DUPLICATE_KEY', indices: [0, 1], individu: deptA, date: '2025-03-01' },
-          { code: 'INDIVIDU_INCONNU', individu: inconnu, indices: [2] },
+          { code: 'INDIVIDU_INCONNU', individu: deptInconnu, indices: [2] },
         ]),
       )
       expect(err.errors).toHaveLength(2)
@@ -221,9 +209,8 @@ describe.concurrent('upsertValeursAvancementBatch', () => {
 
       await expect(
         runAsPrincipal(apiKey.id, () =>
-          upsertValeursAvancementBatch({
-            indicateurPublicId: indId,
-            body: { items: [{ individu: deptA, date: '2025-03-01', valeur: 1 }] },
+          upsertValeursAvancementBatch(indId, {
+            items: [{ individu: deptA, date: '2025-03-01', valeur: 1 }],
           }),
         ),
       ).rejects.toMatchObject({
@@ -250,9 +237,8 @@ describe.concurrent('upsertValeursAvancementBatch', () => {
 
       await expect(
         runAsPrincipal(apiKey.id, () =>
-          upsertValeursAvancementBatch({
-            indicateurPublicId: indId,
-            body: { items: [{ individu: deptA, date: '2025-03-01', valeur: 1 }] },
+          upsertValeursAvancementBatch(indId, {
+            items: [{ individu: deptA, date: '2025-03-01', valeur: 1 }],
           }),
         ),
       ).rejects.toBeInstanceOf(ForbiddenError)
@@ -290,14 +276,11 @@ describe.concurrent('upsertValeursAvancementBatch', () => {
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>
-        upsertValeursAvancementBatch({
-          indicateurPublicId: indId,
-          body: {
-            items: [
-              { individu: deptA, date: '2025-03-01', valeur: 11 },
-              { individu: deptB, date: '2025-03-01', valeur: 22 },
-            ],
-          },
+        upsertValeursAvancementBatch(indId, {
+          items: [
+            { individu: deptA, date: '2025-03-01', valeur: 11 },
+            { individu: deptB, date: '2025-03-01', valeur: 22 },
+          ],
         }),
       )
 

--- a/apps/mb-api/src/valeurAvancement/commands/upsertValeursAvancementBatch.test.ts
+++ b/apps/mb-api/src/valeurAvancement/commands/upsertValeursAvancementBatch.test.ts
@@ -1,0 +1,313 @@
+import { describe, expect, it } from 'vitest'
+
+import { ForbiddenError } from '@/framework/errors/AppError'
+import { db } from '@/framework/persistence/dbStore'
+import { Prisma } from '@/generated/prisma/client'
+import { upsertValeursAvancementBatch } from '@/valeurAvancement/commands/upsertValeursAvancementBatch'
+import { fixtures } from '@/test/fixtures'
+import { integrationTest } from '@/test/integrationTest'
+import { testDeptIds, testIndicateurId, testReferentielId } from '@/test/randomIds'
+import { runAsPrincipal } from '@/test/runAsPrincipal'
+
+describe.concurrent('upsertValeursAvancementBatch', () => {
+  it(
+    'applique le lot complet en distinguant created/updated',
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const refId = testReferentielId()
+      const [deptA, deptB, deptC] = testDeptIds(3)
+      await fixtures.indicateurReferentiel({
+        indicateur: { publicId: indId },
+        referentiel: { publicId: refId },
+      })
+      await fixtures.individu(
+        { publicId: deptA, referentiel: { publicId: refId } },
+        { publicId: deptB, referentiel: { publicId: refId } },
+        { publicId: deptC, referentiel: { publicId: refId } },
+      )
+      await fixtures.valeurAvancement({
+        indicateur: { publicId: indId },
+        individu: { publicId: deptA, referentiel: { publicId: refId } },
+        date: '2025-03-01',
+        valeur: 1,
+      })
+      const apiKey = await fixtures.apiKey({
+        permissions: [{ indicateur: { publicId: indId }, action: 'WRITE' }],
+      })
+
+      const result = await runAsPrincipal(apiKey.id, () =>
+        upsertValeursAvancementBatch({
+          indicateurPublicId: indId,
+          body: {
+            items: [
+              { individu: deptA, date: '2025-03-01', valeur: 10 },
+              { individu: deptB, date: '2025-03-01', valeur: 20 },
+              { individu: deptC, date: '2025-03-01', valeur: 30 },
+            ],
+          },
+        }),
+      )
+
+      expect(result.isOk()).toBe(true)
+      expect(result._unsafeUnwrap()).toEqual({ total: 3, created: 2, updated: 1 })
+      const rows = await db().valeurAvancement.findMany({
+        where: { indicateur: { publicId: indId } },
+        orderBy: [{ individu: { publicId: 'asc' } }],
+      })
+      expect(rows).toHaveLength(3)
+      const valeurParPublicId = new Map<string, number>()
+      for (const row of rows) {
+        const individu = await db().individu.findUniqueOrThrow({
+          where: { id: row.individuId },
+          select: { publicId: true },
+        })
+        valeurParPublicId.set(individu.publicId, row.valeur.toNumber())
+      }
+      expect(valeurParPublicId.get(deptA)).toBe(10)
+      expect(valeurParPublicId.get(deptB)).toBe(20)
+      expect(valeurParPublicId.get(deptC)).toBe(30)
+    }),
+  )
+
+  it(
+    'détecte les doublons (individu, date) du payload et n\'applique rien',
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const refId = testReferentielId()
+      const [deptA, deptB] = testDeptIds(2)
+      await fixtures.indicateurReferentiel({
+        indicateur: { publicId: indId },
+        referentiel: { publicId: refId },
+      })
+      await fixtures.individu(
+        { publicId: deptA, referentiel: { publicId: refId } },
+        { publicId: deptB, referentiel: { publicId: refId } },
+      )
+      const apiKey = await fixtures.apiKey({
+        permissions: [{ indicateur: { publicId: indId }, action: 'WRITE' }],
+      })
+
+      const result = await runAsPrincipal(apiKey.id, () =>
+        upsertValeursAvancementBatch({
+          indicateurPublicId: indId,
+          body: {
+            items: [
+              { individu: deptA, date: '2025-03-01', valeur: 10 },
+              { individu: deptB, date: '2025-03-01', valeur: 20 },
+              { individu: deptA, date: '2025-03-01', valeur: 99 },
+            ],
+          },
+        }),
+      )
+
+      expect(result.isErr()).toBe(true)
+      const err = result._unsafeUnwrapErr()
+      expect(err.type).toBe('BATCH_INVALID')
+      expect(err.errors).toEqual([
+        { code: 'DUPLICATE_KEY', indices: [0, 2], individu: deptA, date: '2025-03-01' },
+      ])
+      const count = await db().valeurAvancement.count({
+        where: { indicateur: { publicId: indId } },
+      })
+      expect(count).toBe(0)
+    }),
+  )
+
+  it(
+    'remonte INDIVIDU_INCONNU agrégé par individu et n\'applique rien',
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const refId = testReferentielId()
+      const refOrphelin = testReferentielId()
+      const [deptA, deptOrphelin] = testDeptIds(2)
+      const inconnu = `DEPT-XX`
+      await fixtures.indicateurReferentiel({
+        indicateur: { publicId: indId },
+        referentiel: { publicId: refId },
+      })
+      await fixtures.individu({ publicId: deptA, referentiel: { publicId: refId } })
+      await fixtures.individu({
+        publicId: deptOrphelin,
+        referentiel: { publicId: refOrphelin },
+      })
+      const apiKey = await fixtures.apiKey({
+        permissions: [{ indicateur: { publicId: indId }, action: 'WRITE' }],
+      })
+
+      const result = await runAsPrincipal(apiKey.id, () =>
+        upsertValeursAvancementBatch({
+          indicateurPublicId: indId,
+          body: {
+            items: [
+              { individu: deptA, date: '2025-03-01', valeur: 1 },
+              { individu: inconnu, date: '2025-03-01', valeur: 2 },
+              { individu: deptOrphelin, date: '2025-03-01', valeur: 3 },
+              { individu: inconnu, date: '2025-04-01', valeur: 4 },
+            ],
+          },
+        }),
+      )
+
+      expect(result.isErr()).toBe(true)
+      const err = result._unsafeUnwrapErr()
+      expect(err.type).toBe('BATCH_INVALID')
+      expect(err.errors).toEqual(
+        expect.arrayContaining([
+          { code: 'INDIVIDU_INCONNU', individu: inconnu, indices: [1, 3] },
+          { code: 'INDIVIDU_INCONNU', individu: deptOrphelin, indices: [2] },
+        ]),
+      )
+      expect(err.errors).toHaveLength(2)
+      const count = await db().valeurAvancement.count({
+        where: { indicateur: { publicId: indId } },
+      })
+      expect(count).toBe(0)
+    }),
+  )
+
+  it(
+    'agrège plusieurs causes en une seule réponse',
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const refId = testReferentielId()
+      const [deptA, deptB] = testDeptIds(2)
+      const inconnu = `DEPT-YY`
+      await fixtures.indicateurReferentiel({
+        indicateur: { publicId: indId },
+        referentiel: { publicId: refId },
+      })
+      await fixtures.individu(
+        { publicId: deptA, referentiel: { publicId: refId } },
+        { publicId: deptB, referentiel: { publicId: refId } },
+      )
+      const apiKey = await fixtures.apiKey({
+        permissions: [{ indicateur: { publicId: indId }, action: 'WRITE' }],
+      })
+
+      const result = await runAsPrincipal(apiKey.id, () =>
+        upsertValeursAvancementBatch({
+          indicateurPublicId: indId,
+          body: {
+            items: [
+              { individu: deptA, date: '2025-03-01', valeur: 1 },
+              { individu: deptA, date: '2025-03-01', valeur: 2 },
+              { individu: inconnu, date: '2025-04-01', valeur: 3 },
+              { individu: deptB, date: '2025-04-01', valeur: 4 },
+            ],
+          },
+        }),
+      )
+
+      expect(result.isErr()).toBe(true)
+      const err = result._unsafeUnwrapErr()
+      expect(err.errors).toEqual(
+        expect.arrayContaining([
+          { code: 'DUPLICATE_KEY', indices: [0, 1], individu: deptA, date: '2025-03-01' },
+          { code: 'INDIVIDU_INCONNU', individu: inconnu, indices: [2] },
+        ]),
+      )
+      expect(err.errors).toHaveLength(2)
+    }),
+  )
+
+  it(
+    "rejette avec 404 quand l'indicateur n'existe pas",
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const refId = testReferentielId()
+      const [deptA] = testDeptIds(1)
+      await fixtures.individu({ publicId: deptA, referentiel: { publicId: refId } })
+      const apiKey = await fixtures.apiKey()
+
+      await expect(
+        runAsPrincipal(apiKey.id, () =>
+          upsertValeursAvancementBatch({
+            indicateurPublicId: indId,
+            body: { items: [{ individu: deptA, date: '2025-03-01', valeur: 1 }] },
+          }),
+        ),
+      ).rejects.toMatchObject({
+        constructor: Prisma.PrismaClientKnownRequestError,
+        code: 'P2025',
+      })
+    }),
+  )
+
+  it(
+    "rejette avec 403 quand le principal n'a que la permission READ",
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const refId = testReferentielId()
+      const [deptA] = testDeptIds(1)
+      await fixtures.indicateurReferentiel({
+        indicateur: { publicId: indId },
+        referentiel: { publicId: refId },
+      })
+      await fixtures.individu({ publicId: deptA, referentiel: { publicId: refId } })
+      const apiKey = await fixtures.apiKey({
+        permissions: [{ indicateur: { publicId: indId }, action: 'READ' }],
+      })
+
+      await expect(
+        runAsPrincipal(apiKey.id, () =>
+          upsertValeursAvancementBatch({
+            indicateurPublicId: indId,
+            body: { items: [{ individu: deptA, date: '2025-03-01', valeur: 1 }] },
+          }),
+        ),
+      ).rejects.toBeInstanceOf(ForbiddenError)
+    }),
+  )
+
+  it(
+    'remplace plusieurs valeurs existantes en un seul appel (idempotence du rejeu)',
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const refId = testReferentielId()
+      const [deptA, deptB] = testDeptIds(2)
+      await fixtures.indicateurReferentiel({
+        indicateur: { publicId: indId },
+        referentiel: { publicId: refId },
+      })
+      await fixtures.individu(
+        { publicId: deptA, referentiel: { publicId: refId } },
+        { publicId: deptB, referentiel: { publicId: refId } },
+      )
+      await fixtures.valeurAvancement({
+        indicateur: { publicId: indId },
+        individu: { publicId: deptA, referentiel: { publicId: refId } },
+        date: '2025-03-01',
+        valeur: 1,
+      })
+      await fixtures.valeurAvancement({
+        indicateur: { publicId: indId },
+        individu: { publicId: deptB, referentiel: { publicId: refId } },
+        date: '2025-03-01',
+        valeur: 2,
+      })
+      const apiKey = await fixtures.apiKey({
+        permissions: [{ indicateur: { publicId: indId }, action: 'WRITE' }],
+      })
+
+      const result = await runAsPrincipal(apiKey.id, () =>
+        upsertValeursAvancementBatch({
+          indicateurPublicId: indId,
+          body: {
+            items: [
+              { individu: deptA, date: '2025-03-01', valeur: 11 },
+              { individu: deptB, date: '2025-03-01', valeur: 22 },
+            ],
+          },
+        }),
+      )
+
+      expect(result.isOk()).toBe(true)
+      expect(result._unsafeUnwrap()).toEqual({ total: 2, created: 0, updated: 2 })
+      const rows = await db().valeurAvancement.findMany({
+        where: { indicateur: { publicId: indId } },
+      })
+      expect(rows).toHaveLength(2)
+      expect(rows.map((row) => row.valeur.toNumber()).sort()).toEqual([11, 22])
+    }),
+  )
+})

--- a/apps/mb-api/src/valeurAvancement/commands/upsertValeursAvancementBatch.test.ts
+++ b/apps/mb-api/src/valeurAvancement/commands/upsertValeursAvancementBatch.test.ts
@@ -65,7 +65,7 @@ describe.concurrent('upsertValeursAvancementBatch', () => {
   )
 
   it(
-    'détecte les doublons (individu, date) du payload et n\'applique rien',
+    "détecte les doublons (individu, date) du payload et n'applique rien",
     integrationTest(async () => {
       const indId = testIndicateurId()
       const refId = testReferentielId()

--- a/apps/mb-api/src/valeurAvancement/commands/upsertValeursAvancementBatch.ts
+++ b/apps/mb-api/src/valeurAvancement/commands/upsertValeursAvancementBatch.ts
@@ -30,9 +30,12 @@ export const upsertValeursAvancementBatch = (
     ),
   )
 
-// Pipeline de validation hors transaction. On rassemble toutes les erreurs détectées
-// avant de toucher la table : pour préserver la garantie « tout-ou-rien transactionnel »
-// promise au client, on ne veut jamais aborter un INSERT à mi-parcours.
+// Pipeline de validation avant toute écriture en base. En pratique l'appelant
+// enveloppe la commande dans `withTransaction`, donc cette validation s'exécute
+// dans la transaction courante — l'important est qu'elle court-circuite avant
+// le premier INSERT : on rassemble toutes les erreurs détectées pour préserver
+// la garantie « tout-ou-rien transactionnel » promise au client (on ne veut
+// jamais aborter un INSERT à mi-parcours).
 const validateAndResolveIndividus = ({
   indicateurId,
   items,
@@ -191,9 +194,7 @@ const executeBatch = ({
   })
 
   return ResultAsync.fromSafePromise(
-    db().$queryRawTyped(
-      upsertValeursAvancementBatchQuery(indicateurId, { items: sqlItems }),
-    ),
+    db().$queryRawTyped(upsertValeursAvancementBatchQuery(indicateurId, { items: sqlItems })),
   ).map((rows) => {
     const total = rows.length
     const created = rows.reduce((sum, row) => sum + (row.created === true ? 1 : 0), 0)

--- a/apps/mb-api/src/valeurAvancement/commands/upsertValeursAvancementBatch.ts
+++ b/apps/mb-api/src/valeurAvancement/commands/upsertValeursAvancementBatch.ts
@@ -6,13 +6,9 @@ import {
 import { errAsync, okAsync, ResultAsync } from 'neverthrow'
 import { uuidv7 } from 'uuidv7'
 
-import { requireCurrentPrincipalId } from '@/framework/auth/userContext'
 import { db } from '@/framework/persistence/dbStore'
 import { upsertValeursAvancementBatch as upsertValeursAvancementBatchQuery } from '@/generated/prisma/sql'
-import {
-  ensureIndicateurWritePermission,
-  withIndicateurReadPermission,
-} from '@/indicateur/permissions'
+import { resolveIndicateurForWrite } from '@/indicateur/resolveIndicateurForWrite'
 
 export type BatchInvalidError = {
   type: 'BATCH_INVALID'
@@ -21,50 +17,59 @@ export type BatchInvalidError = {
 
 export type UpsertValeursAvancementBatchError = BatchInvalidError
 
-type UpsertValeursAvancementBatchParams = {
-  indicateurPublicId: string
-  body: UpsertValeursAvancementBatchBody
-}
+type BatchItems = UpsertValeursAvancementBatchBody['items']
+type IndividuIdsByPublicId = Map<string, string>
 
-export const upsertValeursAvancementBatch = ({
-  indicateurPublicId,
-  body,
-}: UpsertValeursAvancementBatchParams): ResultAsync<
-  UpsertValeursAvancementBatchResultApiModel,
-  UpsertValeursAvancementBatchError
-> => {
-  const principalId = requireCurrentPrincipalId()
-  return ResultAsync.fromSafePromise(
-    db().indicateur.findFirstOrThrow({
-      where: withIndicateurReadPermission({ publicId: indicateurPublicId }, principalId),
-      select: { id: true, publicId: true },
-    }),
+export const upsertValeursAvancementBatch = (
+  indicateurPublicId: string,
+  { items }: UpsertValeursAvancementBatchBody,
+): ResultAsync<UpsertValeursAvancementBatchResultApiModel, UpsertValeursAvancementBatchError> =>
+  resolveIndicateurForWrite({ indicateurPublicId }).andThen(({ indicateur }) =>
+    validateAndResolveIndividus({ indicateurId: indicateur.id, items }).andThen((individus) =>
+      executeBatch({ indicateurId: indicateur.id, individus, items }),
+    ),
   )
-    .andThen((indicateur) =>
-      ensureIndicateurWritePermission({ indicateurId: indicateur.id, principalId }).map(
-        () => indicateur,
-      ),
-    )
-    .andThen((indicateur) =>
-      validateAndResolveIndividus({ indicateurId: indicateur.id, items: body.items }).andThen(
-        (resolved) => executeBatch({ indicateurId: indicateur.id, resolved, items: body.items }),
-      ),
-    )
-}
 
-type ResolvedIndividus = Map<string, string>
-
-const KEY_SEP = '\u0000'
-
+// Pipeline de validation hors transaction. On rassemble toutes les erreurs détectées
+// avant de toucher la table : pour préserver la garantie « tout-ou-rien transactionnel »
+// promise au client, on ne veut jamais aborter un INSERT à mi-parcours.
 const validateAndResolveIndividus = ({
   indicateurId,
   items,
 }: {
   indicateurId: string
-  items: UpsertValeursAvancementBatchBody['items']
-}): ResultAsync<ResolvedIndividus, BatchInvalidError> => {
-  const errors: BatchInvalidErrorEntryApiModel[] = []
+  items: BatchItems
+}): ResultAsync<IndividuIdsByPublicId, BatchInvalidError> => {
+  const duplicateErrors = detectDuplicateKeys(items)
 
+  return loadIndividusContext({ indicateurId, items }).andThen(
+    ({ individuByPublicId, linkedReferentielIds }) => {
+      const inconnuErrors = detectIndividusInconnus({
+        items,
+        individuByPublicId,
+        linkedReferentielIds,
+      })
+      const errors = [...duplicateErrors, ...inconnuErrors]
+      if (errors.length > 0) {
+        return errAsync<IndividuIdsByPublicId, BatchInvalidError>({
+          type: 'BATCH_INVALID',
+          errors,
+        })
+      }
+      const individuIdsByPublicId: IndividuIdsByPublicId = new Map()
+      for (const [publicId, individu] of individuByPublicId) {
+        individuIdsByPublicId.set(publicId, individu.id)
+      }
+      return okAsync<IndividuIdsByPublicId, BatchInvalidError>(individuIdsByPublicId)
+    },
+  )
+}
+
+// Détecte les couples `(individu, date)` qui apparaissent plus d'une fois dans le payload.
+// Un import « propre » n'a pas de doublon ; on refuse explicitement plutôt que de laisser
+// passer un last-write-wins silencieux qui dépendrait de l'ordre d'apparition.
+const detectDuplicateKeys = (items: BatchItems): BatchInvalidErrorEntryApiModel[] => {
+  const KEY_SEP = '\u0000'
   const indicesByKey = new Map<string, number[]>()
   items.forEach((item, index) => {
     const key = `${item.individu}${KEY_SEP}${item.date}`
@@ -72,13 +77,32 @@ const validateAndResolveIndividus = ({
     if (list) list.push(index)
     else indicesByKey.set(key, [index])
   })
+  const errors: BatchInvalidErrorEntryApiModel[] = []
   for (const [key, indices] of indicesByKey) {
     if (indices.length > 1) {
       const [individu, date] = key.split(KEY_SEP) as [string, string]
       errors.push({ code: 'DUPLICATE_KEY', indices, individu, date })
     }
   }
+  return errors
+}
 
+type IndividuRow = { id: string; publicId: string; referentielId: string }
+
+// Charge en deux requêtes ce qu'il faut pour valider chaque item :
+//  - tous les individus distincts présents dans le payload (par publicId), avec leur referentielId
+//  - parmi leurs référentiels, ceux qui sont effectivement liés à l'indicateur cible.
+// Les deux Map/Set permettent ensuite une vérification O(n) sans round-trip supplémentaire.
+const loadIndividusContext = ({
+  indicateurId,
+  items,
+}: {
+  indicateurId: string
+  items: BatchItems
+}): ResultAsync<
+  { individuByPublicId: Map<string, IndividuRow>; linkedReferentielIds: Set<string> },
+  never
+> => {
   const distinctIndividuPublicIds = Array.from(new Set(items.map((item) => item.individu)))
 
   return ResultAsync.fromSafePromise(
@@ -86,59 +110,77 @@ const validateAndResolveIndividus = ({
       where: { publicId: { in: distinctIndividuPublicIds } },
       select: { id: true, publicId: true, referentielId: true },
     }),
-  )
-    .andThen((individus) => {
-      const byPublicId = new Map(individus.map((individu) => [individu.publicId, individu]))
-      const distinctReferentielIds = Array.from(
-        new Set(individus.map((individu) => individu.referentielId)),
-      )
-      return ResultAsync.fromSafePromise(
-        db().indicateurReferentiel.findMany({
-          where: { indicateurId, referentielId: { in: distinctReferentielIds } },
-          select: { referentielId: true },
-        }),
-      ).map((links) => ({
-        byPublicId,
-        linkedReferentielIds: new Set(links.map((link) => link.referentielId)),
-      }))
-    })
-    .andThen(({ byPublicId, linkedReferentielIds }) => {
-      const indicesByInconnu = new Map<string, number[]>()
-      items.forEach((item, index) => {
-        const individu = byPublicId.get(item.individu)
-        if (!individu || !linkedReferentielIds.has(individu.referentielId)) {
-          const list = indicesByInconnu.get(item.individu)
-          if (list) list.push(index)
-          else indicesByInconnu.set(item.individu, [index])
-        }
-      })
-      for (const [individu, indices] of indicesByInconnu) {
-        errors.push({ code: 'INDIVIDU_INCONNU', individu, indices })
-      }
-
-      if (errors.length > 0) {
-        return errAsync<ResolvedIndividus, BatchInvalidError>({
-          type: 'BATCH_INVALID',
-          errors,
-        })
-      }
-      const resolved: ResolvedIndividus = new Map()
-      for (const [publicId, individu] of byPublicId) resolved.set(publicId, individu.id)
-      return okAsync<ResolvedIndividus, BatchInvalidError>(resolved)
-    })
+  ).andThen((individus) => {
+    const individuByPublicId = new Map(individus.map((individu) => [individu.publicId, individu]))
+    const distinctReferentielIds = Array.from(
+      new Set(individus.map((individu) => individu.referentielId)),
+    )
+    return ResultAsync.fromSafePromise(
+      db().indicateurReferentiel.findMany({
+        where: { indicateurId, referentielId: { in: distinctReferentielIds } },
+        select: { referentielId: true },
+      }),
+    ).map((links) => ({
+      individuByPublicId,
+      linkedReferentielIds: new Set(links.map((link) => link.referentielId)),
+    }))
+  })
 }
 
+// Pour chaque item, l'individu doit (a) exister et (b) appartenir à un référentiel
+// effectivement lié à l'indicateur. Toute violation produit une seule erreur
+// `INDIVIDU_INCONNU` par publicId — agrégée pour pointer toutes les lignes
+// concernées en une seule entrée (DX d'import).
+const detectIndividusInconnus = ({
+  items,
+  individuByPublicId,
+  linkedReferentielIds,
+}: {
+  items: BatchItems
+  individuByPublicId: Map<string, IndividuRow>
+  linkedReferentielIds: Set<string>
+}): BatchInvalidErrorEntryApiModel[] => {
+  const indicesByInconnu = new Map<string, number[]>()
+  items.forEach((item, index) => {
+    const individu = individuByPublicId.get(item.individu)
+    if (!individu || !linkedReferentielIds.has(individu.referentielId)) {
+      const list = indicesByInconnu.get(item.individu)
+      if (list) list.push(index)
+      else indicesByInconnu.set(item.individu, [index])
+    }
+  })
+  const errors: BatchInvalidErrorEntryApiModel[] = []
+  for (const [individu, indices] of indicesByInconnu) {
+    errors.push({ code: 'INDIVIDU_INCONNU', individu, indices })
+  }
+  return errors
+}
+
+// Forme transmise au paramètre `payload.items` de la requête TypedSQL.
+// Doit rester en miroir de `prisma/sql/upsertValeursAvancementBatch.sql` (clés extraites
+// via `input->>'…'`). On passe `valeur` en string pour préserver la précision décimale
+// (numeric(20, 2)) à la traversée du JSON.
+type SqlBatchItem = {
+  id: string
+  individuId: string
+  date: string
+  valeur: string
+}
+
+// Exécute l'upsert atomique en un seul appel TypedSQL. Le `RETURNING (xmax = 0)`
+// indique, ligne par ligne, si l'opération a été un INSERT (true) ou un UPDATE (false).
+// On agrège pour produire les compteurs renvoyés au client.
 const executeBatch = ({
   indicateurId,
-  resolved,
+  individus,
   items,
 }: {
   indicateurId: string
-  resolved: ResolvedIndividus
-  items: UpsertValeursAvancementBatchBody['items']
+  individus: IndividuIdsByPublicId
+  items: BatchItems
 }): ResultAsync<UpsertValeursAvancementBatchResultApiModel, never> => {
-  const sqlItems = items.map((item) => {
-    const individuId = resolved.get(item.individu)
+  const sqlItems: SqlBatchItem[] = items.map((item) => {
+    const individuId = individus.get(item.individu)
     if (!individuId) throw new Error(`Individu non résolu: ${item.individu}`)
     return {
       id: uuidv7(),

--- a/apps/mb-api/src/valeurAvancement/commands/upsertValeursAvancementBatch.ts
+++ b/apps/mb-api/src/valeurAvancement/commands/upsertValeursAvancementBatch.ts
@@ -1,0 +1,160 @@
+import {
+  type BatchInvalidErrorEntryApiModel,
+  type UpsertValeursAvancementBatchBody,
+  type UpsertValeursAvancementBatchResultApiModel,
+} from '@pilote/mb-shared/valeurAvancement'
+import { errAsync, okAsync, ResultAsync } from 'neverthrow'
+import { uuidv7 } from 'uuidv7'
+
+import { requireCurrentPrincipalId } from '@/framework/auth/userContext'
+import { db } from '@/framework/persistence/dbStore'
+import { upsertValeursAvancementBatch as upsertValeursAvancementBatchQuery } from '@/generated/prisma/sql'
+import {
+  ensureIndicateurWritePermission,
+  withIndicateurReadPermission,
+} from '@/indicateur/permissions'
+
+export type BatchInvalidError = {
+  type: 'BATCH_INVALID'
+  errors: BatchInvalidErrorEntryApiModel[]
+}
+
+export type UpsertValeursAvancementBatchError = BatchInvalidError
+
+type UpsertValeursAvancementBatchParams = {
+  indicateurPublicId: string
+  body: UpsertValeursAvancementBatchBody
+}
+
+export const upsertValeursAvancementBatch = ({
+  indicateurPublicId,
+  body,
+}: UpsertValeursAvancementBatchParams): ResultAsync<
+  UpsertValeursAvancementBatchResultApiModel,
+  UpsertValeursAvancementBatchError
+> => {
+  const principalId = requireCurrentPrincipalId()
+  return ResultAsync.fromSafePromise(
+    db().indicateur.findFirstOrThrow({
+      where: withIndicateurReadPermission({ publicId: indicateurPublicId }, principalId),
+      select: { id: true, publicId: true },
+    }),
+  )
+    .andThen((indicateur) =>
+      ensureIndicateurWritePermission({ indicateurId: indicateur.id, principalId }).map(
+        () => indicateur,
+      ),
+    )
+    .andThen((indicateur) =>
+      validateAndResolveIndividus({ indicateurId: indicateur.id, items: body.items }).andThen(
+        (resolved) => executeBatch({ indicateurId: indicateur.id, resolved, items: body.items }),
+      ),
+    )
+}
+
+type ResolvedIndividus = Map<string, string>
+
+const KEY_SEP = '\u0000'
+
+const validateAndResolveIndividus = ({
+  indicateurId,
+  items,
+}: {
+  indicateurId: string
+  items: UpsertValeursAvancementBatchBody['items']
+}): ResultAsync<ResolvedIndividus, BatchInvalidError> => {
+  const errors: BatchInvalidErrorEntryApiModel[] = []
+
+  const indicesByKey = new Map<string, number[]>()
+  items.forEach((item, index) => {
+    const key = `${item.individu}${KEY_SEP}${item.date}`
+    const list = indicesByKey.get(key)
+    if (list) list.push(index)
+    else indicesByKey.set(key, [index])
+  })
+  for (const [key, indices] of indicesByKey) {
+    if (indices.length > 1) {
+      const [individu, date] = key.split(KEY_SEP) as [string, string]
+      errors.push({ code: 'DUPLICATE_KEY', indices, individu, date })
+    }
+  }
+
+  const distinctIndividuPublicIds = Array.from(new Set(items.map((item) => item.individu)))
+
+  return ResultAsync.fromSafePromise(
+    db().individu.findMany({
+      where: { publicId: { in: distinctIndividuPublicIds } },
+      select: { id: true, publicId: true, referentielId: true },
+    }),
+  )
+    .andThen((individus) => {
+      const byPublicId = new Map(individus.map((individu) => [individu.publicId, individu]))
+      const distinctReferentielIds = Array.from(
+        new Set(individus.map((individu) => individu.referentielId)),
+      )
+      return ResultAsync.fromSafePromise(
+        db().indicateurReferentiel.findMany({
+          where: { indicateurId, referentielId: { in: distinctReferentielIds } },
+          select: { referentielId: true },
+        }),
+      ).map((links) => ({
+        byPublicId,
+        linkedReferentielIds: new Set(links.map((link) => link.referentielId)),
+      }))
+    })
+    .andThen(({ byPublicId, linkedReferentielIds }) => {
+      const indicesByInconnu = new Map<string, number[]>()
+      items.forEach((item, index) => {
+        const individu = byPublicId.get(item.individu)
+        if (!individu || !linkedReferentielIds.has(individu.referentielId)) {
+          const list = indicesByInconnu.get(item.individu)
+          if (list) list.push(index)
+          else indicesByInconnu.set(item.individu, [index])
+        }
+      })
+      for (const [individu, indices] of indicesByInconnu) {
+        errors.push({ code: 'INDIVIDU_INCONNU', individu, indices })
+      }
+
+      if (errors.length > 0) {
+        return errAsync<ResolvedIndividus, BatchInvalidError>({
+          type: 'BATCH_INVALID',
+          errors,
+        })
+      }
+      const resolved: ResolvedIndividus = new Map()
+      for (const [publicId, individu] of byPublicId) resolved.set(publicId, individu.id)
+      return okAsync<ResolvedIndividus, BatchInvalidError>(resolved)
+    })
+}
+
+const executeBatch = ({
+  indicateurId,
+  resolved,
+  items,
+}: {
+  indicateurId: string
+  resolved: ResolvedIndividus
+  items: UpsertValeursAvancementBatchBody['items']
+}): ResultAsync<UpsertValeursAvancementBatchResultApiModel, never> => {
+  const sqlItems = items.map((item) => {
+    const individuId = resolved.get(item.individu)
+    if (!individuId) throw new Error(`Individu non résolu: ${item.individu}`)
+    return {
+      id: uuidv7(),
+      individuId,
+      date: item.date,
+      valeur: item.valeur.toString(),
+    }
+  })
+
+  return ResultAsync.fromSafePromise(
+    db().$queryRawTyped(
+      upsertValeursAvancementBatchQuery(indicateurId, { items: sqlItems }),
+    ),
+  ).map((rows) => {
+    const total = rows.length
+    const created = rows.reduce((sum, row) => sum + (row.created === true ? 1 : 0), 0)
+    return { total, created, updated: total - created }
+  })
+}

--- a/apps/mb-api/src/valeurAvancement/routes.ts
+++ b/apps/mb-api/src/valeurAvancement/routes.ts
@@ -180,12 +180,12 @@ const upsertValeursAvancementBatchRoute = createRoute({
   method: 'put',
   path: '/indicateurs/{id}/valeurs:batch',
   tags: ['Indicateur'],
-  summary: "Saisir ou mettre à jour un lot de valeurs pour un indicateur",
+  summary: 'Saisir ou mettre à jour un lot de valeurs pour un indicateur',
   description:
     "Upsert atomique d'un lot de valeurs (1..1000) sur la clé `(indicateur, individu, date)`. " +
-    "Tout-ou-rien : si une seule entrée est invalide (individu inconnu/non lié, doublon `(individu, date)` " +
+    'Tout-ou-rien : si une seule entrée est invalide (individu inconnu/non lié, doublon `(individu, date)` ' +
     'dans le payload), aucune valeur n’est appliquée et la réponse 400 `BATCH_INVALID` liste ' +
-    "exhaustivement les erreurs détectées (agrégées par cause avec leurs `indices` dans `items`).",
+    'exhaustivement les erreurs détectées (agrégées par cause avec leurs `indices` dans `items`).',
   middleware: [requireAuthentication],
   request: {
     params: indicateurParamsSchema,
@@ -202,10 +202,16 @@ const upsertValeursAvancementBatchRoute = createRoute({
       description: 'Lot appliqué. Compteurs `total`, `created`, `updated`.',
     },
     400: {
-      content: { 'application/json': { schema: BatchInvalidErrorApiModelSchema } },
+      content: {
+        'application/json': {
+          schema: z.union([BatchInvalidErrorApiModelSchema, ErrorApiModelSchema]),
+        },
+      },
       description:
-        'Lot invalide. Aucune valeur n’a été appliquée. `details.errors` détaille les causes ' +
-        '(`INVALID_ITEM`, `INDIVIDU_INCONNU`, `DUPLICATE_KEY`) avec leurs `indices` dans `items`.',
+        "Lot invalide. Aucune valeur n'a été appliquée. " +
+        '`BATCH_INVALID` (lot rejeté par la validation métier) — `details.errors` détaille les causes ' +
+        '(`INVALID_ITEM`, `INDIVIDU_INCONNU`, `DUPLICATE_KEY`) avec leurs `indices` dans `items`. ' +
+        '`VALIDATION_ERROR` (payload JSON/schema invalide en amont du handler).',
     },
     403: {
       content: { 'application/json': { schema: ErrorApiModelSchema } },

--- a/apps/mb-api/src/valeurAvancement/routes.ts
+++ b/apps/mb-api/src/valeurAvancement/routes.ts
@@ -382,7 +382,7 @@ valeurAvancementRoutes.openapi(upsertValeursAvancementBatchRoute, async (context
   const body = context.req.valid('json')
 
   const result = await withTransaction(async () =>
-    upsertValeursAvancementBatch({ indicateurPublicId: id, body }),
+    upsertValeursAvancementBatch(id, { items: body.items }),
   )
 
   return result.match(

--- a/apps/mb-api/src/valeurAvancement/routes.ts
+++ b/apps/mb-api/src/valeurAvancement/routes.ts
@@ -3,6 +3,7 @@ import { errorApiModelSchema } from '@pilote/mb-shared/error'
 import { indicateurPublicIdSchema } from '@pilote/mb-shared/publicIds'
 import { createPaginatedApiListSchema } from '@pilote/mb-shared/pagination'
 import {
+  batchInvalidErrorDetailsApiModelSchema,
   deleteValeurAvancementBodySchema,
   individuAvecValeursApiModelSchema,
   listIndividusWithValeursQuerySchema,
@@ -11,6 +12,8 @@ import {
   listValeursRemarquablesForIndicateurQuerySchema,
   syntheseIndividusListApiModelSchema,
   upsertValeurAvancementBodySchema,
+  upsertValeursAvancementBatchBodySchema,
+  upsertValeursAvancementBatchResultApiModelSchema,
   valeurAvancementListApiModelSchema,
   valeurSaisieApiModelSchema,
   valeursRemarquablesListApiModelSchema,
@@ -22,6 +25,7 @@ import { jsonResponseError, jsonResponseOk } from '@/framework/openapi/jsonRespo
 import { withTransaction } from '@/framework/persistence/withTransaction'
 import { deleteValeurAvancement } from '@/valeurAvancement/commands/deleteValeurAvancement'
 import { upsertValeurAvancement } from '@/valeurAvancement/commands/upsertValeurAvancement'
+import { upsertValeursAvancementBatch } from '@/valeurAvancement/commands/upsertValeursAvancementBatch'
 import { listIndividusWithValeurs } from '@/valeurAvancement/queries/listIndividusWithValeurs'
 import { listSyntheseIndividus } from '@/valeurAvancement/queries/listSyntheseIndividus'
 import { listValeursForIndicateur } from '@/valeurAvancement/queries/listValeursForIndicateur'
@@ -37,6 +41,19 @@ const UpsertValeurAvancementBodySchema = upsertValeurAvancementBodySchema.openap
 const DeleteValeurAvancementBodySchema = deleteValeurAvancementBodySchema.openapi(
   'DeleteValeurAvancementBody',
 )
+const UpsertValeursAvancementBatchBodySchema = upsertValeursAvancementBatchBodySchema.openapi(
+  'UpsertValeursAvancementBatchBody',
+)
+const UpsertValeursAvancementBatchResultApiModelSchema =
+  upsertValeursAvancementBatchResultApiModelSchema.openapi(
+    'UpsertValeursAvancementBatchResultApiModel',
+  )
+const BatchInvalidErrorDetailsApiModelSchema = batchInvalidErrorDetailsApiModelSchema.openapi(
+  'BatchInvalidErrorDetailsApiModel',
+)
+const BatchInvalidErrorApiModelSchema = errorApiModelSchema
+  .extend({ details: BatchInvalidErrorDetailsApiModelSchema })
+  .openapi('BatchInvalidErrorApiModel')
 const IndividusWithValeursListApiModelSchema = createPaginatedApiListSchema(
   individuAvecValeursApiModelSchema,
 ).openapi('IndividusWithValeursListApiModel')
@@ -149,6 +166,46 @@ const deleteValeurAvancementRoute = createRoute({
     400: {
       content: { 'application/json': { schema: ErrorApiModelSchema } },
       description: 'Requête invalide (body invalide ou individu inconnu/non autorisé)',
+    },
+    403: {
+      content: { 'application/json': { schema: ErrorApiModelSchema } },
+      description: 'Pas de permission WRITE sur cet indicateur',
+    },
+  },
+})
+
+// --- PUT /indicateurs/:id/valeurs:batch --------------------------------------
+
+const upsertValeursAvancementBatchRoute = createRoute({
+  method: 'put',
+  path: '/indicateurs/{id}/valeurs:batch',
+  tags: ['Indicateur'],
+  summary: "Saisir ou mettre à jour un lot de valeurs pour un indicateur",
+  description:
+    "Upsert atomique d'un lot de valeurs (1..1000) sur la clé `(indicateur, individu, date)`. " +
+    "Tout-ou-rien : si une seule entrée est invalide (individu inconnu/non lié, doublon `(individu, date)` " +
+    'dans le payload), aucune valeur n’est appliquée et la réponse 400 `BATCH_INVALID` liste ' +
+    "exhaustivement les erreurs détectées (agrégées par cause avec leurs `indices` dans `items`).",
+  middleware: [requireAuthentication],
+  request: {
+    params: indicateurParamsSchema,
+    body: {
+      content: { 'application/json': { schema: UpsertValeursAvancementBatchBodySchema } },
+      required: true,
+    },
+  },
+  responses: {
+    200: {
+      content: {
+        'application/json': { schema: UpsertValeursAvancementBatchResultApiModelSchema },
+      },
+      description: 'Lot appliqué. Compteurs `total`, `created`, `updated`.',
+    },
+    400: {
+      content: { 'application/json': { schema: BatchInvalidErrorApiModelSchema } },
+      description:
+        'Lot invalide. Aucune valeur n’a été appliquée. `details.errors` détaille les causes ' +
+        '(`INVALID_ITEM`, `INDIVIDU_INCONNU`, `DUPLICATE_KEY`) avec leurs `indices` dans `items`.',
     },
     403: {
       content: { 'application/json': { schema: ErrorApiModelSchema } },
@@ -315,6 +372,36 @@ valeurAvancementRoutes.openapi(deleteValeurAvancementRoute, async (context) => {
           details: { individu: error.individu },
         },
         schema: ErrorApiModelSchema,
+        status: 400,
+      }),
+  )
+})
+
+valeurAvancementRoutes.openapi(upsertValeursAvancementBatchRoute, async (context) => {
+  const { id } = context.req.valid('param')
+  const body = context.req.valid('json')
+
+  const result = await withTransaction(async () =>
+    upsertValeursAvancementBatch({ indicateurPublicId: id, body }),
+  )
+
+  return result.match(
+    (data) =>
+      jsonResponseOk({
+        context,
+        data,
+        schema: UpsertValeursAvancementBatchResultApiModelSchema,
+        status: 200,
+      }),
+    (error) =>
+      jsonResponseError({
+        context,
+        error: {
+          code: error.type,
+          message: "Aucune valeur n'a été appliquée.",
+          details: { errors: error.errors },
+        },
+        schema: BatchInvalidErrorApiModelSchema,
         status: 400,
       }),
   )

--- a/packages/mb-shared/src/valeurAvancement.ts
+++ b/packages/mb-shared/src/valeurAvancement.ts
@@ -64,6 +64,95 @@ export const deleteValeurAvancementBodySchema = z.object({
 })
 export type DeleteValeurAvancementBody = z.infer<typeof deleteValeurAvancementBodySchema>
 
+export const MAX_VALEURS_PAR_BATCH = 1000
+
+export const upsertValeursAvancementBatchBodySchema = z.object({
+  items: z
+    .array(upsertValeurAvancementBodySchema)
+    .min(1, 'Au moins une entrée est requise')
+    .max(MAX_VALEURS_PAR_BATCH, `Au plus ${MAX_VALEURS_PAR_BATCH} entrées par requête`)
+    .describe(
+      `Entrées à upserter sur l'indicateur (clé unique \`(individu, date)\`). 1..${MAX_VALEURS_PAR_BATCH} entrées.`,
+    ),
+})
+export type UpsertValeursAvancementBatchBody = z.infer<
+  typeof upsertValeursAvancementBatchBodySchema
+>
+
+export const upsertValeursAvancementBatchResultApiModelSchema = z.object({
+  total: z.number().int().nonnegative().describe('Nombre total d’entrées traitées.'),
+  created: z
+    .number()
+    .int()
+    .nonnegative()
+    .describe('Nombre d’entrées nouvellement créées dans la base.'),
+  updated: z
+    .number()
+    .int()
+    .nonnegative()
+    .describe('Nombre d’entrées préexistantes dont la valeur a été remplacée.'),
+})
+export type UpsertValeursAvancementBatchResultApiModel = z.infer<
+  typeof upsertValeursAvancementBatchResultApiModelSchema
+>
+
+export const batchInvalidIssueApiModelSchema = z.object({
+  path: z
+    .string()
+    .describe(
+      "Chemin Zod relatif à l'item (ex. `valeur`, `individu`). Vide si l'erreur porte sur l'item entier.",
+    ),
+  message: z.string().describe('Message Zod en français.'),
+})
+export type BatchInvalidIssueApiModel = z.infer<typeof batchInvalidIssueApiModelSchema>
+
+export const batchInvalidErrorEntryApiModelSchema = z.discriminatedUnion('code', [
+  z.object({
+    code: z.literal('INVALID_ITEM'),
+    indices: z
+      .array(z.number().int().nonnegative())
+      .min(1)
+      .describe("Index (toujours 1 élément pour INVALID_ITEM) de l'item invalide dans `items`."),
+    issues: z
+      .array(batchInvalidIssueApiModelSchema)
+      .min(1)
+      .describe("Liste des problèmes Zod détectés sur l'item."),
+  }),
+  z.object({
+    code: z.literal('INDIVIDU_INCONNU'),
+    indices: z
+      .array(z.number().int().nonnegative())
+      .min(1)
+      .describe(
+        'Tous les index où cet individu apparaît (l’individu est inconnu ou non lié à l’indicateur).',
+      ),
+    individu: individuPublicIdSchema,
+  }),
+  z.object({
+    code: z.literal('DUPLICATE_KEY'),
+    indices: z
+      .array(z.number().int().nonnegative())
+      .min(2)
+      .describe('Les index où le couple `(individu, date)` apparaît (au moins 2).'),
+    individu: individuPublicIdSchema,
+    date: dateSchema,
+  }),
+])
+export type BatchInvalidErrorEntryApiModel = z.infer<typeof batchInvalidErrorEntryApiModelSchema>
+
+export const batchInvalidErrorDetailsApiModelSchema = z.object({
+  errors: z
+    .array(batchInvalidErrorEntryApiModelSchema)
+    .min(1)
+    .describe(
+      'Liste exhaustive des erreurs détectées. Toutes les erreurs sont remontées en une fois ' +
+        '(pas de plafond). Aucune valeur n’a été appliquée.',
+    ),
+})
+export type BatchInvalidErrorDetailsApiModel = z.infer<
+  typeof batchInvalidErrorDetailsApiModelSchema
+>
+
 
 export const listValeursForIndicateurQuerySchema = z
   .object({


### PR DESCRIPTION
## Summary

Nouvel endpoint `PUT /indicateurs/{id}/valeurs:batch` qui upserte jusqu'à 1000 entrées en une seule transaction. Le client obtient un vrai import tout-ou-rien à la place de N appels unitaires.

- **URL/méthode** : `PUT /indicateurs/{id}/valeurs:batch` (scoped à un indicateur, permission WRITE vérifiée une fois).
- **Comportement** : tout-ou-rien strict. Validation pré-transaction des doublons `(individu, date)` dans le payload + résolution des individus (existence + lien au référentiel de l'indicateur). Si une seule entrée est invalide, rien n'est appliqué et la réponse `400 BATCH_INVALID` liste toutes les erreurs en une fois (agrégées par cause avec leurs `indices`).
- **Payload** : `{ items: [{ individu, date, valeur }, ...] }` — 1..1000 entrées.
- **Réponse 200** : `{ total, created, updated }` — le breakdown sort gratuitement du `RETURNING (xmax = 0)` PostgreSQL.
- **Écriture** : un seul appel TypedSQL `INSERT ... ON CONFLICT DO UPDATE`, ce qui évite les N round-trips d'une boucle d'upserts.

Catalogue d'erreurs :
- `INDIVIDU_INCONNU` — individu absent ou pas lié à un référentiel de l'indicateur (agrégé par publicId d'individu).
- `DUPLICATE_KEY` — même couple `(individu, date)` apparaît plusieurs fois.
- (validation Zod du payload : gérée en amont par le framework, mêmes 400 que sur les autres routes.)

## Test plan

- [x] `npx tsc --noEmit` passe.
- [x] `npx eslint src` passe.
- [x] Suite complète mb-api : 253 tests OK.
- [x] Tests d'intégration nouveaux (7) : cas nominal créé/maj, doublon payload, INDIVIDU_INCONNU agrégé, multi-causes agrégées, 404 indicateur inconnu, 403 READ-only, idempotence du rejeu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)