### PR TITLE
fix: ne pas vérifier les habilitations sur les territoires comparés

### DIFF
--- a/apps/pilote-ppg/src/pages/chantier/[id]/[territoireCode].tsx
+++ b/apps/pilote-ppg/src/pages/chantier/[id]/[territoireCode].tsx
@@ -85,10 +85,6 @@ export const getServerSideProps = async (
   );
   const territoireSélectionné =
     await territoireRepository.récupérer(territoireCode);
-  const territoireCodes =
-    territoiresCompares.length > 0
-      ? [...territoiresCompares, territoireCode]
-      : [territoireCode];
 
   try {
     const [
@@ -138,7 +134,13 @@ export const getServerSideProps = async (
         .run(chantierId, session.user!.id),
       getContainer("chantiers")
         .resolve("recupererDetailsIndicateursV2UseCase")
-        .run(chantierId, territoireCodes, session.habilitations, jalon),
+        .run(
+          chantierId,
+          territoireCode,
+          territoiresCompares,
+          session.habilitations,
+          jalon,
+        ),
       getContainer("chantiers")
         .resolve("récupérerStatistiquesAvancementChantiersUseCase")
         .run([chantierId], mailleQuery, session.habilitations, jalon)

--- a/apps/pilote-ppg/src/server/chantiers/usecases/RecupererDetailsIndicateursV2UseCase.ts
+++ b/apps/pilote-ppg/src/server/chantiers/usecases/RecupererDetailsIndicateursV2UseCase.ts
@@ -20,7 +20,8 @@ export class RecupererDetailsIndicateursV2UseCase {
 
   async run(
     chantierId: string,
-    territoireCodes: string[],
+    territoireCode: string,
+    territoiresCompares: string[],
     habilitations: Habilitations,
     jalon: number,
   ) {
@@ -28,12 +29,9 @@ export class RecupererDetailsIndicateursV2UseCase {
       await this.datajobsExecutionQueries.recupererEtatCourant();
     const habilitation = new Habilitation(habilitations);
 
-    territoireCodes.forEach((territoireCode) => {
-      habilitation.vérifierLesHabilitationsEnLecture(
-        chantierId,
-        territoireCode,
-      );
-    });
+    habilitation.vérifierLesHabilitationsEnLecture(chantierId, territoireCode);
+
+    const territoireCodes = [territoireCode, ...territoiresCompares];
 
     // TODO(PVA:JOTA:2025-08-11): Il y a du metier dans le repository à enlever et mettre dans le use case
     const result =


### PR DESCRIPTION
## Problème

Quand un utilisateur accède à une page chantier avec des territoires comparés (`territoiresCompares=DEPT-42`), une erreur 404 était levée si son profil n'avait pas accès à ces territoires. La vérification d'habilitation s'appliquait à tous les territoires passés au use case, y compris les territoires comparés.

## Solution

Modification de la signature de `RecupererDetailsIndicateursV2UseCase.run()` pour distinguer explicitement le territoire principal (soumis à vérification d'habilitation) des territoires comparés (librement accessibles).

- `territoireCode` : territoire principal — habilitation vérifiée
- `territoiresCompares` : territoires de comparaison — non vérifiés

Les deux sont ensuite combinés pour la requête repository.

## Test plan

- [ ] Accéder à une page chantier avec un territoire principal autorisé et des territoires comparés non autorisés → la page s'affiche correctement
- [ ] Accéder à une page chantier avec un territoire principal non autorisé → 404 attendu

🤖 Generated with [Claude Code](https://claude.com/claude-code)