### PR TITLE
feat(taux-progression): calculer et afficher le taux de progression par objectif

### DIFF
--- a/apps/mb-api/docs/architecture/taux-progression.md
+++ b/apps/mb-api/docs/architecture/taux-progression.md
@@ -1,0 +1,192 @@
+# Taux de progression — Specs et plan d'implémentation
+
+## Contexte
+
+Un indicateur peut être associé à des objectifs temporels par individu (`ObjectifIndicateurIndividu`). Cette feature expose un taux de progression calculé comme :
+
+```
+tauxProgression = min(100, (valeur / valeurCible) × 100)
+```
+
+où `valeurCible` est celle de l'objectif applicable à la date de chaque valeur d'avancement.
+
+**V1 — périmètre restreint :**
+- Indicateurs de type saisie uniquement (pas d'agrégation)
+- Pas de troncature de date — on travaille sur les dates brutes des saisies
+- Pas d'héritage d'objectif depuis un parent hiérarchique
+
+---
+
+## Règle métier — Objectif applicable
+
+À la date D d'une valeur d'avancement sur un individu I :
+
+> L'objectif applicable est le **premier objectif de I dont `dateCible` est strictement supérieure à D**.
+> Si D est supérieure ou égale à toutes les `dateCible` connues → **dernier objectif** (le plus grand `dateCible`).
+> Si I n'a aucun objectif → ce point est **exclu** de la réponse.
+
+### Exemple
+
+| Objectif | valeurCible | dateCible  |
+|----------|-------------|------------|
+| 1        | 10          | 2024-01-01 |
+| 2        | 50          | 2025-01-01 |
+| 3        | 60          | 2025-06-01 |
+| 4        | 100         | 2026-02-01 |
+
+| Date de la valeur       | Objectif applicable | valeurCible |
+|-------------------------|---------------------|-------------|
+| D < 2024-01-01          | Objectif 1          | 10          |
+| 2024-01-01 ≤ D < 2025-01-01 | Objectif 2     | 50          |
+| 2025-01-01 ≤ D < 2025-06-01 | Objectif 3     | 60          |
+| 2025-06-01 ≤ D < 2026-02-01 | Objectif 4     | 100         |
+| D ≥ 2026-02-01          | Objectif 4          | 100         |
+
+### Cas limites
+
+| Situation | Comportement |
+|-----------|-------------|
+| `valeurCible = 0` | `tauxProgression = null` |
+| `valeur > valeurCible` | Plafonné à `100` |
+| Individu sans aucun objectif | Exclu des `items` |
+
+---
+
+## API
+
+### Endpoint
+
+```
+GET /indicateurs/:id/taux-progression
+```
+
+### Query params
+
+| Param      | Type         | Requis | Description |
+|------------|--------------|--------|-------------|
+| `individus` | CSV publicId | Oui   | 1..N individus (même convention que `/valeurs`) |
+| `dateDebut` | `YYYY-MM-DD` | Non  | Filtre inclusif sur `date` |
+| `dateFin`   | `YYYY-MM-DD` | Non  | Filtre inclusif sur `date` |
+
+Pas de `dateTrunc` — les dates brutes des saisies sont utilisées.
+
+### Response
+
+**`TauxProgressionListApiModel`** :
+
+```typescript
+{
+  items: Array<{
+    indicateur: string       // publicId de l'indicateur
+    individu: string         // publicId de l'individu
+    date: string             // date brute de la saisie (YYYY-MM-DD)
+    valeur: number           // valeur d'avancement
+    valeurCible: number      // valeurCible de l'objectif applicable
+    dateCible: string        // dateCible de l'objectif applicable
+    tauxProgression: number | null  // min(100, valeur/valeurCible×100), null si valeurCible=0
+  }>
+}
+```
+
+`valeurCible` et `dateCible` sont exposés pour permettre au client de tracer la ligne d'objectif sur un graphique futur et de savoir quand l'objectif change.
+
+**Tri** : par `individu` (publicId asc) puis par `date` asc.
+
+---
+
+## Algorithme de résolution (backend)
+
+L'implémentation suit le pattern établi : **chargement bulk en amont, résolution pure sans I/O**.
+
+```
+1. Charger en bulk toutes les ValeurAvancement pour les individus demandés
+2. Charger en bulk tous les ObjectifIndicateurIndividu pour ces mêmes individus
+3. Grouper les objectifs par individu, triés par dateCible ASC
+4. Pour chaque (individu, valeur) :
+   a. Si l'individu n'a aucun objectif → exclure
+   b. Trouver l'objectif applicable :
+      - Premier objectif avec dateCible > valeur.date (strictement)
+      - Si aucun (D ≥ tous les dateCible) → dernier objectif
+   c. Si valeurCible = 0 → tauxProgression = null
+      Sinon → tauxProgression = Math.min(100, (valeur.valeur / valeurCible) × 100)
+5. Appliquer les filtres dateDebut / dateFin sur valeur.date
+6. Trier par individu publicId asc, puis date asc
+```
+
+### Note d'évolution (V2)
+
+En V2, il faudra gérer :
+- Les **valeurs dérivées** : résoudre d'abord la série agrégée (`resolveSerieIndividu`), puis calculer le taux sur chaque point résultant
+- Les **objectifs dérivés** : utiliser `resolveObjectifIndividu` pour obtenir la `valeurCible` applicable à chaque bucket
+- La **troncature** : comparer les dates post-`dateTrunc` plutôt que les dates brutes
+
+L'architecture bulk + résolution pure facilitera cette extension sans changer le contrat API.
+
+---
+
+## Plan d'implémentation
+
+### Étape 1 — Schema partagé (`mb-shared`)
+
+**Fichier** : `packages/mb-shared/src/tauxProgression.ts` (nouveau)
+
+- Définir `tauxProgressionPointApiModelSchema` (un point de la série)
+- Définir `tauxProgressionListApiModelSchema` (`{ items: [...] }`)
+- Définir `listTauxProgressionQuerySchema` (`individus`, `dateDebut`, `dateFin`)
+- Exporter les types inférés
+
+### Étape 2 — Query de chargement (`mb-api`)
+
+**Fichier** : `apps/mb-api/src/tauxProgression/queries/listTauxProgressionForIndicateur.ts` (nouveau)
+
+- Charger les `ValeurAvancement` en bulk (réutiliser ou s'inspirer de `getValeursForIndicateur`)
+- Charger les `ObjectifIndicateurIndividu` en bulk (réutiliser ou s'inspirer de `listObjectifsForIndicateur`)
+
+### Étape 3 — Résolution pure (`mb-api`)
+
+**Fichier** : `apps/mb-api/src/tauxProgression/resolveTauxProgression.ts` (nouveau)
+
+- Fonction pure `resolveTauxProgression(valeurs, objectifsParIndividu)` → `TauxProgressionPoint[]`
+- Implémenter la recherche d'objectif applicable (`findObjectifApplicable`)
+- Implémenter le calcul du taux avec cap à 100 et gestion de la division par zéro
+- Couvrir par des tests unitaires
+
+### Étape 4 — Route (`mb-api`)
+
+**Fichier** : `apps/mb-api/src/tauxProgression/routes.ts` (nouveau)
+
+- `GET /indicateurs/{id}/taux-progression`
+- Validation Zod des query params via `listTauxProgressionQuerySchema`
+- Vérification des permissions sur l'indicateur (réutiliser `requireIndicateurReadPermission`)
+- Appel query + résolution + retour JSON
+
+**Fichier** : `apps/mb-api/src/app.ts` — enregistrer la nouvelle route
+
+### Étape 5 — Frontend : query (`mb-webapp`)
+
+**Fichier** : `apps/mb-webapp/src/api/indicateurs.ts`
+
+- Ajouter `fetchTauxProgressionForIndicateur(indicateurId, params)`
+
+**Fichier** : `apps/mb-webapp/src/queries/indicateurs.ts`
+
+- Ajouter `indicateurTauxProgressionQueryOptions(indicateurId, individuId)`
+- Ajouter au `prefetchIndicateurValeursForIndividu`
+
+### Étape 6 — Frontend : affichage (`mb-webapp`)
+
+**Fichier** : `apps/mb-webapp/src/components/indicateurs/IndicateurStatsPanel.tsx`
+
+- Consommer `indicateurTauxProgressionQueryOptions`
+- Afficher le **dernier taux de progression** dans une `StatCard`
+- Format : `"87 %"` (entier arrondi, suffixe %)
+- Si aucun point retourné (individu sans objectif) → ne pas afficher la StatCard
+
+---
+
+## Hors scope V1
+
+- Indicateurs dérivés (agrégation)
+- `dateTrunc` / buckets
+- Héritage d'objectif depuis un parent hiérarchique
+- Graphique historique du taux (le query sera prêt côté frontend, l'UI graphique sera ajoutée en V2)

--- a/apps/mb-api/src/app.ts
+++ b/apps/mb-api/src/app.ts
@@ -14,6 +14,7 @@ import { panierRoutes } from '@/panier/routes'
 import { referentielRoutes } from '@/referentiel/routes'
 import { sharedMessage } from '@/shared/routes/sharedMessage'
 import { objectifIndicateurIndividuRoutes } from '@/objectifIndicateurIndividu/routes'
+import { tauxProgressionRoutes } from '@/tauxProgression/routes'
 import { valeurAvancementRoutes } from '@/valeurAvancement/routes'
 
 export const app = new OpenAPIHono()
@@ -35,6 +36,7 @@ app.route('/', sharedMessage)
 app.route('/', indicateurRoutes)
 app.route('/', valeurAvancementRoutes)
 app.route('/', objectifIndicateurIndividuRoutes)
+app.route('/', tauxProgressionRoutes)
 app.route('/', referentielRoutes)
 app.route('/', individuRoutes)
 app.route('/', panierRoutes)

--- a/apps/mb-api/src/tauxProgression/queries/listTauxProgressionForIndicateur.test.ts
+++ b/apps/mb-api/src/tauxProgression/queries/listTauxProgressionForIndicateur.test.ts
@@ -1,0 +1,378 @@
+import { describe, expect, it } from 'vitest'
+
+import { listTauxProgressionForIndicateur } from '@/tauxProgression/queries/listTauxProgressionForIndicateur'
+import { fixtures } from '@/test/fixtures'
+import { integrationTest } from '@/test/integrationTest'
+import { testDeptId, testDeptIds, testIndicateurId, testReferentielId } from '@/test/randomIds'
+import { runAsPrincipal } from '@/test/runAsPrincipal'
+
+describe.concurrent('listTauxProgressionForIndicateur', () => {
+  // ---------------------------------------------------------------------------
+  // Cas de base
+  // ---------------------------------------------------------------------------
+
+  it(
+    'retourne une liste vide quand aucun individu connu',
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const apiKey = await fixtures.apiKey({
+        permissions: [{ indicateur: { publicId: indId }, action: 'READ' }],
+      })
+
+      const result = await runAsPrincipal(apiKey.id, () =>
+        listTauxProgressionForIndicateur(indId, { individus: ['DEPT-INCONNU'] }),
+      )
+
+      expect(result._unsafeUnwrap()).toEqual({ items: [] })
+    }),
+  )
+
+  it(
+    "retourne une liste vide quand l'individu n'a pas d'objectif",
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const refId = testReferentielId()
+      const deptId = testDeptId()
+      await fixtures.valeurAvancement({
+        indicateur: { publicId: indId, nom: 'Test' },
+        individu: { publicId: deptId, referentiel: { publicId: refId } },
+        date: '2024-06-01',
+        valeur: 50,
+      })
+      const apiKey = await fixtures.apiKey({
+        permissions: [{ indicateur: { publicId: indId }, action: 'READ' }],
+      })
+
+      const result = await runAsPrincipal(apiKey.id, () =>
+        listTauxProgressionForIndicateur(indId, { individus: [deptId] }),
+      )
+
+      expect(result._unsafeUnwrap()).toEqual({ items: [] })
+    }),
+  )
+
+  it(
+    'calcule le taux de progression pour une valeur avec un objectif',
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const refId = testReferentielId()
+      const deptId = testDeptId()
+      await fixtures.indicateurReferentiel({
+        indicateur: { publicId: indId },
+        referentiel: { publicId: refId },
+      })
+      await fixtures.valeurAvancement({
+        indicateur: { publicId: indId, nom: 'Test' },
+        individu: { publicId: deptId, referentiel: { publicId: refId } },
+        date: '2024-06-01',
+        valeur: 75,
+      })
+      await fixtures.objectifIndicateurIndividu({
+        indicateur: { publicId: indId },
+        individu: { publicId: deptId },
+        dateCible: '2024-12-31',
+        valeurCible: 100,
+      })
+      const apiKey = await fixtures.apiKey({
+        permissions: [{ indicateur: { publicId: indId }, action: 'READ' }],
+      })
+
+      const result = await runAsPrincipal(apiKey.id, () =>
+        listTauxProgressionForIndicateur(indId, { individus: [deptId] }),
+      )
+
+      expect(result._unsafeUnwrap()).toEqual({
+        items: [
+          {
+            indicateur: indId,
+            individu: deptId,
+            date: '2024-06-01',
+            valeur: 75,
+            valeurCible: 100,
+            dateCible: '2024-12-31',
+            tauxProgression: 75,
+          },
+        ],
+      })
+    }),
+  )
+
+  it(
+    'plafonne le taux à 100 quand la valeur dépasse la cible',
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const refId = testReferentielId()
+      const deptId = testDeptId()
+      await fixtures.indicateurReferentiel({
+        indicateur: { publicId: indId },
+        referentiel: { publicId: refId },
+      })
+      await fixtures.valeurAvancement({
+        indicateur: { publicId: indId, nom: 'Test' },
+        individu: { publicId: deptId, referentiel: { publicId: refId } },
+        date: '2024-06-01',
+        valeur: 150,
+      })
+      await fixtures.objectifIndicateurIndividu({
+        indicateur: { publicId: indId },
+        individu: { publicId: deptId },
+        dateCible: '2024-12-31',
+        valeurCible: 100,
+      })
+      const apiKey = await fixtures.apiKey({
+        permissions: [{ indicateur: { publicId: indId }, action: 'READ' }],
+      })
+
+      const result = await runAsPrincipal(apiKey.id, () =>
+        listTauxProgressionForIndicateur(indId, { individus: [deptId] }),
+      )
+
+      const items = result._unsafeUnwrap().items
+      expect(items).toHaveLength(1)
+      expect(items[0]!.tauxProgression).toBe(100)
+    }),
+  )
+
+  // ---------------------------------------------------------------------------
+  // Sélection de l'objectif applicable
+  // ---------------------------------------------------------------------------
+
+  it(
+    'sélectionne le premier objectif dont la dateCible est après la date de la valeur',
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const refId = testReferentielId()
+      const deptId = testDeptId()
+      await fixtures.indicateurReferentiel({
+        indicateur: { publicId: indId },
+        referentiel: { publicId: refId },
+      })
+      await fixtures.valeurAvancement({
+        indicateur: { publicId: indId, nom: 'Test' },
+        individu: { publicId: deptId, referentiel: { publicId: refId } },
+        date: '2024-06-01',
+        valeur: 40,
+      })
+      // deux objectifs : la valeur est avant le premier → objectif 2024 sélectionné
+      await fixtures.objectifIndicateurIndividu(
+        {
+          indicateur: { publicId: indId },
+          individu: { publicId: deptId },
+          dateCible: '2024-12-31',
+          valeurCible: 50,
+        },
+        {
+          indicateur: { publicId: indId },
+          individu: { publicId: deptId },
+          dateCible: '2025-12-31',
+          valeurCible: 100,
+        },
+      )
+      const apiKey = await fixtures.apiKey({
+        permissions: [{ indicateur: { publicId: indId }, action: 'READ' }],
+      })
+
+      const result = await runAsPrincipal(apiKey.id, () =>
+        listTauxProgressionForIndicateur(indId, { individus: [deptId] }),
+      )
+
+      const items = result._unsafeUnwrap().items
+      expect(items).toHaveLength(1)
+      expect(items[0]).toMatchObject({
+        dateCible: '2024-12-31',
+        valeurCible: 50,
+        tauxProgression: 80,
+      })
+    }),
+  )
+
+  it(
+    'utilise le dernier objectif quand toutes les dateCibles sont dépassées',
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const refId = testReferentielId()
+      const deptId = testDeptId()
+      await fixtures.indicateurReferentiel({
+        indicateur: { publicId: indId },
+        referentiel: { publicId: refId },
+      })
+      // valeur après les deux objectifs → dernier objectif utilisé
+      await fixtures.valeurAvancement({
+        indicateur: { publicId: indId, nom: 'Test' },
+        individu: { publicId: deptId, referentiel: { publicId: refId } },
+        date: '2026-01-01',
+        valeur: 80,
+      })
+      await fixtures.objectifIndicateurIndividu(
+        {
+          indicateur: { publicId: indId },
+          individu: { publicId: deptId },
+          dateCible: '2024-12-31',
+          valeurCible: 50,
+        },
+        {
+          indicateur: { publicId: indId },
+          individu: { publicId: deptId },
+          dateCible: '2025-12-31',
+          valeurCible: 100,
+        },
+      )
+      const apiKey = await fixtures.apiKey({
+        permissions: [{ indicateur: { publicId: indId }, action: 'READ' }],
+      })
+
+      const result = await runAsPrincipal(apiKey.id, () =>
+        listTauxProgressionForIndicateur(indId, { individus: [deptId] }),
+      )
+
+      const items = result._unsafeUnwrap().items
+      expect(items).toHaveLength(1)
+      expect(items[0]).toMatchObject({
+        dateCible: '2025-12-31',
+        valeurCible: 100,
+        tauxProgression: 80,
+      })
+    }),
+  )
+
+  // ---------------------------------------------------------------------------
+  // Filtres de date
+  // ---------------------------------------------------------------------------
+
+  it(
+    'filtre les valeurs par dateDebut et dateFin',
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const refId = testReferentielId()
+      const deptId = testDeptId()
+      await fixtures.indicateurReferentiel({
+        indicateur: { publicId: indId },
+        referentiel: { publicId: refId },
+      })
+      await fixtures.valeurAvancement(
+        {
+          indicateur: { publicId: indId, nom: 'Test' },
+          individu: { publicId: deptId, referentiel: { publicId: refId } },
+          date: '2023-01-01',
+          valeur: 10,
+        },
+        {
+          indicateur: { publicId: indId },
+          individu: { publicId: deptId },
+          date: '2024-06-01',
+          valeur: 60,
+        },
+        {
+          indicateur: { publicId: indId },
+          individu: { publicId: deptId },
+          date: '2025-01-01',
+          valeur: 90,
+        },
+      )
+      await fixtures.objectifIndicateurIndividu({
+        indicateur: { publicId: indId },
+        individu: { publicId: deptId },
+        dateCible: '2025-12-31',
+        valeurCible: 100,
+      })
+      const apiKey = await fixtures.apiKey({
+        permissions: [{ indicateur: { publicId: indId }, action: 'READ' }],
+      })
+
+      const result = await runAsPrincipal(apiKey.id, () =>
+        listTauxProgressionForIndicateur(indId, {
+          individus: [deptId],
+          dateDebut: '2024-01-01',
+          dateFin: '2024-12-31',
+        }),
+      )
+
+      const items = result._unsafeUnwrap().items
+      expect(items).toHaveLength(1)
+      expect(items[0]!.date).toBe('2024-06-01')
+    }),
+  )
+
+  // ---------------------------------------------------------------------------
+  // Multi-individus
+  // ---------------------------------------------------------------------------
+
+  it(
+    'retourne les points pour plusieurs individus triés par individu puis par date',
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const refId = testReferentielId()
+      const [dept1, dept2] = testDeptIds(2)
+      await fixtures.indicateurReferentiel({
+        indicateur: { publicId: indId },
+        referentiel: { publicId: refId },
+      })
+      await fixtures.valeurAvancement(
+        {
+          indicateur: { publicId: indId, nom: 'Test' },
+          individu: { publicId: dept1, referentiel: { publicId: refId } },
+          date: '2024-01-01',
+          valeur: 30,
+        },
+        {
+          indicateur: { publicId: indId },
+          individu: { publicId: dept2, referentiel: { publicId: refId } },
+          date: '2024-01-01',
+          valeur: 60,
+        },
+      )
+      await fixtures.objectifIndicateurIndividu(
+        {
+          indicateur: { publicId: indId },
+          individu: { publicId: dept1 },
+          dateCible: '2024-12-31',
+          valeurCible: 100,
+        },
+        {
+          indicateur: { publicId: indId },
+          individu: { publicId: dept2 },
+          dateCible: '2024-12-31',
+          valeurCible: 100,
+        },
+      )
+      const apiKey = await fixtures.apiKey({
+        permissions: [{ indicateur: { publicId: indId }, action: 'READ' }],
+      })
+
+      const result = await runAsPrincipal(apiKey.id, () =>
+        listTauxProgressionForIndicateur(indId, { individus: [dept1, dept2] }),
+      )
+
+      const items = result._unsafeUnwrap().items
+      expect(items).toHaveLength(2)
+      const individus = items.map((i) => i.individu)
+      expect(individus).toContain(dept1)
+      expect(individus).toContain(dept2)
+      expect(items.find((i) => i.individu === dept1)!.tauxProgression).toBe(30)
+      expect(items.find((i) => i.individu === dept2)!.tauxProgression).toBe(60)
+    }),
+  )
+
+  // ---------------------------------------------------------------------------
+  // Permissions
+  // ---------------------------------------------------------------------------
+
+  it(
+    "lève une erreur quand le principal n'a pas accès à l'indicateur",
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const autreIndId = testIndicateurId()
+      const deptId = testDeptId()
+      // clé sans permission sur indId
+      const apiKey = await fixtures.apiKey({
+        permissions: [{ indicateur: { publicId: autreIndId }, action: 'READ' }],
+      })
+
+      await expect(
+        runAsPrincipal(apiKey.id, () =>
+          listTauxProgressionForIndicateur(indId, { individus: [deptId] }),
+        ),
+      ).rejects.toThrow()
+    }),
+  )
+})

--- a/apps/mb-api/src/tauxProgression/queries/listTauxProgressionForIndicateur.ts
+++ b/apps/mb-api/src/tauxProgression/queries/listTauxProgressionForIndicateur.ts
@@ -1,0 +1,106 @@
+import {
+  type ListTauxProgressionQuery,
+  type TauxProgressionListApiModel,
+  type TauxProgressionPointApiModel,
+} from '@pilote/mb-shared/tauxProgression'
+import { ResultAsync } from 'neverthrow'
+
+import { requireCurrentPrincipalId } from '@/framework/auth/userContext'
+import { db } from '@/framework/persistence/dbStore'
+import { loadIndividusParPublicId } from '@/indicateur/queries/loadIndicateurIndividuContext'
+import { withIndicateurReadPermission } from '@/indicateur/permissions'
+import {
+  type ObjectifBrut,
+  type ValeurBrute,
+  resolveTauxProgression,
+} from '@/tauxProgression/resolveTauxProgression'
+
+export const listTauxProgressionForIndicateur = (
+  indicateurPublicId: string,
+  params: ListTauxProgressionQuery,
+): ResultAsync<TauxProgressionListApiModel, never> => {
+  const principalId = requireCurrentPrincipalId()
+  return ResultAsync.fromSafePromise(
+    db().indicateur.findFirstOrThrow({
+      where: withIndicateurReadPermission({ publicId: indicateurPublicId }, principalId),
+      select: { id: true, publicId: true },
+    }),
+  ).andThen((indicateur) => ResultAsync.fromSafePromise(buildList({ indicateur, params })))
+}
+
+const buildList = async ({
+  indicateur,
+  params,
+}: {
+  indicateur: { id: string; publicId: string }
+  params: ListTauxProgressionQuery
+}): Promise<TauxProgressionListApiModel> => {
+  const individusCibles = await loadIndividusParPublicId(params.individus)
+  if (individusCibles.length === 0) return { items: [] }
+
+  const individuIds = individusCibles.map((i) => i.id)
+
+  const [rawValeurs, rawObjectifs] = await Promise.all([
+    db().valeurAvancement.findMany({
+      where: {
+        indicateurId: indicateur.id,
+        individuId: { in: individuIds },
+        ...(params.dateDebut || params.dateFin
+          ? {
+              date: {
+                ...(params.dateDebut ? { gte: params.dateDebut } : {}),
+                ...(params.dateFin ? { lte: params.dateFin } : {}),
+              },
+            }
+          : {}),
+      },
+      orderBy: [{ individuId: 'asc' }, { date: 'asc' }],
+    }),
+    db().objectifIndicateurIndividu.findMany({
+      where: { indicateurId: indicateur.id, individuId: { in: individuIds } },
+      orderBy: [{ individuId: 'asc' }, { dateCible: 'asc' }],
+    }),
+  ])
+
+  const individuParId = new Map(individusCibles.map((i) => [i.id, i]))
+
+  const valeurs: ValeurBrute[] = rawValeurs.flatMap((v) => {
+    const individu = individuParId.get(v.individuId)
+    if (!individu) return []
+    return [
+      {
+        individuId: v.individuId,
+        individuPublicId: individu.publicId,
+        date: v.date,
+        valeur: v.valeur,
+      },
+    ]
+  })
+
+  const objectifsParIndividu = new Map<string, ObjectifBrut[]>()
+  for (const o of rawObjectifs) {
+    const liste = objectifsParIndividu.get(o.individuId) ?? []
+    liste.push({ dateCible: o.dateCible, valeurCible: o.valeurCible })
+    objectifsParIndividu.set(o.individuId, liste)
+  }
+
+  const points = resolveTauxProgression({ valeurs, objectifsParIndividu })
+
+  points.sort((a, b) =>
+    a.individuPublicId !== b.individuPublicId
+      ? a.individuPublicId.localeCompare(b.individuPublicId)
+      : a.date.localeCompare(b.date),
+  )
+
+  const items: TauxProgressionPointApiModel[] = points.map((p) => ({
+    indicateur: indicateur.publicId,
+    individu: p.individuPublicId,
+    date: p.date,
+    valeur: p.valeur.toNumber(),
+    valeurCible: p.valeurCible.toNumber(),
+    dateCible: p.dateCible,
+    tauxProgression: p.tauxProgression,
+  }))
+
+  return { items }
+}

--- a/apps/mb-api/src/tauxProgression/queries/listTauxProgressionForIndicateur.ts
+++ b/apps/mb-api/src/tauxProgression/queries/listTauxProgressionForIndicateur.ts
@@ -9,11 +9,11 @@ import { requireCurrentPrincipalId } from '@/framework/auth/userContext'
 import { db } from '@/framework/persistence/dbStore'
 import { loadIndividusParPublicId } from '@/indicateur/queries/loadIndicateurIndividuContext'
 import { withIndicateurReadPermission } from '@/indicateur/permissions'
+import { resolveTauxProgression } from '@/tauxProgression/resolveTauxProgression'
 import {
-  type ObjectifBrut,
-  type ValeurBrute,
-  resolveTauxProgression,
-} from '@/tauxProgression/resolveTauxProgression'
+  loadObjectifs,
+  loadValeursAvancement,
+} from '@/tauxProgression/queries/loadTauxProgressionData'
 
 export const listTauxProgressionForIndicateur = (
   indicateurPublicId: string,
@@ -38,51 +38,13 @@ const buildList = async ({
   const individusCibles = await loadIndividusParPublicId(params.individus)
   if (individusCibles.length === 0) return { items: [] }
 
-  const individuIds = individusCibles.map((i) => i.id)
-
-  const [rawValeurs, rawObjectifs] = await Promise.all([
-    db().valeurAvancement.findMany({
-      where: {
-        indicateurId: indicateur.id,
-        individuId: { in: individuIds },
-        ...(params.dateDebut || params.dateFin
-          ? {
-              date: {
-                ...(params.dateDebut ? { gte: params.dateDebut } : {}),
-                ...(params.dateFin ? { lte: params.dateFin } : {}),
-              },
-            }
-          : {}),
-      },
-      orderBy: [{ individuId: 'asc' }, { date: 'asc' }],
-    }),
-    db().objectifIndicateurIndividu.findMany({
-      where: { indicateurId: indicateur.id, individuId: { in: individuIds } },
-      orderBy: [{ individuId: 'asc' }, { dateCible: 'asc' }],
-    }),
+  const [valeurs, objectifsParIndividu] = await Promise.all([
+    loadValeursAvancement(indicateur.id, individusCibles, params),
+    loadObjectifs(
+      indicateur.id,
+      individusCibles.map((i) => i.id),
+    ),
   ])
-
-  const individuParId = new Map(individusCibles.map((i) => [i.id, i]))
-
-  const valeurs: ValeurBrute[] = rawValeurs.flatMap((v) => {
-    const individu = individuParId.get(v.individuId)
-    if (!individu) return []
-    return [
-      {
-        individuId: v.individuId,
-        individuPublicId: individu.publicId,
-        date: v.date,
-        valeur: v.valeur,
-      },
-    ]
-  })
-
-  const objectifsParIndividu = new Map<string, ObjectifBrut[]>()
-  for (const o of rawObjectifs) {
-    const liste = objectifsParIndividu.get(o.individuId) ?? []
-    liste.push({ dateCible: o.dateCible, valeurCible: o.valeurCible })
-    objectifsParIndividu.set(o.individuId, liste)
-  }
 
   const points = resolveTauxProgression({ valeurs, objectifsParIndividu })
 

--- a/apps/mb-api/src/tauxProgression/queries/loadTauxProgressionData.ts
+++ b/apps/mb-api/src/tauxProgression/queries/loadTauxProgressionData.ts
@@ -1,0 +1,67 @@
+import { db } from '@/framework/persistence/dbStore'
+import { type IndividuRef } from '@/valeurAvancement/resolveSerieIndividu'
+import { type ObjectifBrut, type ValeurBrute } from '@/tauxProgression/resolveTauxProgression'
+import { type ListTauxProgressionQuery } from '@pilote/mb-shared/tauxProgression'
+
+// V2 : remplacer le findMany par resolveSerieIndividu(individuId, ctx, cache)
+// après avoir construit un ResolveSerieContext via loadSousArbre + loadFonctionsAgregation.
+// La signature de cette fonction ne changera pas.
+export const loadValeursAvancement = async (
+  indicateurId: string,
+  individusCibles: IndividuRef[],
+  params: ListTauxProgressionQuery,
+): Promise<ValeurBrute[]> => {
+  const individuIds = individusCibles.map((i) => i.id)
+  const individuParId = new Map(individusCibles.map((i) => [i.id, i]))
+
+  const rows = await db().valeurAvancement.findMany({
+    where: {
+      indicateurId,
+      individuId: { in: individuIds },
+      ...(params.dateDebut || params.dateFin
+        ? {
+            date: {
+              ...(params.dateDebut ? { gte: params.dateDebut } : {}),
+              ...(params.dateFin ? { lte: params.dateFin } : {}),
+            },
+          }
+        : {}),
+    },
+    orderBy: [{ individuId: 'asc' }, { date: 'asc' }],
+  })
+
+  return rows.flatMap((v) => {
+    const individu = individuParId.get(v.individuId)
+    if (!individu) return []
+    return [
+      {
+        individuId: v.individuId,
+        individuPublicId: individu.publicId,
+        date: v.date,
+        valeur: v.valeur,
+      },
+    ]
+  })
+}
+
+// V2 : remplacer le findMany par resolveObjectifIndividu(individuId, ctx, cache)
+// après avoir construit un ResolveObjectifContext. Adapter Map<dateCible, PointObjectifInterne>
+// → ObjectifBrut[] via { dateCible, valeurCible: point.valeur }.
+// La signature de cette fonction ne changera pas.
+export const loadObjectifs = async (
+  indicateurId: string,
+  individuIds: string[],
+): Promise<Map<string, ObjectifBrut[]>> => {
+  const rows = await db().objectifIndicateurIndividu.findMany({
+    where: { indicateurId, individuId: { in: individuIds } },
+    orderBy: [{ individuId: 'asc' }, { dateCible: 'asc' }],
+  })
+
+  const objectifsParIndividu = new Map<string, ObjectifBrut[]>()
+  for (const o of rows) {
+    const liste = objectifsParIndividu.get(o.individuId) ?? []
+    liste.push({ dateCible: o.dateCible, valeurCible: o.valeurCible })
+    objectifsParIndividu.set(o.individuId, liste)
+  }
+  return objectifsParIndividu
+}

--- a/apps/mb-api/src/tauxProgression/resolveTauxProgression.ts
+++ b/apps/mb-api/src/tauxProgression/resolveTauxProgression.ts
@@ -1,0 +1,69 @@
+import { Decimal } from '@/framework/decimal'
+
+export type ValeurBrute = {
+  individuId: string
+  individuPublicId: string
+  date: string
+  valeur: Decimal
+}
+
+export type ObjectifBrut = {
+  dateCible: string
+  valeurCible: Decimal
+}
+
+export type TauxProgressionPoint = {
+  individuId: string
+  individuPublicId: string
+  date: string
+  valeur: Decimal
+  valeurCible: Decimal
+  dateCible: string
+  tauxProgression: number | null
+}
+
+// objectifs doit être trié par dateCible ASC
+const findObjectifApplicable = (
+  valeurDate: string,
+  objectifs: ReadonlyArray<ObjectifBrut>,
+): ObjectifBrut | null => {
+  if (objectifs.length === 0) return null
+  return objectifs.find((o) => o.dateCible > valeurDate) ?? objectifs[objectifs.length - 1]!
+}
+
+const computeTaux = (valeur: Decimal, valeurCible: Decimal): number | null => {
+  if (valeurCible.isZero()) return null
+  const taux = valeur.div(valeurCible).mul(100).toNumber()
+  return Math.min(100, taux)
+}
+
+export const resolveTauxProgression = ({
+  valeurs,
+  objectifsParIndividu,
+}: {
+  valeurs: ReadonlyArray<ValeurBrute>
+  // valeurs dans chaque liste triées par dateCible ASC
+  objectifsParIndividu: Map<string, ReadonlyArray<ObjectifBrut>>
+}): TauxProgressionPoint[] => {
+  const points: TauxProgressionPoint[] = []
+
+  for (const valeur of valeurs) {
+    const objectifs = objectifsParIndividu.get(valeur.individuId)
+    if (!objectifs || objectifs.length === 0) continue
+
+    const objectif = findObjectifApplicable(valeur.date, objectifs)
+    if (!objectif) continue
+
+    points.push({
+      individuId: valeur.individuId,
+      individuPublicId: valeur.individuPublicId,
+      date: valeur.date,
+      valeur: valeur.valeur,
+      valeurCible: objectif.valeurCible,
+      dateCible: objectif.dateCible,
+      tauxProgression: computeTaux(valeur.valeur, objectif.valeurCible),
+    })
+  }
+
+  return points
+}

--- a/apps/mb-api/src/tauxProgression/routes.ts
+++ b/apps/mb-api/src/tauxProgression/routes.ts
@@ -1,0 +1,74 @@
+import { createRoute, OpenAPIHono, z } from '@hono/zod-openapi'
+import { errorApiModelSchema } from '@pilote/mb-shared/error'
+import { indicateurPublicIdSchema } from '@pilote/mb-shared/publicIds'
+import {
+  listTauxProgressionQuerySchema,
+  tauxProgressionListApiModelSchema,
+} from '@pilote/mb-shared/tauxProgression'
+
+import { requireAuthentication } from '@/framework/auth/requireAuthentication'
+import { never } from '@/framework/errors/never'
+import { jsonResponseOk } from '@/framework/openapi/jsonResponse'
+import { listTauxProgressionForIndicateur } from '@/tauxProgression/queries/listTauxProgressionForIndicateur'
+
+const TauxProgressionListApiModelSchema = tauxProgressionListApiModelSchema.openapi(
+  'TauxProgressionListApiModel',
+)
+const ErrorApiModelSchema = errorApiModelSchema.openapi('ErrorApiModel')
+
+const indicateurParamsSchema = z.object({
+  id: indicateurPublicIdSchema,
+})
+
+// --- GET /indicateurs/:id/taux-progression -----------------------------------
+
+const getTauxProgressionRoute = createRoute({
+  method: 'get',
+  path: '/indicateurs/{id}/taux-progression',
+  tags: ['Indicateur'],
+  summary: "Lister le taux de progression par valeur d'avancement pour des individus",
+  description:
+    'Retourne, pour chaque saisie des individus demandés, le taux de progression calculé ' +
+    "comme `min(100, valeur / valeurCible × 100)` où `valeurCible` est celle de l'objectif " +
+    "applicable à la date de la saisie. L'objectif applicable est le premier objectif dont " +
+    '`dateCible` est strictement supérieure à la date de la saisie ; si la saisie est ' +
+    'postérieure à tous les objectifs, le dernier objectif connu est retenu. ' +
+    'Les individus sans aucun objectif sont absents de la réponse. ' +
+    'Les dates sont brutes (pas de troncature). ' +
+    'Triés par `(individu publicId asc, date asc)`.',
+  middleware: [requireAuthentication],
+  request: {
+    params: indicateurParamsSchema,
+    query: listTauxProgressionQuerySchema,
+  },
+  responses: {
+    200: {
+      content: { 'application/json': { schema: TauxProgressionListApiModelSchema } },
+      description: 'Taux de progression pour les individus demandés',
+    },
+    400: {
+      content: { 'application/json': { schema: ErrorApiModelSchema } },
+      description: 'Paramètres de requête invalides',
+    },
+  },
+})
+
+// --- App registration --------------------------------------------------------
+
+export const tauxProgressionRoutes = new OpenAPIHono()
+
+tauxProgressionRoutes.openapi(getTauxProgressionRoute, async (context) => {
+  const { id } = context.req.valid('param')
+  const query = context.req.valid('query')
+
+  return listTauxProgressionForIndicateur(id, query).match(
+    (data) =>
+      jsonResponseOk({
+        context,
+        data,
+        schema: TauxProgressionListApiModelSchema,
+        status: 200,
+      }),
+    never,
+  )
+})

--- a/apps/mb-api/tsconfig.json
+++ b/apps/mb-api/tsconfig.json
@@ -23,6 +23,7 @@
       "@/objectifIndicateurIndividu/*": ["./src/objectifIndicateurIndividu/*"],
       "@/widget/*": ["./src/widget/*"],
       "@/panier/*": ["./src/panier/*"],
+      "@/tauxProgression/*": ["./src/tauxProgression/*"],
       "@/shared/*": ["./src/shared/*"],
       "@/generated/*": ["./src/generated/*"],
       "@/test/*": ["./src/test/*"],

--- a/apps/mb-webapp/src/api/indicateurs.ts
+++ b/apps/mb-webapp/src/api/indicateurs.ts
@@ -6,6 +6,11 @@ import {
   type ListIndicateursQuery,
 } from '@pilote/mb-shared/indicateur'
 import {
+  type ListTauxProgressionQuery,
+  type TauxProgressionListApiModel,
+  tauxProgressionListApiModelSchema,
+} from '@pilote/mb-shared/tauxProgression'
+import {
   type IndividusWithValeursListApiModel,
   individusWithValeursListApiModelSchema,
   type ListIndividusWithValeursQuery,
@@ -97,4 +102,20 @@ export const fetchSyntheseIndividus = async (
     })
     .json()
   return syntheseIndividusListApiModelSchema.parse(json)
+}
+
+export const fetchTauxProgressionForIndicateur = async (
+  indicateurId: string,
+  params: ListTauxProgressionQuery,
+): Promise<TauxProgressionListApiModel> => {
+  const json = await apiClient
+    .get(`indicateurs/${indicateurId}/taux-progression`, {
+      searchParams: {
+        individus: params.individus.join(','),
+        ...(params.dateDebut ? { dateDebut: params.dateDebut } : {}),
+        ...(params.dateFin ? { dateFin: params.dateFin } : {}),
+      },
+    })
+    .json()
+  return tauxProgressionListApiModelSchema.parse(json)
 }

--- a/apps/mb-webapp/src/components/indicateurs/IndicateurValeursRemarquables.tsx
+++ b/apps/mb-webapp/src/components/indicateurs/IndicateurValeursRemarquables.tsx
@@ -6,6 +6,7 @@ import { StatGrid } from '@/components/ui/StatGrid'
 import { formatDateFr, formatNumberFr, formatVariationFr } from '@/lib/format'
 import {
   indicateurSyntheseIndividuQueryOptions,
+  indicateurTauxProgressionQueryOptions,
   indicateurValeursQueryOptions,
 } from '@/queries/indicateurs'
 
@@ -37,12 +38,18 @@ export function IndicateurValeursRemarquables({
   const { data: valeurs } = useSuspenseQuery(
     indicateurValeursQueryOptions(indicateurId, individuId),
   )
+  const { data: tauxProgression } = useSuspenseQuery(
+    indicateurTauxProgressionQueryOptions(indicateurId, individuId),
+  )
 
   const derniereValeur = derniereValeurFromItems(valeurs.items)
   const variation = synthese.items[0]?.variation ?? null
 
+  const dernierPoint = tauxProgression.items[tauxProgression.items.length - 1]
+  const hasTaux = dernierPoint !== undefined
+
   return (
-    <StatGrid columns={2}>
+    <StatGrid columns={hasTaux ? 3 : 2}>
       <StatCard
         label="Valeur la plus récente"
         tone={derniereValeur ? 'neutral' : 'muted'}
@@ -54,6 +61,18 @@ export function IndicateurValeursRemarquables({
         tone={variationTone(variation)}
         value={variation === null ? '—' : formatVariationFr(variation)}
       />
+      {hasTaux && (
+        <StatCard
+          label="Taux de progression"
+          tone={dernierPoint.tauxProgression === null ? 'muted' : 'neutral'}
+          value={
+            dernierPoint.tauxProgression === null
+              ? '—'
+              : `${Math.round(dernierPoint.tauxProgression)} %`
+          }
+          caption={`cible : ${formatNumberFr(dernierPoint.valeurCible)} au ${formatDateFr(dernierPoint.dateCible)}`}
+        />
+      )}
     </StatGrid>
   )
 }

--- a/apps/mb-webapp/src/queries/indicateurs.ts
+++ b/apps/mb-webapp/src/queries/indicateurs.ts
@@ -6,6 +6,7 @@ import {
   fetchIndicateurs,
   fetchIndividusForIndicateur,
   fetchSyntheseIndividus,
+  fetchTauxProgressionForIndicateur,
   fetchValeursForIndicateur,
   fetchValeursRemarquablesForIndicateur,
 } from '@/api/indicateurs'
@@ -85,6 +86,13 @@ export const indicateurSyntheseIndividuQueryOptions = (indicateurId: string, ind
     staleTime: DEFAULT_STALE_TIME,
   })
 
+export const indicateurTauxProgressionQueryOptions = (indicateurId: string, individuId: string) =>
+  queryOptions({
+    queryKey: ['indicateur', indicateurId, 'taux-progression', individuId],
+    queryFn: () => fetchTauxProgressionForIndicateur(indicateurId, { individus: [individuId] }),
+    staleTime: DEFAULT_STALE_TIME,
+  })
+
 export const prefetchIndicateurValeursForIndividu = async ({
   queryClient,
   indicateurId,
@@ -100,5 +108,6 @@ export const prefetchIndicateurValeursForIndividu = async ({
     queryClient.fetchQuery(indicateurValeursQueryOptions(indicateurId, individuId)),
     queryClient.fetchQuery(indicateurValeursRemarquablesQueryOptions(indicateurId, referentielId)),
     queryClient.fetchQuery(indicateurSyntheseIndividuQueryOptions(indicateurId, individuId)),
+    queryClient.fetchQuery(indicateurTauxProgressionQueryOptions(indicateurId, individuId)),
   ])
 }

--- a/packages/mb-shared/package.json
+++ b/packages/mb-shared/package.json
@@ -55,6 +55,10 @@
     "./panier": {
       "types": "./src/panier.ts",
       "default": "./src/panier.ts"
+    },
+    "./tauxProgression": {
+      "types": "./src/tauxProgression.ts",
+      "default": "./src/tauxProgression.ts"
     }
   },
   "files": [

--- a/packages/mb-shared/src/tauxProgression.ts
+++ b/packages/mb-shared/src/tauxProgression.ts
@@ -1,0 +1,51 @@
+import { z } from 'zod'
+
+import { dateSchema } from './dates'
+import { indicateurPublicIdSchema } from './publicIds'
+import { individuPublicIdSchema } from './individu'
+import { individusCsvSchema, MAX_INDIVIDUS_PAR_REQUETE } from './individusCsv'
+
+export const listTauxProgressionQuerySchema = z
+  .object({
+    individus: individusCsvSchema.describe(
+      `Liste d'identifiants d'individus séparés par une virgule (ex. DEPT-84,DEPT-13). 1..${MAX_INDIVIDUS_PAR_REQUETE} identifiants.`,
+    ),
+    dateDebut: dateSchema.optional().describe(
+      'Date ISO YYYY-MM-DD inclusive (filtre les points dont la date de saisie est >= dateDebut).',
+    ),
+    dateFin: dateSchema.optional().describe(
+      'Date ISO YYYY-MM-DD inclusive (filtre les points dont la date de saisie est <= dateFin).',
+    ),
+  })
+  .refine(
+    (value) => !value.dateDebut || !value.dateFin || value.dateDebut <= value.dateFin,
+    { message: 'dateDebut doit être <= dateFin', path: ['dateDebut'] },
+  )
+export type ListTauxProgressionQuery = z.infer<typeof listTauxProgressionQuerySchema>
+
+export const tauxProgressionPointApiModelSchema = z.object({
+  indicateur: indicateurPublicIdSchema,
+  individu: individuPublicIdSchema,
+  date: dateSchema.describe('Date brute de la saisie (YYYY-MM-DD), sans troncature.'),
+  valeur: z.number().describe("Valeur d'avancement à cette date."),
+  valeurCible: z.number().describe("Valeur cible de l'objectif applicable à cette date."),
+  dateCible: dateSchema.describe("Date cible de l'objectif applicable."),
+  tauxProgression: z
+    .number()
+    .nullable()
+    .describe(
+      'Taux de progression en pourcentage : min(100, valeur / valeurCible × 100). ' +
+        'null si valeurCible vaut 0.',
+    ),
+})
+export type TauxProgressionPointApiModel = z.infer<typeof tauxProgressionPointApiModelSchema>
+
+export const tauxProgressionListApiModelSchema = z.object({
+  items: z
+    .array(tauxProgressionPointApiModelSchema)
+    .describe(
+      "Un point par saisie des individus demandés ayant au moins un objectif. " +
+        "Les individus sans objectif sont absents. Triés par individu (publicId asc) puis par date asc.",
+    ),
+})
+export type TauxProgressionListApiModel = z.infer<typeof tauxProgressionListApiModelSchema>


### PR DESCRIPTION
## Summary

- Ajout d'un endpoint `mb-api` pour calculer le taux de progression d'un indicateur par rapport à ses objectifs
- Affichage du taux de progression dans le composant `IndicateurValeursRemarquables` côté `mb-webapp`
- Extraction des loaders de données dans un module dédié et ajout de tests d'intégration

## Test plan

- [ ] Vérifier que l'endpoint `/taux-progression/:indicateurId` retourne les bonnes valeurs
- [ ] Vérifier l'affichage du taux dans la page indicateur
- [ ] Lancer les tests d'intégration : `listTauxProgressionForIndicateur.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)