### PR TITLE
feat(albert): accès aux données quantitatives de tous les territoires

### DIFF
--- a/apps/pilote-ppg/src/app/api/albert/chat/route.ts
+++ b/apps/pilote-ppg/src/app/api/albert/chat/route.ts
@@ -77,9 +77,7 @@ export async function POST(request: Request) {
       territoiresAccessibles,
       chantiersAccessibles: session.habilitations.lecture.chantiers,
     });
-    const getChantierIndicateurs = createGetChantierIndicateursTool({
-      territoiresAccessibles,
-    });
+    const getChantierIndicateurs = createGetChantierIndicateursTool();
     const getChantierCommentaires = createGetChantierCommentairesTool({
       territoiresAccessibles,
     });

--- a/apps/pilote-ppg/src/server/albert/systemPrompt.ts
+++ b/apps/pilote-ppg/src/server/albert/systemPrompt.ts
@@ -338,7 +338,14 @@ Un chantier ne peut apparaître que dans l'une de ces deux catégories. Les flag
 ${agentContextSection}${consigneSousTerritoires}
 # Territoires accessibles
 
-Tu as accès aux territoires suivants pour l'utilisateur actuel :
+Les territoires sont divisés en deux niveaux d'accès :
+
+- **Territoires avec accès complet** (liste ci-dessous) : données quantitatives ET qualitatives disponibles (taux d'avancement, météo, tendance, écart, commentaires, synthèse).
+- **Tous les autres territoires** : données quantitatives uniquement (taux d'avancement, météo). Les champs tendance, écart, commentaires et synthèse (commentaire) sont masqués par restriction d'accès — et non absents.
+
+**Tu peux interroger n'importe quel territoire via les outils.** La restriction est appliquée automatiquement dans les résultats — tu n'as pas à la gérer en amont.
+
+Territoires avec accès complet pour l'utilisateur actuel :
 ${territoiresList}
 
 # Comprendre les demandes utilisateur
@@ -441,7 +448,7 @@ Une question de suivi qui élargit ou modifie le périmètre nécessite un **nou
 Écris toujours ton court message textuel d'accompagnement AVANT l'appel, **PUIS** invoque display_choices via le mécanisme d'appel d'outil. Ne tape JAMAIS \`display_choices(\` ni aucune syntaxe de tool call dans ton texte : ce serait un bug visible pour l'utilisateur (cf. règle critique du protocole d'outils).
 
 ## Gestion des erreurs
-- Si un territoire demandé est inaccessible, explique à l'utilisateur qu'il n'a pas accès à ce territoire
+- **Ne refuse jamais une demande au motif qu'un territoire n'est pas dans ta liste de territoires accessibles.** Tous les territoires peuvent être interrogés via les outils — les restrictions d'accès sont appliquées automatiquement côté données (voir section "Territoires accessibles"). Appelle toujours les outils et laisse-les retourner ce qui est disponible.
 - Si l'utilisateur mentionne un territoire par nom mais que tu ne peux pas en déduire le code de manière fiable, demande-lui de préciser le code (REG-XX ou DEPT-XX)
 - Si aucun résultat n'est disponible pour un jalon, indique que les données ne sont pas disponibles pour cette année
 

--- a/apps/pilote-ppg/src/server/albert/tools/getChantierIndicateurs.ts
+++ b/apps/pilote-ppg/src/server/albert/tools/getChantierIndicateurs.ts
@@ -29,7 +29,7 @@ export function createGetChantierIndicateursTool({
 }: {
   getChantierIndicateursQuery: GetChantierIndicateursQuery;
 }) {
-  return ({ territoiresAccessibles }: { territoiresAccessibles: string[] }) => {
+  return () => {
     return tool({
       description: `Récupère les valeurs des indicateurs de suivi (VI, VA, VC, TA) d'un chantier sur un territoire donné.
 
@@ -41,12 +41,6 @@ Utilise cet outil UNIQUEMENT quand l'utilisateur demande explicitement :
 - Pour alimenter un export de rapport (étape indicateurs)`,
       inputSchema: getChantierIndicateursInputSchema,
       execute: async (input): Promise<GetChantierIndicateursOutput> => {
-        if (!territoiresAccessibles.includes(input.territoire_code)) {
-          throw new Error(
-            `Accès non autorisé au territoire ${input.territoire_code}`,
-          );
-        }
-
         const result = await getChantierIndicateursQuery.execute({
           territoireCode: input.territoire_code,
           chantierId: input.chantier_id,

--- a/apps/pilote-ppg/src/server/albert/tools/getChantiers.ts
+++ b/apps/pilote-ppg/src/server/albert/tools/getChantiers.ts
@@ -62,20 +62,37 @@ export type GetChantiersOutput = {
 const NON_APPLICABLE_EN_RETARD_NAT_FR =
   "L'analyse des chantiers en retard ne peut pas être réalisée au niveau national.\n\nEn effet, cet indicateur repose sur une comparaison entre le taux d'avancement d'un chantier pour un territoire donné et la valeur médiane observée sur l'ensemble des autres territoires.";
 
-function getOutputInstructions(input: GetChantiersInput): string {
+function getOutputInstructions(
+  input: GetChantiersInput,
+  resultats: GetChantiersResult[],
+  territoiresAccessibles: string[],
+): string {
+  let base: string;
+
   if (input.view === "en_retard") {
-    return "Pour chaque chantier en retard, indique l'écart par rapport à la médiane (en points) et la météo de la synthèse si disponible.";
+    base =
+      "Pour chaque chantier en retard, indique l'écart par rapport à la médiane (en points) et la météo de la synthèse si disponible.";
+  } else if (input.view === "en_difficulte") {
+    base =
+      "Pour chaque chantier en difficulté, indique la météo avec son libellé utilisateur (Objectifs compromis, Appuis nécessaires), sans afficher les codes internes.";
+  } else if (input.chantier_ids && input.chantier_ids.length > 0) {
+    base =
+      "Présente les données détaillées de chaque chantier demandé : taux d'avancement, écart, météo, tendance, et synthèse si disponible.";
+  } else {
+    base =
+      "Présente la liste des chantiers correspondant aux critères avec leurs données clés (taux d'avancement, météo, tendance).";
   }
 
-  if (input.view === "en_difficulte") {
-    return "Pour chaque chantier en difficulté, indique la météo avec son libellé utilisateur (Objectifs compromis, Appuis nécessaires), sans afficher les codes internes.";
-  }
+  const codesRestreints = resultats
+    .map((r) => r.territoire_code)
+    .filter((code) => !territoiresAccessibles.includes(code));
 
-  if (input.chantier_ids && input.chantier_ids.length > 0) {
-    return "Présente les données détaillées de chaque chantier demandé : taux d'avancement, écart, météo, tendance, et synthèse si disponible.";
-  }
+  if (codesRestreints.length === 0) return base;
 
-  return "Présente la liste des chantiers correspondant aux critères avec leurs données clés (taux d'avancement, météo, tendance).";
+  return (
+    base +
+    `\n\nRestriction d'accès : pour les territoires ${codesRestreints.join(", ")}, seuls le taux d'avancement et la météo sont disponibles. Les champs tendance, écart, synthèse (commentaire) et commentaires sont null par restriction d'accès — et non par absence de données. Indique-le clairement à l'utilisateur si ces champs sont demandés.`
+  );
 }
 
 function toQueryParams(
@@ -206,7 +223,11 @@ plusieurs territoires parents sont comparés, fais un appel par parent et par ja
             resultats,
             territoiresAccessibles,
           ),
-          _output_instructions: getOutputInstructions(input),
+          _output_instructions: getOutputInstructions(
+            input,
+            resultats,
+            territoiresAccessibles,
+          ),
         };
       },
     });

--- a/apps/pilote-ppg/src/server/albert/tools/getChantiers.ts
+++ b/apps/pilote-ppg/src/server/albert/tools/getChantiers.ts
@@ -92,6 +92,36 @@ function toQueryParams(
   };
 }
 
+function masquerDonneesNonAccessibles(
+  resultats: GetChantiersResult[],
+  territoiresAccessibles: string[],
+): GetChantiersResult[] {
+  return resultats.map((resultat) => {
+    if (territoiresAccessibles.includes(resultat.territoire_code)) {
+      return resultat;
+    }
+    return {
+      ...resultat,
+      chantiers: resultat.chantiers.map((chantier) => ({
+        ...chantier,
+        tendance: null,
+        ecart: null,
+        est_en_retard: false,
+        est_en_difficulte: false,
+        synthese: chantier.synthese
+          ? {
+              meteo: chantier.synthese.meteo,
+              commentaire: null,
+              date_meteo: chantier.synthese.date_meteo,
+              date_commentaire: null,
+            }
+          : null,
+        commentaires: { donnees: null, autresResultats: null },
+      })),
+    };
+  });
+}
+
 export function createGetChantiersTool({
   getChantiersQuery,
   territoireResolver,
@@ -128,12 +158,6 @@ par jalon (avec include_sous_territoires=true), pas un appel par (sous-territoir
 plusieurs territoires parents sont comparés, fais un appel par parent et par jalon.`,
       inputSchema: getChantiersInputSchema,
       execute: async (input): Promise<GetChantiersOutput> => {
-        if (!territoiresAccessibles.includes(input.territoire_code)) {
-          throw new Error(
-            `Accès non autorisé au territoire ${input.territoire_code}`,
-          );
-        }
-
         if (
           input.territoire_code === "NAT-FR" &&
           input.view === "en_retard" &&
@@ -170,18 +194,18 @@ plusieurs territoires parents sont comparés, fais un appel par parent et par ja
           input.territoire_code,
           input.include_sous_territoires,
         );
-        const codesAccessibles = codes.filter((code) =>
-          territoiresAccessibles.includes(code),
-        );
 
         const resultats = await Promise.all(
-          codesAccessibles.map((code) =>
+          codes.map((code) =>
             getChantiersQuery.execute(toQueryParams(effectiveInput, code)),
           ),
         );
 
         return {
-          resultats,
+          resultats: masquerDonneesNonAccessibles(
+            resultats,
+            territoiresAccessibles,
+          ),
           _output_instructions: getOutputInstructions(input),
         };
       },

--- a/apps/pilote-ppg/src/server/albert/tools/getChantiers.ts
+++ b/apps/pilote-ppg/src/server/albert/tools/getChantiers.ts
@@ -90,8 +90,8 @@ function getOutputInstructions(
   if (codesRestreints.length === 0) return base;
 
   return (
-    base +
-    `\n\nRestriction d'accès : pour les territoires ${codesRestreints.join(", ")}, seuls le taux d'avancement et la météo sont disponibles. Les champs tendance, écart, synthèse (commentaire) et commentaires sont null par restriction d'accès — et non par absence de données. Indique-le clairement à l'utilisateur si ces champs sont demandés.`
+    `⚠️ Restriction d'accès — territoires ${codesRestreints.join(", ")} : seuls le taux d'avancement et la météo sont disponibles. Les champs tendance, écart, synthèse (commentaire) sont null par restriction d'accès, et non par absence de données. Tu DOIS le mentionner explicitement dans ta réponse quand ces champs sont retournés.\n\n` +
+    base
   );
 }
 

--- a/apps/pilote-ppg/src/server/albert/tools/getTauxAvancementTerritoire.ts
+++ b/apps/pilote-ppg/src/server/albert/tools/getTauxAvancementTerritoire.ts
@@ -78,18 +78,9 @@ Utilise cet outil quand l'utilisateur demande :
 - Une vue d'ensemble rapide d'un territoire`,
       inputSchema: getTauxAvancementTerritoireInputSchema,
       execute: async (input): Promise<GetTauxAvancementTerritoireOutput> => {
-        if (!territoiresAccessibles.includes(input.territoire_code)) {
-          throw new Error(
-            `Accès non autorisé au territoire ${input.territoire_code}`,
-          );
-        }
-
         const codes = await territoireResolver.resoudre(
           input.territoire_code,
           input.include_sous_territoires,
-        );
-        const codesAccessibles = codes.filter((code) =>
-          territoiresAccessibles.includes(code),
         );
 
         const db = prisma.getInstance();
@@ -114,7 +105,7 @@ Utilise cet outil quand l'utilisateur demande :
           input.jalon,
         );
 
-        const mailles = new Set(codesAccessibles.map(determineMaille));
+        const mailles = new Set(codes.map(determineMaille));
         const statsByMaille = new Map<Maille, number | null>();
 
         for (const maille of mailles) {
@@ -137,21 +128,28 @@ Utilise cet outil quand l'utilisateur demande :
           }
         }
 
-        const resultats = codesAccessibles.map((code) => {
+        const resultats = codes.map((code) => {
           const maille = determineMaille(code);
           const territoireData = agregat[maille]?.territoires[code];
+          const estAccessible = territoiresAccessibles.includes(code);
 
           const taux_avancement_global =
             territoireData?.repartition.avancements.annuel.moyenne ?? null;
 
-          const mediane_repartition = statsByMaille.get(maille) ?? null;
+          const mediane_repartition = estAccessible
+            ? (statsByMaille.get(maille) ?? null)
+            : null;
 
           let position_mediane:
             | "EN_RETARD"
             | "EN_AVANCE"
             | "DANS_LA_MEDIANE"
             | null = null;
-          if (taux_avancement_global !== null && mediane_repartition !== null) {
+          if (
+            estAccessible &&
+            taux_avancement_global !== null &&
+            mediane_repartition !== null
+          ) {
             const ecart = taux_avancement_global - mediane_repartition;
             if (ecart <= -10) {
               position_mediane = "EN_RETARD";

--- a/apps/pilote-ppg/src/server/albert/tools/getTauxAvancementTerritoire.ts
+++ b/apps/pilote-ppg/src/server/albert/tools/getTauxAvancementTerritoire.ts
@@ -49,7 +49,14 @@ export type GetTauxAvancementTerritoireOutput = {
   _output_instructions: string;
 };
 
-const OUTPUT_INSTRUCTIONS = `Présente le TA, la médiane et la position pour chaque territoire. Un seul territoire → paragraphe factuel. Plusieurs territoires → tableau comparatif.`;
+function getOutputInstructions(codesRestreints: string[]): string {
+  const base = `Présente le TA, la médiane et la position pour chaque territoire. Un seul territoire → paragraphe factuel. Plusieurs territoires → tableau comparatif.`;
+  if (codesRestreints.length === 0) return base;
+  return (
+    `⚠️ Restriction d'accès — territoires ${codesRestreints.join(", ")} : seuls le taux d'avancement est disponible. La médiane et la position par rapport à la médiane sont null par restriction d'accès, et non par absence de données. Tu DOIS le mentionner explicitement dans ta réponse.\n\n` +
+    base
+  );
+}
 
 export function createGetTauxAvancementTerritoireTool({
   prisma,
@@ -128,10 +135,14 @@ Utilise cet outil quand l'utilisateur demande :
           }
         }
 
+        const codesRestreints: string[] = [];
+
         const resultats = codes.map((code) => {
           const maille = determineMaille(code);
           const territoireData = agregat[maille]?.territoires[code];
           const estAccessible = territoiresAccessibles.includes(code);
+
+          if (!estAccessible) codesRestreints.push(code);
 
           const taux_avancement_global =
             territoireData?.repartition.avancements.annuel.moyenne ?? null;
@@ -171,7 +182,7 @@ Utilise cet outil quand l'utilisateur demande :
 
         return {
           resultats,
-          _output_instructions: OUTPUT_INSTRUCTIONS,
+          _output_instructions: getOutputInstructions(codesRestreints),
         };
       },
     });


### PR DESCRIPTION
## Contexte

Dans Pilote PPG, les utilisateurs ont accès aux données quantitatives de tous les territoires, mais uniquement aux commentaires de leurs propres territoires. Les outils Albert ne reflétaient pas cette règle — ils bloquaient complètement l'accès aux territoires hors habilitation.

## Changements

### Outils : accès étendu avec masquage sélectif

#### `getChantiers`
- Suppression du check d'accès territoire en entrée
- Tous les territoires résolus sont interrogés (plus de filtre `codesAccessibles`)
- Post-processing : pour les territoires non accessibles, masquage de `tendance`, `ecart`, `est_en_retard`, `est_en_difficulte`, `synthese.commentaire` et `commentaires` — `meteo`, `taux_avancement` et `synthese.meteo` restent visibles

#### `getTauxAvancementTerritoire`
- Suppression du check d'accès territoire en entrée
- Tous les territoires résolus sont interrogés
- Pour les territoires non accessibles : `taux_avancement_global` retourné, `mediane_repartition` et `position_mediane` masqués

#### `getChantierIndicateurs`
- Suppression du check d'accès territoire (tous les champs sont quantitatifs)
- Suppression du paramètre `territoiresAccessibles` devenu inutile

### Prompt : comportement explicite sur les accès restreints

- **System prompt** : distingue les deux niveaux d'accès (complet vs quantitatif uniquement) et interdit explicitement à Albert de refuser une demande avant d'avoir appelé les outils
- **`output_instructions` dynamiques** dans `getChantiers` et `getTauxAvancementTerritoire` : lorsqu'un territoire à accès restreint est présent dans les résultats, un avertissement ⚠️ est injecté avec l'obligation de le mentionner à l'utilisateur

## Test plan
- [ ] Vérifier qu'un utilisateur avec accès à REG-11 peut interroger REG-01 et obtient `taux_avancement` et `meteo` mais pas les commentaires ni l'écart
- [ ] Vérifier que les commentaires et synthèses sont bien visibles sur les territoires accessibles
- [ ] Vérifier que `get_indicateurs` fonctionne sur un territoire non accessible et retourne les valeurs VI/VA/VC
- [ ] Vérifier qu'Albert mentionne l'avertissement ⚠️ à l'utilisateur quand un territoire à accès restreint apparaît dans les résultats
- [ ] Vérifier qu'Albert ne refuse pas de requêter un territoire hors habilitation avant d'avoir appelé les outils

🤖 Generated with [Claude Code](https://claude.com/claude-code)