### PR TITLE
feat(llm): bandeau d'information données persos sous le chat (PIL-1556)

### DIFF
--- a/apps/pilote-ppg/src/client/components/PageAccueil/BoutonSyntheseTerritoire.tsx
+++ b/apps/pilote-ppg/src/client/components/PageAccueil/BoutonSyntheseTerritoire.tsx
@@ -89,6 +89,7 @@ export const BoutonSyntheseTerritoire = ({
                   className="h-full"
                   placeholder="Posez une question sur ce territoire..."
                   scenarios={scenarios}
+                  showExperimentationBanner
                   agentContext={{
                     jalon,
                     territoireCode,

--- a/apps/pilote-ppg/src/client/components/_commons/ChatUI/ChatExperimentationBanner.tsx
+++ b/apps/pilote-ppg/src/client/components/_commons/ChatUI/ChatExperimentationBanner.tsx
@@ -1,0 +1,56 @@
+import Link from "next/link";
+import { useState } from "react";
+import { Callout } from "@/components/shared/Callout";
+import { CloseLineIcon } from "@/components/_commons/Icones/CloseLineIcon";
+import { ExternalLinkIcon } from "@/components/_commons/Icones/ExternalLinkIcon";
+
+const CHARTE_IA_URL =
+  "https://docs.numerique.gouv.fr/docs/fa8a98a7-bb77-4c07-9a16-bd80006ee5ec/";
+
+export const ChatExperimentationBanner = () => {
+  const [isVisible, setIsVisible] = useState(true);
+
+  if (!isVisible) return null;
+
+  return (
+    <Callout.Root color="info" className="relative pr-10">
+      <Callout.Icon />
+      <Callout.Text>
+        <p className="font-semibold mb-1">Expérimentation en cours</p>
+        <p>
+          Ce chatbot est une expérimentation visant à améliorer nos services.
+          Vos interactions (prompts, réponses, feedbacks) sont analysées pour
+          évaluer sa qualité. Elles sont pseudonymisées par défaut et ne seront
+          réattribuées à votre identité qu&apos;en cas de besoin de support.
+        </p>
+        <div className="flex flex-wrap gap-x-6 gap-y-2 mt-3">
+          <a
+            href={CHARTE_IA_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1 font-semibold text-primary hover:underline"
+          >
+            Charte d&apos;utilisation de l&apos;IA dans PILOTE
+            <ExternalLinkIcon className="w-3.5 h-3.5" fill="currentColor" />
+          </a>
+          <Link
+            href="/donnees-personnelles-cookies"
+            target="_blank"
+            className="inline-flex items-center gap-1 font-semibold text-primary hover:underline"
+          >
+            Données personnelles et cookies
+            <ExternalLinkIcon className="w-3.5 h-3.5" fill="currentColor" />
+          </Link>
+        </div>
+      </Callout.Text>
+      <button
+        type="button"
+        onClick={() => setIsVisible(false)}
+        aria-label="Masquer le bandeau"
+        className="absolute top-2 right-2 p-1 text-gray-500 hover:text-gray-800 transition-colors"
+      >
+        <CloseLineIcon className="w-4 h-4" fill="currentColor" />
+      </button>
+    </Callout.Root>
+  );
+};

--- a/apps/pilote-ppg/src/client/components/_commons/ChatUI/ChatUI.tsx
+++ b/apps/pilote-ppg/src/client/components/_commons/ChatUI/ChatUI.tsx
@@ -9,6 +9,7 @@ import { AssistantMessage } from "@/components/_commons/ChatUI/AssistantMessage"
 import { AssistantLoader } from "@/components/_commons/ChatUI/AssistantLoader";
 import { FeedbackBar } from "@/components/_commons/ChatUI/FeedbackBar";
 import { ChatInputForm } from "@/components/_commons/ChatUI/ChatInputForm";
+import { ChatExperimentationBanner } from "@/components/_commons/ChatUI/ChatExperimentationBanner";
 import { chatMarkdownStyles } from "@/components/_commons/ChatUI/chatMarkdownStyles";
 import { PiloteUIMessage } from "@/server/albert/PiloteUIMessage";
 import { ChatEmptyState } from "@/components/_commons/ChatUI/ChatEmptyState";
@@ -30,6 +31,7 @@ export const ChatUI = ({
   chatId,
   initialMessages,
   onChatFinish,
+  showExperimentationBanner = false,
 }: {
   endpoint: string;
   placeholder?: string;
@@ -39,6 +41,7 @@ export const ChatUI = ({
   chatId?: string;
   initialMessages?: PiloteUIMessage[];
   onChatFinish?: () => void;
+  showExperimentationBanner?: boolean;
 }) => {
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
@@ -209,6 +212,8 @@ export const ChatUI = ({
           onModelChange={handleModelChange}
           placeholder={placeholder}
         />
+
+        {showExperimentationBanner && <ChatExperimentationBanner />}
       </div>
     </ChatContextProvider>
   );


### PR DESCRIPTION
## Summary

- Ajoute un bandeau « Expérimentation en cours » sous le formulaire de saisie du chat LLM (modale de synthèse de territoire)
- Informe l'utilisateur sur la nature expérimentale du chatbot, les données collectées et leur pseudonymisation
- Deux liens : Charte d'utilisation de l'IA (externe) + Données personnelles et cookies (ouvre en nouvel onglet)
- Bandeau masquable via une croix (state local `isVisible`, pas de persistance)
- Activé via une prop opt-in `showExperimentationBanner` sur `ChatUI` → présent dans la modale agent, absent du panel admin

## Implémentation

- Nouveau composant `ChatExperimentationBanner.tsx` basé sur `Callout` (color="info")
- Prop optionnelle `showExperimentationBanner?: boolean` sur `ChatUI`, rendu sous `ChatInputForm`
- Passée à `true` uniquement dans `BoutonSyntheseTerritoire`

## Test plan

- [ ] Ouvrir la modale Synthèse de territoire depuis la page d'accueil
- [ ] Vérifier que le bandeau « Expérimentation en cours » s'affiche en bas, sous le champ de saisie
- [ ] Cliquer sur la croix → le bandeau disparaît immédiatement
- [ ] Fermer puis rouvrir la modale → le bandeau réapparaît (pas de persistance, attendu)
- [ ] Cliquer sur « Charte d'utilisation de l'IA dans PILOTE » → ouvre `https://docs.numerique.gouv.fr/docs/fa8a98a7-bb77-4c07-9a16-bd80006ee5ec/` dans un nouvel onglet
- [ ] Cliquer sur « Données personnelles et cookies » → ouvre `/donnees-personnelles-cookies` dans un nouvel onglet
- [ ] Vérifier que le bandeau **n'apparaît pas** dans le panel admin Albert

Refs: [PIL-1556](https://data-ditp.atlassian.net/browse/PIL-1556)

[PIL-1556]: https://data-ditp.atlassian.net/browse/PIL-1556?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ