### PR TITLE
feat(llm): disclaimer sur les erreurs de l'Assistant (PIL-1558)

### DIFF
--- a/apps/pilote-ppg/src/client/components/_commons/ChatUI/ChatAssistantDisclaimer.tsx
+++ b/apps/pilote-ppg/src/client/components/_commons/ChatUI/ChatAssistantDisclaimer.tsx
@@ -1,0 +1,18 @@
+import { Callout } from "@/components/shared/Callout";
+import { WarningIcon } from "@/components/_commons/Icones/WarningIcon";
+
+export const ChatAssistantDisclaimer = () => (
+  <div className="shrink-0 px-4 pt-2 bg-white">
+    <div className="max-w-3xl mx-auto">
+      <Callout.Root color="moutarde">
+        <Callout.Icon icone={WarningIcon} />
+        <Callout.Text>
+          <p className="font-semibold mb-0">
+            L&apos;Assistant peut faire des erreurs. Veuillez vérifier toutes
+            les informations importantes.
+          </p>
+        </Callout.Text>
+      </Callout.Root>
+    </div>
+  </div>
+);

--- a/apps/pilote-ppg/src/client/components/_commons/ChatUI/ChatUI.tsx
+++ b/apps/pilote-ppg/src/client/components/_commons/ChatUI/ChatUI.tsx
@@ -10,6 +10,7 @@ import { AssistantLoader } from "@/components/_commons/ChatUI/AssistantLoader";
 import { FeedbackBar } from "@/components/_commons/ChatUI/FeedbackBar";
 import { ChatInputForm } from "@/components/_commons/ChatUI/ChatInputForm";
 import { ChatExperimentationBanner } from "@/components/_commons/ChatUI/ChatExperimentationBanner";
+import { ChatAssistantDisclaimer } from "@/components/_commons/ChatUI/ChatAssistantDisclaimer";
 import { chatMarkdownStyles } from "@/components/_commons/ChatUI/chatMarkdownStyles";
 import { PiloteUIMessage } from "@/server/albert/PiloteUIMessage";
 import { ChatEmptyState } from "@/components/_commons/ChatUI/ChatEmptyState";
@@ -204,7 +205,10 @@ export const ChatUI = ({
         )}
 
         {messages.length > 0 && status === "ready" && (
-          <FeedbackBar chatId={chatRef.current.id} />
+          <>
+            <FeedbackBar chatId={chatRef.current.id} />
+            <ChatAssistantDisclaimer />
+          </>
         )}
 
         <ChatInputForm

--- a/apps/pilote-ppg/src/client/components/shared/Callout.tsx
+++ b/apps/pilote-ppg/src/client/components/shared/Callout.tsx
@@ -105,7 +105,7 @@ const CalloutIcon = ({
   return (
     <div
       {...props}
-      className={clsxm("flex-shrink-0 mt-1", context?.iconColor, className)}
+      className={clsxm("flex-shrink-0 mt-0.5", context?.iconColor, className)}
     >
       {isComponent
         ? (() => {


### PR DESCRIPTION
> ⚠️ Cette PR est basée sur [#2177](https://github.com/DITP-pilotage/pilote-2/pull/2177) (PIL-1556). À merger après celle-ci.

## Summary

- Ajoute un disclaimer « L'Assistant peut faire des erreurs. Veuillez vérifier toutes les informations importantes. » sous le widget de feedback du chat LLM
- Composant `ChatAssistantDisclaimer` basé sur `Callout` (color="moutarde", icône `WarningIcon`)
- Affiché aux mêmes conditions que `FeedbackBar` (présence de messages + status ready) — donc visible dans la modale agent ET dans le panel admin Albert
- Petit ajustement sur `Callout` : icône passe de `mt-1` à `mt-0.5` pour mieux s'aligner sur la cap-height du texte

## Test plan

- [ ] Ouvrir la modale Synthèse de territoire, envoyer une question, attendre une réponse
- [ ] Vérifier que le disclaimer jaune s'affiche dans la zone du `FeedbackBar` (au-dessus du champ de saisie)
- [ ] Vérifier le texte : « L'Assistant peut faire des erreurs. Veuillez vérifier toutes les informations importantes. »
- [ ] Vérifier que le disclaimer **n'apparaît pas** tant qu'aucune réponse n'a été reçue
- [ ] Aller dans le panel admin Albert, envoyer une question → le disclaimer doit également s'afficher après la réponse
- [ ] Vérifier visuellement que les autres `Callout` du projet (page admin feature flipping, éditeur riche, ChatExperimentationBanner) restent corrects avec l'ajustement `mt-0.5`

Refs: [PIL-1558](https://data-ditp.atlassian.net/browse/PIL-1558)

[PIL-1558]: https://data-ditp.atlassian.net/browse/PIL-1558?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ