### PR TITLE
feat(rgpd): refonte page données personnelles & cookies pour l'expérimentation IA (PIL-1557)

### DIFF
--- a/apps/pilote-ppg/src/client/components/DonnéesPersonnellesCookies/DonneesPersonnellesCookies.tsx
+++ b/apps/pilote-ppg/src/client/components/DonnéesPersonnellesCookies/DonneesPersonnellesCookies.tsx
@@ -1,200 +1,389 @@
 import Link from "next/link";
 import { FunctionComponent } from "react";
-import Titre from "@/client/components/_commons/Titre/Titre";
-import Bloc from "@/client/components/_commons/Bloc/Bloc";
+import { Callout } from "@/components/shared/Callout";
+
+const linkClassName = "text-primary";
 
 const DonneesPersonnellesCookies: FunctionComponent = () => {
   return (
     <main>
-      <div className="fr-container fr-pb-2w">
-        <div className="fr-grid-row fr-py-4w">
-          <Titre baliseHtml="h1" className="fr-my-auto">
-            Données personnelles et cookies
-          </Titre>
-        </div>
-        <Bloc>
-          <div className="fr-grid-row">
-            <div className="fr-col-12">
-              <p>
-                La Direction interministérielle de la transformation publique
-                (mission Pilotage), située 20 avenue de Ségur à Paris (75007),
-                est responsable du traitement des données personnelles pour le
-                site PILOTE.
-              </p>
-              <p className="fr-text fr-col-12">
-                Pour toute question au sujet de la gestion des cookies, vous
-                pouvez utiliser l'adresse suivante :{" "}
+      <div className="max-w-screen-lg mx-auto px-4 py-8">
+        <h1 className="text-3xl font-bold text-primary mb-6">
+          Données personnelles et cookies
+        </h1>
+
+        <article className="bg-white border border-dsfr-grey-925 rounded-lg p-6 space-y-10">
+          <section className="space-y-3">
+            <h2 className="text-xl font-bold text-primary">
+              Responsable de traitement
+            </h2>
+            <p>
+              La Direction interministérielle de la transformation publique
+              (mission Pilotage), située au 20 avenue de Ségur, 75007 Paris, est
+              responsable du traitement des données personnelles pour le site
+              PILOTE et ses fonctionnalités, y compris le chatbot expérimental.
+            </p>
+            <p>
+              Pour toute question relative à la protection des données, vous
+              pouvez contacter :
+            </p>
+            <ul className="list-disc pl-6 space-y-1">
+              <li>
+                Par email :{" "}
                 <Link
-                  href="mailto:pilote.ditp@modernisation.gouv.fr"
-                  title="Envoyer un courriel à pilote.ditp@modernisation.gouv.fr"
+                  className={linkClassName}
+                  href="mailto:contactrgpd.ditp@modernisation.gouv.fr"
                 >
-                  pilote.ditp@modernisation.gouv.fr
+                  contactrgpd.ditp@modernisation.gouv.fr
                 </Link>
-              </p>
-            </div>
-          </div>
-          <div className="fr-grid-row">
-            <div className="fr-col-12">
-              <h2 className="fr-h2 fr-col-12 fr-text-title--blue-france">
-                Cookies
-              </h2>
-              <h4 className="fr-h4 fr-col-12">Informations cookies</h4>
-              <p className="fr-text fr-col-12">
+              </li>
+              <li>
+                Par voie postale : Direction interministérielle de la
+                transformation publique TSA 70732 75334 Paris Cedex 07
+              </li>
+            </ul>
+          </section>
+
+          <section className="space-y-6">
+            <h2 className="text-2xl font-bold text-primary">Cookies</h2>
+
+            <div className="space-y-3">
+              <h3 className="text-xl font-bold text-primary">
+                Informations sur les cookies
+              </h3>
+              <p>
                 Lors de la consultation de notre site{" "}
                 <Link
+                  className={linkClassName}
                   href="https://pilote.modernisation.gouv.fr"
-                  title="Lien vers pilote.modernisation.gouv.fr"
                 >
                   https://pilote.modernisation.gouv.fr
                 </Link>
-                , des cookies sont déposés sur votre ordinateur, votre mobile ou
-                votre tablette.
+                , des cookies sont déposés sur votre ordinateur, mobile ou
+                tablette.
+              </p>
+              <p>
+                <span className="font-semibold">
+                  Définition d&apos;un cookie :
+                </span>{" "}
+                Un cookie est un fichier texte déposé sur votre terminal lors de
+                la visite d&apos;un site. Il permet de collecter des
+                informations relatives à votre navigation et de vous proposer
+                des services adaptés.
               </p>
             </div>
-          </div>
-          <div className="fr-grid-row">
-            <div className="fr-col-12">
-              <h4 className="fr-h4 fr-col-12">Définition d'un cookie</h4>
-              <p className="fr-text fr-col-12">
-                Un cookie est un fichier texte déposé sur votre ordinateur et
-                stocké par votre navigateur internet lors de la visite d'un site
-                ou de la consultation d'une publicité. Il a pour but de
-                collecter des informations relatives à votre navigation et de
-                vous adresser des services adaptés à votre terminal (ordinateur,
-                mobile ou tablette).
-              </p>
-            </div>
-          </div>
-          <div className="fr-grid-row">
-            <div className="fr-col-12">
-              <h4 className="fr-h4 fr-col-12">
-                Détails des cookies utilisés sur Pilote
-              </h4>
-              <p className="fr-text fr-col-12 fr-mb-0 fr-pb-1v">
-                Deux types de cookies sont déposés sur{" "}
-                <Link
-                  href="https://pilote.modernisation.gouv.fr"
-                  title="Lien vers pilote.modernisation.gouv.fr"
-                >
-                  https://pilote.modernisation.gouv.fr
-                </Link>{" "}
-                :
-              </p>
-              <ul className="fr-text fr-col-12">
-                <li>
-                  Les cookies techniques qui nous permettent de personnaliser
-                  votre utilisation du site{" "}
-                  <Link
-                    href="https://pilote.modernisation.gouv.fr"
-                    title="Lien vers pilote.modernisation.gouv.fr"
-                  >
-                    https://pilote.modernisation.gouv.fr
-                  </Link>{" "}
-                  (par exemple afficher des cartes ou des réformes spécifiques
-                  suivant votre profil).
-                </li>
-                <li>
-                  Les cookies destinés à la mesure d'audience qui permettent :
-                  <ul>
-                    <li>La mesure de l'audience, page par page ;</li>
+
+            <div className="space-y-3">
+              <h3 className="text-xl font-bold text-primary">
+                Cookies utilisés sur PILOTE
+              </h3>
+              <p>Deux types de cookies sont déposés :</p>
+
+              <Callout.Root color="neutral">
+                <div className="space-y-2 flex-1">
+                  <h4 className="text-base font-semibold text-primary">
+                    Cookies techniques :
+                  </h4>
+                  <ul className="list-disc pl-6 space-y-1">
                     <li>
-                      La liste des pages à partir desquelles un lien a été suivi
-                      ;
+                      Permettent de personnaliser votre utilisation du site (ex.
+                      : afficher des cartes ou des réformes spécifiques selon
+                      votre profil).
                     </li>
                     <li>
-                      Les types de terminal et navigateur des visiteurs, par
-                      page et agrégé de manière journalière ;
-                    </li>
-                    <li>
-                      Des statistiques de temps de chargement des pages, par
-                      page et agrégée de manière horaire ;
-                    </li>
-                    <li>
-                      Des statistiques de temps passé sur chaque page, par page
-                      et agrégée de manière journalière.
+                      Assurent le bon fonctionnement du chatbot expérimental
+                      (ex. : conservation des préférences d&apos;affichage).
                     </li>
                   </ul>
-                </li>
-              </ul>
-              <p className="fr-text fr-col-12">
-                Pour assurer le suivi d'audience sur PILOTE, nous utilisons{" "}
-                <Link href="https://matomo.org/" title="Lien vers matomo.org">
-                  Matomo
-                </Link>
-                , un outil libre, paramétré pour être en conformité avec la
-                recommandation « Cookies » de la{" "}
-                <Link
-                  href="https://www.cnil.fr/fr/cookies-et-autres-traceurs/regles/cookies-solutions-pour-les-outils-de-mesure-daudience"
-                  title="Lien vers /www.cnil.fr/fr/cookies-et-autres-traceurs/regles/cookies-solutions-pour-les-outils-de-mesure-daudience"
-                >
-                  CNIL
-                </Link>
-                . Cela signifie que votre adresse IP, par exemple, est
-                anonymisée avant d'être enregistrée. Il est donc impossible
-                d'associer vos visites sur ce site à votre personne.
-              </p>
-              <p className="fr-text fr-col-12">
-                Si vous souhaitez désactiver ce suivi statistique, il vous
-                suffit d'activer la fonctionnalité « Ne pas me pister » de votre
-                navigateur. Notre outil de suivi le prendra en compte, et
-                cessera d'inclure vos visites dans les statistiques.
-              </p>
+                </div>
+              </Callout.Root>
+
+              <Callout.Root color="neutral">
+                <div className="space-y-2 flex-1">
+                  <h4 className="text-base font-semibold text-primary">
+                    Cookies de mesure d&apos;audience :
+                  </h4>
+                  <ul className="list-disc pl-6 space-y-1">
+                    <li>
+                      Utilisés pour analyser la fréquentation du site (pages
+                      consultées, durée de visite, etc.).
+                    </li>
+                    <li>
+                      Outil utilisé :{" "}
+                      <span className="font-semibold">Matomo</span>, configuré
+                      pour être conforme à la recommandation &quot;Cookies&quot;
+                      de la CNIL (anonymisation des adresses IP).
+                    </li>
+                  </ul>
+                  <p>
+                    <span className="font-semibold">
+                      Désactivation du suivi statistique :
+                    </span>{" "}
+                    Si vous ne souhaitez pas être inclus dans les statistiques,
+                    activez la fonction &quot;Ne pas me pister&quot; (Do Not
+                    Track) dans votre navigateur. Matomo respectera ce
+                    paramètre.
+                  </p>
+                </div>
+              </Callout.Root>
             </div>
-          </div>
-          <div className="fr-grid-row">
-            <div className="fr-col-12" />
-            <h2 className="fr-h2 fr-col-12 fr-text-title--blue-france">
+          </section>
+
+          <section className="space-y-6">
+            <h2 className="text-2xl font-bold text-primary">
               Données personnelles
             </h2>
-            <h4 className="fr-h4 fr-col-12">
-              Droit d'accès, de modification, et de suppression
-            </h4>
-            <p className="fr-text fr-col-12">
-              Conformément au RGPD et à la loi « Informatique et Libertés » du 6
-              janvier 1978 modifiée, vous disposez d'un droit d'accès (article
-              15 du RGPD) et de rectification (article 16 du RGPD) des données
-              vous concernant ainsi que d'un droit à demander la limitation du
-              traitement de vos données (article 18 du RGPD).
-            </p>
-            <p className="fr-text fr-col-12">
-              Vous pouvez exercer ces droits en transmettant votre demande au
-              responsable de traitement par voie postale à :
-              <br />
-              Direction interministérielle de la transformation publique - TSA
-              70732 - 75334 Paris Cedex 07
-              <br />
-              ou par courriel à :{" "}
-              <Link
-                href="mailto:pilote.ditp@modernisation.gouv.fr"
-                title="Envoyer un courriel à pilote.ditp@modernisation.gouv.fr"
-              >
-                pilote.ditp@modernisation.gouv.fr
-              </Link>
-            </p>
-            <p className="fr-text fr-col-12">
-              Pour des demandes plus largement sur l'application du RGPD vous
-              pouvez contacter l'adresse :{" "}
-              <Link
-                href="mailto:contactrgpd.ditp@modernisation.gouv.fr"
-                title="Envoyer un courriel à contactrgpd.ditp@modernisation.gouv.fr"
-              >
-                contactrgpd.ditp@modernisation.gouv.fr
-              </Link>
-            </p>
-            <p className="fr-text fr-col-12">
-              Pour toute demande d'information complémentaire sur la protection
-              des données, merci de nous contacter à l'adresse suivante :{" "}
-              <Link
-                href="mailto:contactrgpd.ditp@modernisation.gouv.fr"
-                title="Envoyer un courriel à contactrgpd.ditp@modernisation.gouv.fr"
-              >
-                contactrgpd.ditp@modernisation.gouv.fr
-              </Link>
-              <br />
-              En cas de difficulté non résolue, vous pouvez contacter la CNIL.
-            </p>
-          </div>
-        </Bloc>
+
+            <div className="space-y-3">
+              <h3 className="text-xl font-bold text-primary">
+                Traitement des données via le site PILOTE
+              </h3>
+              <p>
+                Conformément au RGPD et à la loi &quot;Informatique et
+                Libertés&quot; du 6 janvier 1978 modifiée, vous disposez des
+                droits suivants :
+              </p>
+              <ul className="list-disc pl-6 space-y-1">
+                <li>
+                  <span className="font-semibold">Droit d&apos;accès</span>{" "}
+                  (article 15 du RGPD) : Demander une copie des données vous
+                  concernant.
+                </li>
+                <li>
+                  <span className="font-semibold">Droit de rectification</span>{" "}
+                  (article 16 du RGPD) : Corriger des données inexactes.
+                </li>
+                <li>
+                  <span className="font-semibold">
+                    Droit à la limitation du traitement
+                  </span>{" "}
+                  (article 18 du RGPD) : Suspendre temporairement
+                  l&apos;utilisation de vos données.
+                </li>
+                <li>
+                  <span className="font-semibold">
+                    Droit à l&apos;effacement
+                  </span>{" "}
+                  (article 17 du RGPD) : Sous réserve des obligations légales de
+                  conservation.
+                </li>
+                <li>
+                  <span className="font-semibold">Droit d&apos;opposition</span>{" "}
+                  (article 21 du RGPD) : Pour des motifs légitimes, sauf si le
+                  traitement est obligatoire pour une mission de service public.
+                </li>
+              </ul>
+              <p>Pour exercer ces droits, envoyez votre demande :</p>
+              <ul className="list-disc pl-6 space-y-1">
+                <li>
+                  Par email :{" "}
+                  <Link
+                    className={linkClassName}
+                    href="mailto:pilote.ditp@modernisation.gouv.fr"
+                  >
+                    pilote.ditp@modernisation.gouv.fr
+                  </Link>
+                </li>
+                <li>Par voie postale (adresse ci-dessus).</li>
+              </ul>
+              <p>
+                En cas de difficulté non résolue, vous pouvez saisir la CNIL.
+              </p>
+            </div>
+
+            <div className="space-y-3">
+              <h3 className="text-xl font-bold text-primary">
+                Dans le cadre de l&apos;expérimentation Assistant IA PILOTE
+              </h3>
+
+              <h4 className="text-base font-semibold text-primary">
+                Finalités :
+              </h4>
+              <p>Le chatbot est une expérimentation visant à :</p>
+              <ul className="list-disc pl-6 space-y-1">
+                <li>
+                  Faciliter l&apos;exploitation du tableau de bord par les
+                  agents, en leur permettant d&apos;interroger les données de
+                  manière intuitive, en utilisant des fonctionnalités
+                  d&apos;intelligence artificielle (modèles de langage).
+                </li>
+                <li>
+                  Optimiser l&apos;utilisation des indicateurs pour améliorer
+                  les résultats de l&apos;action publique.
+                </li>
+                <li>
+                  Recueillir des retours utilisateurs uniquement sur la qualité
+                  des réponses du chatbot (ex. : pertinence, complétude,
+                  exactitude), afin d&apos;ajuster son fonctionnement technique.
+                </li>
+              </ul>
+
+              <h4 className="text-base font-semibold text-primary">
+                Données collectées :
+              </h4>
+              <ul className="list-disc pl-6 space-y-1">
+                <li>
+                  Prompts (questions posées au chatbot, ex. : &quot;Quels sont
+                  les indicateurs clés pour le programme X ?&quot;).
+                </li>
+                <li>Réponses générées par l&apos;IA.</li>
+                <li>
+                  Feedbacks (👍/👎, catégories de problèmes : hallucination,
+                  réponse incomplète, hors sujet, problème technique, autre).
+                </li>
+                <li>
+                  Commentaires libres (facultatifs, strictement limités à
+                  l&apos;évaluation des réponses).
+                </li>
+                <li>
+                  Logs d&apos;utilisation (horodatage, identifiants
+                  pseudonymisés).
+                </li>
+              </ul>
+
+              <p>
+                <span className="font-semibold">Base légale :</span> Le
+                traitement repose sur l&apos;article 6.1.e du RGPD (mission
+                d&apos;intérêt public), car il contribue à améliorer
+                l&apos;efficacité des outils d&apos;analyse des politiques
+                publiques.
+              </p>
+
+              <Callout.Root color="info">
+                <div className="space-y-2 flex-1">
+                  <h4 className="text-base font-semibold text-primary">
+                    Pseudonymisation et réidentification
+                  </h4>
+                  <p>
+                    Vos données sont{" "}
+                    <span className="font-semibold">
+                      pseudonymisées par défaut
+                    </span>{" "}
+                    : vos interactions ne sont pas directement associées à votre
+                    identité.
+                  </p>
+                  <p>
+                    Une réidentification est possible{" "}
+                    <span className="font-semibold">
+                      uniquement en cas de besoin de support technique
+                    </span>{" "}
+                    (ex. : résolution d&apos;un bug, demande explicite de votre
+                    part), et uniquement par des personnes habilitées.
+                  </p>
+                  <p className="italic">
+                    Exemple de cas de réidentification : &quot;Si vous signalez
+                    une erreur critique dans une réponse du chatbot, notre
+                    équipe support pourra temporairement accéder à vos données
+                    pour reproduire et corriger le problème.&quot;
+                  </p>
+                </div>
+              </Callout.Root>
+
+              <h4 className="text-base font-semibold text-primary">
+                Durées de conservation
+              </h4>
+              <ul className="list-disc pl-6 space-y-1">
+                <li>
+                  Prompts, réponses et retours utilisateurs : Conservés pendant
+                  la durée de l&apos;expérimentation (1 an), puis supprimés.
+                </li>
+                <li>
+                  Données nominatives (en cas de réidentification) : Supprimées
+                  dès la résolution du support (maximum 3 mois).
+                </li>
+              </ul>
+            </div>
+
+            <div className="space-y-3">
+              <h3 className="text-xl font-bold text-primary">
+                Vos droits et recommandations
+              </h3>
+
+              <h4 className="text-base font-semibold text-primary">
+                Droits RGPD :
+              </h4>
+              <ul className="list-disc pl-6 space-y-1">
+                <li>
+                  Vous pouvez accéder, rectifier ou supprimer vos données (sous
+                  réserve des obligations légales).
+                </li>
+                <li>
+                  Vous pouvez refuser de fournir un feedback ou un commentaire
+                  libre.
+                </li>
+                <li>
+                  Pour les commentaires libres, vous pouvez autoriser ou refuser
+                  d&apos;être recontacté(e) pour approfondir votre retour.
+                </li>
+              </ul>
+
+              <h4 className="text-base font-semibold text-primary">
+                Recommandations :
+              </h4>
+              <ul className="list-disc pl-6 space-y-1">
+                <li>
+                  Évitez de saisir des données personnelles (noms, numéros de
+                  dossier, etc.) dans les prompts ou commentaires.
+                </li>
+                <li>
+                  Signalez les réponses inappropriées (ex. : erreurs factuelles,
+                  hallucinations) via le bouton &quot;Signaler un problème&quot;
+                  intégré au chatbot.
+                </li>
+              </ul>
+            </div>
+
+            <div className="space-y-3">
+              <h3 className="text-xl font-bold text-primary">
+                Exercice de vos droits
+              </h3>
+              <p>
+                Pour toute question ou demande relative à vos données traitées
+                via le chatbot, contactez :
+              </p>
+              <ul className="list-disc pl-6 space-y-1">
+                <li>
+                  Par email :{" "}
+                  <Link
+                    className={linkClassName}
+                    href="mailto:pilote.ditp@modernisation.gouv.fr"
+                  >
+                    pilote.ditp@modernisation.gouv.fr
+                  </Link>
+                </li>
+                <li>Par voie postale (adresse ci-dessus).</li>
+              </ul>
+            </div>
+
+            <div className="space-y-3">
+              <h3 className="text-xl font-bold text-primary">
+                Pour toute information complémentaire
+              </h3>
+              <p>
+                Pour des demandes plus largement liées à l&apos;application du
+                RGPD, vous pouvez contacter :
+              </p>
+              <ul className="list-disc pl-6 space-y-1">
+                <li>
+                  Par email :{" "}
+                  <Link
+                    className={linkClassName}
+                    href="mailto:contactrgpd.ditp@modernisation.gouv.fr"
+                  >
+                    contactrgpd.ditp@modernisation.gouv.fr
+                  </Link>
+                </li>
+              </ul>
+              <p>
+                En cas de difficulté non résolue, vous pouvez contacter la{" "}
+                <Link className={linkClassName} href="https://www.cnil.fr">
+                  CNIL
+                </Link>
+                .
+              </p>
+            </div>
+          </section>
+        </article>
       </div>
     </main>
   );

--- a/apps/pilote-ppg/src/client/components/PageAccueil/BoutonSyntheseTerritoire.tsx
+++ b/apps/pilote-ppg/src/client/components/PageAccueil/BoutonSyntheseTerritoire.tsx
@@ -89,6 +89,7 @@ export const BoutonSyntheseTerritoire = ({
                   className="h-full"
                   placeholder="Posez une question sur ce territoire..."
                   scenarios={scenarios}
+                  showExperimentationBanner
                   agentContext={{
                     jalon,
                     territoireCode,

--- a/apps/pilote-ppg/src/client/components/_commons/ChatUI/ChatAssistantDisclaimer.tsx
+++ b/apps/pilote-ppg/src/client/components/_commons/ChatUI/ChatAssistantDisclaimer.tsx
@@ -1,0 +1,18 @@
+import { Callout } from "@/components/shared/Callout";
+import { WarningIcon } from "@/components/_commons/Icones/WarningIcon";
+
+export const ChatAssistantDisclaimer = () => (
+  <div className="shrink-0 px-4 pt-2 bg-white">
+    <div className="max-w-3xl mx-auto">
+      <Callout.Root color="moutarde">
+        <Callout.Icon icone={WarningIcon} />
+        <Callout.Text>
+          <p className="font-semibold mb-0">
+            L&apos;Assistant peut faire des erreurs. Veuillez vérifier toutes
+            les informations importantes.
+          </p>
+        </Callout.Text>
+      </Callout.Root>
+    </div>
+  </div>
+);

--- a/apps/pilote-ppg/src/client/components/_commons/ChatUI/ChatExperimentationBanner.tsx
+++ b/apps/pilote-ppg/src/client/components/_commons/ChatUI/ChatExperimentationBanner.tsx
@@ -31,7 +31,6 @@ export const ChatExperimentationBanner = () => {
             className="inline-flex items-center gap-1 font-semibold text-primary hover:underline"
           >
             Charte d&apos;utilisation de l&apos;IA dans PILOTE
-            <ExternalLinkIcon className="w-3.5 h-3.5" fill="currentColor" />
           </a>
           <Link
             href="/donnees-personnelles-cookies"
@@ -39,7 +38,6 @@ export const ChatExperimentationBanner = () => {
             className="inline-flex items-center gap-1 font-semibold text-primary hover:underline"
           >
             Données personnelles et cookies
-            <ExternalLinkIcon className="w-3.5 h-3.5" fill="currentColor" />
           </Link>
         </div>
       </Callout.Text>

--- a/apps/pilote-ppg/src/client/components/_commons/ChatUI/ChatExperimentationBanner.tsx
+++ b/apps/pilote-ppg/src/client/components/_commons/ChatUI/ChatExperimentationBanner.tsx
@@ -1,0 +1,56 @@
+import Link from "next/link";
+import { useState } from "react";
+import { Callout } from "@/components/shared/Callout";
+import { CloseLineIcon } from "@/components/_commons/Icones/CloseLineIcon";
+import { ExternalLinkIcon } from "@/components/_commons/Icones/ExternalLinkIcon";
+
+const CHARTE_IA_URL =
+  "https://docs.numerique.gouv.fr/docs/fa8a98a7-bb77-4c07-9a16-bd80006ee5ec/";
+
+export const ChatExperimentationBanner = () => {
+  const [isVisible, setIsVisible] = useState(true);
+
+  if (!isVisible) return null;
+
+  return (
+    <Callout.Root color="info" className="relative pr-10">
+      <Callout.Icon />
+      <Callout.Text>
+        <p className="font-semibold mb-1">Expérimentation en cours</p>
+        <p>
+          Ce chatbot est une expérimentation visant à améliorer nos services.
+          Vos interactions (prompts, réponses, feedbacks) sont analysées pour
+          évaluer sa qualité. Elles sont pseudonymisées par défaut et ne seront
+          réattribuées à votre identité qu&apos;en cas de besoin de support.
+        </p>
+        <div className="flex flex-wrap gap-x-6 gap-y-2 mt-3">
+          <a
+            href={CHARTE_IA_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1 font-semibold text-primary hover:underline"
+          >
+            Charte d&apos;utilisation de l&apos;IA dans PILOTE
+            <ExternalLinkIcon className="w-3.5 h-3.5" fill="currentColor" />
+          </a>
+          <Link
+            href="/donnees-personnelles-cookies"
+            target="_blank"
+            className="inline-flex items-center gap-1 font-semibold text-primary hover:underline"
+          >
+            Données personnelles et cookies
+            <ExternalLinkIcon className="w-3.5 h-3.5" fill="currentColor" />
+          </Link>
+        </div>
+      </Callout.Text>
+      <button
+        type="button"
+        onClick={() => setIsVisible(false)}
+        aria-label="Masquer le bandeau"
+        className="absolute top-2 right-2 p-1 text-gray-500 hover:text-gray-800 transition-colors"
+      >
+        <CloseLineIcon className="w-4 h-4" fill="currentColor" />
+      </button>
+    </Callout.Root>
+  );
+};

--- a/apps/pilote-ppg/src/client/components/_commons/ChatUI/ChatUI.tsx
+++ b/apps/pilote-ppg/src/client/components/_commons/ChatUI/ChatUI.tsx
@@ -9,6 +9,7 @@ import { AssistantMessage } from "@/components/_commons/ChatUI/AssistantMessage"
 import { AssistantLoader } from "@/components/_commons/ChatUI/AssistantLoader";
 import { FeedbackBar } from "@/components/_commons/ChatUI/FeedbackBar";
 import { ChatInputForm } from "@/components/_commons/ChatUI/ChatInputForm";
+import { ChatExperimentationBanner } from "@/components/_commons/ChatUI/ChatExperimentationBanner";
 import { chatMarkdownStyles } from "@/components/_commons/ChatUI/chatMarkdownStyles";
 import { PiloteUIMessage } from "@/server/albert/PiloteUIMessage";
 import { ChatEmptyState } from "@/components/_commons/ChatUI/ChatEmptyState";
@@ -30,6 +31,7 @@ export const ChatUI = ({
   chatId,
   initialMessages,
   onChatFinish,
+  showExperimentationBanner = false,
 }: {
   endpoint: string;
   placeholder?: string;
@@ -39,6 +41,7 @@ export const ChatUI = ({
   chatId?: string;
   initialMessages?: PiloteUIMessage[];
   onChatFinish?: () => void;
+  showExperimentationBanner?: boolean;
 }) => {
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
@@ -209,6 +212,8 @@ export const ChatUI = ({
           onModelChange={handleModelChange}
           placeholder={placeholder}
         />
+
+        {showExperimentationBanner && <ChatExperimentationBanner />}
       </div>
     </ChatContextProvider>
   );

--- a/apps/pilote-ppg/src/client/components/_commons/ChatUI/ChatUI.tsx
+++ b/apps/pilote-ppg/src/client/components/_commons/ChatUI/ChatUI.tsx
@@ -10,6 +10,7 @@ import { AssistantLoader } from "@/components/_commons/ChatUI/AssistantLoader";
 import { FeedbackBar } from "@/components/_commons/ChatUI/FeedbackBar";
 import { ChatInputForm } from "@/components/_commons/ChatUI/ChatInputForm";
 import { ChatExperimentationBanner } from "@/components/_commons/ChatUI/ChatExperimentationBanner";
+import { ChatAssistantDisclaimer } from "@/components/_commons/ChatUI/ChatAssistantDisclaimer";
 import { chatMarkdownStyles } from "@/components/_commons/ChatUI/chatMarkdownStyles";
 import { PiloteUIMessage } from "@/server/albert/PiloteUIMessage";
 import { ChatEmptyState } from "@/components/_commons/ChatUI/ChatEmptyState";
@@ -204,7 +205,10 @@ export const ChatUI = ({
         )}
 
         {messages.length > 0 && status === "ready" && (
-          <FeedbackBar chatId={chatRef.current.id} />
+          <>
+            <FeedbackBar chatId={chatRef.current.id} />
+            <ChatAssistantDisclaimer />
+          </>
         )}
 
         <ChatInputForm

--- a/apps/pilote-ppg/src/client/components/_commons/EditeurRiche/extensions/CalloutExtension.tsx
+++ b/apps/pilote-ppg/src/client/components/_commons/EditeurRiche/extensions/CalloutExtension.tsx
@@ -6,18 +6,10 @@ import {
   NodeViewWrapper,
   ReactNodeViewRenderer,
 } from "@tiptap/react";
-import { Callout } from "@/client/components/shared/Callout";
+import { Callout, CalloutColor } from "@/client/components/shared/Callout";
 import { InformationPleineIcon } from "@/components/_commons/Icones/InformationPleineIcon";
 import { WarningIcon } from "@/components/_commons/Icones/WarningIcon";
 import { ErrorWarningIcon } from "@/components/_commons/Icones/ErrorWarningIcon";
-
-type CalloutColor =
-  | "info"
-  | "success"
-  | "warning"
-  | "error"
-  | "blue"
-  | "moutarde";
 
 const CALLOUT_COLORS: CalloutColor[] = [
   "info",
@@ -26,6 +18,7 @@ const CALLOUT_COLORS: CalloutColor[] = [
   "error",
   "blue",
   "moutarde",
+  "neutral",
 ];
 
 const colorIconMap: Record<
@@ -38,6 +31,7 @@ const colorIconMap: Record<
   error: ErrorWarningIcon,
   blue: InformationPleineIcon,
   moutarde: WarningIcon,
+  neutral: InformationPleineIcon,
 };
 
 const colorLabels: Record<CalloutColor, string> = {
@@ -47,6 +41,7 @@ const colorLabels: Record<CalloutColor, string> = {
   error: "Erreur",
   blue: "Bleu",
   moutarde: "Moutarde",
+  neutral: "Neutre",
 };
 
 function CalloutNodeView({ node, updateAttributes, editor }: NodeViewProps) {

--- a/apps/pilote-ppg/src/client/components/shared/Callout.tsx
+++ b/apps/pilote-ppg/src/client/components/shared/Callout.tsx
@@ -17,7 +17,8 @@ export type CalloutColor =
   | "warning"
   | "error"
   | "blue"
-  | "moutarde";
+  | "moutarde"
+  | "neutral";
 
 const colorVariants: Record<
   CalloutColor,
@@ -52,6 +53,11 @@ const colorVariants: Record<
     bg: "bg-dsfr-moutarde-main-975",
     border: "!border-l-dsfr-moutarde-main-679",
     iconColor: "!text-dsfr-moutarde-main-679",
+  },
+  neutral: {
+    bg: "bg-dsfr-grey-1000",
+    border: "!border-l-dsfr-grey-625",
+    iconColor: "!text-dsfr-grey-200",
   },
 };
 

--- a/apps/pilote-ppg/src/client/components/shared/Callout.tsx
+++ b/apps/pilote-ppg/src/client/components/shared/Callout.tsx
@@ -105,7 +105,7 @@ const CalloutIcon = ({
   return (
     <div
       {...props}
-      className={clsxm("flex-shrink-0 mt-1", context?.iconColor, className)}
+      className={clsxm("flex-shrink-0 mt-0.5", context?.iconColor, className)}
     >
       {isComponent
         ? (() => {


### PR DESCRIPTION
> ⚠️ Cette PR est stackée sur [#2178](https://github.com/DITP-pilotage/pilote-2/pull/2178) (PIL-1558), elle-même stackée sur [#2177](https://github.com/DITP-pilotage/pilote-2/pull/2177) (PIL-1556). À merger dans l'ordre.

## Summary

Mise à jour de `/donnees-personnelles-cookies` pour la conformité RGPD liée à l'expérimentation Assistant IA PILOTE.

### Modifications de contenu
- Section "Responsable de traitement" : mention explicite du chatbot expérimental
- Contact RGPD général : passage à `contactrgpd.ditp@modernisation.gouv.fr`
- Droits RGPD listés : 3 → 5 (ajout art. 17 effacement et art. 21 opposition)
- Section "Cookies techniques" : mention du chatbot expérimental
- Section "Cookies de mesure d'audience" : description simplifiée (l'ancienne liste granulaire de 5 puces est remplacée par un texte court)

### Sections entièrement nouvelles
- **Dans le cadre de l'expérimentation Assistant IA PILOTE** : finalités, données collectées, base légale (art. 6.1.e RGPD), pseudonymisation/réidentification, durées de conservation
- **Vos droits et recommandations** : droits RGPD spécifiques chatbot + recommandations (éviter les données perso dans les prompts, signaler les réponses inappropriées)
- **Exercice de vos droits** : contact dédié au chatbot
- **Pour toute information complémentaire** : réorganisée en bas de page

### Refonte technique (hors scope strict du ticket mais cohérent avec la préférence Tailwind > DSFR)
- Migration de `DonneesPersonnellesCookies.tsx` des classes `fr-*` vers Tailwind + composants `shared/`
- 2 `Callout` neutres pour les blocs cookies, 1 `Callout` info pour la pseudonymisation
- Ajout d'une variante `neutral` (gris) à `Callout` (fichier `Callout.tsx`)
- Alignement du type `CalloutColor` local de `CalloutExtension` sur le type partagé (correction d'une désynchronisation existante)

## Test plan

- [ ] Naviguer vers `/donnees-personnelles-cookies` (depuis le footer ou un lien direct)
- [ ] Vérifier la présence et l'ordre des sections : Responsable / Cookies / Données personnelles (avec la sous-section Assistant IA) / Vos droits / Exercice / Information complémentaire
- [ ] Vérifier l'affichage des 2 blocs gris (Cookies techniques + Cookies de mesure d'audience)
- [ ] Vérifier l'affichage du bloc bleu (Pseudonymisation et réidentification) avec l'exemple en italique
- [ ] Cliquer sur les liens email (`mailto:`) : ouvrent bien le client mail
- [ ] Cliquer sur les liens externes (`pilote.modernisation.gouv.fr`, `CNIL`) : ouvrent les bonnes destinations
- [ ] Vérifier que l'éditeur riche du centre d'aide (`/centre-aide-admin` ou équivalent) propose toujours les 6 couleurs de callout + la nouvelle "Neutre"
- [ ] Vérifier les pages utilisant déjà `Callout` (page admin feature flipping, ChatExperimentationBanner, ChatAssistantDisclaimer) : rendu inchangé

Refs: [PIL-1557](https://data-ditp.atlassian.net/browse/PIL-1557)

[PIL-1557]: https://data-ditp.atlassian.net/browse/PIL-1557?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ