### PR TITLE
[DITP-pilotage/pilote-2] feature(PIL-1571): pseudonymisation du dashboard du panel admin Albert

### DIFF
--- a/apps/pilote-ppg/src/client/components/PagePanelAdministrateur/Albert/AlbertDashboardTable.tsx
+++ b/apps/pilote-ppg/src/client/components/PagePanelAdministrateur/Albert/AlbertDashboardTable.tsx
@@ -98,7 +98,6 @@ export const AlbertDashboardTable = ({
           <thead className="!bg-dsfr-grey-1000">
             <tr>
               <th className="!text-left !px-4 !py-2">Conversation</th>
-              <th className="!text-left !px-4 !py-2">Utilisateur</th>
               <th className="!text-left !px-4 !py-2">Profil</th>
               <th className="!text-left !px-4 !py-2">
                 <ColonneTri
@@ -140,15 +139,6 @@ export const AlbertDashboardTable = ({
                       {conversation.extraitPremierMessageUser}
                     </div>
                   )}
-                </td>
-                <td className="!px-4 !py-3">
-                  <div>
-                    {conversation.utilisateur.prenom}{" "}
-                    {conversation.utilisateur.nom}
-                  </div>
-                  <div className="!text-xs !text-dsfr-mention-grey">
-                    {conversation.utilisateur.email}
-                  </div>
                 </td>
                 <td className="!px-4 !py-3">
                   <span className="!inline-block !px-2 !py-1 !text-xs !bg-dsfr-grey-1000 !rounded">

--- a/apps/pilote-ppg/src/client/components/PagePanelAdministrateur/Albert/ConversationDetailModale.tsx
+++ b/apps/pilote-ppg/src/client/components/PagePanelAdministrateur/Albert/ConversationDetailModale.tsx
@@ -86,11 +86,6 @@ export const ConversationDetailModale = ({
       {!isLoading && data && (
         <>
           <div className="grid grid-cols-1 md:grid-cols-4 gap-4 pb-5 mb-6 border-b border-dsfr-grey-925">
-            <ChipMeta
-              label="Utilisateur"
-              valeur={`${data.utilisateur.prenom} ${data.utilisateur.nom}`}
-            />
-            <ChipMeta label="Email" valeur={data.utilisateur.email} />
             <ChipMeta label="Profil" valeur={data.utilisateur.profilNom} />
             <ChipMeta label="Tours" valeur={`${data.llmCalls.length}`} />
             <ChipMeta

--- a/apps/pilote-ppg/src/client/components/_commons/ChatUI/ChatExperimentationBanner.tsx
+++ b/apps/pilote-ppg/src/client/components/_commons/ChatUI/ChatExperimentationBanner.tsx
@@ -2,7 +2,6 @@ import Link from "next/link";
 import { useState } from "react";
 import { Callout } from "@/components/shared/Callout";
 import { CloseLineIcon } from "@/components/_commons/Icones/CloseLineIcon";
-import { ExternalLinkIcon } from "@/components/_commons/Icones/ExternalLinkIcon";
 
 const CHARTE_IA_URL =
   "https://docs.numerique.gouv.fr/docs/fa8a98a7-bb77-4c07-9a16-bd80006ee5ec/";

--- a/apps/pilote-ppg/src/server/albert/__tests__/queries/ListerConversationsAdminQuery.integration.test.ts
+++ b/apps/pilote-ppg/src/server/albert/__tests__/queries/ListerConversationsAdminQuery.integration.test.ts
@@ -75,8 +75,7 @@ describe("ListerConversationsAdminQuery", () => {
           id: idConvB,
           titre: "Conv Bob",
           utilisateur: expect.objectContaining({
-            nom: "Martin",
-            prenom: "Bob",
+            profilCode: ID_PROFIL_DITP_ADMIN,
           }),
           nbPouce: 0,
           nbPouceBas: 0,
@@ -87,11 +86,15 @@ describe("ListerConversationsAdminQuery", () => {
           titre: "Conv Alice",
           extraitPremierMessageUser: expect.stringContaining("Bonjour Albert"),
           utilisateur: expect.objectContaining({
-            nom: "Dupont",
-            prenom: "Alice",
             profilCode: ID_PROFIL_DITP_ADMIN,
           }),
         }),
+      ]);
+      // Pseudonymisation : aucune donnée nominative ne doit être exposée
+      expect(Object.keys(result.items[0].utilisateur).sort()).toEqual([
+        "id",
+        "profilCode",
+        "profilNom",
       ]);
     }),
   );

--- a/apps/pilote-ppg/src/server/albert/queries/ListerConversationsAdminQuery.ts
+++ b/apps/pilote-ppg/src/server/albert/queries/ListerConversationsAdminQuery.ts
@@ -23,9 +23,6 @@ export type ConversationAdminResume = {
   extraitPremierMessageUser: string;
   utilisateur: {
     id: string;
-    prenom: string;
-    nom: string;
-    email: string;
     profilCode: string;
     profilNom: string;
   };
@@ -46,9 +43,6 @@ type LigneListe = {
   titre: string;
   extrait_premier_message_user: string;
   utilisateur_id: string;
-  utilisateur_prenom: string;
-  utilisateur_nom: string;
-  utilisateur_email: string;
   profil_code: string;
   profil_nom: string;
   created_at: Date;
@@ -104,9 +98,6 @@ export class ListerConversationsAdminQuery {
           ) AS extrait_premier_message_user,
           LOWER(COALESCE((c.messages->0->'parts'->0->>'text'), '')) AS premier_message_user_complet,
           u.id AS utilisateur_id,
-          u.prenom AS utilisateur_prenom,
-          u.nom AS utilisateur_nom,
-          u.email AS utilisateur_email,
           p.code AS profil_code,
           p.nom AS profil_nom,
           c.created_at,
@@ -124,9 +115,6 @@ export class ListerConversationsAdminQuery {
         b.titre,
         b.extrait_premier_message_user,
         b.utilisateur_id,
-        b.utilisateur_prenom,
-        b.utilisateur_nom,
-        b.utilisateur_email,
         b.profil_code,
         b.profil_nom,
         b.created_at,
@@ -156,9 +144,6 @@ export class ListerConversationsAdminQuery {
       extraitPremierMessageUser: ligne.extrait_premier_message_user,
       utilisateur: {
         id: ligne.utilisateur_id,
-        prenom: ligne.utilisateur_prenom,
-        nom: ligne.utilisateur_nom,
-        email: ligne.utilisateur_email,
         profilCode: ligne.profil_code,
         profilNom: ligne.profil_nom,
       },

--- a/apps/pilote-ppg/src/server/albert/queries/RecupererConversationAdminQuery.ts
+++ b/apps/pilote-ppg/src/server/albert/queries/RecupererConversationAdminQuery.ts
@@ -8,9 +8,6 @@ export type ConversationAdminDetail = {
   extraitPremierMessageUser: string;
   utilisateur: {
     id: string;
-    prenom: string;
-    nom: string;
-    email: string;
     profilCode: string;
     profilNom: string;
   };
@@ -33,9 +30,6 @@ type LigneDetail = {
   contexte: unknown;
   extrait_premier_message_user: string;
   utilisateur_id: string;
-  utilisateur_prenom: string;
-  utilisateur_nom: string;
-  utilisateur_email: string;
   profil_code: string;
   profil_nom: string;
   created_at: Date;
@@ -66,9 +60,6 @@ export class RecupererConversationAdminQuery {
           ''
         ) AS extrait_premier_message_user,
         u.id AS utilisateur_id,
-        u.prenom AS utilisateur_prenom,
-        u.nom AS utilisateur_nom,
-        u.email AS utilisateur_email,
         p.code AS profil_code,
         p.nom AS profil_nom,
         c.created_at,
@@ -96,9 +87,6 @@ export class RecupererConversationAdminQuery {
       extraitPremierMessageUser: ligne.extrait_premier_message_user,
       utilisateur: {
         id: ligne.utilisateur_id,
-        prenom: ligne.utilisateur_prenom,
-        nom: ligne.utilisateur_nom,
-        email: ligne.utilisateur_email,
         profilCode: ligne.profil_code,
         profilNom: ligne.profil_nom,
       },


### PR DESCRIPTION
## Contexte

[PIL-1571](https://data-ditp.atlassian.net/browse/PIL-1571) — _LLM - Pseudonymisation des feedbacks : retirer nom et prénom du dashboard du panel admin_

Solution temporaire pour tenir les délais d'ouverture au **11 juin** : ne plus exposer ni afficher les informations personnelles dans le dashboard du panel admin, en attendant l'arbitrage en refinement sur la pseudonymisation dès l'enregistrement en base.

## Changements

### Affichage
- Suppression de la colonne **« Utilisateur »** (prénom, nom, email) du tableau du dashboard Albert (`AlbertDashboardTable.tsx`).
- Suppression des chips **« Utilisateur »** et **« Email »** dans la modale de détail (`ConversationDetailModale.tsx`).
- La donnée **« Profil »** (non nominative) est conservée partout.

### API (pseudonymisation à la source)
- Les champs `prenom`, `nom` et `email` ne sont plus sélectionnés ni renvoyés par les queries admin (`ListerConversationsAdminQuery`, `RecupererConversationAdminQuery`). Ils n'étaient plus affichés mais transitaient encore sur le réseau.
- Seuls `id`, `profilCode` et `profilNom` (non nominatifs) restent exposés.

### Tests
- Mise à jour des assertions de `ListerConversationsAdminQuery.integration.test.ts`.
- Ajout d'une assertion verrouillant l'absence de toute donnée nominative dans le retour de l'API.

### Divers
- Nettoyage d'un import inutilisé (`ExternalLinkIcon`) dans `ChatExperimentationBanner.tsx` qui bloquait le lint.

## Vérifications

- `pnpm lint` (eslint + tsc) ✅
- Tests d'intégration à lancer côté reviewer/CI.

[PIL-1571]: https://data-ditp.atlassian.net/browse/PIL-1571?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ