### PR TITLE
feat(mb-api): permissions sur les paniers (visibilité + propagation READ vers indicateurs)

### DIFF
--- a/apps/mb-api/docs/architecture/paniers-design.md
+++ b/apps/mb-api/docs/architecture/paniers-design.md
@@ -40,12 +40,23 @@ Périmètre v0 délibérément minimaliste :
 Un panier n'appartient ni à une organisation, ni à un référentiel, ni à un
 principal. Tout principal authentifié peut lister et lire tous les paniers.
 
-### D2. Pas de modèle de permissions sur le panier (v0)
+### D2. Modèle de permissions sur le panier (révisé)
 
-Pas de champ `visibilite`, pas de table `PanierPermission`. Cohérent avec D1
-et avec le fait que la création est aujourd'hui une opération de seed
-contrôlée. Si un besoin de paniers privés / par organisation émerge, on
-introduira un modèle de permissions à ce moment-là.
+**Statut : implémenté.** Initialement reporté à plus tard, le besoin de paniers
+privés est arrivé immédiatement après la mise en production v0. Le modèle
+reprend point pour point le pattern indicateur :
+
+- Champ `visibilite: Visibilite` (PUBLIC / PRIVE) sur `Panier`.
+- Table `PanierPermission(principalId, panierId, action)` avec `action ∈
+  {READ, WRITE}`, PK composite, index sur `principalId`.
+- Helper `withPanierReadPermission(where, principalId)` appliqué dans
+  `listPaniers` et `getPanierByPublicId`.
+- **Propagation panier → indicateurs** : un principal qui a READ ou WRITE sur
+  un panier obtient automatiquement READ sur tous ses indicateurs (la clause
+  `withIndicateurReadPermission` ajoute un branche OR via `paniers.some`). Le
+  WRITE indicateur reste exclusivement direct.
+
+Détails et invariants généraux : voir `permissions-design.md`.
 
 ### D3. Composition N-N via join table, ordre par `createdAt`
 
@@ -67,19 +78,18 @@ Pas d'endpoint `POST/PUT/DELETE /paniers`. Cycle de vie 100% via
 `prisma/seed.ts`. À introduire plus tard quand un cas d'usage explicite
 arrive (admin UI, intégration externe).
 
-### D6. Pas de filtrage des indicateurs contenus par les permissions du principal (v0)
+### D6. Pas de filtrage des indicateurs contenus par les permissions du principal
 
 `GET /paniers/:publicId` renvoie l'**intégralité** des `indicateurPublicIds`
 de la jonction, sans intersection avec les droits du principal courant.
 
 L'invariant « tous les indicateurs d'un panier sont accessibles au principal »
-est garanti **par le seed** (qui n'y met que des indicateurs PUBLIC), pas par
-le modèle Prisma.
+est désormais garanti **par le modèle de permissions** (D2 révisée) : la
+visibilité d'un panier propage READ vers ses indicateurs, donc un principal
+qui voit un panier voit nécessairement les indicateurs qui le composent.
 
-**Évolution prévue** : à terme, intersecter avec
-`withIndicateurReadPermission` dans `getPanierByPublicId` /
-`listPaniers` pour ne renvoyer que les `publicId` visibles. Trivial à
-brancher (helper déjà disponible), mais hors scope v0.
+Conséquence : pas besoin d'intersection sur les `indicateurPublicIds` — la
+contention est portée au niveau du panier lui-même.
 
 ### D7. Recomposition côté front via bulk fetch `GET /indicateurs?ids=...`
 

--- a/apps/mb-api/docs/architecture/permissions-design.md
+++ b/apps/mb-api/docs/architecture/permissions-design.md
@@ -1,0 +1,213 @@
+# Permissions — design transverse
+
+Date : 2026-06-04
+Statut : implémenté
+
+## Contexte
+
+mb-api expose plusieurs ressources métier (indicateurs, paniers, à terme :
+référentiels, individus, widgets) que tout principal authentifié n'a pas
+forcément le droit de voir ou modifier. Ce document décrit le **modèle de
+permissions transverse** utilisé pour ces ressources, les invariants qu'il
+garantit, et les conventions à respecter pour étendre le modèle à une nouvelle
+ressource.
+
+Le besoin produit qui a déclenché la formalisation : permettre des
+paniers d'indicateurs privés (visibles uniquement par certains principals)
+sans dupliquer la mécanique déjà en place pour les indicateurs eux-mêmes.
+
+## Modèle
+
+### Principal
+
+Toute identité authentifiée — utilisateur OIDC ou clé API — est représentée
+par une ligne dans `principal`. Les tables `utilisateur` et `api_key` ont leur
+PK qui référence `principal.id`. C'est cette identité unique qui porte les
+permissions, indépendamment du canal d'authentification.
+
+```
+Principal (id: UUID)
+├── Utilisateur (1-1)
+└── ApiKey (1-1)
+```
+
+### Visibilité
+
+Chaque ressource « sécurisée » porte une colonne `visibilite: Visibilite` avec
+deux valeurs :
+
+- `PUBLIC` — accessible en lecture (READ) à tout principal authentifié, sans
+  permission explicite.
+- `PRIVE` — accessible uniquement aux principals avec une permission explicite
+  sur la ressource.
+
+C'est la sémantique appliquée aujourd'hui aux indicateurs et aux paniers. Les
+ressources sans concept de visibilité (référentiels, widgets, individus en v0)
+restent ouvertes à tout principal authentifié.
+
+### Permissions
+
+Pour chaque ressource sécurisée, une table de jonction
+`{ressource}_permission(principal_id, {ressource}_id, action)` matérialise
+les droits explicites :
+
+- PK composite `(principal_id, {ressource}_id, action)` — un principal peut
+  avoir plusieurs actions sur une ressource (typiquement READ et WRITE).
+- Index sur `{ressource}_id` (lookups inverses fréquents).
+- Index sur `principal_id` quand la table est utilisée pour des `where`
+  filtrés par principal (cas paniers/indicateurs : la PK couvre déjà ce
+  cas via son ordre, donc pas d'index supplémentaire nécessaire).
+- FK avec `ON DELETE CASCADE` sur les deux côtés.
+
+### Actions
+
+```
+PermissionAction ∈ { READ, WRITE }
+```
+
+- `READ` : autorise la lecture (queries `list*`, `get*ByPublicId`).
+- `WRITE` : autorise la modification (commands `upsert*`, `delete*`). **WRITE
+  n'implique pas READ par la sémantique de l'enum**, mais par convention, les
+  helpers `with*ReadPermission` acceptent les deux actions comme valant un
+  READ (un principal qui peut écrire peut lire). Voir constantes
+  `INDICATEUR_READ_PERMISSIONS` / `PANIER_READ_PERMISSIONS`.
+
+## Helpers
+
+### `with{Ressource}ReadPermission(where, principalId)`
+
+Compose un `Prisma.{Ressource}WhereInput` avec la clause de filtrage par
+permission. Pattern systématique :
+
+```ts
+({ AND: [where, { OR: [
+  { visibilite: 'PUBLIC' },
+  { permissions: { some: { principalId, action: { in: [READ, WRITE] } } } },
+  // ... éventuelles branches de propagation (voir ci-dessous)
+] }] })
+```
+
+Appliqué dans **toutes** les queries de lecture (`list*`, `get*ByPublicId`).
+Aucune query de lecture sécurisée ne doit accéder à `db().{ressource}` sans
+passer par ce helper.
+
+### `ensure{Ressource}WritePermission({ principalId, ...id })`
+
+Renvoie un `ResultAsync<void, never>` qui throw `ForbiddenError` si le
+principal n'a pas la permission WRITE explicite sur la ressource. Appliqué au
+début de toute command (`upsert`, `delete`).
+
+Le WRITE est strictement direct : il ne se propage **jamais** depuis une autre
+ressource (cf. invariant ci-dessous).
+
+## Propagation panier → indicateur
+
+Cas particulier explicite : un principal qui a READ ou WRITE sur un panier
+gagne **automatiquement** READ sur tous les indicateurs qui composent le
+panier. Le helper `withIndicateurReadPermission` ajoute donc une troisième
+branche OR :
+
+```ts
+{ paniers: { some: { panier: { permissions: { some: { principalId, action: { in: [READ, WRITE] } } } } } } }
+```
+
+**Pourquoi cette direction (panier → indicateur, pas indicateur → panier) :**
+le panier est une « vue » composée, c'est un cas d'usage explicite de
+partage groupé. Permettre à un destinataire de panier de consulter les
+indicateurs qu'il contient est attendu et naturel. L'inverse (accès à un
+indicateur ⇒ accès à tous les paniers qui le citent) n'aurait pas de sens.
+
+**Pourquoi READ uniquement, pas WRITE :** un panier est un container — le
+fait de pouvoir gérer un panier (ajouter/retirer des indicateurs) ne doit
+**pas** permettre de modifier les valeurs ou la définition des indicateurs
+eux-mêmes. La distinction container vs contenu est portée par la sémantique
+des permissions : `WRITE` sur panier = modifier le panier, pas son contenu.
+
+## Invariants
+
+1. **Toute query de lecture sur une ressource sécurisée passe par
+   `with{Ressource}ReadPermission`.** Aucune exception : si une nouvelle
+   query est ajoutée, elle doit appliquer ce helper, sinon elle expose des
+   données sans contrôle d'accès.
+
+2. **Toute command sur une ressource sécurisée appelle
+   `ensure{Ressource}WritePermission` en première instruction.** Pas
+   d'écriture sans WRITE explicite.
+
+3. **WRITE est strictement direct, jamais propagé.** Si on étend la
+   propagation à d'autres ressources (ex. catégorie ⇒ indicateurs), elle se
+   limite à READ. La propagation WRITE introduirait des escalations de
+   privilèges indirectes très difficiles à raisonner.
+
+4. **Les routes protégées par permissions DOIVENT exiger `requireAuthentication`
+   en middleware.** Le helper `requireCurrentPrincipalId()` throw
+   `UnauthorizedError` sinon — c'est la garantie qu'on n'exécute jamais une
+   query permissionnée avec un principal nul.
+
+5. **PUBLIC vs PRIVE est une propriété de la ressource, pas du contenu.**
+   Le contenu d'une ressource publique peut inclure des éléments privés (rare
+   mais possible) : la visibilité du conteneur ne « rend » pas son contenu
+   public. La propagation panier → indicateur est l'inverse — elle propage la
+   visibilité du conteneur vers son contenu, ce qui est explicite et
+   sémantiquement justifié.
+
+## Performance
+
+Les helpers `with*ReadPermission` introduisent un OR avec une sous-requête
+`permissions.some`. Pour rester performant :
+
+- Index sur `{ressource}_permission.principal_id` (ou couverture par la PK
+  composite si l'ordre est `(principal_id, ...)`, ce qui est le cas).
+- Quand on ajoute une branche de propagation traversant N-N (ex. paniers via
+  `panier_indicateur` puis `panier_permission`), l'index `panier_permission(principal_id)`
+  devient critique — la profondeur du `some.some` ne permet pas à PostgreSQL
+  de l'inférer sans aide.
+- Le pattern actuel (≤ 3 branches OR par helper) reste OK jusqu'à quelques
+  millions de lignes par table. Si on dépasse, envisager une projection
+  matérialisée des permissions effectives par principal.
+
+## Pas d'API de gestion des permissions
+
+L'attribution des permissions est aujourd'hui exclusivement gérée via
+`prisma/seed.ts`. Pas d'endpoints `POST /permissions/...`. Quand un besoin
+d'administration émerge (ex. UI admin pour la DITP), on introduira des
+commands dédiées en suivant le pattern existant des autres commands
+(neverthrow, `ensure*WritePermission` sur la ressource gestionnaire, etc.).
+
+## Comment étendre à une nouvelle ressource
+
+Pour ajouter le modèle de permissions à une nouvelle ressource `Foo` :
+
+1. **Schéma Prisma** : ajouter `visibilite: Visibilite` sur `Foo`, créer
+   `FooPermission(principalId, fooId, action)` avec PK composite, index sur
+   `fooId`, relation inverse sur `Principal`.
+2. **Migration** : suivre le pattern de
+   `20260521120000_add_indicateur_visibilite` (colonne nullable → backfill →
+   NOT NULL) et `20260512120000_add_principal_and_permissions` (création
+   table + FK).
+3. **Helpers** : créer `src/foo/permissions.ts` avec `withFooReadPermission`
+   et `ensureFooWritePermission`.
+4. **Queries / commands** : appliquer les helpers partout. Aucune exception.
+5. **Routes** : middleware `requireAuthentication` obligatoire.
+6. **Fixtures** : étendre `fixtures.foo` avec `visibilite` + `permissions`,
+   et étendre `fixtures.apiKey` / `fixtures.utilisateur` avec
+   `fooPermissions`.
+7. **Tests** : tests d'intégration sur la liste/détail avec PUBLIC, PRIVE
+   avec permission, PRIVE sans permission.
+8. **Propagation éventuelle** : si la ressource agrège d'autres ressources
+   sécurisées, décider explicitement de la propagation READ et la documenter
+   ici.
+
+## Limitations connues
+
+- **Pas de notion de groupe / rôle.** Les permissions sont attribuées
+  principal par principal. Pour un usage large, on passera par un système
+  de groupes (`PrincipalGroup` + `GroupPermission`) — pas avant qu'un cas
+  d'usage métier l'exige.
+- **Pas d'héritage hiérarchique.** Un panier de paniers, ou un référentiel
+  parent qui propage à ses enfants, n'existe pas. À traiter au cas par cas
+  si le besoin émerge.
+- **Pas de permissions négatives (deny).** Le modèle est purement additif :
+  on accorde, on ne retire pas explicitement.
+- **Pas d'audit / pas d'historisation des changements de permission.** À
+  ajouter si la conformité l'exige.

--- a/apps/mb-api/prisma/migrations/20260604081841_add_panier_permissions/migration.sql
+++ b/apps/mb-api/prisma/migrations/20260604081841_add_panier_permissions/migration.sql
@@ -1,0 +1,28 @@
+-- AlterTable (add nullable column to allow backfill)
+ALTER TABLE "panier" ADD COLUMN "visibilite" "visibilite_enum";
+
+-- Backfill existing paniers as PUBLIC (comportement antérieur : tous les paniers
+-- étaient accessibles sans filtrage).
+UPDATE "panier" SET "visibilite" = 'PUBLIC' WHERE "visibilite" IS NULL;
+
+-- Enforce NOT NULL
+ALTER TABLE "panier" ALTER COLUMN "visibilite" SET NOT NULL;
+
+-- CreateTable
+CREATE TABLE "panier_permission" (
+    "principal_id" UUID NOT NULL,
+    "panier_id" UUID NOT NULL,
+    "action" "permission_action_enum" NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "panier_permission_pkey" PRIMARY KEY ("principal_id", "panier_id", "action")
+);
+
+-- CreateIndex
+CREATE INDEX "panier_permission_panier_id_idx" ON "panier_permission"("panier_id");
+
+-- AddForeignKey
+ALTER TABLE "panier_permission" ADD CONSTRAINT "panier_permission_principal_id_fkey" FOREIGN KEY ("principal_id") REFERENCES "principal"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "panier_permission" ADD CONSTRAINT "panier_permission_panier_id_fkey" FOREIGN KEY ("panier_id") REFERENCES "panier"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/mb-api/prisma/schema.prisma
+++ b/apps/mb-api/prisma/schema.prisma
@@ -14,9 +14,10 @@ model Principal {
   id        String   @id @db.Uuid
   createdAt DateTime @default(now()) @map("created_at")
 
-  utilisateur          Utilisateur?
-  apiKey               ApiKey?
+  utilisateur           Utilisateur?
+  apiKey                ApiKey?
   indicateurPermissions IndicateurPermission[]
+  panierPermissions     PanierPermission[]
 
   @@map("principal")
 }
@@ -228,16 +229,32 @@ model ObjectifIndicateurIndividu {
 }
 
 model Panier {
-  id          String   @id @db.Uuid
-  publicId    String   @unique @map("public_id")
+  id          String     @id @db.Uuid
+  publicId    String     @unique @map("public_id")
   nom         String
   description String?
-  createdAt   DateTime @default(now()) @map("created_at")
-  updatedAt   DateTime @updatedAt      @map("updated_at")
+  visibilite  Visibilite
+  createdAt   DateTime   @default(now()) @map("created_at")
+  updatedAt   DateTime   @updatedAt      @map("updated_at")
 
   indicateurs PanierIndicateur[]
+  permissions PanierPermission[]
 
   @@map("panier")
+}
+
+model PanierPermission {
+  principalId String           @map("principal_id") @db.Uuid
+  panierId    String           @map("panier_id")    @db.Uuid
+  action      PermissionAction
+  createdAt   DateTime         @default(now()) @map("created_at")
+
+  principal Principal @relation(fields: [principalId], references: [id], onDelete: Cascade)
+  panier    Panier    @relation(fields: [panierId],    references: [id], onDelete: Cascade)
+
+  @@id([principalId, panierId, action])
+  @@index([panierId])
+  @@map("panier_permission")
 }
 
 model PanierIndicateur {

--- a/apps/mb-api/prisma/seed.ts
+++ b/apps/mb-api/prisma/seed.ts
@@ -514,54 +514,82 @@ const main = async () => {
     objectifsCount += result.count
   }
 
-  // Paniers d'indicateurs (v0) : collections thématiques pour le front. L'ordre
+  // Paniers d'indicateurs : collections thématiques pour le front. L'ordre
   // du tableau `indicateurPublicIds` détermine l'ordre d'affichage (via createdAt
-  // ASC de la jonction). On ne seede que des indicateurs PUBLIC : tant que le
-  // panier n'applique pas le filtrage par permissions du principal (cf.
-  // docs/architecture/paniers-design.md, D6), l'invariant est porté par le seed.
+  // ASC de la jonction).
+  //
+  // Visibilité (cf. docs/architecture/permissions-design.md) :
+  // - PUBLIC : visible à tout principal authentifié ;
+  // - PRIVE : visible uniquement aux principals avec une permission explicite
+  //   sur le panier (et propage READ sur ses indicateurs).
+  //
+  // PAN-001..004 restent PUBLIC pour conserver le comportement antérieur (les
+  // 5 indicateurs IND-046..050 sont eux-mêmes PUBLIC, donc accessibles à tous).
+  // PAN-005 est PRIVE et contient des indicateurs PRIVE (IND-001..003) : il
+  // démontre la propagation panier → indicateur (un principal qui a accès à
+  // PAN-005 voit IND-001..003 même sans permission directe sur eux).
   const paniersSeed: ReadonlyArray<{
     publicId: string
     nom: string
     description: string | null
+    visibilite: 'PUBLIC' | 'PRIVE'
     indicateurPublicIds: ReadonlyArray<string>
   }> = [
     {
       publicId: 'PAN-001',
       nom: 'Indicateurs sociaux',
       description: 'Pauvreté, alphabétisation et accès numérique.',
+      visibilite: 'PUBLIC',
       indicateurPublicIds: ['IND-048', 'IND-049', 'IND-050'],
     },
     {
       publicId: 'PAN-002',
       nom: 'Santé et démographie',
       description: 'Démographie générale et espérance de vie.',
+      visibilite: 'PUBLIC',
       indicateurPublicIds: ['IND-046', 'IND-047'],
     },
     {
       publicId: 'PAN-003',
       nom: "Vue d'ensemble — indicateurs publics",
       description: "L'ensemble des indicateurs publics du référentiel mb.",
+      visibilite: 'PUBLIC',
       indicateurPublicIds: ['IND-046', 'IND-047', 'IND-048', 'IND-049', 'IND-050'],
     },
     {
       publicId: 'PAN-004',
       nom: 'Niveau de vie',
       description: 'Indicateurs de bien-être matériel et de connectivité.',
+      visibilite: 'PUBLIC',
       indicateurPublicIds: ['IND-048', 'IND-050'],
+    },
+    {
+      publicId: 'PAN-005',
+      nom: 'Panier admin — économie',
+      description: 'Panier privé démontrant la propagation READ vers ses indicateurs.',
+      visibilite: 'PRIVE',
+      indicateurPublicIds: ['IND-001', 'IND-002', 'IND-003'],
     },
   ]
 
+  const paniersByPublicId = new Map<string, { id: string }>()
   for (const panierItem of paniersSeed) {
     const panier = await prisma.panier.upsert({
       where: { publicId: panierItem.publicId },
-      update: { nom: panierItem.nom, description: panierItem.description },
+      update: {
+        nom: panierItem.nom,
+        description: panierItem.description,
+        visibilite: panierItem.visibilite,
+      },
       create: {
         id: uuidv7(),
         publicId: panierItem.publicId,
         nom: panierItem.nom,
         description: panierItem.description,
+        visibilite: panierItem.visibilite,
       },
     })
+    paniersByPublicId.set(panierItem.publicId, { id: panier.id })
     for (const indicateurPublicId of panierItem.indicateurPublicIds) {
       const indicateur = await prisma.indicateur.findUniqueOrThrow({
         where: { publicId: indicateurPublicId },
@@ -584,10 +612,37 @@ const main = async () => {
     0,
   )
 
+  // Permissions panier : on accorde READ + WRITE à ditp.admin sur PAN-005
+  // (le panier privé). Comme PAN-005 contient des indicateurs PRIVE
+  // (IND-001..003) sur lesquels ditp.admin a déjà des permissions directes
+  // (cf. boucle indicateursSeed.slice(0, 8) plus haut), la propagation
+  // n'apporte rien ici en pratique pour ditp.admin — c'est volontaire : la
+  // démo de propagation reste vérifiée en tests d'intégration.
+  for (const action of ['READ', 'WRITE'] as const) {
+    const panier = paniersByPublicId.get('PAN-005')
+    if (!panier) continue
+    await prisma.panierPermission.upsert({
+      where: {
+        principalId_panierId_action: {
+          principalId: ditpAdmin.id,
+          panierId: panier.id,
+          action,
+        },
+      },
+      update: {},
+      create: {
+        principalId: ditpAdmin.id,
+        panierId: panier.id,
+        action,
+      },
+    })
+  }
+  const panierPermissionsCount = 2
+
   const permissionsCount = 8 * 2
   const widgetLiaisonsCount = widgetsSeed.reduce((acc, w) => acc + w.referentielPublicIds.length, 0)
   console.log(
-    `Seed terminé : ${indicateursSeed.length} indicateurs, ${utilisateursSeed.length} utilisateurs, ${permissionsCount} permissions, ${referentielsSeed.length} référentiels, ${individusSeed.length} individus, ${liaisonsCount} liaisons indicateur-référentiel, ${relationsSeed.length} relations, ${valeursCount} valeurs insérées, ${objectifsCount} objectifs insérés (les doublons ont été ignorés), ${widgetsSeed.length} widgets, ${widgetLiaisonsCount} liaisons référentiel-widget, ${paniersSeed.length} paniers (${panierLiaisonsCount} liaisons panier-indicateur).`,
+    `Seed terminé : ${indicateursSeed.length} indicateurs, ${utilisateursSeed.length} utilisateurs, ${permissionsCount} permissions indicateur, ${referentielsSeed.length} référentiels, ${individusSeed.length} individus, ${liaisonsCount} liaisons indicateur-référentiel, ${relationsSeed.length} relations, ${valeursCount} valeurs insérées, ${objectifsCount} objectifs insérés (les doublons ont été ignorés), ${widgetsSeed.length} widgets, ${widgetLiaisonsCount} liaisons référentiel-widget, ${paniersSeed.length} paniers (${panierLiaisonsCount} liaisons panier-indicateur, ${panierPermissionsCount} permissions panier).`,
   )
 }
 

--- a/apps/mb-api/src/indicateur/permissions.test.ts
+++ b/apps/mb-api/src/indicateur/permissions.test.ts
@@ -1,0 +1,229 @@
+import { describe, expect, it } from 'vitest'
+
+import { db } from '@/framework/persistence/dbStore'
+import {
+  ensureIndicateurWritePermission,
+  withIndicateurReadPermission,
+} from '@/indicateur/permissions'
+import { fixtures } from '@/test/fixtures'
+import { integrationTest } from '@/test/integrationTest'
+import { testIndicateurIds } from '@/test/randomIds'
+
+const listIndicateursWithReadPermission = async (principalId: string) =>
+  db().indicateur.findMany({
+    where: withIndicateurReadPermission({}, principalId),
+    select: { publicId: true },
+    orderBy: { publicId: 'asc' },
+  })
+
+describe.concurrent('withIndicateurReadPermission', () => {
+  it(
+    'expose un indicateur PUBLIC à un principal sans aucune permission',
+    integrationTest(async () => {
+      const [pub] = testIndicateurIds(1)
+      await fixtures.indicateur({ publicId: pub, visibilite: 'PUBLIC' })
+      const apiKey = await fixtures.apiKey()
+
+      const rows = await listIndicateursWithReadPermission(apiKey.id)
+
+      expect(rows.map((r) => r.publicId)).toContain(pub)
+    }),
+  )
+
+  it(
+    'cache un indicateur PRIVE à un principal sans aucune permission',
+    integrationTest(async () => {
+      const [priv] = testIndicateurIds(1)
+      await fixtures.indicateur({ publicId: priv, visibilite: 'PRIVE' })
+      const apiKey = await fixtures.apiKey()
+
+      const rows = await listIndicateursWithReadPermission(apiKey.id)
+
+      expect(rows.map((r) => r.publicId)).not.toContain(priv)
+    }),
+  )
+
+  it(
+    'expose un indicateur PRIVE à un principal avec permission READ directe',
+    integrationTest(async () => {
+      const [priv] = testIndicateurIds(1)
+      await fixtures.indicateur({ publicId: priv, visibilite: 'PRIVE' })
+      const apiKey = await fixtures.apiKey({
+        permissions: [{ indicateur: { publicId: priv }, action: 'READ' }],
+      })
+
+      const rows = await listIndicateursWithReadPermission(apiKey.id)
+
+      expect(rows.map((r) => r.publicId)).toContain(priv)
+    }),
+  )
+
+  it(
+    'expose un indicateur PRIVE à un principal avec permission WRITE directe (WRITE implique READ)',
+    integrationTest(async () => {
+      const [priv] = testIndicateurIds(1)
+      await fixtures.indicateur({ publicId: priv, visibilite: 'PRIVE' })
+      const apiKey = await fixtures.apiKey({
+        permissions: [{ indicateur: { publicId: priv }, action: 'WRITE' }],
+      })
+
+      const rows = await listIndicateursWithReadPermission(apiKey.id)
+
+      expect(rows.map((r) => r.publicId)).toContain(priv)
+    }),
+  )
+
+  it(
+    'propage READ depuis un panier (action READ sur le panier)',
+    integrationTest(async () => {
+      const [viaPanier] = testIndicateurIds(1)
+      await fixtures.indicateur({ publicId: viaPanier, visibilite: 'PRIVE' })
+      await fixtures.panier({
+        publicId: 'PAN-PERM-RPROP-R',
+        visibilite: 'PRIVE',
+        indicateurs: [{ publicId: viaPanier }],
+      })
+      const apiKey = await fixtures.apiKey({
+        panierPermissions: [{ panier: { publicId: 'PAN-PERM-RPROP-R' }, action: 'READ' }],
+      })
+
+      const rows = await listIndicateursWithReadPermission(apiKey.id)
+
+      expect(rows.map((r) => r.publicId)).toContain(viaPanier)
+    }),
+  )
+
+  it(
+    'propage READ depuis un panier (action WRITE sur le panier)',
+    integrationTest(async () => {
+      const [viaPanier] = testIndicateurIds(1)
+      await fixtures.indicateur({ publicId: viaPanier, visibilite: 'PRIVE' })
+      await fixtures.panier({
+        publicId: 'PAN-PERM-RPROP-W',
+        visibilite: 'PRIVE',
+        indicateurs: [{ publicId: viaPanier }],
+      })
+      const apiKey = await fixtures.apiKey({
+        panierPermissions: [{ panier: { publicId: 'PAN-PERM-RPROP-W' }, action: 'WRITE' }],
+      })
+
+      const rows = await listIndicateursWithReadPermission(apiKey.id)
+
+      expect(rows.map((r) => r.publicId)).toContain(viaPanier)
+    }),
+  )
+
+  it(
+    "ne propage rien depuis un panier auquel le principal n'a pas accès",
+    integrationTest(async () => {
+      const [hidden] = testIndicateurIds(1)
+      await fixtures.indicateur({ publicId: hidden, visibilite: 'PRIVE' })
+      await fixtures.panier({
+        publicId: 'PAN-PERM-RPROP-NONE',
+        visibilite: 'PRIVE',
+        indicateurs: [{ publicId: hidden }],
+      })
+      const apiKey = await fixtures.apiKey()
+
+      const rows = await listIndicateursWithReadPermission(apiKey.id)
+
+      expect(rows.map((r) => r.publicId)).not.toContain(hidden)
+    }),
+  )
+
+  it(
+    'préserve le where externe (AND avec la clause de permission)',
+    integrationTest(async () => {
+      const [a, b] = testIndicateurIds(2)
+      await fixtures.indicateur(
+        { publicId: a, nom: 'Cible', visibilite: 'PUBLIC' },
+        { publicId: b, nom: 'Autre', visibilite: 'PUBLIC' },
+      )
+      const apiKey = await fixtures.apiKey()
+
+      const rows = await db().indicateur.findMany({
+        where: withIndicateurReadPermission({ nom: 'Cible' }, apiKey.id),
+        select: { publicId: true },
+      })
+
+      expect(rows.map((r) => r.publicId)).toEqual([a])
+    }),
+  )
+})
+
+describe.concurrent('ensureIndicateurWritePermission', () => {
+  it(
+    'passe quand le principal a la permission WRITE directe',
+    integrationTest(async () => {
+      const [pub] = testIndicateurIds(1)
+      const indicateur = await fixtures.indicateur({ publicId: pub, visibilite: 'PRIVE' })
+      const apiKey = await fixtures.apiKey({
+        permissions: [{ indicateur: { publicId: pub }, action: 'WRITE' }],
+      })
+
+      const result = await ensureIndicateurWritePermission({
+        indicateurId: indicateur.id,
+        principalId: apiKey.id,
+      })
+
+      expect(result.isOk()).toBe(true)
+    }),
+  )
+
+  it(
+    "rejette quand le principal n'a que la permission READ (READ n'implique pas WRITE)",
+    integrationTest(async () => {
+      const [pub] = testIndicateurIds(1)
+      const indicateur = await fixtures.indicateur({ publicId: pub, visibilite: 'PRIVE' })
+      const apiKey = await fixtures.apiKey({
+        permissions: [{ indicateur: { publicId: pub }, action: 'READ' }],
+      })
+
+      await expect(
+        ensureIndicateurWritePermission({
+          indicateurId: indicateur.id,
+          principalId: apiKey.id,
+        }),
+      ).rejects.toThrow(/permission/i)
+    }),
+  )
+
+  it(
+    "rejette même si l'indicateur est PUBLIC (PUBLIC ne couvre que la lecture)",
+    integrationTest(async () => {
+      const [pub] = testIndicateurIds(1)
+      const indicateur = await fixtures.indicateur({ publicId: pub, visibilite: 'PUBLIC' })
+      const apiKey = await fixtures.apiKey()
+
+      await expect(
+        ensureIndicateurWritePermission({
+          indicateurId: indicateur.id,
+          principalId: apiKey.id,
+        }),
+      ).rejects.toThrow(/permission/i)
+    }),
+  )
+
+  it(
+    "rejette même si le principal a WRITE sur un panier qui contient l'indicateur (WRITE indicateur reste direct, pas de propagation)",
+    integrationTest(async () => {
+      const [viaPanier] = testIndicateurIds(1)
+      const indicateur = await fixtures.indicateur({ publicId: viaPanier, visibilite: 'PRIVE' })
+      await fixtures.panier({
+        publicId: 'PAN-PERM-WPROP-NO',
+        visibilite: 'PRIVE',
+        indicateurs: [{ publicId: viaPanier }],
+      })
+      const apiKey = await fixtures.apiKey({
+        panierPermissions: [{ panier: { publicId: 'PAN-PERM-WPROP-NO' }, action: 'WRITE' }],
+      })
+
+      await expect(
+        ensureIndicateurWritePermission({
+          indicateurId: indicateur.id,
+          principalId: apiKey.id,
+        }),
+      ).rejects.toThrow(/permission/i)
+    }),
+  )
+})

--- a/apps/mb-api/src/indicateur/permissions.ts
+++ b/apps/mb-api/src/indicateur/permissions.ts
@@ -4,12 +4,19 @@ import { ForbiddenError } from '@/framework/errors/AppError'
 import { db } from '@/framework/persistence/dbStore'
 import { Prisma } from '@/generated/prisma/client'
 import { PermissionAction, Visibilite } from '@/generated/prisma/enums'
+import { PANIER_READ_PERMISSIONS } from '@/panier/permissions'
 
 const INDICATEUR_READ_PERMISSIONS: PermissionAction[] = [
   PermissionAction.READ,
   PermissionAction.WRITE,
 ]
 
+// La permission de lecture sur un indicateur est accordée si :
+// - l'indicateur est PUBLIC, OU
+// - le principal a READ/WRITE direct sur l'indicateur, OU
+// - le principal a READ/WRITE sur un panier qui contient l'indicateur
+//   (propagation panier → indicateur, cf. permissions-design.md).
+// Le WRITE indicateur reste strictement direct (ensureIndicateurWritePermission).
 export const withIndicateurReadPermission = (
   where: Prisma.IndicateurWhereInput,
   principalId: string,
@@ -20,6 +27,17 @@ export const withIndicateurReadPermission = (
       OR: [
         { visibilite: Visibilite.PUBLIC },
         { permissions: { some: { principalId, action: { in: INDICATEUR_READ_PERMISSIONS } } } },
+        {
+          paniers: {
+            some: {
+              panier: {
+                permissions: {
+                  some: { principalId, action: { in: PANIER_READ_PERMISSIONS } },
+                },
+              },
+            },
+          },
+        },
       ],
     },
   ],

--- a/apps/mb-api/src/indicateur/queries/listIndicateurs.test.ts
+++ b/apps/mb-api/src/indicateur/queries/listIndicateurs.test.ts
@@ -60,6 +60,52 @@ describe.concurrent('listIndicateurs', () => {
   )
 
   it(
+    'propage READ via les permissions panier : un principal qui a accès à un panier voit ses indicateurs PRIVE',
+    integrationTest(async () => {
+      const [viaPanier, hidden] = testIndicateurIds(2)
+      await fixtures.indicateur(
+        { publicId: viaPanier, visibilite: 'PRIVE' },
+        { publicId: hidden, visibilite: 'PRIVE' },
+      )
+      await fixtures.panier({
+        publicId: 'PAN-PROPAG-1',
+        visibilite: 'PRIVE',
+        indicateurs: [{ publicId: viaPanier }],
+      })
+      const apiKey = await fixtures.apiKey({
+        panierPermissions: [{ panier: { publicId: 'PAN-PROPAG-1' }, action: 'READ' }],
+      })
+
+      const result = await runAsPrincipal(apiKey.id, () => listIndicateurs({}))
+
+      const value = result._unsafeUnwrap()
+      expect(value.items.map((i) => i.id)).toEqual([viaPanier])
+      expect(value.total).toBe(1)
+    }),
+  )
+
+  it(
+    'la propagation panier → indicateur fonctionne aussi avec WRITE sur le panier',
+    integrationTest(async () => {
+      const [viaPanier] = testIndicateurIds(1)
+      await fixtures.indicateur({ publicId: viaPanier, visibilite: 'PRIVE' })
+      await fixtures.panier({
+        publicId: 'PAN-PROPAG-2',
+        visibilite: 'PRIVE',
+        indicateurs: [{ publicId: viaPanier }],
+      })
+      const apiKey = await fixtures.apiKey({
+        panierPermissions: [{ panier: { publicId: 'PAN-PROPAG-2' }, action: 'WRITE' }],
+      })
+
+      const result = await runAsPrincipal(apiKey.id, () => listIndicateurs({}))
+
+      const value = result._unsafeUnwrap()
+      expect(value.items.map((i) => i.id)).toEqual([viaPanier])
+    }),
+  )
+
+  it(
     'retourne tous les indicateurs autorisés quand leur nombre est inférieur à la taille de page',
     integrationTest(async () => {
       const [ind1, ind2, ind3] = testIndicateurIds(3)

--- a/apps/mb-api/src/panier/permissions.test.ts
+++ b/apps/mb-api/src/panier/permissions.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from 'vitest'
+
+import { db } from '@/framework/persistence/dbStore'
+import { ensurePanierWritePermission, withPanierReadPermission } from '@/panier/permissions'
+import { fixtures } from '@/test/fixtures'
+import { integrationTest } from '@/test/integrationTest'
+
+const listPaniersWithReadPermission = async (principalId: string) =>
+  db().panier.findMany({
+    where: withPanierReadPermission({}, principalId),
+    select: { publicId: true },
+    orderBy: { publicId: 'asc' },
+  })
+
+describe.concurrent('withPanierReadPermission', () => {
+  it(
+    'expose un panier PUBLIC à un principal sans aucune permission',
+    integrationTest(async () => {
+      await fixtures.panier({ publicId: 'PAN-W-PUB-001', visibilite: 'PUBLIC' })
+      const apiKey = await fixtures.apiKey()
+
+      const rows = await listPaniersWithReadPermission(apiKey.id)
+
+      expect(rows.map((r) => r.publicId)).toContain('PAN-W-PUB-001')
+    }),
+  )
+
+  it(
+    'cache un panier PRIVE à un principal sans permission',
+    integrationTest(async () => {
+      await fixtures.panier({ publicId: 'PAN-W-PRI-001', visibilite: 'PRIVE' })
+      const apiKey = await fixtures.apiKey()
+
+      const rows = await listPaniersWithReadPermission(apiKey.id)
+
+      expect(rows.map((r) => r.publicId)).not.toContain('PAN-W-PRI-001')
+    }),
+  )
+
+  it(
+    'expose un panier PRIVE à un principal avec permission READ directe',
+    integrationTest(async () => {
+      await fixtures.panier({ publicId: 'PAN-W-PRI-READ', visibilite: 'PRIVE' })
+      const apiKey = await fixtures.apiKey({
+        panierPermissions: [{ panier: { publicId: 'PAN-W-PRI-READ' }, action: 'READ' }],
+      })
+
+      const rows = await listPaniersWithReadPermission(apiKey.id)
+
+      expect(rows.map((r) => r.publicId)).toContain('PAN-W-PRI-READ')
+    }),
+  )
+
+  it(
+    'expose un panier PRIVE à un principal avec permission WRITE directe (WRITE implique READ)',
+    integrationTest(async () => {
+      await fixtures.panier({ publicId: 'PAN-W-PRI-WRITE', visibilite: 'PRIVE' })
+      const apiKey = await fixtures.apiKey({
+        panierPermissions: [{ panier: { publicId: 'PAN-W-PRI-WRITE' }, action: 'WRITE' }],
+      })
+
+      const rows = await listPaniersWithReadPermission(apiKey.id)
+
+      expect(rows.map((r) => r.publicId)).toContain('PAN-W-PRI-WRITE')
+    }),
+  )
+
+  it(
+    'isole les permissions par principal : un panier PRIVE accessible à A reste caché à B',
+    integrationTest(async () => {
+      await fixtures.panier({ publicId: 'PAN-W-ISO-001', visibilite: 'PRIVE' })
+      const [a, b] = await fixtures.apiKey(
+        { panierPermissions: [{ panier: { publicId: 'PAN-W-ISO-001' }, action: 'READ' }] },
+        {},
+      )
+
+      const rowsA = await listPaniersWithReadPermission(a!.id)
+      const rowsB = await listPaniersWithReadPermission(b!.id)
+
+      expect(rowsA.map((r) => r.publicId)).toContain('PAN-W-ISO-001')
+      expect(rowsB.map((r) => r.publicId)).not.toContain('PAN-W-ISO-001')
+    }),
+  )
+
+  it(
+    'préserve le where externe (AND avec la clause de permission)',
+    integrationTest(async () => {
+      await fixtures.panier(
+        { publicId: 'PAN-W-AND-A', nom: 'Cible', visibilite: 'PUBLIC' },
+        { publicId: 'PAN-W-AND-B', nom: 'Autre', visibilite: 'PUBLIC' },
+      )
+      const apiKey = await fixtures.apiKey()
+
+      const rows = await db().panier.findMany({
+        where: withPanierReadPermission({ nom: 'Cible' }, apiKey.id),
+        select: { publicId: true },
+      })
+
+      expect(rows.map((r) => r.publicId)).toEqual(['PAN-W-AND-A'])
+    }),
+  )
+})
+
+describe.concurrent('ensurePanierWritePermission', () => {
+  it(
+    'passe quand le principal a la permission WRITE directe',
+    integrationTest(async () => {
+      const panier = await fixtures.panier({ publicId: 'PAN-EW-OK', visibilite: 'PRIVE' })
+      const apiKey = await fixtures.apiKey({
+        panierPermissions: [{ panier: { publicId: 'PAN-EW-OK' }, action: 'WRITE' }],
+      })
+
+      const result = await ensurePanierWritePermission({
+        panierId: panier.id,
+        principalId: apiKey.id,
+      })
+
+      expect(result.isOk()).toBe(true)
+    }),
+  )
+
+  it(
+    "rejette quand le principal n'a aucune permission",
+    integrationTest(async () => {
+      const panier = await fixtures.panier({ publicId: 'PAN-EW-NONE', visibilite: 'PRIVE' })
+      const apiKey = await fixtures.apiKey()
+
+      await expect(
+        ensurePanierWritePermission({ panierId: panier.id, principalId: apiKey.id }),
+      ).rejects.toThrow(/permission/i)
+    }),
+  )
+
+  it(
+    "rejette quand le principal n'a que la permission READ (READ n'implique pas WRITE)",
+    integrationTest(async () => {
+      const panier = await fixtures.panier({ publicId: 'PAN-EW-RONLY', visibilite: 'PRIVE' })
+      const apiKey = await fixtures.apiKey({
+        panierPermissions: [{ panier: { publicId: 'PAN-EW-RONLY' }, action: 'READ' }],
+      })
+
+      await expect(
+        ensurePanierWritePermission({ panierId: panier.id, principalId: apiKey.id }),
+      ).rejects.toThrow(/permission/i)
+    }),
+  )
+
+  it(
+    'rejette quand le panier est PUBLIC mais sans permission WRITE explicite (PUBLIC ne couvre que la lecture)',
+    integrationTest(async () => {
+      const panier = await fixtures.panier({ publicId: 'PAN-EW-PUB', visibilite: 'PUBLIC' })
+      const apiKey = await fixtures.apiKey()
+
+      await expect(
+        ensurePanierWritePermission({ panierId: panier.id, principalId: apiKey.id }),
+      ).rejects.toThrow(/permission/i)
+    }),
+  )
+})

--- a/apps/mb-api/src/panier/permissions.ts
+++ b/apps/mb-api/src/panier/permissions.ts
@@ -1,0 +1,51 @@
+import { ResultAsync } from 'neverthrow'
+
+import { ForbiddenError } from '@/framework/errors/AppError'
+import { db } from '@/framework/persistence/dbStore'
+import { Prisma } from '@/generated/prisma/client'
+import { PermissionAction, Visibilite } from '@/generated/prisma/enums'
+
+export const PANIER_READ_PERMISSIONS: PermissionAction[] = [
+  PermissionAction.READ,
+  PermissionAction.WRITE,
+]
+
+export const withPanierReadPermission = (
+  where: Prisma.PanierWhereInput,
+  principalId: string,
+): Prisma.PanierWhereInput => ({
+  AND: [
+    where,
+    {
+      OR: [
+        { visibilite: Visibilite.PUBLIC },
+        { permissions: { some: { principalId, action: { in: PANIER_READ_PERMISSIONS } } } },
+      ],
+    },
+  ],
+})
+
+export const ensurePanierWritePermission = ({
+  panierId,
+  principalId,
+}: {
+  panierId: string
+  principalId: string
+}): ResultAsync<void, never> =>
+  ResultAsync.fromSafePromise(
+    db()
+      .panierPermission.findUnique({
+        where: {
+          principalId_panierId_action: {
+            principalId,
+            panierId,
+            action: PermissionAction.WRITE,
+          },
+        },
+      })
+      .then((hasWrite) => {
+        if (!hasWrite) {
+          throw new ForbiddenError("Vous n'avez pas la permission de modifier ce panier")
+        }
+      }),
+  )

--- a/apps/mb-api/src/panier/queries/getPanierByPublicId.test.ts
+++ b/apps/mb-api/src/panier/queries/getPanierByPublicId.test.ts
@@ -4,26 +4,30 @@ import { getPanierByPublicId } from '@/panier/queries/getPanierByPublicId'
 import { fixtures } from '@/test/fixtures'
 import { integrationTest } from '@/test/integrationTest'
 import { testIndicateurIds } from '@/test/randomIds'
+import { runAsPrincipal } from '@/test/runAsPrincipal'
 
 describe.concurrent('getPanierByPublicId', () => {
   it(
-    "retourne le panier avec ses indicateurs triés par ordre d'insertion",
+    "retourne le panier PUBLIC avec ses indicateurs triés par ordre d'insertion",
     integrationTest(async () => {
       const [indA, indB] = testIndicateurIds(2)
       const panier = await fixtures.panier({
         publicId: 'PAN-DETAIL-1',
         nom: 'Panier de détail',
         description: 'Une description',
+        visibilite: 'PUBLIC',
         indicateurs: [{ publicId: indA }, { publicId: indB }],
       })
+      const apiKey = await fixtures.apiKey()
 
-      const result = await getPanierByPublicId('PAN-DETAIL-1')
+      const result = await runAsPrincipal(apiKey.id, () => getPanierByPublicId('PAN-DETAIL-1'))
 
       expect(result.isOk()).toBe(true)
       expect(result._unsafeUnwrap()).toEqual({
         id: 'PAN-DETAIL-1',
         nom: 'Panier de détail',
         description: 'Une description',
+        visibilite: 'PUBLIC',
         indicateurIds: [indA, indB],
         createdAt: panier.createdAt.toISOString(),
         updatedAt: panier.updatedAt.toISOString(),
@@ -34,9 +38,14 @@ describe.concurrent('getPanierByPublicId', () => {
   it(
     'retourne un panier sans indicateurs avec un tableau vide',
     integrationTest(async () => {
-      await fixtures.panier({ publicId: 'PAN-DETAIL-EMPTY', nom: 'Sans indicateurs' })
+      await fixtures.panier({
+        publicId: 'PAN-DETAIL-EMPTY',
+        nom: 'Sans indicateurs',
+        visibilite: 'PUBLIC',
+      })
+      const apiKey = await fixtures.apiKey()
 
-      const result = await getPanierByPublicId('PAN-DETAIL-EMPTY')
+      const result = await runAsPrincipal(apiKey.id, () => getPanierByPublicId('PAN-DETAIL-EMPTY'))
 
       expect(result._unsafeUnwrap()).toMatchObject({
         id: 'PAN-DETAIL-EMPTY',
@@ -47,9 +56,39 @@ describe.concurrent('getPanierByPublicId', () => {
   )
 
   it(
+    "retourne un panier PRIVE quand le principal dispose d'une permission",
+    integrationTest(async () => {
+      await fixtures.panier({ publicId: 'PAN-DETAIL-PRIV', visibilite: 'PRIVE' })
+      const apiKey = await fixtures.apiKey({
+        panierPermissions: [{ panier: { publicId: 'PAN-DETAIL-PRIV' }, action: 'READ' }],
+      })
+
+      const result = await runAsPrincipal(apiKey.id, () => getPanierByPublicId('PAN-DETAIL-PRIV'))
+
+      expect(result._unsafeUnwrap().id).toBe('PAN-DETAIL-PRIV')
+    }),
+  )
+
+  it(
+    'lève une erreur quand un panier PRIVE est demandé sans permission',
+    integrationTest(async () => {
+      await fixtures.panier({ publicId: 'PAN-DETAIL-NOACL', visibilite: 'PRIVE' })
+      const apiKey = await fixtures.apiKey()
+
+      await expect(
+        runAsPrincipal(apiKey.id, () => getPanierByPublicId('PAN-DETAIL-NOACL')),
+      ).rejects.toThrow()
+    }),
+  )
+
+  it(
     'lève une erreur quand aucun panier ne correspond',
     integrationTest(async () => {
-      await expect(getPanierByPublicId('PAN-NOPE-001')).rejects.toThrow()
+      const apiKey = await fixtures.apiKey()
+
+      await expect(
+        runAsPrincipal(apiKey.id, () => getPanierByPublicId('PAN-NOPE-001')),
+      ).rejects.toThrow()
     }),
   )
 })

--- a/apps/mb-api/src/panier/queries/getPanierByPublicId.ts
+++ b/apps/mb-api/src/panier/queries/getPanierByPublicId.ts
@@ -1,13 +1,16 @@
 import { type PanierApiModel } from '@pilote/mb-shared/panier'
 import { ResultAsync } from 'neverthrow'
 
+import { requireCurrentPrincipalId } from '@/framework/auth/userContext'
 import { db } from '@/framework/persistence/dbStore'
+import { withPanierReadPermission } from '@/panier/permissions'
 import { toPanierApiModel } from '@/panier/utils'
 
 export const getPanierByPublicId = (publicId: string): ResultAsync<PanierApiModel, never> => {
+  const principalId = requireCurrentPrincipalId()
   return ResultAsync.fromSafePromise(
-    db().panier.findUniqueOrThrow({
-      where: { publicId },
+    db().panier.findFirstOrThrow({
+      where: withPanierReadPermission({ publicId }, principalId),
       include: {
         indicateurs: {
           orderBy: { createdAt: 'asc' },

--- a/apps/mb-api/src/panier/queries/listPaniers.test.ts
+++ b/apps/mb-api/src/panier/queries/listPaniers.test.ts
@@ -5,12 +5,14 @@ import { listPaniers } from '@/panier/queries/listPaniers'
 import { fixtures } from '@/test/fixtures'
 import { integrationTest } from '@/test/integrationTest'
 import { testIndicateurIds } from '@/test/randomIds'
+import { runAsPrincipal } from '@/test/runAsPrincipal'
 
 describe.concurrent('listPaniers', () => {
   it(
     "retourne une liste vide quand aucun panier n'existe",
     integrationTest(async () => {
-      const result = await listPaniers({})
+      const apiKey = await fixtures.apiKey()
+      const result = await runAsPrincipal(apiKey.id, () => listPaniers({}))
 
       expect(result.isOk()).toBe(true)
       expect(result._unsafeUnwrap()).toEqual({
@@ -22,15 +24,16 @@ describe.concurrent('listPaniers', () => {
   )
 
   it(
-    'retourne tous les paniers quand leur nombre est inférieur à la taille de page',
+    'retourne tous les paniers PUBLIC quand leur nombre est inférieur à la taille de page',
     integrationTest(async () => {
       await fixtures.panier(
-        { publicId: 'PAN-LIST-1', nom: 'Panier 1' },
-        { publicId: 'PAN-LIST-2', nom: 'Panier 2' },
-        { publicId: 'PAN-LIST-3', nom: 'Panier 3' },
+        { publicId: 'PAN-LIST-1', nom: 'Panier 1', visibilite: 'PUBLIC' },
+        { publicId: 'PAN-LIST-2', nom: 'Panier 2', visibilite: 'PUBLIC' },
+        { publicId: 'PAN-LIST-3', nom: 'Panier 3', visibilite: 'PUBLIC' },
       )
+      const apiKey = await fixtures.apiKey()
 
-      const result = await listPaniers({})
+      const result = await runAsPrincipal(apiKey.id, () => listPaniers({}))
 
       const value = result._unsafeUnwrap()
       expect(value.items.map((p) => p.id)).toEqual(['PAN-LIST-1', 'PAN-LIST-2', 'PAN-LIST-3'])
@@ -40,15 +43,53 @@ describe.concurrent('listPaniers', () => {
   )
 
   it(
+    "n'inclut que les paniers sur lesquels le principal a une permission",
+    integrationTest(async () => {
+      await fixtures.panier(
+        { publicId: 'PAN-PERM-ACC', visibilite: 'PRIVE' },
+        { publicId: 'PAN-PERM-HID', visibilite: 'PRIVE' },
+      )
+      const apiKey = await fixtures.apiKey({
+        panierPermissions: [{ panier: { publicId: 'PAN-PERM-ACC' }, action: 'READ' }],
+      })
+
+      const result = await runAsPrincipal(apiKey.id, () => listPaniers({}))
+
+      const value = result._unsafeUnwrap()
+      expect(value.items.map((p) => p.id)).toEqual(['PAN-PERM-ACC'])
+      expect(value.total).toBe(1)
+    }),
+  )
+
+  it(
+    "inclut les paniers PUBLIC sur lesquels le principal n'a aucune permission",
+    integrationTest(async () => {
+      await fixtures.panier(
+        { publicId: 'PAN-VIS-PUB', visibilite: 'PUBLIC' },
+        { publicId: 'PAN-VIS-PRI', visibilite: 'PRIVE' },
+      )
+      const apiKey = await fixtures.apiKey()
+
+      const result = await runAsPrincipal(apiKey.id, () => listPaniers({}))
+
+      const value = result._unsafeUnwrap()
+      expect(value.items.map((p) => p.id)).toEqual(['PAN-VIS-PUB'])
+      expect(value.items.map((p) => p.visibilite)).toEqual(['PUBLIC'])
+    }),
+  )
+
+  it(
     "expose les indicateurs du panier triés par ordre d'insertion (createdAt ASC)",
     integrationTest(async () => {
       const [indA, indB, indC] = testIndicateurIds(3)
       await fixtures.panier({
         publicId: 'PAN-ORDER-001',
+        visibilite: 'PUBLIC',
         indicateurs: [{ publicId: indA }, { publicId: indB }, { publicId: indC }],
       })
+      const apiKey = await fixtures.apiKey()
 
-      const result = await listPaniers({})
+      const result = await runAsPrincipal(apiKey.id, () => listPaniers({}))
 
       const value = result._unsafeUnwrap()
       const panier = value.items.find((p) => p.id === 'PAN-ORDER-001')
@@ -59,9 +100,10 @@ describe.concurrent('listPaniers', () => {
   it(
     'retourne un panier sans indicateurs avec un tableau vide',
     integrationTest(async () => {
-      await fixtures.panier({ publicId: 'PAN-EMPTY-001' })
+      await fixtures.panier({ publicId: 'PAN-EMPTY-001', visibilite: 'PUBLIC' })
+      const apiKey = await fixtures.apiKey()
 
-      const result = await listPaniers({})
+      const result = await runAsPrincipal(apiKey.id, () => listPaniers({}))
 
       const value = result._unsafeUnwrap()
       const panier = value.items.find((p) => p.id === 'PAN-EMPTY-001')
@@ -73,15 +115,16 @@ describe.concurrent('listPaniers', () => {
     'pagine quand le nombre de paniers dépasse la taille de page',
     integrationTest(async () => {
       const created = await fixtures.panier(
-        { publicId: 'PAN-PAGE-1' },
-        { publicId: 'PAN-PAGE-2' },
-        { publicId: 'PAN-PAGE-3' },
-        { publicId: 'PAN-PAGE-4' },
-        { publicId: 'PAN-PAGE-5' },
-        { publicId: 'PAN-PAGE-6' },
+        { publicId: 'PAN-PAGE-1', visibilite: 'PUBLIC' },
+        { publicId: 'PAN-PAGE-2', visibilite: 'PUBLIC' },
+        { publicId: 'PAN-PAGE-3', visibilite: 'PUBLIC' },
+        { publicId: 'PAN-PAGE-4', visibilite: 'PUBLIC' },
+        { publicId: 'PAN-PAGE-5', visibilite: 'PUBLIC' },
+        { publicId: 'PAN-PAGE-6', visibilite: 'PUBLIC' },
       )
+      const apiKey = await fixtures.apiKey()
 
-      const result = await listPaniers({ pageSize: 5 })
+      const result = await runAsPrincipal(apiKey.id, () => listPaniers({ pageSize: 5 }))
 
       const value = result._unsafeUnwrap()
       expect(value.items.map((p) => p.id)).toEqual([
@@ -100,15 +143,18 @@ describe.concurrent('listPaniers', () => {
     'retourne la page suivante en utilisant le cursor',
     integrationTest(async () => {
       const created = await fixtures.panier(
-        { publicId: 'PAN-CURSOR-1' },
-        { publicId: 'PAN-CURSOR-2' },
-        { publicId: 'PAN-CURSOR-3' },
-        { publicId: 'PAN-CURSOR-4' },
-        { publicId: 'PAN-CURSOR-5' },
-        { publicId: 'PAN-CURSOR-6' },
+        { publicId: 'PAN-CURSOR-1', visibilite: 'PUBLIC' },
+        { publicId: 'PAN-CURSOR-2', visibilite: 'PUBLIC' },
+        { publicId: 'PAN-CURSOR-3', visibilite: 'PUBLIC' },
+        { publicId: 'PAN-CURSOR-4', visibilite: 'PUBLIC' },
+        { publicId: 'PAN-CURSOR-5', visibilite: 'PUBLIC' },
+        { publicId: 'PAN-CURSOR-6', visibilite: 'PUBLIC' },
       )
+      const apiKey = await fixtures.apiKey()
 
-      const result = await listPaniers({ cursor: encodeCursor(created[4]!.id) })
+      const result = await runAsPrincipal(apiKey.id, () =>
+        listPaniers({ cursor: encodeCursor(created[4]!.id) }),
+      )
 
       const value = result._unsafeUnwrap()
       expect(value.items.map((p) => p.id)).toEqual(['PAN-CURSOR-6'])

--- a/apps/mb-api/src/panier/queries/listPaniers.ts
+++ b/apps/mb-api/src/panier/queries/listPaniers.ts
@@ -1,12 +1,18 @@
 import { type ListPaniersQuery, type PanierListApiModel } from '@pilote/mb-shared/panier'
 import { ResultAsync } from 'neverthrow'
 
+import { requireCurrentPrincipalId } from '@/framework/auth/userContext'
 import { db } from '@/framework/persistence/dbStore'
 import { buildPaginationArgs, toPaginatedResponse } from '@/framework/persistence/paginate'
+import { withPanierReadPermission } from '@/panier/permissions'
 import { toPanierApiModel } from '@/panier/utils'
 
 export const listPaniers = (params: ListPaniersQuery): ResultAsync<PanierListApiModel, never> => {
+  const principalId = requireCurrentPrincipalId()
+  const where = withPanierReadPermission({}, principalId)
+
   const fetchPage = db().panier.findMany({
+    where,
     orderBy: { id: 'asc' },
     include: {
       indicateurs: {
@@ -16,7 +22,7 @@ export const listPaniers = (params: ListPaniersQuery): ResultAsync<PanierListApi
     },
     ...buildPaginationArgs(params.cursor, params.pageSize),
   })
-  const fetchTotal = db().panier.count()
+  const fetchTotal = db().panier.count({ where })
 
   return ResultAsync.fromSafePromise(Promise.all([fetchPage, fetchTotal])).map(([rows, total]) =>
     toPaginatedResponse(rows, total, toPanierApiModel, params.pageSize),

--- a/apps/mb-api/src/panier/utils.ts
+++ b/apps/mb-api/src/panier/utils.ts
@@ -12,6 +12,7 @@ export const toPanierApiModel = (panier: PanierWithIndicateurs): PanierApiModel 
   id: panier.publicId,
   nom: panier.nom,
   description: panier.description,
+  visibilite: panier.visibilite,
   indicateurIds: panier.indicateurs.map((lien) => lien.indicateur.publicId),
   createdAt: panier.createdAt.toISOString(),
   updatedAt: panier.updatedAt.toISOString(),

--- a/apps/mb-api/src/test/fixtures.ts
+++ b/apps/mb-api/src/test/fixtures.ts
@@ -21,6 +21,7 @@ import {
   type IndividuModel,
   type ObjectifIndicateurIndividuModel,
   type PanierModel,
+  type PanierPermissionModel,
   type ReferentielModel,
   type ReferentielWidgetModel,
   type RelationModel,
@@ -452,6 +453,7 @@ type PanierOverrides = Partial<{
   publicId: string
   nom: string
   description: string | null
+  visibilite: Visibilite
   indicateurs: IndicateurOverrides[]
 }>
 
@@ -463,6 +465,7 @@ const upsertPanier = async (o: PanierOverrides = {}) => {
     publicId,
     nom: o.nom ?? 'Panier de test',
     description: o.description ?? null,
+    visibilite: o.visibilite ?? Visibilite.PRIVE,
   }
   const panier = await db().panier.upsert({
     where: { publicId },
@@ -508,6 +511,11 @@ type PrincipalIndicateurPermissionOverrides = {
   action: PermissionAction
 }
 
+type PrincipalPanierPermissionOverrides = {
+  panier: PanierOverrides
+  action: PermissionAction
+}
+
 type ApiKeyOverrides = Partial<{
   id: string
   label: string
@@ -517,6 +525,7 @@ type ApiKeyOverrides = Partial<{
   revokedAt: Date | null
   lastUsedAt: Date | null
   permissions: PrincipalIndicateurPermissionOverrides[]
+  panierPermissions: PrincipalPanierPermissionOverrides[]
 }>
 
 const grantPermissions = async (
@@ -526,6 +535,16 @@ const grantPermissions = async (
   if (!permissions || permissions.length === 0) return
   for (const p of permissions) {
     await upsertIndicateurPermission({ principalId, ...p })
+  }
+}
+
+const grantPanierPermissions = async (
+  principalId: string,
+  permissions: PrincipalPanierPermissionOverrides[] | undefined,
+): Promise<void> => {
+  if (!permissions || permissions.length === 0) return
+  for (const p of permissions) {
+    await upsertPanierPermission({ principalId, ...p })
   }
 }
 
@@ -541,16 +560,18 @@ const upsertApiKey = async (o: ApiKeyOverrides = {}) => {
     revokedAt: o.revokedAt ?? null,
     lastUsedAt: o.lastUsedAt ?? null,
   }
-  const { id: _id, rawKey: _raw, permissions, ...update } = o
+  const { id: _id, rawKey: _raw, permissions, panierPermissions, ...update } = o
   const existing = await db().apiKey.findUnique({ where: { keyHash } })
   if (existing) {
     await grantPermissions(existing.id, permissions)
+    await grantPanierPermissions(existing.id, panierPermissions)
     if (Object.keys(update).length === 0) return existing
     return db().apiKey.update({ where: { keyHash }, data: update })
   }
   await db().principal.create({ data: { id: create.id } })
   const created = await db().apiKey.create({ data: create })
   await grantPermissions(created.id, permissions)
+  await grantPanierPermissions(created.id, panierPermissions)
   return created
 }
 
@@ -575,6 +596,7 @@ type UtilisateurOverrides = Partial<{
   email: string
   providerSub: string | null
   permissions: PrincipalIndicateurPermissionOverrides[]
+  panierPermissions: PrincipalPanierPermissionOverrides[]
 }>
 
 const upsertUtilisateur = async (o: UtilisateurOverrides = {}) => {
@@ -582,7 +604,8 @@ const upsertUtilisateur = async (o: UtilisateurOverrides = {}) => {
   const existing = await db().utilisateur.findUnique({ where: { email } })
   if (existing) {
     await grantPermissions(existing.id, o.permissions)
-    const { id: _id, email: _email, permissions: _p, ...update } = o
+    await grantPanierPermissions(existing.id, o.panierPermissions)
+    const { id: _id, email: _email, permissions: _p, panierPermissions: _pp, ...update } = o
     if (Object.keys(update).length === 0) return existing
     return db().utilisateur.update({ where: { email }, data: update })
   }
@@ -595,6 +618,7 @@ const upsertUtilisateur = async (o: UtilisateurOverrides = {}) => {
   await db().principal.create({ data: { id } })
   const created = await db().utilisateur.create({ data: create })
   await grantPermissions(created.id, o.permissions)
+  await grantPanierPermissions(created.id, o.panierPermissions)
   return created
 }
 
@@ -658,6 +682,48 @@ async function indicateurPermission(
   return results
 }
 
+// --- PanierPermission (deps requises) ----------------------------------------
+
+type PanierPermissionOverrides = {
+  principalId: string
+  panier: PanierOverrides
+  action: PermissionAction
+}
+
+const upsertPanierPermission = async (o: PanierPermissionOverrides) => {
+  const panierRow = await upsertPanier(o.panier)
+  return db().panierPermission.upsert({
+    where: {
+      principalId_panierId_action: {
+        principalId: o.principalId,
+        panierId: panierRow.id,
+        action: o.action,
+      },
+    },
+    update: {},
+    create: {
+      principalId: o.principalId,
+      panierId: panierRow.id,
+      action: o.action,
+    },
+  })
+}
+
+function panierPermission(override: PanierPermissionOverrides): Promise<PanierPermissionModel>
+function panierPermission(
+  o1: PanierPermissionOverrides,
+  o2: PanierPermissionOverrides,
+  ...rest: PanierPermissionOverrides[]
+): Promise<PanierPermissionModel[]>
+async function panierPermission(
+  ...overrides: PanierPermissionOverrides[]
+): Promise<PanierPermissionModel | PanierPermissionModel[]> {
+  if (overrides.length === 1) return upsertPanierPermission(overrides[0]!)
+  const results: PanierPermissionModel[] = []
+  for (const o of overrides) results.push(await upsertPanierPermission(o))
+  return results
+}
+
 export const fixtures = {
   indicateur,
   referentiel,
@@ -672,4 +738,5 @@ export const fixtures = {
   apiKey,
   utilisateur,
   indicateurPermission,
+  panierPermission,
 }

--- a/packages/mb-shared/src/panier.ts
+++ b/packages/mb-shared/src/panier.ts
@@ -3,10 +3,18 @@ import { z } from 'zod'
 import { createPaginatedApiListSchema, paginationCursorSchema, pageSizeSchema } from './pagination'
 import { indicateurPublicIdSchema, panierPublicIdSchema } from './publicIds'
 
+export const panierVisibiliteSchema = z
+  .enum(['PUBLIC', 'PRIVE'])
+  .describe(
+    "Visibilité du panier. PUBLIC : accessible en lecture à tout principal authentifié. PRIVE : accessible uniquement aux principals disposant d'une permission explicite. Un principal qui voit un panier voit aussi les indicateurs qui le composent (propagation READ).",
+  )
+export type PanierVisibilite = z.infer<typeof panierVisibiliteSchema>
+
 export const panierApiModelSchema = z.object({
   id: panierPublicIdSchema,
   nom: z.string().describe('Nom lisible du panier.'),
   description: z.string().nullable().describe('Description libre du panier.'),
+  visibilite: panierVisibiliteSchema,
   indicateurIds: z
     .array(indicateurPublicIdSchema)
     .describe(


### PR DESCRIPTION
## Summary

- Visibilité `PUBLIC` / `PRIVE` sur `Panier` + table `PanierPermission(principalId, panierId, action)` — modèle calqué point pour point sur les indicateurs.
- Helpers `withPanierReadPermission` / `ensurePanierWritePermission` appliqués dans `listPaniers` et `getPanierByPublicId` ; routes panier déjà sous `requireAuthentication`.
- Propagation panier → indicateur : un principal qui a READ ou WRITE sur un panier obtient automatiquement READ sur ses indicateurs (branche OR ajoutée à `withIndicateurReadPermission`). WRITE indicateur reste strictement direct.
- Pas d'API de gestion : permissions pilotées par seed (`PAN-005` PRIVE avec `IND-001..003` PRIVE accordés à `ditp.admin`, démontre la propagation).
- Doc transverse `docs/architecture/permissions-design.md` (modèle, invariants, perfs, procédure d'extension à une nouvelle ressource) + maj `paniers-design.md` (D2/D6 révisés).

## Test plan

- [x] `pnpm test` sur mb-api (252/252 OK, dont nouveaux tests : `listPaniers` PUBLIC/PRIVE/permission, `getPanierByPublicId` PRIVE avec/sans permission, propagation indicateur via panier READ et WRITE)
- [x] `pnpm lint` sur mb-api
- [ ] Vérifier que la migration `20260604081841_add_panier_permissions` s'applique proprement en environnement de review (backfill `visibilite = PUBLIC` sur les paniers existants)
- [ ] Valider qu'un principal sans aucune permission ne voit que `PAN-001..004` (PUBLIC), pas `PAN-005`
- [ ] Valider qu'`ditp.admin` voit les 5 paniers et que `IND-001..003` apparaissent via la propagation

🤖 Generated with [Claude Code](https://claude.com/claude-code)