### PR TITLE
[PIL-1595] Activation heatmap Matomo + upgrade matomo-next 1.13.1

### DIFF
--- a/apps/pilote-ppg/package.json
+++ b/apps/pilote-ppg/package.json
@@ -72,7 +72,7 @@
     "@keycloak/keycloak-admin-client": "26.5.6",
     "@next/env": "16.1.2",
     "@prisma/client": "6.2.1",
-    "@socialgouv/matomo-next": "1.8.1",
+    "@socialgouv/matomo-next": "1.13.1",
     "@tanstack/react-query": "^5.90.19",
     "@tanstack/react-query-devtools": "^5.91.2",
     "@tanstack/react-table": "^8.8.4",

--- a/apps/pilote-ppg/src/pages/_app.tsx
+++ b/apps/pilote-ppg/src/pages/_app.tsx
@@ -7,7 +7,7 @@ import { SessionProvider } from "next-auth/react";
 import { AppProps } from "next/app";
 import { useEffect, useState } from "react";
 import Head from "next/head";
-import init from "@socialgouv/matomo-next";
+import { trackPagesRouter } from "@socialgouv/matomo-next";
 import Router from "next/router";
 import { Toaster } from "sonner";
 import { NuqsAdapter } from "nuqs/adapters/next/pages";
@@ -78,7 +78,11 @@ function MonApplication({ Component, pageProps, nonce: appNonce }: MyAppProps) {
 
   useEffect(() => {
     if (estRecordAnalyticsActive === "true") {
-      init({ url: matomoUrl as string, siteId: matomoSiteId as string });
+      trackPagesRouter({
+        url: matomoUrl as string,
+        siteId: matomoSiteId as string,
+        enableHeatmapSessionRecording: true,
+      });
     }
   }, [estRecordAnalyticsActive, matomoSiteId, matomoUrl]);
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -321,8 +321,8 @@ importers:
         specifier: 6.2.1
         version: 6.2.1(prisma@6.2.1)
       '@socialgouv/matomo-next':
-        specifier: 1.8.1
-        version: 1.8.1(next@16.2.6(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(sass@1.78.0))
+        specifier: 1.13.1
+        version: 1.13.1(next@16.2.6(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(sass@1.78.0))(react@19.2.5)
       '@tanstack/react-query':
         specifier: ^5.90.19
         version: 5.99.0(react@19.2.5)
@@ -3114,10 +3114,12 @@ packages:
   '@sinclair/typebox@0.27.10':
     resolution: {integrity: sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==}
 
-  '@socialgouv/matomo-next@1.8.1':
-    resolution: {integrity: sha512-H6wm5zroqtBcsu1lWG78UQC6X7qj66jQD0o36GRiMSLrABCKP/QwbyLykc7Q0xlxsseJW1IWwSwbBa+9jr6f5Q==}
+  '@socialgouv/matomo-next@1.13.1':
+    resolution: {integrity: sha512-X1772JUsZmGVFfE+rG2k+eWelW1HcEUqq6J8YxviKX4nRDh/jS0Royjft1vKMYPEEdTLrLJK/gvIftq6Rwk+ng==}
+    engines: {node: '>=24.0.0', pnpm: '>=10.0.0'}
     peerDependencies:
-      next: '>= 9.5.5'
+      next: '>= 13.0.0'
+      react: '>= 18.0.0'
 
   '@standard-schema/spec@1.0.0':
     resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
@@ -11685,9 +11687,10 @@ snapshots:
 
   '@sinclair/typebox@0.27.10': {}
 
-  '@socialgouv/matomo-next@1.8.1(next@16.2.6(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(sass@1.78.0))':
+  '@socialgouv/matomo-next@1.13.1(next@16.2.6(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(sass@1.78.0))(react@19.2.5)':
     dependencies:
       next: 16.2.6(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(sass@1.78.0)
+      react: 19.2.5
 
   '@standard-schema/spec@1.0.0': {}
 
@@ -13188,7 +13191,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@opentelemetry/api@1.9.0)(@types/node@22.19.17)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.2(@noble/hashes@1.8.0))(msw@2.14.2(@types/node@22.19.17)(typescript@5.9.3))(vite@8.0.10(@types/node@22.19.17)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.78.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.4(@opentelemetry/api@1.9.0)(@types/node@22.19.17)(@vitest/coverage-v8@4.1.4)(jsdom@29.1.0(@noble/hashes@1.8.0))(msw@2.14.2(@types/node@22.19.17)(typescript@5.9.3))(vite@8.0.10(@types/node@22.19.17)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.78.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
 
   '@vitest/eslint-plugin@1.6.15(@typescript-eslint/eslint-plugin@8.58.2(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.4)':
     dependencies:


### PR DESCRIPTION
## Contexte

[PIL-1595](https://data-ditp.atlassian.net/browse/PIL-1595)

Activation de l'enregistrement de session Matomo pour exploiter la fonctionnalité **heatmap**.

## Changements

- ⬆️ Upgrade `@socialgouv/matomo-next` : `1.8.1` → `1.13.1`
- 🔥 Activation de la heatmap via `enableHeatmapSessionRecording: true` dans l'init Matomo (`apps/pilote-ppg/src/pages/_app.tsx`)
- ♻️ La 1.13.1 supprime le default export `init`. Bascule vers `trackPagesRouter`, la fonction recommandée pour le Pages Router (`init` existe encore en export nommé mais est déprécié)

## Vérifications

- ✅ `pnpm lint` (ESLint + tsc) OK sur `apps/pilote-ppg`

[PIL-1595]: https://data-ditp.atlassian.net/browse/PIL-1595?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ