### PR TITLE
feat(mb-webapp): individu observé par défaut sur la liste indicateurs

### DIFF
--- a/apps/mb-api/prisma/seed.ts
+++ b/apps/mb-api/prisma/seed.ts
@@ -299,6 +299,7 @@ const main = async () => {
       indicateurPublicId: 'IND-001',
       referentiels: [
         { referentielPublicId: 'REF-DEPT', fonctionAgregation: 'NONE' },
+        { referentielPublicId: 'REF-REG', fonctionAgregation: 'NONE' },
         { referentielPublicId: 'REF-NAT', fonctionAgregation: 'NONE' },
       ],
     },
@@ -307,6 +308,7 @@ const main = async () => {
       referentiels: [
         { referentielPublicId: 'REF-DEPT', fonctionAgregation: 'SUM' },
         { referentielPublicId: 'REF-REG', fonctionAgregation: 'SUM' },
+        { referentielPublicId: 'REF-NAT', fonctionAgregation: 'SUM' },
       ],
     },
     {
@@ -319,7 +321,11 @@ const main = async () => {
     },
     {
       indicateurPublicId: 'IND-004',
-      referentiels: [{ referentielPublicId: 'REF-DEPT', fonctionAgregation: 'NONE' }],
+      referentiels: [
+        { referentielPublicId: 'REF-DEPT', fonctionAgregation: 'NONE' },
+        { referentielPublicId: 'REF-REG', fonctionAgregation: 'AVG' },
+        { referentielPublicId: 'REF-NAT', fonctionAgregation: 'AVG' },
+      ],
     },
     {
       indicateurPublicId: 'IND-005',

--- a/apps/mb-webapp/src/api/referentiels.ts
+++ b/apps/mb-webapp/src/api/referentiels.ts
@@ -1,7 +1,19 @@
 import { type IndividuListApiModel, individuListApiModelSchema } from '@pilote/mb-shared/individu'
-import { type ReferentielApiModel, referentielApiModelSchema } from '@pilote/mb-shared/referentiel'
+import {
+  type ReferentielApiModel,
+  referentielApiModelSchema,
+  type ReferentielListApiModel,
+  referentielListApiModelSchema,
+} from '@pilote/mb-shared/referentiel'
 
 import { apiClient } from '@/api/client'
+
+export const fetchReferentiels = async (
+  params: { cursor?: string } = {},
+): Promise<ReferentielListApiModel> => {
+  const json = await apiClient.get('referentiels', { searchParams: params }).json()
+  return referentielListApiModelSchema.parse(json)
+}
 
 export const fetchReferentielById = async (referentielId: string): Promise<ReferentielApiModel> => {
   const json = await apiClient.get(`referentiels/${referentielId}`).json()

--- a/apps/mb-webapp/src/components/indicateurs/IndicateurCard.tsx
+++ b/apps/mb-webapp/src/components/indicateurs/IndicateurCard.tsx
@@ -10,14 +10,17 @@ function formatMiseAJour(iso: string): string {
   return formatMonthYearNumericFr(date)
 }
 
+export type IndicateurCardContext = {
+  individu: string
+  referentiel: string
+}
+
 export function IndicateurCard({
   indicateur,
-  individu,
-  referentiel,
+  context,
 }: {
   indicateur: Pick<IndicateurApiModel, 'id' | 'nom' | 'updatedAt'>
-  individu?: string | undefined
-  referentiel?: string | undefined
+  context?: IndicateurCardContext
 }) {
   return (
     <EntityCard
@@ -28,7 +31,7 @@ export function IndicateurCard({
       <Link
         to="/indicateurs/$id"
         params={{ id: indicateur.id }}
-        search={{ individu, referentiel }}
+        search={context ?? {}}
       />
     </EntityCard>
   )

--- a/apps/mb-webapp/src/components/indicateurs/IndicateurCard.tsx
+++ b/apps/mb-webapp/src/components/indicateurs/IndicateurCard.tsx
@@ -28,11 +28,7 @@ export function IndicateurCard({
       title={indicateur.nom}
       footer={<>Mis à jour {formatMiseAJour(indicateur.updatedAt)}</>}
     >
-      <Link
-        to="/indicateurs/$id"
-        params={{ id: indicateur.id }}
-        search={context ?? {}}
-      />
+      <Link to="/indicateurs/$id" params={{ id: indicateur.id }} search={context ?? {}} />
     </EntityCard>
   )
 }

--- a/apps/mb-webapp/src/components/indicateurs/IndicateurCard.tsx
+++ b/apps/mb-webapp/src/components/indicateurs/IndicateurCard.tsx
@@ -12,8 +12,12 @@ function formatMiseAJour(iso: string): string {
 
 export function IndicateurCard({
   indicateur,
+  individu,
+  referentiel,
 }: {
   indicateur: Pick<IndicateurApiModel, 'id' | 'nom' | 'updatedAt'>
+  individu?: string | undefined
+  referentiel?: string | undefined
 }) {
   return (
     <EntityCard
@@ -21,7 +25,11 @@ export function IndicateurCard({
       title={indicateur.nom}
       footer={<>Mis à jour {formatMiseAJour(indicateur.updatedAt)}</>}
     >
-      <Link to="/indicateurs/$id" params={{ id: indicateur.id }} />
+      <Link
+        to="/indicateurs/$id"
+        params={{ id: indicateur.id }}
+        search={{ individu, referentiel }}
+      />
     </EntityCard>
   )
 }

--- a/apps/mb-webapp/src/components/indicateurs/IndividuSelect.tsx
+++ b/apps/mb-webapp/src/components/indicateurs/IndividuSelect.tsx
@@ -1,66 +1,24 @@
 import * as PopoverPrimitive from '@radix-ui/react-popover'
-import { type IndividuApiModel } from '@pilote/mb-shared/individu'
-import { type ReferentielApiModel } from '@pilote/mb-shared/referentiel'
-import { useSuspenseQueries, useSuspenseQuery } from '@tanstack/react-query'
+import { useSuspenseQueries } from '@tanstack/react-query'
 import { Command } from 'cmdk'
 import { Check, ChevronDown, Search } from 'lucide-react'
 import { useMemo, useState } from 'react'
 
 import { clsxm } from '@/lib/clsxm'
-import { indicateurQueryOptions } from '@/queries/indicateurs'
+import { buildOrderedNodes } from '@/lib/individus/hierarchy'
 import { referentielIndividusQueryOptions, referentielQueryOptions } from '@/queries/referentiels'
-
-type IndividuNode = {
-  individu: IndividuApiModel
-  referentiel: ReferentielApiModel
-  depth: number
-  parentPath: ReadonlyArray<string>
-}
-
-const buildOrderedNodes = (
-  individus: ReadonlyArray<IndividuApiModel>,
-  referentielsById: ReadonlyMap<string, ReferentielApiModel>,
-): IndividuNode[] => {
-  const byId = new Map(individus.map((i) => [i.id, i] as const))
-  const childrenByParent = new Map<string | null, IndividuApiModel[]>()
-  for (const individu of individus) {
-    const parent = [...individu.parents].sort().find((p) => byId.has(p)) ?? null
-    const bucket = childrenByParent.get(parent) ?? []
-    bucket.push(individu)
-    childrenByParent.set(parent, bucket)
-  }
-  for (const bucket of childrenByParent.values()) {
-    bucket.sort((a, b) => a.nom.localeCompare(b.nom, 'fr'))
-  }
-
-  const ordered: IndividuNode[] = []
-  const visit = (individu: IndividuApiModel, depth: number, parentPath: ReadonlyArray<string>) => {
-    const referentiel = referentielsById.get(individu.referentiel)
-    if (!referentiel) return
-    ordered.push({ individu, referentiel, depth, parentPath })
-    const children = childrenByParent.get(individu.id) ?? []
-    const nextPath = [...parentPath, individu.nom]
-    for (const child of children) visit(child, depth + 1, nextPath)
-  }
-  for (const root of childrenByParent.get(null) ?? []) visit(root, 0, [])
-  return ordered
-}
 
 type IndividuSelectProps = {
   id?: string
-  indicateurId: string
+  referentielIds: ReadonlyArray<string>
   value: string
   onChange: (next: { individu: string; referentiel: string }) => void
 }
 
-export function IndividuSelect({ id, indicateurId, value, onChange }: IndividuSelectProps) {
+export function IndividuSelect({ id, referentielIds, value, onChange }: IndividuSelectProps) {
   const [open, setOpen] = useState(false)
   const [search, setSearch] = useState('')
 
-  const { data: indicateur } = useSuspenseQuery(indicateurQueryOptions(indicateurId))
-  const referentielIds = indicateur.referentiels.map(
-    (configuration) => configuration.referentielPublicId,
-  )
   const referentiels = useSuspenseQueries({
     queries: referentielIds.map((refId) => referentielQueryOptions(refId)),
     combine: (results) => results.map((r) => r.data),

--- a/apps/mb-webapp/src/components/paniers/PanierCard.tsx
+++ b/apps/mb-webapp/src/components/paniers/PanierCard.tsx
@@ -3,10 +3,17 @@ import { Link } from '@tanstack/react-router'
 
 import { EntityCard } from '@/components/ui/EntityCard'
 
+export type PanierCardContext = {
+  individu: string
+  referentiel: string
+}
+
 export function PanierCard({
   panier,
+  context,
 }: {
   panier: Pick<PanierApiModel, 'id' | 'nom' | 'description' | 'indicateurIds'>
+  context?: PanierCardContext | undefined
 }) {
   const nb = panier.indicateurIds.length
   return (
@@ -21,7 +28,7 @@ export function PanierCard({
         </>
       }
     >
-      <Link to="/paniers/$id" params={{ id: panier.id }} />
+      <Link to="/paniers/$id" params={{ id: panier.id }} search={context ?? {}} />
     </EntityCard>
   )
 }

--- a/apps/mb-webapp/src/lib/individus/hierarchy.test.ts
+++ b/apps/mb-webapp/src/lib/individus/hierarchy.test.ts
@@ -1,0 +1,125 @@
+import { type IndividuApiModel } from '@pilote/mb-shared/individu'
+import { type ReferentielApiModel } from '@pilote/mb-shared/referentiel'
+import { describe, expect, it } from 'vitest'
+
+import { buildOrderedNodes, pickRoot } from './hierarchy'
+
+const referentiel = (id: string, nom: string): ReferentielApiModel => ({
+  id,
+  nom,
+  description: null,
+  nombreIndividus: 0,
+  widgets: [],
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+})
+
+const individu = (
+  id: string,
+  nom: string,
+  referentielId: string,
+  parents: string[] = [],
+): IndividuApiModel => ({
+  id,
+  nom,
+  referentiel: referentielId,
+  parents,
+  metadata: null,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+})
+
+describe('buildOrderedNodes', () => {
+  it('place les individus sans parent en racine (depth 0)', () => {
+    const refNat = referentiel('REF-NAT', 'National')
+    const refsById = new Map([[refNat.id, refNat]])
+    const fr = individu('IND-FR', 'France', 'REF-NAT')
+
+    const nodes = buildOrderedNodes([fr], refsById)
+
+    expect(nodes).toHaveLength(1)
+    expect(nodes[0]!.depth).toBe(0)
+    expect(nodes[0]!.parentPath).toEqual([])
+    expect(nodes[0]!.individu.id).toBe('IND-FR')
+  })
+
+  it('lie un enfant à son parent présent dans la liste', () => {
+    const refNat = referentiel('REF-NAT', 'National')
+    const refReg = referentiel('REF-REG', 'Régions')
+    const refsById = new Map([
+      [refNat.id, refNat],
+      [refReg.id, refReg],
+    ])
+    const fr = individu('IND-FR', 'France', 'REF-NAT')
+    const idf = individu('IND-IDF', 'Île-de-France', 'REF-REG', ['IND-FR'])
+
+    const nodes = buildOrderedNodes([fr, idf], refsById)
+
+    expect(nodes.map((n) => [n.individu.id, n.depth])).toEqual([
+      ['IND-FR', 0],
+      ['IND-IDF', 1],
+    ])
+    expect(nodes[1]!.parentPath).toEqual(['France'])
+  })
+
+  it("trie chaque niveau par nom dans l'ordre français", () => {
+    const ref = referentiel('REF-REG', 'Régions')
+    const refsById = new Map([[ref.id, ref]])
+    const occitanie = individu('IND-OCC', 'Occitanie', 'REF-REG')
+    const auvergne = individu('IND-ARA', 'Auvergne', 'REF-REG')
+    const ileDeFrance = individu('IND-IDF', 'Île-de-France', 'REF-REG')
+
+    const nodes = buildOrderedNodes([occitanie, auvergne, ileDeFrance], refsById)
+
+    expect(nodes.map((n) => n.individu.id)).toEqual(['IND-ARA', 'IND-IDF', 'IND-OCC'])
+  })
+
+  it("ignore un parent qui n'est pas dans la liste fournie (racine implicite)", () => {
+    const ref = referentiel('REF-REG', 'Régions')
+    const refsById = new Map([[ref.id, ref]])
+    const idf = individu('IND-IDF', 'Île-de-France', 'REF-REG', ['IND-FR-ABSENT'])
+
+    const nodes = buildOrderedNodes([idf], refsById)
+
+    expect(nodes).toHaveLength(1)
+    expect(nodes[0]!.depth).toBe(0)
+  })
+
+  it("écarte les individus dont le référentiel n'est pas fourni", () => {
+    const ref = referentiel('REF-NAT', 'National')
+    const refsById = new Map([[ref.id, ref]])
+    const fr = individu('IND-FR', 'France', 'REF-NAT')
+    const orphelin = individu('IND-X', 'Orphelin', 'REF-INCONNU')
+
+    const nodes = buildOrderedNodes([fr, orphelin], refsById)
+
+    expect(nodes.map((n) => n.individu.id)).toEqual(['IND-FR'])
+  })
+})
+
+describe('pickRoot', () => {
+  it('renvoie la première racine rencontrée', () => {
+    const ref = referentiel('REF-NAT', 'National')
+    const refsById = new Map([[ref.id, ref]])
+    const fr = individu('IND-FR', 'France', 'REF-NAT')
+
+    const root = pickRoot(buildOrderedNodes([fr], refsById))
+
+    expect(root?.individu.id).toBe('IND-FR')
+  })
+
+  it('renvoie la première racine par ordre du nom quand il y en a plusieurs', () => {
+    const ref = referentiel('REF-MIN', 'Ministères')
+    const refsById = new Map([[ref.id, ref]])
+    const economie = individu('IND-ECO', 'Économie', 'REF-MIN')
+    const culture = individu('IND-CUL', 'Culture', 'REF-MIN')
+
+    const root = pickRoot(buildOrderedNodes([economie, culture], refsById))
+
+    expect(root?.individu.id).toBe('IND-CUL')
+  })
+
+  it('renvoie null sur un arbre vide', () => {
+    expect(pickRoot([])).toBeNull()
+  })
+})

--- a/apps/mb-webapp/src/lib/individus/hierarchy.ts
+++ b/apps/mb-webapp/src/lib/individus/hierarchy.ts
@@ -1,0 +1,41 @@
+import { type IndividuApiModel } from '@pilote/mb-shared/individu'
+import { type ReferentielApiModel } from '@pilote/mb-shared/referentiel'
+
+export type IndividuNode = {
+  individu: IndividuApiModel
+  referentiel: ReferentielApiModel
+  depth: number
+  parentPath: ReadonlyArray<string>
+}
+
+export const buildOrderedNodes = (
+  individus: ReadonlyArray<IndividuApiModel>,
+  referentielsById: ReadonlyMap<string, ReferentielApiModel>,
+): IndividuNode[] => {
+  const byId = new Map(individus.map((i) => [i.id, i] as const))
+  const childrenByParent = new Map<string | null, IndividuApiModel[]>()
+  for (const individu of individus) {
+    const parent = individu.parents.find((p) => byId.has(p)) ?? null
+    const bucket = childrenByParent.get(parent) ?? []
+    bucket.push(individu)
+    childrenByParent.set(parent, bucket)
+  }
+  for (const bucket of childrenByParent.values()) {
+    bucket.sort((a, b) => a.nom.localeCompare(b.nom, 'fr'))
+  }
+
+  const ordered: IndividuNode[] = []
+  const visit = (individu: IndividuApiModel, depth: number, parentPath: ReadonlyArray<string>) => {
+    const referentiel = referentielsById.get(individu.referentiel)
+    if (!referentiel) return
+    ordered.push({ individu, referentiel, depth, parentPath })
+    const children = childrenByParent.get(individu.id) ?? []
+    const nextPath = [...parentPath, individu.nom]
+    for (const child of children) visit(child, depth + 1, nextPath)
+  }
+  for (const root of childrenByParent.get(null) ?? []) visit(root, 0, [])
+  return ordered
+}
+
+export const pickRoot = (nodes: ReadonlyArray<IndividuNode>): IndividuNode | null =>
+  nodes.find((node) => node.depth === 0) ?? null

--- a/apps/mb-webapp/src/lib/individus/pair.test.ts
+++ b/apps/mb-webapp/src/lib/individus/pair.test.ts
@@ -1,0 +1,94 @@
+import { type IndividuApiModel } from '@pilote/mb-shared/individu'
+import { type ReferentielApiModel } from '@pilote/mb-shared/referentiel'
+import { describe, expect, it } from 'vitest'
+
+import { buildOrderedNodes } from './hierarchy'
+import { resolveIndividuReferentielPair } from './pair'
+
+const referentiel = (id: string, nom: string): ReferentielApiModel => ({
+  id,
+  nom,
+  description: null,
+  nombreIndividus: 0,
+  widgets: [],
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+})
+
+const individu = (
+  id: string,
+  nom: string,
+  referentielId: string,
+  parents: string[] = [],
+): IndividuApiModel => ({
+  id,
+  nom,
+  referentiel: referentielId,
+  parents,
+  metadata: null,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+})
+
+const buildTree = () => {
+  const refNat = referentiel('REF-NAT', 'National')
+  const refReg = referentiel('REF-REG', 'Régions')
+  const refsById = new Map([
+    [refNat.id, refNat],
+    [refReg.id, refReg],
+  ])
+  const fr = individu('IND-FR', 'France', 'REF-NAT')
+  const idf = individu('IND-IDF', 'Île-de-France', 'REF-REG', ['IND-FR'])
+  return buildOrderedNodes([fr, idf], refsById)
+}
+
+describe('resolveIndividuReferentielPair', () => {
+  it('renvoie `no-hierarchy` quand aucun node disponible', () => {
+    expect(resolveIndividuReferentielPair([], { individu: 'IND-FR' })).toEqual({
+      kind: 'no-hierarchy',
+    })
+  })
+
+  it('valide une paire (individu, referentiel) cohérente', () => {
+    const nodes = buildTree()
+    expect(
+      resolveIndividuReferentielPair(nodes, { individu: 'IND-IDF', referentiel: 'REF-REG' }),
+    ).toEqual({
+      kind: 'valid',
+      pair: { individu: 'IND-IDF', referentiel: 'REF-REG' },
+    })
+  })
+
+  it("renvoie un mismatch avec fallback sur l'individu connu si referentiel incohérent", () => {
+    const nodes = buildTree()
+    const resolution = resolveIndividuReferentielPair(nodes, {
+      individu: 'IND-IDF',
+      referentiel: 'REF-NAT',
+    })
+    expect(resolution).toEqual({
+      kind: 'mismatch',
+      fallback: { individu: 'IND-IDF', referentiel: 'REF-REG' },
+    })
+  })
+
+  it('fallback sur la racine si individu inconnu', () => {
+    const nodes = buildTree()
+    const resolution = resolveIndividuReferentielPair(nodes, {
+      individu: 'IND-INCONNU',
+      referentiel: 'REF-REG',
+    })
+    expect(resolution).toEqual({
+      kind: 'mismatch',
+      fallback: { individu: 'IND-FR', referentiel: 'REF-NAT' },
+    })
+  })
+
+  it('fallback sur la racine si individu absent des deps', () => {
+    const nodes = buildTree()
+    const resolution = resolveIndividuReferentielPair(nodes, {})
+    expect(resolution).toEqual({
+      kind: 'mismatch',
+      fallback: { individu: 'IND-FR', referentiel: 'REF-NAT' },
+    })
+  })
+})

--- a/apps/mb-webapp/src/lib/individus/pair.ts
+++ b/apps/mb-webapp/src/lib/individus/pair.ts
@@ -1,0 +1,51 @@
+import { type QueryClient } from '@tanstack/react-query'
+
+import { type IndividuNode, pickRoot } from '@/lib/individus/hierarchy'
+import { loadHierarchyFromReferentiels } from '@/queries/referentiels'
+
+export type IndividuReferentielPair = {
+  individu: string
+  referentiel: string
+}
+
+export type PairResolution =
+  | { kind: 'no-hierarchy' }
+  | { kind: 'valid'; pair: IndividuReferentielPair }
+  | { kind: 'mismatch'; fallback: IndividuReferentielPair }
+
+export const resolveIndividuReferentielPair = (
+  nodes: ReadonlyArray<IndividuNode>,
+  deps: { individu?: string | undefined; referentiel?: string | undefined },
+): PairResolution => {
+  if (nodes.length === 0) return { kind: 'no-hierarchy' }
+  const known = deps.individu
+    ? nodes.find((n) => n.individu.id === deps.individu)?.individu
+    : undefined
+  if (known && known.referentiel === deps.referentiel) {
+    return { kind: 'valid', pair: { individu: known.id, referentiel: known.referentiel } }
+  }
+  const fallback = known ?? pickRoot(nodes)?.individu ?? nodes[0]!.individu
+  return {
+    kind: 'mismatch',
+    fallback: { individu: fallback.id, referentiel: fallback.referentiel },
+  }
+}
+
+export const ensureIndividuReferentielPair = async ({
+  queryClient,
+  referentielIds,
+  deps,
+  onMismatch,
+}: {
+  queryClient: QueryClient
+  referentielIds: ReadonlyArray<string>
+  deps: { individu?: string | undefined; referentiel?: string | undefined }
+  onMismatch: (fallback: IndividuReferentielPair) => never
+}): Promise<IndividuReferentielPair | null> => {
+  if (referentielIds.length === 0) return null
+  const nodes = await loadHierarchyFromReferentiels({ queryClient, referentielIds })
+  const resolution = resolveIndividuReferentielPair(nodes, deps)
+  if (resolution.kind === 'no-hierarchy') return null
+  if (resolution.kind === 'mismatch') return onMismatch(resolution.fallback)
+  return resolution.pair
+}

--- a/apps/mb-webapp/src/queries/referentiels.ts
+++ b/apps/mb-webapp/src/queries/referentiels.ts
@@ -1,8 +1,11 @@
-import { type IndividuApiModel } from '@pilote/mb-shared/individu'
-import { type ReferentielApiModel } from '@pilote/mb-shared/referentiel'
 import { type QueryClient, queryOptions } from '@tanstack/react-query'
 
-import { fetchIndividusForReferentiel, fetchReferentielById } from '@/api/referentiels'
+import {
+  fetchIndividusForReferentiel,
+  fetchReferentielById,
+  fetchReferentiels,
+} from '@/api/referentiels'
+import { buildOrderedNodes, type IndividuNode } from '@/lib/individus/hierarchy'
 
 import { DEFAULT_STALE_TIME, fetchAllPaginatedItems } from './utils'
 
@@ -23,23 +26,31 @@ export const referentielIndividusQueryOptions = (referentielId: string) =>
     staleTime: DEFAULT_STALE_TIME,
   })
 
-type ReferentielGroupe = {
-  referentiel: ReferentielApiModel
-  individus: ReadonlyArray<IndividuApiModel>
+export const allReferentielsQueryOptions = queryOptions({
+  queryKey: ['referentiels', 'all'],
+  queryFn: () => fetchAllPaginatedItems((cursor) => fetchReferentiels(cursor ? { cursor } : {})),
+  staleTime: DEFAULT_STALE_TIME,
+})
+
+export const loadAllReferentielIds = async ({
+  queryClient,
+}: {
+  queryClient: QueryClient
+}): Promise<string[]> => {
+  const referentiels = await queryClient.fetchQuery(allReferentielsQueryOptions)
+  for (const referentiel of referentiels) {
+    queryClient.setQueryData(referentielQueryOptions(referentiel.id).queryKey, referentiel)
+  }
+  return referentiels.map((r) => r.id)
 }
 
-const flattenAndSort = (groupes: ReadonlyArray<ReferentielGroupe>): IndividuApiModel[] =>
-  groupes
-    .flatMap((groupe) => [...groupe.individus])
-    .sort((a, b) => a.nom.localeCompare(b.nom, 'fr'))
-
-export const loadIndividusFromReferentiels = async ({
+export const loadHierarchyFromReferentiels = async ({
   queryClient,
   referentielIds,
 }: {
   queryClient: QueryClient
   referentielIds: ReadonlyArray<string>
-}): Promise<IndividuApiModel[]> => {
+}): Promise<IndividuNode[]> => {
   const groupes = await Promise.all(
     referentielIds.map(async (refId) => {
       const [referentiel, individus] = await Promise.all([
@@ -49,5 +60,7 @@ export const loadIndividusFromReferentiels = async ({
       return { referentiel, individus }
     }),
   )
-  return flattenAndSort(groupes)
+  const referentielsById = new Map(groupes.map((g) => [g.referentiel.id, g.referentiel] as const))
+  const allIndividus = groupes.flatMap((g) => [...g.individus])
+  return buildOrderedNodes(allIndividus, referentielsById)
 }

--- a/apps/mb-webapp/src/routes/__root.tsx
+++ b/apps/mb-webapp/src/routes/__root.tsx
@@ -1,5 +1,5 @@
 import type { QueryClient } from '@tanstack/react-query'
-import { createRootRouteWithContext, Link, Outlet } from '@tanstack/react-router'
+import { createRootRouteWithContext, Link, Outlet, useSearch } from '@tanstack/react-router'
 import { TanStackRouterDevtools } from '@tanstack/react-router-devtools'
 import type { ReactNode } from 'react'
 
@@ -84,10 +84,11 @@ function RootComponent() {
 }
 
 function NavLink({ to, children }: { to: '/indicateurs' | '/paniers'; children: ReactNode }) {
+  const search = useSearch({ strict: false })
   return (
     <Link
       to={to}
-      search={{}}
+      search={{ individu: search.individu, referentiel: search.referentiel }}
       className="rounded-md px-3 py-2 text-sm font-medium text-text-muted transition-colors hover:bg-surface-tinted hover:text-primary data-[status=active]:bg-primary-tinted data-[status=active]:text-primary"
       activeProps={{ 'data-status': 'active' }}
     >

--- a/apps/mb-webapp/src/routes/_authenticated/indicateurs/$id.tsx
+++ b/apps/mb-webapp/src/routes/_authenticated/indicateurs/$id.tsx
@@ -42,7 +42,7 @@ export const Route = createFileRoute('/_authenticated/indicateurs/$id')({
     stringify: ({ id }) => ({ id }),
   },
   validateSearch: searchSchema,
-  loaderDeps: ({ search }) => ({ individu: search.individu }),
+  loaderDeps: ({ search }) => ({ individu: search.individu, referentiel: search.referentiel }),
   loader: async ({ context, params, deps }) => {
     const { queryClient } = context
     const indicateur = await loadIndicateur({ queryClient, indicateurId: params.id })
@@ -58,14 +58,15 @@ export const Route = createFileRoute('/_authenticated/indicateurs/$id')({
     const selected = deps.individu
       ? nodes.find((n) => n.individu.id === deps.individu)?.individu
       : undefined
-    if (!selected) {
-      const fallback = pickRoot(nodes) ?? nodes[0]!
+    const pairValid = selected && selected.referentiel === deps.referentiel
+    if (!pairValid) {
+      const fallback = selected ?? pickRoot(nodes)?.individu ?? nodes[0]!.individu
       throw redirect({
         to: '/indicateurs/$id',
         params,
         search: {
-          individu: fallback.individu.id,
-          referentiel: fallback.individu.referentiel,
+          individu: fallback.id,
+          referentiel: fallback.referentiel,
         },
         replace: true,
       })

--- a/apps/mb-webapp/src/routes/_authenticated/indicateurs/$id.tsx
+++ b/apps/mb-webapp/src/routes/_authenticated/indicateurs/$id.tsx
@@ -19,13 +19,12 @@ import { EmptyState } from '@/components/ui/EmptyState'
 import { FormField } from '@/components/ui/FormField'
 import { Page } from '@/components/ui/Page'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/Tabs'
-import { pickRoot } from '@/lib/individus/hierarchy'
+import { ensureIndividuReferentielPair } from '@/lib/individus/pair'
 import {
   indicateurQueryOptions,
   loadIndicateur,
   prefetchIndicateurValeursForIndividu,
 } from '@/queries/indicateurs'
-import { loadHierarchyFromReferentiels } from '@/queries/referentiels'
 
 const paramsSchema = z.object({
   id: indicateurPublicIdSchema,
@@ -50,34 +49,28 @@ export const Route = createFileRoute('/_authenticated/indicateurs/$id')({
     const referentielIds = indicateur.referentiels.map(
       (configuration) => configuration.referentielPublicId,
     )
-    if (referentielIds.length === 0) return { indicateur }
+    const pair = await ensureIndividuReferentielPair({
+      queryClient,
+      referentielIds,
+      deps,
+      onMismatch: ({ individu, referentiel }) => {
+        throw redirect({
+          to: '/indicateurs/$id',
+          params,
+          search: { individu, referentiel },
+          replace: true,
+        })
+      },
+    })
 
-    const nodes = await loadHierarchyFromReferentiels({ queryClient, referentielIds })
-    if (nodes.length === 0) return { indicateur }
-
-    const selected = deps.individu
-      ? nodes.find((n) => n.individu.id === deps.individu)?.individu
-      : undefined
-    const pairValid = selected && selected.referentiel === deps.referentiel
-    if (!pairValid) {
-      const fallback = selected ?? pickRoot(nodes)?.individu ?? nodes[0]!.individu
-      throw redirect({
-        to: '/indicateurs/$id',
-        params,
-        search: {
-          individu: fallback.id,
-          referentiel: fallback.referentiel,
-        },
-        replace: true,
+    if (pair) {
+      await prefetchIndicateurValeursForIndividu({
+        queryClient,
+        indicateurId: params.id,
+        individuId: pair.individu,
+        referentielId: pair.referentiel,
       })
     }
-
-    await prefetchIndicateurValeursForIndividu({
-      queryClient,
-      indicateurId: params.id,
-      individuId: selected.id,
-      referentielId: selected.referentiel,
-    })
 
     return { indicateur }
   },

--- a/apps/mb-webapp/src/routes/_authenticated/indicateurs/$id.tsx
+++ b/apps/mb-webapp/src/routes/_authenticated/indicateurs/$id.tsx
@@ -19,12 +19,13 @@ import { EmptyState } from '@/components/ui/EmptyState'
 import { FormField } from '@/components/ui/FormField'
 import { Page } from '@/components/ui/Page'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/Tabs'
+import { pickRoot } from '@/lib/individus/hierarchy'
 import {
   indicateurQueryOptions,
   loadIndicateur,
   prefetchIndicateurValeursForIndividu,
 } from '@/queries/indicateurs'
-import { loadIndividusFromReferentiels } from '@/queries/referentiels'
+import { loadHierarchyFromReferentiels } from '@/queries/referentiels'
 
 const paramsSchema = z.object({
   id: indicateurPublicIdSchema,
@@ -51,19 +52,21 @@ export const Route = createFileRoute('/_authenticated/indicateurs/$id')({
     )
     if (referentielIds.length === 0) return { indicateur }
 
-    const individus = await loadIndividusFromReferentiels({
-      queryClient,
-      referentielIds,
-    })
-    if (individus.length === 0) return { indicateur }
+    const nodes = await loadHierarchyFromReferentiels({ queryClient, referentielIds })
+    if (nodes.length === 0) return { indicateur }
 
-    const selected = deps.individu ? individus.find((i) => i.id === deps.individu) : undefined
+    const selected = deps.individu
+      ? nodes.find((n) => n.individu.id === deps.individu)?.individu
+      : undefined
     if (!selected) {
-      const first = individus[0]!
+      const fallback = pickRoot(nodes) ?? nodes[0]!
       throw redirect({
         to: '/indicateurs/$id',
         params,
-        search: { individu: first.id, referentiel: first.referentiel },
+        search: {
+          individu: fallback.individu.id,
+          referentiel: fallback.individu.referentiel,
+        },
         replace: true,
       })
     }
@@ -92,7 +95,10 @@ function IndicateurDetailComponent() {
 
   const back = (
     <BackLink asChild>
-      <Link to="/indicateurs" search={{}}>
+      <Link
+        to="/indicateurs"
+        search={{ individu: search.individu, referentiel: search.referentiel }}
+      >
         Retour à la liste
       </Link>
     </BackLink>
@@ -116,6 +122,7 @@ function IndicateurDetailComponent() {
 
   const individuId = search.individu
   const referentielId = search.referentiel
+  const referentielIds = indicateur.referentiels.map((c) => c.referentielPublicId)
 
   return (
     <Page title={indicateur.nom} back={back}>
@@ -129,7 +136,7 @@ function IndicateurDetailComponent() {
         <FormField label="Individu" htmlFor={selectId}>
           <IndividuSelect
             id={selectId}
-            indicateurId={id}
+            referentielIds={referentielIds}
             value={individuId}
             onChange={({ individu, referentiel }) => {
               startTransition(() => {

--- a/apps/mb-webapp/src/routes/_authenticated/indicateurs/index.tsx
+++ b/apps/mb-webapp/src/routes/_authenticated/indicateurs/index.tsx
@@ -15,14 +15,10 @@ import { FormField } from '@/components/ui/FormField'
 import { Page } from '@/components/ui/Page'
 import { SearchField } from '@/components/ui/SearchField'
 import { Text } from '@/components/ui/Typography'
-import { pickRoot } from '@/lib/individus/hierarchy'
+import { ensureIndividuReferentielPair } from '@/lib/individus/pair'
 import { DEFAULT_PAGE_SIZE_OPTIONS, Pagination } from '@/components/ui/Pagination'
 import { indicateursQueryOptions, loadIndicateurs } from '@/queries/indicateurs'
-import {
-  allReferentielsQueryOptions,
-  loadAllReferentielIds,
-  loadHierarchyFromReferentiels,
-} from '@/queries/referentiels'
+import { allReferentielsQueryOptions, loadAllReferentielIds } from '@/queries/referentiels'
 
 const indicateursSearchSchema = z.object({
   recherche: z.string().optional(),
@@ -37,29 +33,19 @@ export const Route = createFileRoute('/_authenticated/indicateurs/')({
   loaderDeps: ({ search }) => search,
   loader: async ({ context, deps }) => {
     const { queryClient } = context
-
     const referentielIds = await loadAllReferentielIds({ queryClient })
-    if (referentielIds.length > 0) {
-      const nodes = await loadHierarchyFromReferentiels({ queryClient, referentielIds })
-      const knownIndividu = deps.individu
-        ? nodes.find((n) => n.individu.id === deps.individu)?.individu
-        : undefined
-      const pairValid = knownIndividu && knownIndividu.referentiel === deps.referentiel
-      if (!pairValid) {
-        const fallback = knownIndividu ?? pickRoot(nodes)?.individu ?? nodes[0]?.individu
-        if (fallback) {
-          throw redirect({
-            to: '/indicateurs',
-            search: {
-              ...deps,
-              individu: fallback.id,
-              referentiel: fallback.referentiel,
-            },
-            replace: true,
-          })
-        }
-      }
-    }
+    await ensureIndividuReferentielPair({
+      queryClient,
+      referentielIds,
+      deps,
+      onMismatch: ({ individu, referentiel }) => {
+        throw redirect({
+          to: '/indicateurs',
+          search: { ...deps, individu, referentiel },
+          replace: true,
+        })
+      },
+    })
 
     return loadIndicateurs({ queryClient, query: deps })
   },

--- a/apps/mb-webapp/src/routes/_authenticated/indicateurs/index.tsx
+++ b/apps/mb-webapp/src/routes/_authenticated/indicateurs/index.tsx
@@ -1,28 +1,67 @@
+import { individuPublicIdSchema } from '@pilote/mb-shared/individu'
+import { referentielPublicIdSchema } from '@pilote/mb-shared/referentiel'
 import { useSuspenseQuery } from '@tanstack/react-query'
-import { createFileRoute, useNavigate } from '@tanstack/react-router'
+import { createFileRoute, redirect, useNavigate } from '@tanstack/react-router'
+import { startTransition, useId } from 'react'
 import { z } from 'zod'
 
 import { RouteError } from '@/components/RouteError'
 import { RouteLoading } from '@/components/RouteLoading'
 import { IndicateurCard } from '@/components/indicateurs/IndicateurCard'
+import { IndividuSelect } from '@/components/indicateurs/IndividuSelect'
 import { CardGrid } from '@/components/ui/CardGrid'
 import { EmptyState } from '@/components/ui/EmptyState'
+import { FormField } from '@/components/ui/FormField'
 import { Page } from '@/components/ui/Page'
 import { SearchField } from '@/components/ui/SearchField'
 import { Text } from '@/components/ui/Typography'
-import { indicateursQueryOptions, loadIndicateurs } from '@/queries/indicateurs'
+import { pickRoot } from '@/lib/individus/hierarchy'
 import { DEFAULT_PAGE_SIZE_OPTIONS, Pagination } from '@/components/ui/Pagination'
+import { indicateursQueryOptions, loadIndicateurs } from '@/queries/indicateurs'
+import {
+  allReferentielsQueryOptions,
+  loadAllReferentielIds,
+  loadHierarchyFromReferentiels,
+} from '@/queries/referentiels'
 
 const indicateursSearchSchema = z.object({
   recherche: z.string().optional(),
   cursor: z.string().optional(),
   pageSize: z.coerce.number().int().min(1).max(100).optional(),
+  individu: individuPublicIdSchema.optional(),
+  referentiel: referentielPublicIdSchema.optional(),
 })
 
 export const Route = createFileRoute('/_authenticated/indicateurs/')({
   validateSearch: indicateursSearchSchema,
   loaderDeps: ({ search }) => search,
-  loader: ({ context, deps }) => loadIndicateurs({ queryClient: context.queryClient, query: deps }),
+  loader: async ({ context, deps }) => {
+    const { queryClient } = context
+
+    const referentielIds = await loadAllReferentielIds({ queryClient })
+    if (referentielIds.length > 0) {
+      const nodes = await loadHierarchyFromReferentiels({ queryClient, referentielIds })
+      const knownIndividu = deps.individu
+        ? nodes.find((n) => n.individu.id === deps.individu)?.individu
+        : undefined
+      if (!knownIndividu) {
+        const fallback = pickRoot(nodes) ?? nodes[0]
+        if (fallback) {
+          throw redirect({
+            to: '/indicateurs',
+            search: {
+              ...deps,
+              individu: fallback.individu.id,
+              referentiel: fallback.individu.referentiel,
+            },
+            replace: true,
+          })
+        }
+      }
+    }
+
+    return loadIndicateurs({ queryClient, query: deps })
+  },
   pendingComponent: () => <RouteLoading message="Chargement des indicateurs…" />,
   errorComponent: RouteError,
   component: IndicateursListComponent,
@@ -31,11 +70,33 @@ export const Route = createFileRoute('/_authenticated/indicateurs/')({
 function IndicateursListComponent() {
   const search = Route.useSearch()
   const navigate = useNavigate({ from: Route.fullPath })
+  const selectId = useId()
   const { data } = useSuspenseQuery(indicateursQueryOptions(search))
+  const { data: referentiels } = useSuspenseQuery(allReferentielsQueryOptions)
+  const referentielIds = referentiels.map((r) => r.id)
 
   return (
     <Page kicker="Catalogue" title="Indicateurs">
       <div className="flex flex-col gap-6">
+        {search.individu ? (
+          <div className="max-w-md">
+            <FormField label="Individu observé" htmlFor={selectId}>
+              <IndividuSelect
+                id={selectId}
+                referentielIds={referentielIds}
+                value={search.individu}
+                onChange={({ individu, referentiel }) => {
+                  startTransition(() => {
+                    void navigate({
+                      search: (prev) => ({ ...prev, individu, referentiel }),
+                    })
+                  })
+                }}
+              />
+            </FormField>
+          </div>
+        ) : null}
+
         <div className="flex flex-wrap items-center justify-between gap-4">
           <Text as="span" variant="kicker" tone="muted">
             {data.total} indicateur{data.total > 1 ? 's' : ''}
@@ -59,7 +120,12 @@ function IndicateursListComponent() {
         ) : (
           <CardGrid>
             {data.items.map((indicateur) => (
-              <IndicateurCard key={indicateur.id} indicateur={indicateur} />
+              <IndicateurCard
+                key={indicateur.id}
+                indicateur={indicateur}
+                individu={search.individu}
+                referentiel={search.referentiel}
+              />
             ))}
           </CardGrid>
         )}

--- a/apps/mb-webapp/src/routes/_authenticated/indicateurs/index.tsx
+++ b/apps/mb-webapp/src/routes/_authenticated/indicateurs/index.tsx
@@ -44,15 +44,16 @@ export const Route = createFileRoute('/_authenticated/indicateurs/')({
       const knownIndividu = deps.individu
         ? nodes.find((n) => n.individu.id === deps.individu)?.individu
         : undefined
-      if (!knownIndividu) {
-        const fallback = pickRoot(nodes) ?? nodes[0]
+      const pairValid = knownIndividu && knownIndividu.referentiel === deps.referentiel
+      if (!pairValid) {
+        const fallback = knownIndividu ?? pickRoot(nodes)?.individu ?? nodes[0]?.individu
         if (fallback) {
           throw redirect({
             to: '/indicateurs',
             search: {
               ...deps,
-              individu: fallback.individu.id,
-              referentiel: fallback.individu.referentiel,
+              individu: fallback.id,
+              referentiel: fallback.referentiel,
             },
             replace: true,
           })
@@ -123,8 +124,9 @@ function IndicateursListComponent() {
               <IndicateurCard
                 key={indicateur.id}
                 indicateur={indicateur}
-                individu={search.individu}
-                referentiel={search.referentiel}
+                {...(search.individu && search.referentiel
+                  ? { context: { individu: search.individu, referentiel: search.referentiel } }
+                  : {})}
               />
             ))}
           </CardGrid>

--- a/apps/mb-webapp/src/routes/_authenticated/paniers/$id.tsx
+++ b/apps/mb-webapp/src/routes/_authenticated/paniers/$id.tsx
@@ -1,21 +1,33 @@
+import { individuPublicIdSchema } from '@pilote/mb-shared/individu'
+import { referentielPublicIdSchema } from '@pilote/mb-shared/referentiel'
 import { panierPublicIdSchema } from '@pilote/mb-shared/publicIds'
 import { useSuspenseQuery } from '@tanstack/react-query'
-import { createFileRoute, Link } from '@tanstack/react-router'
+import { createFileRoute, Link, redirect, useNavigate } from '@tanstack/react-router'
+import { startTransition, useId } from 'react'
 import { z } from 'zod'
 
 import { RouteError } from '@/components/RouteError'
 import { RouteLoading } from '@/components/RouteLoading'
 import { IndicateurCard } from '@/components/indicateurs/IndicateurCard'
+import { IndividuSelect } from '@/components/indicateurs/IndividuSelect'
 import { BackLink } from '@/components/ui/BackLink'
 import { CardGrid } from '@/components/ui/CardGrid'
 import { EmptyState } from '@/components/ui/EmptyState'
+import { FormField } from '@/components/ui/FormField'
 import { Page } from '@/components/ui/Page'
 import { Text } from '@/components/ui/Typography'
+import { ensureIndividuReferentielPair } from '@/lib/individus/pair'
 import { indicateursQueryOptions } from '@/queries/indicateurs'
 import { loadPanier, panierQueryOptions } from '@/queries/paniers'
+import { allReferentielsQueryOptions, loadAllReferentielIds } from '@/queries/referentiels'
 
 const paramsSchema = z.object({
   id: panierPublicIdSchema,
+})
+
+const searchSchema = z.object({
+  individu: individuPublicIdSchema.optional(),
+  referentiel: referentielPublicIdSchema.optional(),
 })
 
 export const Route = createFileRoute('/_authenticated/paniers/$id')({
@@ -23,12 +35,30 @@ export const Route = createFileRoute('/_authenticated/paniers/$id')({
     parse: (raw) => paramsSchema.parse(raw),
     stringify: ({ id }) => ({ id }),
   },
-  loader: async ({ context, params }) => {
+  validateSearch: searchSchema,
+  loaderDeps: ({ search }) => ({ individu: search.individu, referentiel: search.referentiel }),
+  loader: async ({ context, params, deps }) => {
     const { queryClient } = context
     const panier = await loadPanier({ queryClient, panierId: params.id })
     if (panier.indicateurIds.length > 0) {
       await queryClient.ensureQueryData(indicateursQueryOptions({ ids: panier.indicateurIds }))
     }
+
+    const referentielIds = await loadAllReferentielIds({ queryClient })
+    await ensureIndividuReferentielPair({
+      queryClient,
+      referentielIds,
+      deps,
+      onMismatch: ({ individu, referentiel }) => {
+        throw redirect({
+          to: '/paniers/$id',
+          params,
+          search: { individu, referentiel },
+          replace: true,
+        })
+      },
+    })
+
     return { panier }
   },
   pendingComponent: () => <RouteLoading message="Chargement du panier…" />,
@@ -38,10 +68,15 @@ export const Route = createFileRoute('/_authenticated/paniers/$id')({
 
 function PanierDetailComponent() {
   const { id } = Route.useParams()
+  const search = Route.useSearch()
+  const navigate = useNavigate({ from: Route.fullPath })
+  const selectId = useId()
   const { data: panier } = useSuspenseQuery(panierQueryOptions(id))
   const { data: indicateurs } = useSuspenseQuery(
     indicateursQueryOptions({ ids: panier.indicateurIds }),
   )
+  const { data: referentiels } = useSuspenseQuery(allReferentielsQueryOptions)
+  const referentielIds = referentiels.map((r) => r.id)
 
   // Re-tri selon l'ordre du panier : la query indicateurs ne garantit pas
   // l'ordre du filtre `ids`.
@@ -52,15 +87,39 @@ function PanierDetailComponent() {
 
   const back = (
     <BackLink asChild>
-      <Link to="/paniers" search={{}}>
+      <Link to="/paniers" search={{ individu: search.individu, referentiel: search.referentiel }}>
         Retour aux paniers
       </Link>
     </BackLink>
   )
 
+  const cardContext =
+    search.individu && search.referentiel
+      ? { individu: search.individu, referentiel: search.referentiel }
+      : undefined
+
   return (
     <Page title={panier.nom} description={panier.description ?? undefined} back={back}>
       <div className="flex flex-col gap-6">
+        {search.individu ? (
+          <div className="max-w-md">
+            <FormField label="Individu observé" htmlFor={selectId}>
+              <IndividuSelect
+                id={selectId}
+                referentielIds={referentielIds}
+                value={search.individu}
+                onChange={({ individu, referentiel }) => {
+                  startTransition(() => {
+                    void navigate({
+                      search: (prev) => ({ ...prev, individu, referentiel }),
+                    })
+                  })
+                }}
+              />
+            </FormField>
+          </div>
+        ) : null}
+
         <Text as="span" variant="kicker" tone="muted">
           {orderedIndicateurs.length} indicateur{orderedIndicateurs.length > 1 ? 's' : ''}
         </Text>
@@ -69,7 +128,11 @@ function PanierDetailComponent() {
         ) : (
           <CardGrid>
             {orderedIndicateurs.map((indicateur) => (
-              <IndicateurCard key={indicateur.id} indicateur={indicateur} />
+              <IndicateurCard
+                key={indicateur.id}
+                indicateur={indicateur}
+                {...(cardContext ? { context: cardContext } : {})}
+              />
             ))}
           </CardGrid>
         )}

--- a/apps/mb-webapp/src/routes/_authenticated/paniers/index.tsx
+++ b/apps/mb-webapp/src/routes/_authenticated/paniers/index.tsx
@@ -1,26 +1,55 @@
+import { individuPublicIdSchema } from '@pilote/mb-shared/individu'
+import { referentielPublicIdSchema } from '@pilote/mb-shared/referentiel'
 import { useSuspenseQuery } from '@tanstack/react-query'
-import { createFileRoute, useNavigate } from '@tanstack/react-router'
+import { createFileRoute, redirect, useNavigate } from '@tanstack/react-router'
+import { startTransition, useId } from 'react'
 import { z } from 'zod'
 
 import { RouteError } from '@/components/RouteError'
 import { RouteLoading } from '@/components/RouteLoading'
+import { IndividuSelect } from '@/components/indicateurs/IndividuSelect'
 import { PanierCard } from '@/components/paniers/PanierCard'
 import { CardGrid } from '@/components/ui/CardGrid'
 import { EmptyState } from '@/components/ui/EmptyState'
+import { FormField } from '@/components/ui/FormField'
 import { Page } from '@/components/ui/Page'
 import { DEFAULT_PAGE_SIZE_OPTIONS, Pagination } from '@/components/ui/Pagination'
 import { Text } from '@/components/ui/Typography'
+import { ensureIndividuReferentielPair } from '@/lib/individus/pair'
 import { loadPaniers, paniersQueryOptions } from '@/queries/paniers'
+import { allReferentielsQueryOptions, loadAllReferentielIds } from '@/queries/referentiels'
 
 const paniersSearchSchema = z.object({
   cursor: z.string().optional(),
   pageSize: z.coerce.number().int().min(1).max(100).optional(),
+  individu: individuPublicIdSchema.optional(),
+  referentiel: referentielPublicIdSchema.optional(),
 })
 
 export const Route = createFileRoute('/_authenticated/paniers/')({
   validateSearch: paniersSearchSchema,
   loaderDeps: ({ search }) => search,
-  loader: ({ context, deps }) => loadPaniers({ queryClient: context.queryClient, query: deps }),
+  loader: async ({ context, deps }) => {
+    const { queryClient } = context
+    const referentielIds = await loadAllReferentielIds({ queryClient })
+    await ensureIndividuReferentielPair({
+      queryClient,
+      referentielIds,
+      deps,
+      onMismatch: ({ individu, referentiel }) => {
+        throw redirect({
+          to: '/paniers',
+          search: { ...deps, individu, referentiel },
+          replace: true,
+        })
+      },
+    })
+
+    return loadPaniers({
+      queryClient,
+      query: { cursor: deps.cursor, pageSize: deps.pageSize },
+    })
+  },
   pendingComponent: () => <RouteLoading message="Chargement des paniers…" />,
   errorComponent: RouteError,
   component: PaniersListComponent,
@@ -29,11 +58,40 @@ export const Route = createFileRoute('/_authenticated/paniers/')({
 function PaniersListComponent() {
   const search = Route.useSearch()
   const navigate = useNavigate({ from: Route.fullPath })
-  const { data } = useSuspenseQuery(paniersQueryOptions(search))
+  const selectId = useId()
+  const { data } = useSuspenseQuery(
+    paniersQueryOptions({ cursor: search.cursor, pageSize: search.pageSize }),
+  )
+  const { data: referentiels } = useSuspenseQuery(allReferentielsQueryOptions)
+  const referentielIds = referentiels.map((r) => r.id)
+
+  const cardContext =
+    search.individu && search.referentiel
+      ? { individu: search.individu, referentiel: search.referentiel }
+      : undefined
 
   return (
     <Page kicker="Collections thématiques" title="Paniers">
       <div className="flex flex-col gap-6">
+        {search.individu ? (
+          <div className="max-w-md">
+            <FormField label="Individu observé" htmlFor={selectId}>
+              <IndividuSelect
+                id={selectId}
+                referentielIds={referentielIds}
+                value={search.individu}
+                onChange={({ individu, referentiel }) => {
+                  startTransition(() => {
+                    void navigate({
+                      search: (prev) => ({ ...prev, individu, referentiel }),
+                    })
+                  })
+                }}
+              />
+            </FormField>
+          </div>
+        ) : null}
+
         <Text as="span" variant="kicker" tone="muted">
           {data.total} panier{data.total > 1 ? 's' : ''}
         </Text>
@@ -43,7 +101,7 @@ function PaniersListComponent() {
         ) : (
           <CardGrid>
             {data.items.map((panier) => (
-              <PanierCard key={panier.id} panier={panier} />
+              <PanierCard key={panier.id} panier={panier} context={cardContext} />
             ))}
           </CardGrid>
         )}

--- a/apps/mb-webapp/src/tests/factories/api.ts
+++ b/apps/mb-webapp/src/tests/factories/api.ts
@@ -1,5 +1,6 @@
 import { type IndicateurApiModel, indicateurApiModelSchema } from '@pilote/mb-shared/indicateur'
 import { type MeApiModel, meApiModelSchema } from '@pilote/mb-shared/me'
+import { type ReferentielApiModel, referentielApiModelSchema } from '@pilote/mb-shared/referentiel'
 
 export const buildMe = (override: Partial<MeApiModel> = {}): MeApiModel =>
   meApiModelSchema.parse({
@@ -25,6 +26,26 @@ export const buildIndicateur = (override: Partial<IndicateurApiModel> = {}): Ind
   })
 
 export const buildIndicateursList = (items: IndicateurApiModel[] = []) => ({
+  items,
+  pagination: { cursor: null, hasMore: false },
+  total: items.length,
+})
+
+export const buildReferentiel = (
+  override: Partial<ReferentielApiModel> = {},
+): ReferentielApiModel =>
+  referentielApiModelSchema.parse({
+    id: 'REF-NAT',
+    nom: 'National',
+    description: null,
+    nombreIndividus: 0,
+    widgets: [],
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...override,
+  })
+
+export const buildReferentielsList = (items: ReferentielApiModel[] = []) => ({
   items,
   pagination: { cursor: null, hasMore: false },
   total: items.length,

--- a/apps/mb-webapp/src/tests/server.ts
+++ b/apps/mb-webapp/src/tests/server.ts
@@ -2,7 +2,12 @@ import { http, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'
 
 import { env } from '@/env'
-import { buildIndicateur, buildIndicateursList, buildMe } from '@/tests/factories/api'
+import {
+  buildIndicateur,
+  buildIndicateursList,
+  buildMe,
+  buildReferentielsList,
+} from '@/tests/factories/api'
 import { buildLogoutResponse, buildRefreshResponse } from '@/tests/factories/bff'
 
 const apiOrigin = new URL(env.apiUrl).origin
@@ -18,6 +23,7 @@ export const defaultHandlers = [
   http.get(apiUrl('/me'), () => HttpResponse.json(buildMe())),
   http.get(apiUrl('/indicateurs'), () => HttpResponse.json(buildIndicateursList())),
   http.get(apiUrl('/indicateurs/:id'), () => HttpResponse.json(buildIndicateur())),
+  http.get(apiUrl('/referentiels'), () => HttpResponse.json(buildReferentielsList())),
 ]
 
 export const server = setupServer(...defaultHandlers)

--- a/apps/mb-webapp/src/tests/server.ts
+++ b/apps/mb-webapp/src/tests/server.ts
@@ -6,6 +6,7 @@ import {
   buildIndicateur,
   buildIndicateursList,
   buildMe,
+  buildReferentiel,
   buildReferentielsList,
 } from '@/tests/factories/api'
 import { buildLogoutResponse, buildRefreshResponse } from '@/tests/factories/bff'
@@ -24,6 +25,9 @@ export const defaultHandlers = [
   http.get(apiUrl('/indicateurs'), () => HttpResponse.json(buildIndicateursList())),
   http.get(apiUrl('/indicateurs/:id'), () => HttpResponse.json(buildIndicateur())),
   http.get(apiUrl('/referentiels'), () => HttpResponse.json(buildReferentielsList())),
+  http.get(apiUrl('/referentiels/:id'), ({ params }) =>
+    HttpResponse.json(buildReferentiel({ id: String(params.id) })),
+  ),
 ]
 
 export const server = setupServer(...defaultHandlers)


### PR DESCRIPTION
## Contexte

Aujourd'hui la sélection d'individu par défaut sur la page indicateur prend le premier dans l'ordre alphabétique français. Cette PR introduit un mécanisme explicite et cohérent : on force le choix d'un individu observé dès l'arrivée sur la liste, on conserve le contexte dans l'URL, on prend la racine de la hiérarchie comme défaut.

> ⚠️ Cette PR est basée sur `mb-individu-select-hierarchie` (#2189). À mettre à mort après merge de cette dernière.

## Changements

### Foundation

- `apps/mb-webapp/src/lib/individus/hierarchy.ts` : extrait `buildOrderedNodes` (auparavant dans `IndividuSelect.tsx`) et ajoute `pickRoot()` qui renvoie le premier node `depth === 0`. Tests unitaires couvrant racine unique, hiérarchie, ordre français, parents hors-périmètre, multi-racines.
- `IndividuSelect` : prop `indicateurId` remplacée par `referentielIds`. Le composant n'est plus couplé à un indicateur, il opère directement sur les référentiels qu'on lui passe.
- `queries/referentiels.ts` : ajout `allReferentielsQueryOptions`, `loadAllReferentielIds` (avec priming du cache `referentielQueryOptions(id)` pour éviter une double fetch), et `loadHierarchyFromReferentiels` qui retourne directement les `IndividuNode[]`.

### `/indicateurs` (liste)

- Schema de search enrichi avec `individu` + `referentiel` (optional).
- Loader auto-redirect : si `?individu=` absent, on charge tous les référentiels, on construit la hiérarchie, on prend la racine via `pickRoot` et on redirige avec les params.
- Sélecteur global au-dessus de la liste avec tous les référentiels.
- `IndicateurCard` propage `individu` + `referentiel` au clic vers la page détail.

### `/indicateurs/$id` (détail)

- Sélection par défaut via `pickRoot` au lieu du premier alphabétique.
- `BackLink` propage `?individu=` + `?referentiel=` vers `/indicateurs`.

## Page marketing `/`

Intacte — pas de sélecteur, pas d'auto-redirect. La home reste statique pour le moment, l'enrichissement éventuel sera traité quand la vue cible (vue liste / vue paniers) sera décidée.

## Comportement avec le seed actuel

Avec 3 référentiels (REF-NAT, REF-REG, REF-DEPT) chargés ensemble, la hiérarchie remonte tout à `FR` grâce à `parents.find((p) => byId.has(p))`. La racine pickée est donc systématiquement `FR` côté REF-NAT, ce qui correspond à l'attente PO ("mécaniquement nat-fr") sans hardcoder de référentiel par défaut.

## Test plan

- [ ] `/indicateurs` sans param → redirect avec `?individu=IND-FR&referentiel=REF-NAT` (ou équivalent seed local).
- [ ] Sélecteur global affiche tous les référentiels regroupés (NAT, REG, DEPT), recherche fonctionne.
- [ ] Changement d'individu sur la liste → URL mise à jour, contexte préservé.
- [ ] Clic sur un card → page détail s'ouvre avec le même `?individu=` propagé.
- [ ] BackLink depuis détail → retour à la liste avec le contexte intact.
- [ ] Page indicateur ouverte directement sans param → redirect avec la racine de l'arbre des référentiels rattachés (et non le premier alphabétique).

🤖 Generated with [Claude Code](https://claude.com/claude-code)