### PR TITLE
feat(chat-ui): réduire l'empreinte visuelle des bandeaux et modale de feedback

### DIFF
--- a/apps/pilote-ppg/src/client/components/_commons/ChatUI/ChatAssistantDisclaimer.tsx
+++ b/apps/pilote-ppg/src/client/components/_commons/ChatUI/ChatAssistantDisclaimer.tsx
@@ -1,18 +1,6 @@
-import { Callout } from "@/components/shared/Callout";
-import { WarningIcon } from "@/components/_commons/Icones/WarningIcon";
-
 export const ChatAssistantDisclaimer = () => (
-  <div className="shrink-0 px-4 pt-2 bg-white">
-    <div className="max-w-3xl mx-auto">
-      <Callout.Root color="moutarde">
-        <Callout.Icon icone={WarningIcon} />
-        <Callout.Text>
-          <p className="font-semibold mb-0">
-            L&apos;Assistant peut faire des erreurs. Veuillez vérifier toutes
-            les informations importantes.
-          </p>
-        </Callout.Text>
-      </Callout.Root>
-    </div>
-  </div>
+  <p className="text-xs text-center text-gray-400 my-2">
+    L&apos;Assistant peut faire des erreurs. Veuillez vérifier toutes les
+    informations importantes.
+  </p>
 );

--- a/apps/pilote-ppg/src/client/components/_commons/ChatUI/ChatExperimentationBanner.tsx
+++ b/apps/pilote-ppg/src/client/components/_commons/ChatUI/ChatExperimentationBanner.tsx
@@ -12,17 +12,17 @@ export const ChatExperimentationBanner = () => {
   if (!isVisible) return null;
 
   return (
-    <Callout.Root color="info" className="relative pr-10">
+    <Callout.Root color="info" className="relative pr-6 pl-2 py-2 ">
       <Callout.Icon />
       <Callout.Text>
-        <p className="font-semibold mb-1">Expérimentation en cours</p>
-        <p>
+        <p className="font-semibold mb-0">Expérimentation en cours</p>
+        <p className="mb-0 text-sm">
           Ce chatbot est une expérimentation visant à améliorer nos services.
           Vos interactions (prompts, réponses, feedbacks) sont analysées pour
-          évaluer sa qualité. Elles sont pseudonymisées par défaut et ne seront
+          évaluer sa qualité. Elles sont pseudonymisées et ne seront
           réattribuées à votre identité qu&apos;en cas de besoin de support.
         </p>
-        <div className="flex flex-wrap gap-x-6 gap-y-2 mt-3">
+        <div className="flex flex-wrap gap-x-6 gap-y-1 mt-2">
           <a
             href={CHARTE_IA_URL}
             target="_blank"

--- a/apps/pilote-ppg/src/client/components/_commons/ChatUI/ChatExperimentationBanner.tsx
+++ b/apps/pilote-ppg/src/client/components/_commons/ChatUI/ChatExperimentationBanner.tsx
@@ -12,17 +12,18 @@ export const ChatExperimentationBanner = () => {
   if (!isVisible) return null;
 
   return (
-    <Callout.Root color="info" className="relative pr-6 pl-2 py-2 ">
+    <Callout.Root color="info" className="relative pr-8 pl-2 py-2">
       <Callout.Icon />
       <Callout.Text>
-        <p className="font-semibold mb-0">Expérimentation en cours</p>
-        <p className="mb-0 text-sm">
-          Ce chatbot est une expérimentation visant à améliorer nos services.
-          Vos interactions (prompts, réponses, feedbacks) sont analysées pour
-          évaluer sa qualité. Elles sont pseudonymisées et ne seront
-          réattribuées à votre identité qu&apos;en cas de besoin de support.
+        <p className="mb-1">
+          <span className="font-semibold">Expérimentation en cours</span>
+          <span className="mx-3 text-gray-300">|</span>
+          <span className="text-sm">
+            Ce chatbot est une expérimentation. Vos interactions sont analysées
+            pour évaluer sa qualité et sont pseudonymisées.
+          </span>
         </p>
-        <div className="flex flex-wrap gap-x-6 gap-y-1 mt-2">
+        <div className="flex flex-wrap items-center gap-y-1">
           <a
             href={CHARTE_IA_URL}
             target="_blank"
@@ -31,6 +32,7 @@ export const ChatExperimentationBanner = () => {
           >
             Charte d&apos;utilisation de l&apos;IA dans PILOTE
           </a>
+          <span className="mx-3 text-gray-300">|</span>
           <Link
             href="/donnees-personnelles-cookies"
             target="_blank"

--- a/apps/pilote-ppg/src/client/components/_commons/ChatUI/ChatInputForm.tsx
+++ b/apps/pilote-ppg/src/client/components/_commons/ChatUI/ChatInputForm.tsx
@@ -13,6 +13,7 @@ import { StopIcon } from "@/components/_commons/Icones/StopIcon";
 import { useChatContext } from "@/components/_commons/ChatUI/ChatContext";
 import { useSpeechRecognition } from "@/components/_commons/ChatUI/useSpeechRecognition";
 import { Select } from "@/components/shared/Select";
+import { ChatAssistantDisclaimer } from "@/components/_commons/ChatUI/ChatAssistantDisclaimer";
 
 export type AlbertModel = "openweight-medium" | "openweight-large";
 
@@ -72,7 +73,7 @@ export const ChatInputForm = ({
   };
 
   return (
-    <div className="shrink-0 border-t border-gray-100 p-4 bg-white">
+    <div className="shrink-0 border-t border-gray-100 px-4 pt-4 pb-2 bg-white">
       <form className="max-w-3xl mx-auto relative" onSubmit={handleSubmit}>
         <textarea
           ref={textareaRef}
@@ -162,6 +163,7 @@ export const ChatInputForm = ({
           )}
         </div>
       </form>
+      <ChatAssistantDisclaimer />
     </div>
   );
 };

--- a/apps/pilote-ppg/src/client/components/_commons/ChatUI/ChatUI.tsx
+++ b/apps/pilote-ppg/src/client/components/_commons/ChatUI/ChatUI.tsx
@@ -10,7 +10,6 @@ import { AssistantLoader } from "@/components/_commons/ChatUI/AssistantLoader";
 import { FeedbackBar } from "@/components/_commons/ChatUI/FeedbackBar";
 import { ChatInputForm } from "@/components/_commons/ChatUI/ChatInputForm";
 import { ChatExperimentationBanner } from "@/components/_commons/ChatUI/ChatExperimentationBanner";
-import { ChatAssistantDisclaimer } from "@/components/_commons/ChatUI/ChatAssistantDisclaimer";
 import { chatMarkdownStyles } from "@/components/_commons/ChatUI/chatMarkdownStyles";
 import { PiloteUIMessage } from "@/server/albert/PiloteUIMessage";
 import { ChatEmptyState } from "@/components/_commons/ChatUI/ChatEmptyState";
@@ -205,10 +204,7 @@ export const ChatUI = ({
         )}
 
         {messages.length > 0 && status === "ready" && (
-          <>
-            <FeedbackBar chatId={chatRef.current.id} />
-            <ChatAssistantDisclaimer />
-          </>
+          <FeedbackBar chatId={chatRef.current.id} />
         )}
 
         <ChatInputForm

--- a/apps/pilote-ppg/src/client/components/_commons/ChatUI/FeedbackCategorieCard.tsx
+++ b/apps/pilote-ppg/src/client/components/_commons/ChatUI/FeedbackCategorieCard.tsx
@@ -15,7 +15,7 @@ export const FeedbackCategorieCard = ({
     <button
       aria-pressed={selectionnee}
       className={clsxm(
-        "flex items-start gap-3 rounded-md border p-3 text-left transition-colors",
+        "flex items-start gap-2 rounded-md border p-2 text-left transition-colors",
         selectionnee
           ? "border-dsfr-blue-france-sun-113 bg-dsfr-blue-france-975"
           : "border-gray-300 hover:bg-gray-50",
@@ -28,7 +28,7 @@ export const FeedbackCategorieCard = ({
         <span className="font-medium text-sm text-gray-900">
           {categorie.titre}
         </span>
-        <span className="text-sm text-gray-500">{categorie.sousTitre}</span>
+        <span className="text-xs text-gray-500">{categorie.sousTitre}</span>
       </span>
     </button>
   );

--- a/apps/pilote-ppg/src/client/components/_commons/ChatUI/FeedbackCategorieCard.tsx
+++ b/apps/pilote-ppg/src/client/components/_commons/ChatUI/FeedbackCategorieCard.tsx
@@ -15,7 +15,7 @@ export const FeedbackCategorieCard = ({
     <button
       aria-pressed={selectionnee}
       className={clsxm(
-        "flex items-start gap-3 rounded-md border p-4 text-left transition-colors",
+        "flex items-start gap-3 rounded-md border p-3 text-left transition-colors",
         selectionnee
           ? "border-dsfr-blue-france-sun-113 bg-dsfr-blue-france-975"
           : "border-gray-300 hover:bg-gray-50",
@@ -25,7 +25,9 @@ export const FeedbackCategorieCard = ({
     >
       <Icone className={clsxm("w-5 h-5 shrink-0", categorie.couleurIcone)} />
       <span className="flex flex-col">
-        <span className="font-medium text-gray-900">{categorie.titre}</span>
+        <span className="font-medium text-sm text-gray-900">
+          {categorie.titre}
+        </span>
         <span className="text-sm text-gray-500">{categorie.sousTitre}</span>
       </span>
     </button>

--- a/apps/pilote-ppg/src/client/components/_commons/ChatUI/FeedbackNegatifModale.tsx
+++ b/apps/pilote-ppg/src/client/components/_commons/ChatUI/FeedbackNegatifModale.tsx
@@ -66,8 +66,9 @@ export const FeedbackNegatifModale = ({
       }}
       open={open}
       titleClassName="!mb-2"
-      size="md"
+      size="sm"
       sousTitre="Dites-nous ce qui n'a pas fonctionné"
+      sousTitreClassName="mb-2"
       title="Aidez-nous à nous améliorer"
       trigger={
         <button
@@ -81,9 +82,11 @@ export const FeedbackNegatifModale = ({
     >
       <fieldset className="border-0 p-0 m-0">
         <legend className="text-sm font-medium text-gray-900 mb-2">
-          Quel(s) type(s) de problème avez-vous rencontré ?{" "}
+          <span className="block">
+            Quel(s) type(s) de problème avez-vous rencontré ?
+          </span>
           <span className="font-normal text-gray-500">
-            (vous pouvez en sélectionner plusieurs)
+            (Vous pouvez sélectionner plusieurs options)
           </span>
         </legend>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
@@ -107,7 +110,7 @@ export const FeedbackNegatifModale = ({
           <span className="font-normal text-gray-500">(optionnel)</span>
         </label>
         <textarea
-          className="mt-1 w-full rounded-md border border-gray-300 p-2 text-sm h-24 resize-none"
+          className="mt-1 w-full rounded-md border border-gray-300 p-2 text-sm h-22 resize-none"
           id="feedback-negatif-commentaire"
           onChange={(event) => setCommentaire(event.target.value)}
           placeholder="Décrivez ce qui n'a pas fonctionné..."

--- a/apps/pilote-ppg/src/client/components/_commons/ChatUI/FeedbackNegatifModale.tsx
+++ b/apps/pilote-ppg/src/client/components/_commons/ChatUI/FeedbackNegatifModale.tsx
@@ -65,6 +65,7 @@ export const FeedbackNegatifModale = ({
         }
       }}
       open={open}
+      titleClassName="!mb-2"
       size="md"
       sousTitre="Dites-nous ce qui n'a pas fonctionné"
       title="Aidez-nous à nous améliorer"
@@ -79,13 +80,13 @@ export const FeedbackNegatifModale = ({
       }
     >
       <fieldset className="border-0 p-0 m-0">
-        <legend className="font-medium text-gray-900 mb-3">
+        <legend className="text-sm font-medium text-gray-900 mb-2">
           Quel(s) type(s) de problème avez-vous rencontré ?{" "}
           <span className="font-normal text-gray-500">
             (vous pouvez en sélectionner plusieurs)
           </span>
         </legend>
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
           {FEEDBACK_CATEGORIES.map((categorie) => (
             <FeedbackCategorieCard
               categorie={categorie}
@@ -97,16 +98,16 @@ export const FeedbackNegatifModale = ({
         </div>
       </fieldset>
 
-      <div className="mt-6">
+      <div className="mt-4">
         <label
-          className="font-medium text-gray-900"
+          className="text-sm font-medium text-gray-900"
           htmlFor="feedback-negatif-commentaire"
         >
           Décrivez le problème{" "}
           <span className="font-normal text-gray-500">(optionnel)</span>
         </label>
         <textarea
-          className="mt-2 w-full rounded-md border border-gray-300 p-3 text-sm h-40 resize-none"
+          className="mt-1 w-full rounded-md border border-gray-300 p-2 text-sm h-24 resize-none"
           id="feedback-negatif-commentaire"
           onChange={(event) => setCommentaire(event.target.value)}
           placeholder="Décrivez ce qui n'a pas fonctionné..."
@@ -114,7 +115,7 @@ export const FeedbackNegatifModale = ({
         />
       </div>
 
-      <div className="flex justify-end gap-2 mt-4">
+      <div className="flex justify-end gap-2 mt-3">
         <Dialog.Close asChild>
           <Bouton label="Annuler" variant="secondary" />
         </Dialog.Close>

--- a/apps/pilote-ppg/src/client/components/_commons/ChatUI/feedbackCategories.ts
+++ b/apps/pilote-ppg/src/client/components/_commons/ChatUI/feedbackCategories.ts
@@ -24,7 +24,7 @@ export const FEEDBACK_CATEGORIES: FeedbackCategorie[] = [
   {
     valeur: $Enums.llm_call_categorie_probleme.INCOMPREHENSION,
     titre: "Incompréhension",
-    sousTitre: "Réponse pas claire",
+    sousTitre: "La réponse manque de précision ou de clarté",
     icone: QuestionIcon,
     couleurIcone: "text-dsfr-blue-france-sun-113",
   },

--- a/apps/pilote-ppg/src/client/components/shared/Modale.tsx
+++ b/apps/pilote-ppg/src/client/components/shared/Modale.tsx
@@ -12,6 +12,7 @@ export const Modale = ({
   children,
   size = "lg",
   titleClassName,
+  sousTitreClassName,
   ...props
 }: Pick<
   ComponentProps<typeof Dialog.Root>,
@@ -20,6 +21,7 @@ export const Modale = ({
   title: ReactNode;
   titleClassName?: string;
   sousTitre?: string;
+  sousTitreClassName?: string;
   titleHidden?: boolean;
   trigger?: ReactNode;
   size?: "sm" | "md" | "lg" | "xl";
@@ -65,7 +67,11 @@ export const Modale = ({
             >
               {title}
             </Dialog.Title>
-            {sousTitre ? <p className="fr-text--lg bold">{sousTitre}</p> : null}
+            {sousTitre ? (
+              <p className={clsxm("fr-text--lg bold", sousTitreClassName)}>
+                {sousTitre}
+              </p>
+            ) : null}
             <div className="max-h-[70vh] overflow-y-auto -mx-8 px-8 -mb-8 pb-8">
               {children}
             </div>


### PR DESCRIPTION
## Résumé

- **Disclaimer** : remplace le Callout jaune conditionnel par un texte `xs` centré sous la textarea, toujours visible
- **Bandeau expérimentation** : refonte du layout — titre + texte sur une ligne séparés par `|`, liens sur la ligne du dessous avec `|` entre eux (aligné sur la maquette Tchap)
- **Modale feedback négatif** : marges resserrées (`mt-6→mt-4`, `gap-3→gap-2`), hauteur textarea réduite (`h-40→h-24`)
- **Modale (composant partagé)** : ajout de la prop `sousTitreClassName` (comme `titleClassName`)

## Test

- [ ] Vérifier l'affichage du disclaimer sous le champ de saisie
- [ ] Vérifier que le bandeau expérimentation s'affiche et se ferme correctement
- [ ] Vérifier la modale feedback négatif (ouverture, sélection de catégories, envoi)
- [ ] Vérifier que `sousTitreClassName` fonctionne sur la Modale