### PR TITLE
feat(sync): synchronisation du champ unite vers mb-api

### DIFF
--- a/apps/pilote-ppg/src/server/mb-sync/__tests__/infrastructure/adapters/PrismaIndicateurIdentiteRepository.integration.test.ts
+++ b/apps/pilote-ppg/src/server/mb-sync/__tests__/infrastructure/adapters/PrismaIndicateurIdentiteRepository.integration.test.ts
@@ -23,6 +23,7 @@ describe("PrismaIndicateurIdentiteRepository", () => {
           chantier_id: chantier.id,
           nom: "Taux de chômage",
           mailles_applicables: ["NAT", "REG"],
+          unite_mesure: "pourcentage",
         });
 
         // When
@@ -32,6 +33,7 @@ describe("PrismaIndicateurIdentiteRepository", () => {
         expect(result).toEqual({
           nom: "Taux de chômage",
           maillesApplicables: ["NAT", "REG"],
+          uniteMesure: "pourcentage",
         });
       }),
     );

--- a/apps/pilote-ppg/src/server/mb-sync/__tests__/usecases/SyncMbMetadonneesUseCase.unit.test.ts
+++ b/apps/pilote-ppg/src/server/mb-sync/__tests__/usecases/SyncMbMetadonneesUseCase.unit.test.ts
@@ -24,6 +24,7 @@ describe("SyncMbMetadonneesUseCase", () => {
     indicateurIdentiteRepository.findById.mockResolvedValue({
       nom: "Taux de chômage",
       maillesApplicables: ["NAT", "REG"],
+      uniteMesure: null,
     });
 
     // When
@@ -35,6 +36,7 @@ describe("SyncMbMetadonneesUseCase", () => {
       payload: {
         nom: "Taux de chômage",
         visibilite: "PUBLIC",
+        unite: null,
         referentiels: [
           { referentielPublicId: "REF-NAT", fonctionAgregation: "NONE" },
           { referentielPublicId: "REF-REG", fonctionAgregation: "NONE" },
@@ -45,6 +47,35 @@ describe("SyncMbMetadonneesUseCase", () => {
       indicateurs: [{ id: INDIC_ID, statut: "ok" }],
     });
   });
+
+  it.each([
+    { uniteMesure: "%", expected: "POURCENTAGE" },
+    { uniteMesure: "Pourcentage", expected: "POURCENTAGE" },
+    { uniteMesure: "ans", expected: "ANNEES" },
+    { uniteMesure: "Années", expected: "ANNEES" },
+    { uniteMesure: "kg", expected: null },
+    { uniteMesure: null, expected: null },
+  ])(
+    "mappe uniteMesure=$uniteMesure vers unite=$expected",
+    async ({ uniteMesure, expected }) => {
+      // Given
+      indicateurIdentiteRepository.findById.mockResolvedValue({
+        nom: "Mon indicateur",
+        maillesApplicables: ["NAT"],
+        uniteMesure,
+      });
+
+      // When
+      await useCase.execute([INDIC_ID]);
+
+      // Then
+      expect(mbApiClient.upsertIndicateur).toHaveBeenCalledExactlyOnceWith(
+        expect.objectContaining({
+          payload: expect.objectContaining({ unite: expected }),
+        }),
+      );
+    },
+  );
 
   it("ignore un indicateur absent sans bloquer", async () => {
     // Given
@@ -65,6 +96,7 @@ describe("SyncMbMetadonneesUseCase", () => {
     indicateurIdentiteRepository.findById.mockResolvedValue({
       nom: "Mon indicateur",
       maillesApplicables: ["NAT"],
+      uniteMesure: null,
     });
     mbApiClient.upsertIndicateur.mockRejectedValue(
       new Error("mb-api indisponible"),

--- a/apps/pilote-ppg/src/server/mb-sync/domain/ports/IndicateurIdentiteRepository.ts
+++ b/apps/pilote-ppg/src/server/mb-sync/domain/ports/IndicateurIdentiteRepository.ts
@@ -3,6 +3,7 @@ import { type $Enums } from "@prisma/client";
 export type IndicateurIdentite = {
   nom: string;
   maillesApplicables: $Enums.Maille[];
+  uniteMesure: string | null;
 };
 
 export interface IndicateurIdentiteRepository {

--- a/apps/pilote-ppg/src/server/mb-sync/domain/ports/MbApiClient.ts
+++ b/apps/pilote-ppg/src/server/mb-sync/domain/ports/MbApiClient.ts
@@ -7,6 +7,7 @@ export type UpsertValeurAvancementItem = {
 export type UpsertIndicateurPayload = {
   nom: string;
   visibilite: "PRIVE" | "PUBLIC";
+  unite: "POURCENTAGE" | "ANNEES" | null;
   referentiels: Array<{
     referentielPublicId: string;
     fonctionAgregation: "SUM" | "AVG" | "NONE";

--- a/apps/pilote-ppg/src/server/mb-sync/infrastructure/adapters/PrismaIndicateurIdentiteRepository.ts
+++ b/apps/pilote-ppg/src/server/mb-sync/infrastructure/adapters/PrismaIndicateurIdentiteRepository.ts
@@ -14,9 +14,13 @@ export class PrismaIndicateurIdentiteRepository implements IndicateurIdentiteRep
   async findById(id: string): Promise<IndicateurIdentite | null> {
     const row = await this.prisma.indicateur_identite.findUnique({
       where: { id },
-      select: { nom: true, mailles_applicables: true },
+      select: { nom: true, mailles_applicables: true, unite_mesure: true },
     });
     if (!row) return null;
-    return { nom: row.nom, maillesApplicables: row.mailles_applicables };
+    return {
+      nom: row.nom,
+      maillesApplicables: row.mailles_applicables,
+      uniteMesure: row.unite_mesure,
+    };
   }
 }

--- a/apps/pilote-ppg/src/server/mb-sync/usecases/SyncMbMetadonneesUseCase.ts
+++ b/apps/pilote-ppg/src/server/mb-sync/usecases/SyncMbMetadonneesUseCase.ts
@@ -1,6 +1,9 @@
 import { $Enums } from "@prisma/client";
 import logger from "@/server/infrastructure/Logger";
-import { type MbApiClient } from "@/server/mb-sync/domain/ports/MbApiClient";
+import {
+  type MbApiClient,
+  type UpsertIndicateurPayload,
+} from "@/server/mb-sync/domain/ports/MbApiClient";
 import { type IndicateurIdentiteRepository } from "@/server/mb-sync/domain/ports/IndicateurIdentiteRepository";
 
 const MAILLE_VERS_REFERENTIEL: Record<$Enums.Maille, string> = {
@@ -8,6 +11,21 @@ const MAILLE_VERS_REFERENTIEL: Record<$Enums.Maille, string> = {
   REG: "REF-REG",
   DEPT: "REF-DEPT",
 };
+
+function mapUniteMesure(
+  uniteMesure: string | null,
+): UpsertIndicateurPayload["unite"] {
+  if (!uniteMesure) return null;
+  const normalized = uniteMesure.trim().toLowerCase();
+  if (normalized === "%" || normalized === "pourcentage") return "POURCENTAGE";
+  if (
+    normalized === "ans" ||
+    normalized === "années" ||
+    normalized === "annees"
+  )
+    return "ANNEES";
+  return null;
+}
 
 export type SyncMetadonneesResultat = {
   indicateurs: Array<{ id: string; statut: "ok" | "non_trouve" }>;
@@ -59,6 +77,7 @@ export class SyncMbMetadonneesUseCase {
         payload: {
           nom: indicateur.nom,
           visibilite: "PUBLIC",
+          unite: mapUniteMesure(indicateur.uniteMesure),
           referentiels,
         },
       });


### PR DESCRIPTION
## Contexte

Le cron `sync-mb-valeurs` échouait pour tous les indicateurs avec une erreur HTTP 400 de mb-api :

```
ZodError: Invalid option for `unite`: expected one of "POURCENTAGE"|"ANNEES"
```

mb-api définit `unite` comme champ **requis** (nullable mais non optionnel) dans son schema Zod. PILOTE envoyait le payload sans ce champ, ce qui provoquait l'erreur.

## Changements

- **`IndicateurIdentiteRepository.ts`** — ajout de `uniteMesure: string | null` au type domaine
- **`PrismaIndicateurIdentiteRepository.ts`** — sélection de `unite_mesure` depuis la base
- **`MbApiClient.ts`** — ajout de `unite: "POURCENTAGE" | "ANNEES" | null` au type `UpsertIndicateurPayload`
- **`SyncMbMetadonneesUseCase.ts`** — fonction `mapUniteMesure` + envoi du champ dans le payload

## Mapping `unite_mesure` → code mb-api

| Valeur PILOTE | Code mb-api |
|---|---|
| `%`, `Pourcentage` | `POURCENTAGE` |
| `ans`, `Années`, `annees` | `ANNEES` |
| Toute autre valeur / `null` | `null` |

## Tests

6 cas de mapping ajoutés dans `SyncMbMetadonneesUseCase.unit.test.ts`.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)