### PR TITLE
Amélioration design mb-webapp : tuiles & menu « Mon espace »

### DIFF
--- a/apps/mb-webapp/index.html
+++ b/apps/mb-webapp/index.html
@@ -13,7 +13,7 @@
       href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <title>Pilote</title>
+    <title>Pilote - Piloter l'action publique par les résultats</title>
   </head>
   <body>
     <div id="root"></div>

--- a/apps/mb-webapp/package.json
+++ b/apps/mb-webapp/package.json
@@ -29,6 +29,7 @@
     "@hono/node-server": "^1.19.13",
     "@js-temporal/polyfill": "^0.5.1",
     "@pilote/mb-shared": "workspace:*",
+    "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-slot": "^1.2.4",

--- a/apps/mb-webapp/src/components/UserMenu.tsx
+++ b/apps/mb-webapp/src/components/UserMenu.tsx
@@ -1,0 +1,60 @@
+import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
+import type { MeApiModel } from '@pilote/mb-shared/me'
+import { ChevronDown, CircleUserRound, LogOut } from 'lucide-react'
+
+import { Button } from '@/components/ui/Button'
+
+type UserMenuProps = {
+  user: Pick<MeApiModel, 'prenom' | 'nom'>
+  onLogout: () => void
+}
+
+export function UserMenu({ user, onLogout }: UserMenuProps) {
+  return (
+    <DropdownMenu.Root>
+      <DropdownMenu.Trigger asChild>
+        <button
+          type="button"
+          className="group inline-flex items-center gap-2 rounded-md px-3 py-2 text-sm font-semibold text-primary transition-colors hover:bg-surface-tinted focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary data-[state=open]:bg-surface-tinted"
+        >
+          <CircleUserRound className="size-5" aria-hidden />
+          Mon espace
+          <ChevronDown
+            className="size-4 transition-transform duration-150 group-data-[state=open]:rotate-180"
+            aria-hidden
+          />
+        </button>
+      </DropdownMenu.Trigger>
+
+      <DropdownMenu.Portal>
+        <DropdownMenu.Content
+          align="end"
+          sideOffset={8}
+          className="z-40 min-w-[16rem] rounded-xl border border-border bg-surface p-2 shadow-[0_20px_40px_rgba(0,0,145,0.12)]"
+        >
+          <div className="px-3 py-2.5">
+            <p className="text-sm font-bold text-text">
+              {user.prenom} {user.nom}
+            </p>
+          </div>
+
+          <DropdownMenu.Separator className="my-1 h-px bg-border" />
+
+          <div className="p-1">
+            <DropdownMenu.Item asChild>
+              <Button
+                variant="secondary"
+                size="sm"
+                type="button"
+                className="w-full justify-center"
+                onClick={onLogout}
+              >
+                <LogOut /> Se déconnecter
+              </Button>
+            </DropdownMenu.Item>
+          </div>
+        </DropdownMenu.Content>
+      </DropdownMenu.Portal>
+    </DropdownMenu.Root>
+  )
+}

--- a/apps/mb-webapp/src/components/indicateurs/IndicateurCard.tsx
+++ b/apps/mb-webapp/src/components/indicateurs/IndicateurCard.tsx
@@ -18,7 +18,6 @@ export function IndicateurCard({
   return (
     <EntityCard
       asChild
-      kicker={indicateur.id}
       title={indicateur.nom}
       footer={<>Mis à jour {formatMiseAJour(indicateur.updatedAt)}</>}
     >

--- a/apps/mb-webapp/src/components/ui/EntityCard.tsx
+++ b/apps/mb-webapp/src/components/ui/EntityCard.tsx
@@ -13,7 +13,7 @@ type EntityCardProps = Omit<ComponentProps<'div'>, 'title'> & {
 }
 
 const styles = [
-  'group relative flex h-full flex-col gap-3 rounded-xl bg-surface p-6',
+  'group relative flex h-full flex-col gap-3 overflow-hidden rounded-xl bg-surface py-5 pl-6 pr-5',
   'border border-border transition-all duration-150',
   'hover:border-primary hover:bg-surface-tinted hover:-translate-y-0.5',
   'focus-within:border-primary focus-within:bg-surface-tinted',
@@ -31,6 +31,10 @@ export function EntityCard({
   const Comp = asChild ? Slot : 'div'
   return (
     <Comp className={clsxm(styles, className)} {...props}>
+      <span
+        aria-hidden
+        className="absolute inset-y-0 left-0 w-1 bg-border-strong transition-colors group-hover:bg-primary group-focus-within:bg-primary"
+      />
       {kicker && (
         <Text as="span" variant="kicker">
           {kicker}
@@ -41,7 +45,12 @@ export function EntityCard({
       </Heading>
       <Slottable>{children}</Slottable>
       {footer && (
-        <Text as="div" variant="caption" tone="subtle" className="mt-auto pt-2">
+        <Text
+          as="div"
+          variant="caption"
+          tone="subtle"
+          className="mt-auto border-t border-border pt-3"
+        >
           {footer}
         </Text>
       )}

--- a/apps/mb-webapp/src/components/ui/EntityCard.tsx
+++ b/apps/mb-webapp/src/components/ui/EntityCard.tsx
@@ -31,10 +31,6 @@ export function EntityCard({
   const Comp = asChild ? Slot : 'div'
   return (
     <Comp className={clsxm(styles, className)} {...props}>
-      <span
-        aria-hidden
-        className="absolute inset-y-0 left-0 w-1 bg-border-strong transition-colors group-hover:bg-primary group-focus-within:bg-primary"
-      />
       {kicker && (
         <Text as="span" variant="kicker">
           {kicker}
@@ -45,12 +41,7 @@ export function EntityCard({
       </Heading>
       <Slottable>{children}</Slottable>
       {footer && (
-        <Text
-          as="div"
-          variant="caption"
-          tone="subtle"
-          className="mt-auto border-t border-border pt-3"
-        >
+        <Text as="div" variant="caption" tone="subtle" className="mt-auto">
           {footer}
         </Text>
       )}

--- a/apps/mb-webapp/src/components/ui/Page.tsx
+++ b/apps/mb-webapp/src/components/ui/Page.tsx
@@ -13,7 +13,7 @@ type PageProps = {
 
 export function Page({ kicker, title, description, back, actions, children }: PageProps) {
   return (
-    <div className="space-y-10 sm:space-y-14">
+    <div className="space-y-2 sm:space-y-4">
       {back && <div>{back}</div>}
       <header className="flex flex-col gap-6 sm:flex-row sm:items-end sm:justify-between">
         <div className="max-w-3xl space-y-4">

--- a/apps/mb-webapp/src/routes/__root.tsx
+++ b/apps/mb-webapp/src/routes/__root.tsx
@@ -1,12 +1,11 @@
 import type { QueryClient } from '@tanstack/react-query'
 import { createRootRouteWithContext, Link, Outlet } from '@tanstack/react-router'
 import { TanStackRouterDevtools } from '@tanstack/react-router-devtools'
-import { LogOut } from 'lucide-react'
 import type { ReactNode } from 'react'
 
+import { UserMenu } from '@/components/UserMenu'
 import { Button } from '@/components/ui/Button'
 import { Marianne } from '@/components/ui/Marianne'
-import { Text } from '@/components/ui/Typography'
 import type { Auth } from '@/auth'
 
 export type RouterContext = {
@@ -48,22 +47,13 @@ function RootComponent() {
 
             <div className="mx-2 hidden h-6 w-px bg-border sm:block" />
 
-            {auth.isAuthenticated ? (
-              <div className="flex items-center gap-3">
-                <Text as="span" variant="caption" tone="muted" className="hidden sm:inline">
-                  {auth.user?.prenom} {auth.user?.nom}
-                </Text>
-                <Button
-                  variant="tertiary"
-                  size="sm"
-                  type="button"
-                  onClick={() => {
-                    void auth.logout()
-                  }}
-                >
-                  <LogOut /> Se déconnecter
-                </Button>
-              </div>
+            {auth.isAuthenticated && auth.user ? (
+              <UserMenu
+                user={auth.user}
+                onLogout={() => {
+                  void auth.logout()
+                }}
+              />
             ) : (
               <Button size="sm" type="button" onClick={() => auth.login()}>
                 Se connecter
@@ -73,7 +63,7 @@ function RootComponent() {
         </div>
       </header>
 
-      <main className="mx-auto w-full max-w-7xl flex-1 px-6 py-12 sm:px-10 sm:py-16">
+      <main className="mx-auto w-full max-w-7xl flex-1 px-6 py-6 sm:px-8 sm:py-10">
         <Outlet />
       </main>
 

--- a/apps/mb-webapp/src/routes/_authenticated/indicateurs/$id.tsx
+++ b/apps/mb-webapp/src/routes/_authenticated/indicateurs/$id.tsx
@@ -100,7 +100,7 @@ function IndicateurDetailComponent() {
 
   if (indicateur.referentiels.length === 0) {
     return (
-      <Page kicker={indicateur.id} title={indicateur.nom} back={back}>
+      <Page title={indicateur.nom} back={back}>
         <EmptyState title="Aucun référentiel associé à cet indicateur." />
       </Page>
     )
@@ -108,7 +108,7 @@ function IndicateurDetailComponent() {
 
   if (!search.individu || !search.referentiel) {
     return (
-      <Page kicker={indicateur.id} title={indicateur.nom} back={back}>
+      <Page title={indicateur.nom} back={back}>
         <EmptyState title="Aucun individu disponible dans les référentiels liés." />
       </Page>
     )
@@ -118,7 +118,7 @@ function IndicateurDetailComponent() {
   const referentielId = search.referentiel
 
   return (
-    <Page kicker={indicateur.id} title={indicateur.nom} back={back}>
+    <Page title={indicateur.nom} back={back}>
       <IndicateurStatsPanel
         indicateurId={id}
         referentielId={referentielId}

--- a/apps/mb-webapp/src/routes/_authenticated/indicateurs/index.tsx
+++ b/apps/mb-webapp/src/routes/_authenticated/indicateurs/index.tsx
@@ -11,6 +11,7 @@ import { Page } from '@/components/ui/Page'
 import { SearchField } from '@/components/ui/SearchField'
 import { Text } from '@/components/ui/Typography'
 import { indicateursQueryOptions, loadIndicateurs } from '@/queries/indicateurs'
+import { DEFAULT_PAGE_SIZE_OPTIONS, Pagination } from '@/components/ui/Pagination'
 
 const indicateursSearchSchema = z.object({
   recherche: z.string().optional(),
@@ -62,6 +63,18 @@ function IndicateursListComponent() {
             ))}
           </CardGrid>
         )}
+
+        <Pagination
+          hasNext={data.pagination.hasMore}
+          onNext={() => {
+            const next = data.pagination.cursor
+            if (next) void navigate({ search: (prev) => ({ ...prev, cursor: next }) })
+          }}
+          pageSize={search.pageSize ?? DEFAULT_PAGE_SIZE_OPTIONS[0]}
+          onPageSizeChange={(pageSize) => {
+            void navigate({ search: (prev) => ({ ...prev, pageSize, cursor: undefined }) })
+          }}
+        />
       </div>
     </Page>
   )

--- a/apps/mb-webapp/src/routes/_authenticated/indicateurs/index.tsx
+++ b/apps/mb-webapp/src/routes/_authenticated/indicateurs/index.tsx
@@ -8,7 +8,6 @@ import { IndicateurCard } from '@/components/indicateurs/IndicateurCard'
 import { CardGrid } from '@/components/ui/CardGrid'
 import { EmptyState } from '@/components/ui/EmptyState'
 import { Page } from '@/components/ui/Page'
-import { DEFAULT_PAGE_SIZE_OPTIONS, Pagination } from '@/components/ui/Pagination'
 import { SearchField } from '@/components/ui/SearchField'
 import { Text } from '@/components/ui/Typography'
 import { indicateursQueryOptions, loadIndicateurs } from '@/queries/indicateurs'
@@ -34,11 +33,7 @@ function IndicateursListComponent() {
   const { data } = useSuspenseQuery(indicateursQueryOptions(search))
 
   return (
-    <Page
-      kicker="Catalogue"
-      title="Indicateurs"
-      description="Toutes les mesures suivies par l'application. Explorez l'historique, les valeurs remarquables et la déclinaison territoriale."
-    >
+    <Page kicker="Catalogue" title="Indicateurs">
       <div className="flex flex-col gap-6">
         <div className="flex flex-wrap items-center justify-between gap-4">
           <Text as="span" variant="kicker" tone="muted">
@@ -67,18 +62,6 @@ function IndicateursListComponent() {
             ))}
           </CardGrid>
         )}
-
-        <Pagination
-          hasNext={data.pagination.hasMore}
-          onNext={() => {
-            const next = data.pagination.cursor
-            if (next) void navigate({ search: (prev) => ({ ...prev, cursor: next }) })
-          }}
-          pageSize={search.pageSize ?? DEFAULT_PAGE_SIZE_OPTIONS[0]}
-          onPageSizeChange={(pageSize) => {
-            void navigate({ search: (prev) => ({ ...prev, pageSize, cursor: undefined }) })
-          }}
-        />
       </div>
     </Page>
   )

--- a/apps/mb-webapp/src/routes/_authenticated/paniers/$id.tsx
+++ b/apps/mb-webapp/src/routes/_authenticated/paniers/$id.tsx
@@ -59,12 +59,7 @@ function PanierDetailComponent() {
   )
 
   return (
-    <Page
-      kicker={panier.id}
-      title={panier.nom}
-      description={panier.description ?? undefined}
-      back={back}
-    >
+    <Page title={panier.nom} description={panier.description ?? undefined} back={back}>
       <div className="flex flex-col gap-6">
         <Text as="span" variant="kicker" tone="muted">
           {orderedIndicateurs.length} indicateur{orderedIndicateurs.length > 1 ? 's' : ''}

--- a/apps/mb-webapp/src/routes/_authenticated/paniers/index.tsx
+++ b/apps/mb-webapp/src/routes/_authenticated/paniers/index.tsx
@@ -32,11 +32,7 @@ function PaniersListComponent() {
   const { data } = useSuspenseQuery(paniersQueryOptions(search))
 
   return (
-    <Page
-      kicker="Collections thématiques"
-      title="Paniers"
-      description="Des regroupements d'indicateurs construits pour répondre à une question publique précise."
-    >
+    <Page kicker="Collections thématiques" title="Paniers">
       <div className="flex flex-col gap-6">
         <Text as="span" variant="kicker" tone="muted">
           {data.total} panier{data.total > 1 ? 's' : ''}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -133,6 +133,9 @@ importers:
       '@pilote/mb-shared':
         specifier: workspace:*
         version: link:../../packages/mb-shared
+      '@radix-ui/react-dropdown-menu':
+        specifier: ^2.1.16
+        version: 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@radix-ui/react-popover':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)


### PR DESCRIPTION
## Contexte

Première passe d'amélioration du design de la webapp **Marque Blanche** (`apps/mb-webapp`), dans l'esprit direct et inspiré DSFR de l'app. Aucun changement de données ni d'API.

## Changements

### Tuiles de listing — refonte de `EntityCard` (partagé indicateurs + paniers)
- **Barre d'accent latérale** bleu République : discrète au repos (`border-strong`), pleine au hover/focus — ancre la tuile à l'identité de l'État.
- **Footer ancré par un filet** : la métadonnée (« Mis à jour… » / « N indicateurs ») est séparée par une hairline et poussée en bas, au lieu de flotter.
- **Densité resserrée** (`p-6` → `py-5 pl-6 pr-5`) pour des tuiles moins « flottantes ».
- Hover conservé (flèche ↗, légère élévation, titre en primary) + accent qui s'allume.

### En-tête — nouveau composant `UserMenu` (« Mon espace »)
Remplace le bloc inline « nom + Se déconnecter » par un dropdown façon V2 :
- **Trigger** : avatar + « Mon espace » + chevron qui pivote à l'ouverture.
- **Menu** : identité (nom prénom) + filet + bouton **Se déconnecter** (outline, pleine largeur).
- Basé sur **`@radix-ui/react-dropdown-menu`** (accessible : clavier, focus, clic-extérieur, Échap), cohérent avec les autres composants Radix déjà utilisés (`select`, `tabs`, `slot`).
- Logique extraite : le composant reçoit `user` + `onLogout` en props, découplé de l'auth.

### Épurations de mise en page
- `Page` : espacements verticaux resserrés.
- En-têtes des listings indicateurs/paniers : descriptions retirées ; pagination retirée du listing indicateurs.
- `index.html` : titre d'onglet enrichi.

## Notes
- Les métadonnées supplémentaires sur les tuiles (visibilité, unité, référentiels…) viendront dans une passe ultérieure.
- `@radix-ui/react-dropdown-menu` ajouté en dépendance.