### PR TITLE
feat: afficher la dernière valeur d'avancement sur les cards d'indicateurs

### DIFF
--- a/apps/mb-api/src/valeurAvancement/queries/listDernieresValeursForIndividu.test.ts
+++ b/apps/mb-api/src/valeurAvancement/queries/listDernieresValeursForIndividu.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from 'vitest'
+
+import { fixtures } from '@/test/fixtures'
+import { integrationTest } from '@/test/integrationTest'
+import { testDeptId, testIndicateurId, testIndicateurIds, testRegId } from '@/test/randomIds'
+import { runAsPrincipal } from '@/test/runAsPrincipal'
+import { listDernieresValeursForIndividu } from '@/valeurAvancement/queries/listDernieresValeursForIndividu'
+
+describe.concurrent('listDernieresValeursForIndividu', () => {
+  it(
+    "retourne la dernière valeur saisie d'un individu pour un indicateur",
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const deptId = testDeptId()
+      await fixtures.indicateur({ publicId: indId, nom: 'T', visibilite: 'PUBLIC' })
+      await fixtures.valeurAvancement(
+        {
+          indicateur: { publicId: indId },
+          individu: { publicId: deptId, referentiel: { publicId: 'REF-A', nom: 'A' } },
+          date: '2026-01-01',
+          valeur: 10,
+        },
+        {
+          indicateur: { publicId: indId },
+          individu: { publicId: deptId },
+          date: '2026-03-01',
+          valeur: 75,
+        },
+        {
+          indicateur: { publicId: indId },
+          individu: { publicId: deptId },
+          date: '2026-02-01',
+          valeur: 25,
+        },
+      )
+      const apiKey = await fixtures.apiKey()
+
+      const result = await runAsPrincipal(apiKey.id, () =>
+        listDernieresValeursForIndividu(deptId, { indicateurs: [indId] }),
+      )
+
+      expect(result._unsafeUnwrap()).toEqual({
+        items: [{ indicateur: indId, valeur: 75, date: '2026-03-01', type: 'saisie' }],
+      })
+    }),
+  )
+
+  it(
+    "omet l'indicateur si l'individu n'a aucune valeur",
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const deptId = testDeptId()
+      await fixtures.indicateur({ publicId: indId, nom: 'T', visibilite: 'PUBLIC' })
+      await fixtures.individu({ publicId: deptId, referentiel: { publicId: 'REF-A', nom: 'A' } })
+      const apiKey = await fixtures.apiKey()
+
+      const result = await runAsPrincipal(apiKey.id, () =>
+        listDernieresValeursForIndividu(deptId, { indicateurs: [indId] }),
+      )
+
+      expect(result._unsafeUnwrap()).toEqual({ items: [] })
+    }),
+  )
+
+  it(
+    "retourne items vide quand l'individu n'existe pas",
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      await fixtures.indicateur({ publicId: indId, nom: 'T', visibilite: 'PUBLIC' })
+      const apiKey = await fixtures.apiKey()
+
+      const result = await runAsPrincipal(apiKey.id, () =>
+        listDernieresValeursForIndividu('DEPT-99', { indicateurs: [indId] }),
+      )
+
+      expect(result._unsafeUnwrap()).toEqual({ items: [] })
+    }),
+  )
+
+  it(
+    "n'inclut que les indicateurs ayant au moins une valeur pour l'individu",
+    integrationTest(async () => {
+      const [indAvecValeur, indSansValeur] = testIndicateurIds(2)
+      const deptId = testDeptId()
+      await fixtures.indicateur(
+        { publicId: indAvecValeur, nom: 'A', visibilite: 'PUBLIC' },
+        { publicId: indSansValeur, nom: 'B', visibilite: 'PUBLIC' },
+      )
+      await fixtures.valeurAvancement({
+        indicateur: { publicId: indAvecValeur },
+        individu: { publicId: deptId, referentiel: { publicId: 'REF-A', nom: 'A' } },
+        date: '2026-01-01',
+        valeur: 42,
+      })
+      const apiKey = await fixtures.apiKey()
+
+      const result = await runAsPrincipal(apiKey.id, () =>
+        listDernieresValeursForIndividu(deptId, {
+          indicateurs: [indAvecValeur, indSansValeur],
+        }),
+      )
+
+      expect(result._unsafeUnwrap()).toEqual({
+        items: [{ indicateur: indAvecValeur, valeur: 42, date: '2026-01-01', type: 'saisie' }],
+      })
+    }),
+  )
+
+  it(
+    'omet les indicateurs inaccessibles en lecture',
+    integrationTest(async () => {
+      const [indPublic, indPrive] = testIndicateurIds(2)
+      const deptId = testDeptId()
+      await fixtures.indicateur(
+        { publicId: indPublic, nom: 'Public', visibilite: 'PUBLIC' },
+        { publicId: indPrive, nom: 'Privé', visibilite: 'PRIVE' },
+      )
+      await fixtures.valeurAvancement(
+        {
+          indicateur: { publicId: indPublic },
+          individu: { publicId: deptId, referentiel: { publicId: 'REF-A', nom: 'A' } },
+          date: '2026-01-01',
+          valeur: 10,
+        },
+        {
+          indicateur: { publicId: indPrive },
+          individu: { publicId: deptId },
+          date: '2026-01-01',
+          valeur: 99,
+        },
+      )
+      const apiKey = await fixtures.apiKey()
+
+      const result = await runAsPrincipal(apiKey.id, () =>
+        listDernieresValeursForIndividu(deptId, { indicateurs: [indPublic, indPrive] }),
+      )
+
+      expect(result._unsafeUnwrap()).toEqual({
+        items: [{ indicateur: indPublic, valeur: 10, date: '2026-01-01', type: 'saisie' }],
+      })
+    }),
+  )
+
+  it(
+    'retourne type=derivee pour un individu agrégé sur des enfants ayant des valeurs',
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const regId = testRegId()
+      const deptId = testDeptId()
+      await fixtures.indicateur({ publicId: indId, nom: 'T', visibilite: 'PUBLIC' })
+      await fixtures.indicateurReferentiel({
+        indicateur: { publicId: indId },
+        referentiel: { publicId: 'REF-REG', nom: 'Régions' },
+        fonctionAgregation: 'SUM',
+      })
+      await fixtures.indicateurReferentiel({
+        indicateur: { publicId: indId },
+        referentiel: { publicId: 'REF-DEPT', nom: 'Départements' },
+      })
+      await fixtures.relation({
+        parent: { publicId: regId, referentiel: { publicId: 'REF-REG' } },
+        child: { publicId: deptId, referentiel: { publicId: 'REF-DEPT' } },
+      })
+      await fixtures.valeurAvancement({
+        indicateur: { publicId: indId },
+        individu: { publicId: deptId },
+        date: '2026-01-15',
+        valeur: 12,
+      })
+      const apiKey = await fixtures.apiKey()
+
+      const result = await runAsPrincipal(apiKey.id, () =>
+        listDernieresValeursForIndividu(regId, { indicateurs: [indId] }),
+      )
+
+      expect(result._unsafeUnwrap()).toEqual({
+        items: [{ indicateur: indId, valeur: 12, date: '2026-01-01', type: 'derivee' }],
+      })
+    }),
+  )
+})

--- a/apps/mb-api/src/valeurAvancement/queries/listDernieresValeursForIndividu.ts
+++ b/apps/mb-api/src/valeurAvancement/queries/listDernieresValeursForIndividu.ts
@@ -1,0 +1,84 @@
+import { type DateTrunc } from '@pilote/mb-shared/dates'
+import {
+  type DernieresValeursIndividuListApiModel,
+  type DernierValeurIndividuApiModel,
+  type ListDernieresValeursForIndividuQuery,
+} from '@pilote/mb-shared/valeurAvancement'
+import { ResultAsync } from 'neverthrow'
+
+import { requireCurrentPrincipalId } from '@/framework/auth/userContext'
+import { formatBucket } from '@/framework/bucket'
+import { logger } from '@/framework/logger/logger'
+import { db } from '@/framework/persistence/dbStore'
+import { withIndicateurReadPermission } from '@/indicateur/permissions'
+import { loadResolveSerieContext } from '@/valeurAvancement/queries/loadResolveSerieContext'
+import {
+  type IndividuRef,
+  type PointInterne,
+  resolveSerieIndividu,
+} from '@/valeurAvancement/resolveSerieIndividu'
+
+const DEFAULT_DATE_TRUNC: DateTrunc = 'month'
+
+export const listDernieresValeursForIndividu = (
+  individuPublicId: string,
+  params: ListDernieresValeursForIndividuQuery,
+): ResultAsync<DernieresValeursIndividuListApiModel, never> =>
+  ResultAsync.fromSafePromise(build(individuPublicId, params))
+
+const build = async (
+  individuPublicId: string,
+  params: ListDernieresValeursForIndividuQuery,
+): Promise<DernieresValeursIndividuListApiModel> => {
+  const principalId = requireCurrentPrincipalId()
+
+  const individuRow = await db().individu.findUnique({
+    where: { publicId: individuPublicId },
+    select: { id: true, publicId: true, referentielId: true },
+  })
+  if (!individuRow) return { items: [] }
+  const individu: IndividuRef = individuRow
+
+  const indicateurs = await db().indicateur.findMany({
+    where: withIndicateurReadPermission({ publicId: { in: [...params.indicateurs] } }, principalId),
+    select: { id: true, publicId: true },
+  })
+  if (indicateurs.length === 0) return { items: [] }
+
+  const startedAt = performance.now()
+  const dateTrunc = DEFAULT_DATE_TRUNC
+  const resolus = await Promise.all(
+    indicateurs.map(async (indicateur) => {
+      const { ctx } = await loadResolveSerieContext({
+        indicateurId: indicateur.id,
+        cibles: [individu],
+        dateTrunc,
+      })
+      const cache = new Map<string, ReadonlyArray<PointInterne>>()
+      const serie = await resolveSerieIndividu(individu.id, ctx, cache)
+      const dernier = serie.at(-1)
+      if (!dernier) return null
+      const item: DernierValeurIndividuApiModel = {
+        indicateur: indicateur.publicId,
+        valeur: dernier.valeur.toNumber(),
+        date: formatBucket(dernier.bucket),
+        type: dernier.type,
+      }
+      return item
+    }),
+  )
+  const items = resolus.filter((item): item is DernierValeurIndividuApiModel => item !== null)
+
+  logger.info(
+    {
+      event: 'valeurAvancement.listDernieresValeursForIndividu.timing',
+      individuId: individu.id,
+      nbIndicateursDemandes: params.indicateurs.length,
+      nbIndicateursAccessibles: indicateurs.length,
+      nbItems: items.length,
+      durationMs: Math.round(performance.now() - startedAt),
+    },
+    'listDernieresValeursForIndividu computed',
+  )
+  return { items }
+}

--- a/apps/mb-api/src/valeurAvancement/routes.ts
+++ b/apps/mb-api/src/valeurAvancement/routes.ts
@@ -1,11 +1,13 @@
 import { createRoute, OpenAPIHono, z } from '@hono/zod-openapi'
 import { errorApiModelSchema } from '@pilote/mb-shared/error'
-import { indicateurPublicIdSchema } from '@pilote/mb-shared/publicIds'
+import { indicateurPublicIdSchema, individuPublicIdSchema } from '@pilote/mb-shared/publicIds'
 import { createPaginatedApiListSchema } from '@pilote/mb-shared/pagination'
 import {
   batchInvalidErrorDetailsApiModelSchema,
   deleteValeurAvancementBodySchema,
+  dernieresValeursIndividuListApiModelSchema,
   individuAvecValeursApiModelSchema,
+  listDernieresValeursForIndividuQuerySchema,
   listIndividusWithValeursQuerySchema,
   listSyntheseIndividusQuerySchema,
   listValeursForIndicateurQuerySchema,
@@ -26,6 +28,7 @@ import { withTransaction } from '@/framework/persistence/withTransaction'
 import { deleteValeurAvancement } from '@/valeurAvancement/commands/deleteValeurAvancement'
 import { upsertValeurAvancement } from '@/valeurAvancement/commands/upsertValeurAvancement'
 import { upsertValeursAvancementBatch } from '@/valeurAvancement/commands/upsertValeursAvancementBatch'
+import { listDernieresValeursForIndividu } from '@/valeurAvancement/queries/listDernieresValeursForIndividu'
 import { listIndividusWithValeurs } from '@/valeurAvancement/queries/listIndividusWithValeurs'
 import { listSyntheseIndividus } from '@/valeurAvancement/queries/listSyntheseIndividus'
 import { listValeursForIndicateur } from '@/valeurAvancement/queries/listValeursForIndicateur'
@@ -63,6 +66,8 @@ const ValeursRemarquablesListApiModelSchema = valeursRemarquablesListApiModelSch
 const SyntheseIndividusListApiModelSchema = syntheseIndividusListApiModelSchema.openapi(
   'SyntheseIndividusListApiModel',
 )
+const DernieresValeursIndividuListApiModelSchema =
+  dernieresValeursIndividuListApiModelSchema.openapi('DernieresValeursIndividuListApiModel')
 const ErrorApiModelSchema = errorApiModelSchema.openapi('ErrorApiModel')
 
 const indicateurParamsSchema = z.object({
@@ -307,6 +312,41 @@ const getSyntheseIndividusRoute = createRoute({
   },
 })
 
+// --- GET /individus/:id/dernieres-valeurs ------------------------------------
+
+const individuParamsSchema = z.object({
+  id: individuPublicIdSchema,
+})
+
+const getDernieresValeursForIndividuRoute = createRoute({
+  method: 'get',
+  path: '/individus/{id}/dernieres-valeurs',
+  tags: ['Individu'],
+  summary: "Lister la dernière valeur connue de l'individu pour un lot d'indicateurs",
+  description:
+    'Retourne, pour chaque indicateur demandé accessible en lecture, la dernière valeur ' +
+    "connue de l'individu (saisie ou dérivée par agrégation hiérarchique). Le paramètre " +
+    '`indicateurs` est obligatoire (1..N identifiants séparés par une virgule, ex. ' +
+    '`IND-A,IND-B`). Les indicateurs sans valeur connue pour cet individu ou non accessibles ' +
+    'sont omis de la réponse. Granularité de troncature `month`. Endpoint pensé pour des ' +
+    "appels batch côté client (afficher l'avancement sur une liste de cartes d'indicateurs).",
+  middleware: [requireAuthentication],
+  request: {
+    params: individuParamsSchema,
+    query: listDernieresValeursForIndividuQuerySchema,
+  },
+  responses: {
+    200: {
+      content: { 'application/json': { schema: DernieresValeursIndividuListApiModelSchema } },
+      description: 'Dernières valeurs pour les indicateurs demandés',
+    },
+    400: {
+      content: { 'application/json': { schema: ErrorApiModelSchema } },
+      description: 'Paramètres de requête invalides (ex. `indicateurs` absent ou trop nombreux)',
+    },
+  },
+})
+
 // --- App registration --------------------------------------------------------
 
 export const valeurAvancementRoutes = new OpenAPIHono()
@@ -455,6 +495,22 @@ valeurAvancementRoutes.openapi(getSyntheseIndividusRoute, async (context) => {
         context,
         data,
         schema: SyntheseIndividusListApiModelSchema,
+        status: 200,
+      }),
+    never,
+  )
+})
+
+valeurAvancementRoutes.openapi(getDernieresValeursForIndividuRoute, async (context) => {
+  const { id } = context.req.valid('param')
+  const { indicateurs } = context.req.valid('query')
+
+  return listDernieresValeursForIndividu(id, { indicateurs }).match(
+    (data) =>
+      jsonResponseOk({
+        context,
+        data,
+        schema: DernieresValeursIndividuListApiModelSchema,
         status: 200,
       }),
     never,

--- a/apps/mb-webapp/package.json
+++ b/apps/mb-webapp/package.json
@@ -37,6 +37,7 @@
     "@tanstack/react-query": "^5.62.7",
     "@tanstack/react-router": "^1.168.26",
     "@tanstack/react-router-devtools": "^1.166.13",
+    "@yornaath/batshit": "^0.14.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",

--- a/apps/mb-webapp/src/api/individus.ts
+++ b/apps/mb-webapp/src/api/individus.ts
@@ -1,0 +1,19 @@
+import {
+  type DernieresValeursIndividuListApiModel,
+  dernieresValeursIndividuListApiModelSchema,
+  type ListDernieresValeursForIndividuQuery,
+} from '@pilote/mb-shared/valeurAvancement'
+
+import { apiClient } from '@/api/client'
+
+export const fetchDernieresValeursForIndividu = async (
+  individuId: string,
+  params: ListDernieresValeursForIndividuQuery,
+): Promise<DernieresValeursIndividuListApiModel> => {
+  const json = await apiClient
+    .get(`individus/${individuId}/dernieres-valeurs`, {
+      searchParams: { indicateurs: params.indicateurs.join(',') },
+    })
+    .json()
+  return dernieresValeursIndividuListApiModelSchema.parse(json)
+}

--- a/apps/mb-webapp/src/components/indicateurs/IndicateurAvancement.tsx
+++ b/apps/mb-webapp/src/components/indicateurs/IndicateurAvancement.tsx
@@ -1,0 +1,41 @@
+import { type UniteIndicateurApiModel } from '@pilote/mb-shared/indicateur'
+import { useSuspenseQuery } from '@tanstack/react-query'
+
+import { formatMonthYearNumericFr, formatNumberAvecUniteFr } from '@/lib/format'
+import { dernierValeurIndividuQueryOptions } from '@/queries/dernieresValeurs'
+
+export function IndicateurAvancementSkeleton() {
+  return (
+    <span
+      className="flex animate-pulse flex-col gap-1"
+      role="status"
+      aria-label="Chargement de la valeur d'avancement"
+    >
+      <span className="h-6 w-16 rounded bg-border" />
+      <span className="h-[18px] w-20 rounded bg-border" />
+    </span>
+  )
+}
+
+export function IndicateurAvancement({
+  indicateurId,
+  individuId,
+  unite,
+}: {
+  indicateurId: string
+  individuId: string
+  unite: UniteIndicateurApiModel | null
+}) {
+  const { data } = useSuspenseQuery(dernierValeurIndividuQueryOptions(individuId, indicateurId))
+  if (!data) {
+    return <span className="text-text-subtle">Pas de valeur</span>
+  }
+  return (
+    <span className="flex flex-col gap-1">
+      <span className="text-2xl font-bold leading-none text-primary">
+        {formatNumberAvecUniteFr(data.valeur, unite)}
+      </span>
+      <span className="text-text-muted">au {formatMonthYearNumericFr(data.date)}</span>
+    </span>
+  )
+}

--- a/apps/mb-webapp/src/components/indicateurs/IndicateurCard.tsx
+++ b/apps/mb-webapp/src/components/indicateurs/IndicateurCard.tsx
@@ -1,6 +1,11 @@
 import type { IndicateurApiModel } from '@pilote/mb-shared/indicateur'
 import { Link } from '@tanstack/react-router'
+import { Suspense } from 'react'
 
+import {
+  IndicateurAvancement,
+  IndicateurAvancementSkeleton,
+} from '@/components/indicateurs/IndicateurAvancement'
 import { EntityCard } from '@/components/ui/EntityCard'
 import { formatMonthYearNumericFr } from '@/lib/format'
 
@@ -19,15 +24,23 @@ export function IndicateurCard({
   indicateur,
   context,
 }: {
-  indicateur: Pick<IndicateurApiModel, 'id' | 'nom' | 'updatedAt'>
-  context?: IndicateurCardContext
+  indicateur: Pick<IndicateurApiModel, 'id' | 'nom' | 'updatedAt' | 'unite'>
+  context?: IndicateurCardContext | undefined
 }) {
+  const footer = context ? (
+    <Suspense fallback={<IndicateurAvancementSkeleton />}>
+      <IndicateurAvancement
+        indicateurId={indicateur.id}
+        individuId={context.individu}
+        unite={indicateur.unite}
+      />
+    </Suspense>
+  ) : (
+    <>Mis à jour {formatMiseAJour(indicateur.updatedAt)}</>
+  )
+
   return (
-    <EntityCard
-      asChild
-      title={indicateur.nom}
-      footer={<>Mis à jour {formatMiseAJour(indicateur.updatedAt)}</>}
-    >
+    <EntityCard asChild title={indicateur.nom} footer={footer}>
       <Link to="/indicateurs/$id" params={{ id: indicateur.id }} search={context ?? {}} />
     </EntityCard>
   )

--- a/apps/mb-webapp/src/queries/dernieresValeurs.ts
+++ b/apps/mb-webapp/src/queries/dernieresValeurs.ts
@@ -1,0 +1,54 @@
+import {
+  type DernierValeurIndividuApiModel,
+  MAX_INDICATEURS_PAR_REQUETE,
+} from '@pilote/mb-shared/valeurAvancement'
+import { create, keyResolver, windowedFiniteBatchScheduler } from '@yornaath/batshit'
+import { queryOptions } from '@tanstack/react-query'
+
+import { fetchDernieresValeursForIndividu } from '@/api/individus'
+
+import { DEFAULT_STALE_TIME } from './utils'
+
+// L'endpoint /individus/{id}/dernieres-valeurs est paramétré par individu.
+// On instancie un batcher par individuId pour ne pas mélanger les requêtes
+// de plusieurs individus actifs simultanément (rare en pratique : un seul
+// individu observé est sélectionné à la fois).
+const batchersByIndividu = new Map<string, Batcher>()
+
+type Batcher = ReturnType<typeof createBatcher>
+
+const createBatcher = (individuId: string) =>
+  create({
+    fetcher: async (
+      indicateurIds: string[],
+    ): Promise<ReadonlyArray<DernierValeurIndividuApiModel>> => {
+      const { items } = await fetchDernieresValeursForIndividu(individuId, {
+        indicateurs: indicateurIds,
+      })
+      return items
+    },
+    // Indicateur sans valeur connue : l'API omet l'item. `keyResolver` renvoie
+    // alors `null` au consommateur, ce qui permet à la card d'afficher un
+    // placeholder.
+    resolver: keyResolver('indicateur'),
+    scheduler: windowedFiniteBatchScheduler({
+      windowMs: 10,
+      maxBatchSize: MAX_INDICATEURS_PAR_REQUETE,
+    }),
+  })
+
+const getBatcher = (individuId: string): Batcher => {
+  const existing = batchersByIndividu.get(individuId)
+  if (existing) return existing
+  const batcher = createBatcher(individuId)
+  batchersByIndividu.set(individuId, batcher)
+  return batcher
+}
+
+export const dernierValeurIndividuQueryOptions = (individuId: string, indicateurId: string) =>
+  queryOptions({
+    queryKey: ['dernier-valeur', individuId, indicateurId],
+    queryFn: (): Promise<DernierValeurIndividuApiModel | null> =>
+      getBatcher(individuId).fetch(indicateurId),
+    staleTime: DEFAULT_STALE_TIME,
+  })

--- a/packages/mb-shared/src/indicateursCsv.ts
+++ b/packages/mb-shared/src/indicateursCsv.ts
@@ -1,0 +1,24 @@
+import { z } from 'zod'
+
+import { indicateurPublicIdSchema } from './publicIds'
+
+export const MAX_INDICATEURS_PAR_REQUETE = 100
+
+export const indicateursCsvSchema = z
+  .string()
+  .min(1, "Au moins un identifiant d'indicateur est requis")
+  .transform((value) =>
+    value
+      .split(',')
+      .map((segment) => segment.trim())
+      .filter((segment) => segment.length > 0),
+  )
+  .pipe(
+    z
+      .array(indicateurPublicIdSchema)
+      .min(1)
+      .max(
+        MAX_INDICATEURS_PAR_REQUETE,
+        `Au plus ${MAX_INDICATEURS_PAR_REQUETE} indicateurs par requête`,
+      ),
+  )

--- a/packages/mb-shared/src/valeurAvancement.ts
+++ b/packages/mb-shared/src/valeurAvancement.ts
@@ -2,6 +2,11 @@ import { z } from 'zod'
 
 import { dateSchema, dateTruncSchema } from './dates'
 import { fonctionAgregationSchema } from './indicateur'
+import { indicateursCsvSchema, MAX_INDICATEURS_PAR_REQUETE } from './indicateursCsv'
+
+// Ré-export pour les consommateurs front qui plafonnent leur taille de batch
+// sur la même valeur que celle imposée par l'API.
+export { MAX_INDICATEURS_PAR_REQUETE } from './indicateursCsv'
 import { indicateurPublicIdSchema } from './publicIds'
 import { individuApiModelSchema, individuPublicIdSchema } from './individu'
 import { individusCsvSchema, MAX_INDIVIDUS_PAR_REQUETE } from './individusCsv'
@@ -434,3 +439,39 @@ export const valeurAvancementListApiModelSchema = z.object({
     ),
 })
 export type ValeurAvancementListApiModel = z.infer<typeof valeurAvancementListApiModelSchema>
+
+export const dernierValeurIndividuApiModelSchema = z.object({
+  indicateur: indicateurPublicIdSchema,
+  valeur: valeurSchema.describe("Dernière valeur connue de l'individu pour cet indicateur."),
+  date: dateSchema.describe(
+    "Date du bucket de la dernière valeur connue (post-troncature mensuelle).",
+  ),
+  type: z
+    .enum(['saisie', 'derivee'])
+    .describe(
+      "`saisie` : la valeur provient d'une saisie directe sur cet individu. " +
+        "`derivee` : la valeur est reconstruite par agrégation hiérarchique des descendants.",
+    ),
+})
+export type DernierValeurIndividuApiModel = z.infer<typeof dernierValeurIndividuApiModelSchema>
+
+export const dernieresValeursIndividuListApiModelSchema = z.object({
+  items: z
+    .array(dernierValeurIndividuApiModelSchema)
+    .describe(
+      "Dernière valeur connue de l'individu pour chaque indicateur demandé ayant au moins une " +
+        "valeur. Les indicateurs sans valeur connue pour cet individu sont omis de la réponse.",
+    ),
+})
+export type DernieresValeursIndividuListApiModel = z.infer<
+  typeof dernieresValeursIndividuListApiModelSchema
+>
+
+export const listDernieresValeursForIndividuQuerySchema = z.object({
+  indicateurs: indicateursCsvSchema.describe(
+    `Liste d'identifiants d'indicateurs séparés par une virgule (ex. IND-A,IND-B). 1..${MAX_INDICATEURS_PAR_REQUETE} identifiants.`,
+  ),
+})
+export type ListDernieresValeursForIndividuQuery = z.infer<
+  typeof listDernieresValeursForIndividuQuerySchema
+>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -157,6 +157,9 @@ importers:
       '@tanstack/react-router-devtools':
         specifier: ^1.166.13
         version: 1.166.13(@tanstack/react-router@1.168.26(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@tanstack/router-core@1.168.18)(csstype@3.2.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@yornaath/batshit':
+        specifier: ^0.14.0
+        version: 0.14.0
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -4437,6 +4440,12 @@ packages:
 
   '@xtuc/long@4.2.2':
     resolution: {integrity: sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==}
+
+  '@yornaath/batshit-devtools@1.7.1':
+    resolution: {integrity: sha512-AyttV1Njj5ug+XqEWY1smV45dTWMlWKtj1B8jcFYgBKUFyUlF/qEhD+iP1E5UaRYW6hQRYD9T2WNDwFTrOMWzQ==}
+
+  '@yornaath/batshit@0.14.0':
+    resolution: {integrity: sha512-0I+xMi5JoRs3+qVXXhk2AmsEl43MwrG+L+VW+nqw/qQqMFtgRPszLaxhJCfsBKnjfJ0gJzTI1Q9Q9+y903HyHQ==}
 
   JSONStream@1.3.5:
     resolution: {integrity: sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==}
@@ -13206,7 +13215,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@opentelemetry/api@1.9.0)(@types/node@22.19.17)(@vitest/coverage-v8@4.1.4)(jsdom@29.1.0(@noble/hashes@1.8.0))(msw@2.14.2(@types/node@22.19.17)(typescript@5.9.3))(vite@8.0.10(@types/node@22.19.17)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.78.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.4(@opentelemetry/api@1.9.0)(@types/node@22.19.17)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.2(@noble/hashes@1.8.0))(msw@2.14.2(@types/node@22.19.17)(typescript@5.9.3))(vite@8.0.10(@types/node@22.19.17)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.78.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
 
   '@vitest/eslint-plugin@1.6.15(@typescript-eslint/eslint-plugin@8.58.2(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.4)':
     dependencies:
@@ -13394,6 +13403,12 @@ snapshots:
   '@xtuc/ieee754@1.2.0': {}
 
   '@xtuc/long@4.2.2': {}
+
+  '@yornaath/batshit-devtools@1.7.1': {}
+
+  '@yornaath/batshit@0.14.0':
+    dependencies:
+      '@yornaath/batshit-devtools': 1.7.1
 
   JSONStream@1.3.5:
     dependencies:


### PR DESCRIPTION
## Summary
- Nouvel endpoint **`GET /individus/{id}/dernieres-valeurs?indicateurs=...`** (mb-api) — centré sur l'individu, cap 100 indicateurs, omet ceux sans valeur ou non lisibles ; type `saisie` ou `derivee`.
- DataLoader pattern côté webapp via **`@yornaath/batshit`** : un batcher par `individuId`, fenêtre 10 ms, cap 100. Le cache React Query reste granulé par `(individuId, indicateurId)`.
- `IndicateurCard` rend `<IndicateurAvancement>` quand un individu est observé : `text-2xl text-primary` pour la valeur + date \"au mm/yyyy\" muted. `<Suspense>` par card avec **skeleton anti-layout-shift** (`h-6` + `h-[18px]`, `animate-pulse`).

## Architecture
- **Base PR** : `mb-default-individu` (stacked sur l'étape 1). À rebaser sur `dev` quand cette dernière sera mergée.
- **Évaluation DataLoader** : batshit retenu pour sa simplicité, sa compatibilité Suspense (1-hook-par-card), sa référence officielle dans la doc TanStack Query, et son surface code réduite (recopiable en interne si besoin).

## Test plan
- [ ] `/indicateurs` avec individu observé : chaque card affiche la dernière valeur ; **une seule requête HTTP batchée** par batch de cards (vérifier dans l'onglet Network).
- [ ] `/paniers/$id` avec individu : idem.
- [ ] Indicateurs sans valeur connue : affichent \"Pas de valeur\".
- [ ] Skeleton visible au premier chargement, pas de layout shift quand la valeur arrive.
- [ ] Changement d'individu observé : nouveau batch, anciennes valeurs invalidées.
- [ ] Tests d'intégration mb-api : 6 cas (saisie, dérivée, omission, permission, individu inexistant, multi-indicateurs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)