### PR TITLE
feat(albert): tool search_chantiers pour identifier les chantiers par nom (PIL-1602)

### DIFF
--- a/apps/pilote-ppg/src/app/api/albert/chat/route.ts
+++ b/apps/pilote-ppg/src/app/api/albert/chat/route.ts
@@ -54,6 +54,12 @@ export async function POST(request: Request) {
     const createSearchChantiersTool = container.resolve(
       "createSearchChantiersTool",
     );
+    const createSearchIndicateursTool = container.resolve(
+      "createSearchIndicateursTool",
+    );
+    const createSearchTerritoiresTool = container.resolve(
+      "createSearchTerritoiresTool",
+    );
     const createExportRapportTool = container.resolve(
       "createExportRapportTool",
     );
@@ -87,6 +93,10 @@ export async function POST(request: Request) {
     const searchChantiers = createSearchChantiersTool({
       chantiersAccessibles: session.habilitations.lecture.chantiers,
     });
+    const searchIndicateurs = createSearchIndicateursTool({
+      chantiersAccessibles: session.habilitations.lecture.chantiers,
+    });
+    const searchTerritoires = createSearchTerritoiresTool();
     const exportRapport = createExportRapportTool({
       userId: session.user.id,
     });
@@ -99,6 +109,8 @@ export async function POST(request: Request) {
       get_indicateurs: getChantierIndicateurs,
       get_chantier_commentaires: getChantierCommentaires,
       search_chantiers: searchChantiers,
+      search_indicateurs: searchIndicateurs,
+      search_territoires: searchTerritoires,
       display_choices: displayChoicesTool,
       ...(capacities.dashboard ? { create_dashboard: createDashboard } : {}),
       ...(capacities.exportRapport ? { export_rapport: exportRapport } : {}),

--- a/apps/pilote-ppg/src/app/api/albert/chat/route.ts
+++ b/apps/pilote-ppg/src/app/api/albert/chat/route.ts
@@ -51,6 +51,9 @@ export async function POST(request: Request) {
     const createGetChantierCommentairesTool = container.resolve(
       "createGetChantierCommentairesTool",
     );
+    const createSearchChantiersTool = container.resolve(
+      "createSearchChantiersTool",
+    );
     const createExportRapportTool = container.resolve(
       "createExportRapportTool",
     );
@@ -81,6 +84,9 @@ export async function POST(request: Request) {
     const getChantierCommentaires = createGetChantierCommentairesTool({
       territoiresAccessibles,
     });
+    const searchChantiers = createSearchChantiersTool({
+      chantiersAccessibles: session.habilitations.lecture.chantiers,
+    });
     const exportRapport = createExportRapportTool({
       userId: session.user.id,
     });
@@ -92,6 +98,7 @@ export async function POST(request: Request) {
       get_chantiers: getChantiers,
       get_indicateurs: getChantierIndicateurs,
       get_chantier_commentaires: getChantierCommentaires,
+      search_chantiers: searchChantiers,
       display_choices: displayChoicesTool,
       ...(capacities.dashboard ? { create_dashboard: createDashboard } : {}),
       ...(capacities.exportRapport ? { export_rapport: exportRapport } : {}),

--- a/apps/pilote-ppg/src/client/components/_commons/ChatUI/AssistantMessage.tsx
+++ b/apps/pilote-ppg/src/client/components/_commons/ChatUI/AssistantMessage.tsx
@@ -53,7 +53,8 @@ export const AssistantMessage = memo(function AssistantMessage({
             part.type === "tool-get_taux_avancement_territoire" ||
             part.type === "tool-get_chantiers" ||
             part.type === "tool-get_indicateurs" ||
-            part.type === "tool-get_chantier_commentaires"
+            part.type === "tool-get_chantier_commentaires" ||
+            part.type === "tool-search_chantiers"
           ) {
             return <ToolCallIndicator key={index} part={part} />;
           }

--- a/apps/pilote-ppg/src/client/components/_commons/ChatUI/AssistantMessage.tsx
+++ b/apps/pilote-ppg/src/client/components/_commons/ChatUI/AssistantMessage.tsx
@@ -54,7 +54,9 @@ export const AssistantMessage = memo(function AssistantMessage({
             part.type === "tool-get_chantiers" ||
             part.type === "tool-get_indicateurs" ||
             part.type === "tool-get_chantier_commentaires" ||
-            part.type === "tool-search_chantiers"
+            part.type === "tool-search_chantiers" ||
+            part.type === "tool-search_indicateurs" ||
+            part.type === "tool-search_territoires"
           ) {
             return <ToolCallIndicator key={index} part={part} />;
           }

--- a/apps/pilote-ppg/src/client/components/_commons/ChatUI/ToolCallIndicator.tsx
+++ b/apps/pilote-ppg/src/client/components/_commons/ChatUI/ToolCallIndicator.tsx
@@ -15,7 +15,8 @@ type DataFetchingToolPart = Extract<
       | "tool-get_taux_avancement_territoire"
       | "tool-get_chantiers"
       | "tool-get_indicateurs"
-      | "tool-get_chantier_commentaires";
+      | "tool-get_chantier_commentaires"
+      | "tool-search_chantiers";
   }
 >;
 
@@ -25,6 +26,7 @@ const TOOL_LABELS: Record<DataFetchingToolPart["type"], string> = {
   "tool-get_chantiers": "Récupération des chantiers",
   "tool-get_indicateurs": "Récupération des indicateurs",
   "tool-get_chantier_commentaires": "Récupération des commentaires du chantier",
+  "tool-search_chantiers": "Recherche des chantiers correspondants",
 };
 
 const StatusIcon = ({ state }: { state: DataFetchingToolPart["state"] }) => {

--- a/apps/pilote-ppg/src/client/components/_commons/ChatUI/ToolCallIndicator.tsx
+++ b/apps/pilote-ppg/src/client/components/_commons/ChatUI/ToolCallIndicator.tsx
@@ -16,7 +16,9 @@ type DataFetchingToolPart = Extract<
       | "tool-get_chantiers"
       | "tool-get_indicateurs"
       | "tool-get_chantier_commentaires"
-      | "tool-search_chantiers";
+      | "tool-search_chantiers"
+      | "tool-search_indicateurs"
+      | "tool-search_territoires";
   }
 >;
 
@@ -27,6 +29,8 @@ const TOOL_LABELS: Record<DataFetchingToolPart["type"], string> = {
   "tool-get_indicateurs": "Récupération des indicateurs",
   "tool-get_chantier_commentaires": "Récupération des commentaires du chantier",
   "tool-search_chantiers": "Recherche des chantiers correspondants",
+  "tool-search_indicateurs": "Recherche des indicateurs correspondants",
+  "tool-search_territoires": "Recherche des territoires correspondants",
 };
 
 const StatusIcon = ({ state }: { state: DataFetchingToolPart["state"] }) => {

--- a/apps/pilote-ppg/src/server/albert/Albert.ts
+++ b/apps/pilote-ppg/src/server/albert/Albert.ts
@@ -25,6 +25,9 @@ export function withOptionalDevTools(model: LanguageModelV3): LanguageModelV3 {
 
 const DEFAULT_MODEL = "openweight-large";
 
+const TEMPERATURE_STREAM_TEXT = 0.2;
+const TEMPERATURE_STRUCTURED_OUTPUT = 0;
+
 export class Albert {
   static createProvider() {
     return createOpenAI({
@@ -87,6 +90,7 @@ export class Albert {
       prompt,
       stopWhen: stepCountIs(5),
       output: Output.object({ schema }),
+      temperature: TEMPERATURE_STRUCTURED_OUTPUT,
       abortSignal,
     });
     return result.output;
@@ -116,6 +120,7 @@ export class Albert {
       messages: modelMessages,
       tools,
       stopWhen: stepCountIs(50),
+      temperature: TEMPERATURE_STREAM_TEXT,
       onFinish: (event) => Albert.saveLlmCall({ chatId, userId, event, model }),
     });
   }

--- a/apps/pilote-ppg/src/server/albert/PiloteUIMessage.ts
+++ b/apps/pilote-ppg/src/server/albert/PiloteUIMessage.ts
@@ -28,6 +28,10 @@ import {
   getChantierCommentairesInputSchema,
   type GetChantierCommentairesOutput,
 } from "@/server/albert/tools/getChantierCommentaires";
+import {
+  searchChantiersInputSchema,
+  type SearchChantiersOutput,
+} from "@/server/albert/tools/searchChantiers";
 
 export type PiloteUITools = {
   display_choices: {
@@ -49,6 +53,10 @@ export type PiloteUITools = {
   get_chantier_commentaires: {
     input: z.input<typeof getChantierCommentairesInputSchema>;
     output: GetChantierCommentairesOutput;
+  };
+  search_chantiers: {
+    input: z.input<typeof searchChantiersInputSchema>;
+    output: SearchChantiersOutput;
   };
   create_dashboard: {
     input: z.input<typeof createDashboardInputSchema>;

--- a/apps/pilote-ppg/src/server/albert/PiloteUIMessage.ts
+++ b/apps/pilote-ppg/src/server/albert/PiloteUIMessage.ts
@@ -32,6 +32,14 @@ import {
   searchChantiersInputSchema,
   type SearchChantiersOutput,
 } from "@/server/albert/tools/searchChantiers";
+import {
+  searchIndicateursInputSchema,
+  type SearchIndicateursOutput,
+} from "@/server/albert/tools/searchIndicateurs";
+import {
+  searchTerritoiresInputSchema,
+  type SearchTerritoiresOutput,
+} from "@/server/albert/tools/searchTerritoires";
 
 export type PiloteUITools = {
   display_choices: {
@@ -57,6 +65,14 @@ export type PiloteUITools = {
   search_chantiers: {
     input: z.input<typeof searchChantiersInputSchema>;
     output: SearchChantiersOutput;
+  };
+  search_indicateurs: {
+    input: z.input<typeof searchIndicateursInputSchema>;
+    output: SearchIndicateursOutput;
+  };
+  search_territoires: {
+    input: z.input<typeof searchTerritoiresInputSchema>;
+    output: SearchTerritoiresOutput;
   };
   create_dashboard: {
     input: z.input<typeof createDashboardInputSchema>;

--- a/apps/pilote-ppg/src/server/albert/__tests__/tools/searchChantiers.unit.test.ts
+++ b/apps/pilote-ppg/src/server/albert/__tests__/tools/searchChantiers.unit.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { Albert } from "@/server/albert/Albert";
+import { createSearchChantiersTool } from "@/server/albert/tools/searchChantiers";
+import type {
+  ChantierIdentiteResult,
+  GetChantiersIdentiteQuery,
+} from "@/server/chantiers/query/GetChantiersIdentiteQuery";
+
+const buildQuery = (chantiers: ChantierIdentiteResult[]) =>
+  ({
+    execute: vi.fn().mockResolvedValue(chantiers),
+  }) as unknown as GetChantiersIdentiteQuery;
+
+const buildTool = ({
+  chantiers,
+  chantiersAccessibles,
+}: {
+  chantiers: ChantierIdentiteResult[];
+  chantiersAccessibles: string[];
+}) =>
+  createSearchChantiersTool({ getChantiersIdentiteQuery: buildQuery(chantiers) })(
+    { chantiersAccessibles },
+  );
+
+const executeTool = (
+  tool: ReturnType<ReturnType<typeof createSearchChantiersTool>>,
+  query: string,
+) =>
+  tool.execute!(
+    { query },
+    { toolCallId: "test", messages: [], abortSignal: undefined },
+  );
+
+const chantier = (id: string, nom: string): ChantierIdentiteResult => ({
+  id,
+  nom,
+  axe: "Axe",
+  ppg: "PPG",
+  ministeres: ["Ministère"],
+});
+
+describe("createSearchChantiersTool execute", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("renvoie une liste vide quand aucun chantier n'est accessible", async () => {
+    // Given
+    const tool = buildTool({ chantiers: [], chantiersAccessibles: [] });
+
+    // When
+    const result = await executeTool(tool, "les VSS");
+
+    // Then
+    expect(result).toEqual({
+      chantiers: [],
+      reasoning: "Aucun chantier accessible pour cet utilisateur.",
+      _output_instructions: expect.any(String),
+    });
+  });
+
+  test("filtre les identifiants hallucinés par le sous-agent", async () => {
+    // Given
+    vi.spyOn(Albert, "generateStructuredOutput").mockResolvedValue({
+      chantiers: [
+        { id: "CH-001", nom: "Réel" },
+        { id: "CH-999", nom: "Halluciné" },
+      ],
+      reasoning: "test",
+    });
+    const tool = buildTool({
+      chantiers: [chantier("CH-001", "Réel")],
+      chantiersAccessibles: ["CH-001"],
+    });
+
+    // When
+    const result = await executeTool(tool, "quelque chose");
+
+    // Then
+    expect(result).toEqual({
+      chantiers: [{ id: "CH-001", nom: "Réel" }],
+      reasoning: "test",
+      _output_instructions: expect.any(String),
+    });
+  });
+
+  test("renvoie une sortie vide avec les instructions _vide quand le sous-agent ne matche rien", async () => {
+    // Given
+    vi.spyOn(Albert, "generateStructuredOutput").mockResolvedValue({
+      chantiers: [],
+      reasoning: "Aucune correspondance",
+    });
+    const tool = buildTool({
+      chantiers: [chantier("CH-001", "Réel")],
+      chantiersAccessibles: ["CH-001"],
+    });
+
+    // When
+    const result = await executeTool(tool, "rien");
+
+    // Then
+    expect(result).toEqual({
+      chantiers: [],
+      reasoning: "Aucune correspondance",
+      _output_instructions: expect.any(String),
+    });
+  });
+});

--- a/apps/pilote-ppg/src/server/albert/__tests__/tools/searchChantiers.unit.test.ts
+++ b/apps/pilote-ppg/src/server/albert/__tests__/tools/searchChantiers.unit.test.ts
@@ -18,9 +18,9 @@ const buildTool = ({
   chantiers: ChantierIdentiteResult[];
   chantiersAccessibles: string[];
 }) =>
-  createSearchChantiersTool({ getChantiersIdentiteQuery: buildQuery(chantiers) })(
-    { chantiersAccessibles },
-  );
+  createSearchChantiersTool({
+    getChantiersIdentiteQuery: buildQuery(chantiers),
+  })({ chantiersAccessibles });
 
 const executeTool = (
   tool: ReturnType<ReturnType<typeof createSearchChantiersTool>>,

--- a/apps/pilote-ppg/src/server/albert/__tests__/tools/searchChantiers.unit.test.ts
+++ b/apps/pilote-ppg/src/server/albert/__tests__/tools/searchChantiers.unit.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
 import { Albert } from "@/server/albert/Albert";
 import { createSearchChantiersTool } from "@/server/albert/tools/searchChantiers";
 import type {
@@ -6,22 +7,20 @@ import type {
   GetChantiersIdentiteQuery,
 } from "@/server/chantiers/query/GetChantiersIdentiteQuery";
 
-const buildQuery = (chantiers: ChantierIdentiteResult[]) =>
-  ({
-    execute: vi.fn().mockResolvedValue(chantiers),
-  }) as unknown as GetChantiersIdentiteQuery;
-
 const buildTool = ({
   chantiers,
   chantiersAccessibles,
 }: {
   chantiers: ChantierIdentiteResult[];
   chantiersAccessibles: string[];
-}) =>
-  createSearchChantiersTool({
-    getChantiersIdentiteQuery: buildQuery(chantiers),
+}) => {
+  const chantiersQuery = mock<GetChantiersIdentiteQuery>({
+    execute: async () => chantiers,
+  });
+  return createSearchChantiersTool({
+    getChantiersIdentiteQuery: chantiersQuery,
   })({ chantiersAccessibles });
-
+};
 const executeTool = (
   tool: ReturnType<ReturnType<typeof createSearchChantiersTool>>,
   query: string,

--- a/apps/pilote-ppg/src/server/albert/__tests__/tools/searchIndicateurs.unit.test.ts
+++ b/apps/pilote-ppg/src/server/albert/__tests__/tools/searchIndicateurs.unit.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { Albert } from "@/server/albert/Albert";
+import { createSearchIndicateursTool } from "@/server/albert/tools/searchIndicateurs";
+import type {
+  GetIndicateursIdentiteQuery,
+  IndicateurIdentiteResult,
+} from "@/server/chantiers/query/GetIndicateursIdentiteQuery";
+
+const buildQuery = (indicateurs: IndicateurIdentiteResult[]) => {
+  const execute = vi.fn().mockResolvedValue(indicateurs);
+  const query = { execute } as unknown as GetIndicateursIdentiteQuery;
+  return { query, execute };
+};
+
+const buildTool = ({
+  indicateurs,
+  chantiersAccessibles,
+}: {
+  indicateurs: IndicateurIdentiteResult[];
+  chantiersAccessibles: string[];
+}) => {
+  const { query, execute } = buildQuery(indicateurs);
+  const tool = createSearchIndicateursTool({
+    getIndicateursIdentiteQuery: query,
+  })({ chantiersAccessibles });
+  return { tool, execute };
+};
+
+const executeTool = (
+  tool: ReturnType<
+    ReturnType<typeof createSearchIndicateursTool>
+  >,
+  input: { query: string; chantier_ids?: string[] },
+) =>
+  tool.execute!(input, {
+    toolCallId: "test",
+    messages: [],
+    abortSignal: undefined,
+  });
+
+const indicateur = (
+  id: string,
+  nom: string,
+  chantierId: string,
+): IndicateurIdentiteResult => ({
+  id,
+  nom,
+  description: null,
+  type_nom: null,
+  est_phare: false,
+  chantier: { id: chantierId, nom: "Chantier " + chantierId },
+});
+
+describe("createSearchIndicateursTool execute", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("renvoie une liste vide sans appeler la query quand aucun chantier_ids demandé n'est accessible", async () => {
+    // Given
+    const { tool, execute } = buildTool({
+      indicateurs: [],
+      chantiersAccessibles: ["CH-001"],
+    });
+
+    // When
+    const result = await executeTool(tool, {
+      query: "x",
+      chantier_ids: ["CH-999"],
+    });
+
+    // Then
+    expect(execute).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      indicateurs: [],
+      reasoning:
+        "Aucun des chantiers demandés n'est accessible pour cet utilisateur.",
+      _output_instructions: expect.any(String),
+    });
+  });
+
+  test("filtre les identifiants hallucinés par le sous-agent", async () => {
+    // Given
+    vi.spyOn(Albert, "generateStructuredOutput").mockResolvedValue({
+      indicateurs: [
+        {
+          id: "IND-001",
+          nom: "Réel",
+          chantier: { id: "CH-001", nom: "Chantier CH-001" },
+        },
+        {
+          id: "IND-999",
+          nom: "Halluciné",
+          chantier: { id: "CH-001", nom: "Chantier CH-001" },
+        },
+      ],
+      reasoning: "test",
+    });
+    const { tool } = buildTool({
+      indicateurs: [indicateur("IND-001", "Réel", "CH-001")],
+      chantiersAccessibles: ["CH-001"],
+    });
+
+    // When
+    const result = await executeTool(tool, { query: "x" });
+
+    // Then
+    expect(result).toEqual({
+      indicateurs: [
+        {
+          id: "IND-001",
+          nom: "Réel",
+          chantier: { id: "CH-001", nom: "Chantier CH-001" },
+        },
+      ],
+      reasoning: "test",
+      _output_instructions: expect.any(String),
+    });
+  });
+
+  test("renvoie une sortie vide quand aucun indicateur n'est accessible dans le périmètre", async () => {
+    // Given
+    const { tool } = buildTool({
+      indicateurs: [],
+      chantiersAccessibles: ["CH-001"],
+    });
+
+    // When
+    const result = await executeTool(tool, { query: "x" });
+
+    // Then
+    expect(result).toEqual({
+      indicateurs: [],
+      reasoning: "Aucun indicateur accessible dans le périmètre demandé.",
+      _output_instructions: expect.any(String),
+    });
+  });
+});

--- a/apps/pilote-ppg/src/server/albert/__tests__/tools/searchIndicateurs.unit.test.ts
+++ b/apps/pilote-ppg/src/server/albert/__tests__/tools/searchIndicateurs.unit.test.ts
@@ -27,9 +27,7 @@ const buildTool = ({
 };
 
 const executeTool = (
-  tool: ReturnType<
-    ReturnType<typeof createSearchIndicateursTool>
-  >,
+  tool: ReturnType<ReturnType<typeof createSearchIndicateursTool>>,
   input: { query: string; chantier_ids?: string[] },
 ) =>
   tool.execute!(input, {

--- a/apps/pilote-ppg/src/server/albert/__tests__/tools/searchTerritoires.unit.test.ts
+++ b/apps/pilote-ppg/src/server/albert/__tests__/tools/searchTerritoires.unit.test.ts
@@ -57,9 +57,7 @@ describe("createSearchTerritoiresTool execute", () => {
 
     // Then
     expect(result).toEqual({
-      territoires: [
-        { code: "REG-53", nom: "Bretagne", maille: "regionale" },
-      ],
+      territoires: [{ code: "REG-53", nom: "Bretagne", maille: "regionale" }],
       reasoning: "test",
       _output_instructions: expect.any(String),
     });

--- a/apps/pilote-ppg/src/server/albert/__tests__/tools/searchTerritoires.unit.test.ts
+++ b/apps/pilote-ppg/src/server/albert/__tests__/tools/searchTerritoires.unit.test.ts
@@ -1,0 +1,88 @@
+import type { Maille } from "@prisma/client";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { Albert } from "@/server/albert/Albert";
+import { createSearchTerritoiresTool } from "@/server/albert/tools/searchTerritoires";
+import type {
+  GetTerritoiresIdentiteQuery,
+  TerritoireIdentiteResult,
+} from "@/server/chantiers/query/GetTerritoiresIdentiteQuery";
+
+const buildTool = (territoires: TerritoireIdentiteResult[]) => {
+  const query = {
+    execute: vi.fn().mockResolvedValue(territoires),
+  } as unknown as GetTerritoiresIdentiteQuery;
+  return createSearchTerritoiresTool({ getTerritoiresIdentiteQuery: query })();
+};
+
+const executeTool = (
+  tool: ReturnType<ReturnType<typeof createSearchTerritoiresTool>>,
+  query: string,
+) =>
+  tool.execute!(
+    { query },
+    { toolCallId: "test", messages: [], abortSignal: undefined },
+  );
+
+const territoire = (
+  code: string,
+  nom: string,
+  maille: Maille,
+): TerritoireIdentiteResult => ({
+  code,
+  nom,
+  maille,
+  code_parent: null,
+});
+
+describe("createSearchTerritoiresTool execute", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("filtre les codes hallucinés par le sous-agent", async () => {
+    // Given
+    vi.spyOn(Albert, "generateStructuredOutput").mockResolvedValue({
+      territoires: [
+        { code: "REG-53", nom: "Bretagne", maille: "regionale" },
+        { code: "REG-99", nom: "Inventé", maille: "regionale" },
+      ],
+      reasoning: "test",
+    });
+    const tool = buildTool([
+      territoire("REG-53", "Bretagne", "regionale" as Maille),
+    ]);
+
+    // When
+    const result = await executeTool(tool, "la Bretagne");
+
+    // Then
+    expect(result).toEqual({
+      territoires: [
+        { code: "REG-53", nom: "Bretagne", maille: "regionale" },
+      ],
+      reasoning: "test",
+      _output_instructions: expect.any(String),
+    });
+  });
+
+  test("renvoie une sortie vide avec les instructions _vide quand le sous-agent ne matche rien", async () => {
+    // Given
+    vi.spyOn(Albert, "generateStructuredOutput").mockResolvedValue({
+      territoires: [],
+      reasoning: "Aucune correspondance",
+    });
+    const tool = buildTool([
+      territoire("REG-53", "Bretagne", "regionale" as Maille),
+    ]);
+
+    // When
+    const result = await executeTool(tool, "Pas un territoire");
+
+    // Then
+    expect(result).toEqual({
+      territoires: [],
+      reasoning: "Aucune correspondance",
+      _output_instructions: expect.any(String),
+    });
+  });
+});

--- a/apps/pilote-ppg/src/server/albert/module.ts
+++ b/apps/pilote-ppg/src/server/albert/module.ts
@@ -5,6 +5,8 @@ import { createGetChantiersTool } from "@/server/albert/tools/getChantiers";
 import { createGetChantierIndicateursTool } from "@/server/albert/tools/getChantierIndicateurs";
 import { createGetChantierCommentairesTool } from "@/server/albert/tools/getChantierCommentaires";
 import { createSearchChantiersTool } from "@/server/albert/tools/searchChantiers";
+import { createSearchIndicateursTool } from "@/server/albert/tools/searchIndicateurs";
+import { createSearchTerritoiresTool } from "@/server/albert/tools/searchTerritoires";
 import { createComposeDashboardTool } from "@/server/albert/tools/composeDashboard";
 import type { ChantierExports } from "@/server/chantiers/module";
 import { EvaluerChatUseCase } from "@/server/albert/usecases/EvaluerChatUseCase";
@@ -44,6 +46,8 @@ type AlbertOwnCradle = {
     typeof createGetChantierCommentairesTool
   >;
   createSearchChantiersTool: ReturnType<typeof createSearchChantiersTool>;
+  createSearchIndicateursTool: ReturnType<typeof createSearchIndicateursTool>;
+  createSearchTerritoiresTool: ReturnType<typeof createSearchTerritoiresTool>;
   createComposeDashboardTool: ReturnType<typeof createComposeDashboardTool>;
   createExportRapportTool: ReturnType<typeof createExportRapportTool>;
   evaluerChatUseCase: EvaluerChatUseCase;
@@ -78,6 +82,12 @@ export const albertModule = defineModule<NoExports, AlbertCradle>()({
         createGetChantierCommentairesTool,
       ),
       createSearchChantiersTool: asModuleFunction(createSearchChantiersTool),
+      createSearchIndicateursTool: asModuleFunction(
+        createSearchIndicateursTool,
+      ),
+      createSearchTerritoiresTool: asModuleFunction(
+        createSearchTerritoiresTool,
+      ),
       createComposeDashboardTool: asModuleFunction(createComposeDashboardTool),
       createExportRapportTool: asModuleFunction(createExportRapportTool),
       evaluerChatUseCase: asModuleClass(EvaluerChatUseCase),

--- a/apps/pilote-ppg/src/server/albert/module.ts
+++ b/apps/pilote-ppg/src/server/albert/module.ts
@@ -4,6 +4,7 @@ import { createGetTauxAvancementTerritoireTool } from "@/server/albert/tools/get
 import { createGetChantiersTool } from "@/server/albert/tools/getChantiers";
 import { createGetChantierIndicateursTool } from "@/server/albert/tools/getChantierIndicateurs";
 import { createGetChantierCommentairesTool } from "@/server/albert/tools/getChantierCommentaires";
+import { createSearchChantiersTool } from "@/server/albert/tools/searchChantiers";
 import { createComposeDashboardTool } from "@/server/albert/tools/composeDashboard";
 import type { ChantierExports } from "@/server/chantiers/module";
 import { EvaluerChatUseCase } from "@/server/albert/usecases/EvaluerChatUseCase";
@@ -42,6 +43,7 @@ type AlbertOwnCradle = {
   createGetChantierCommentairesTool: ReturnType<
     typeof createGetChantierCommentairesTool
   >;
+  createSearchChantiersTool: ReturnType<typeof createSearchChantiersTool>;
   createComposeDashboardTool: ReturnType<typeof createComposeDashboardTool>;
   createExportRapportTool: ReturnType<typeof createExportRapportTool>;
   evaluerChatUseCase: EvaluerChatUseCase;
@@ -75,6 +77,7 @@ export const albertModule = defineModule<NoExports, AlbertCradle>()({
       createGetChantierCommentairesTool: asModuleFunction(
         createGetChantierCommentairesTool,
       ),
+      createSearchChantiersTool: asModuleFunction(createSearchChantiersTool),
       createComposeDashboardTool: asModuleFunction(createComposeDashboardTool),
       createExportRapportTool: asModuleFunction(createExportRapportTool),
       evaluerChatUseCase: asModuleClass(EvaluerChatUseCase),

--- a/apps/pilote-ppg/src/server/albert/subagents/filtrerHallucinations.ts
+++ b/apps/pilote-ppg/src/server/albert/subagents/filtrerHallucinations.ts
@@ -1,0 +1,14 @@
+export function filtrerHallucinations<TItem, TReference>({
+  items,
+  references,
+  getId,
+}: {
+  items: TItem[];
+  references: Map<string, TReference>;
+  getId: (item: TItem) => string;
+}): TReference[] {
+  return items.flatMap((item) => {
+    const reference = references.get(getId(item));
+    return reference === undefined ? [] : [reference];
+  });
+}

--- a/apps/pilote-ppg/src/server/albert/subagents/searchChantiersSystemPrompt.ts
+++ b/apps/pilote-ppg/src/server/albert/subagents/searchChantiersSystemPrompt.ts
@@ -1,0 +1,78 @@
+export function buildSearchChantiersSystemPrompt(): string {
+  return `Tu es un agent spécialisé dans l'identification de chantiers PILOTE à partir d'une requête utilisateur en langage naturel.
+
+# Ta mission
+
+Tu reçois :
+- Une **requête** utilisateur en langage naturel (ex: "les chantiers sur les VSS", "chantier handicap", "tout ce qui touche à la sécurité routière")
+- Un bloc <chantiers> listant tous les chantiers disponibles avec leur identité
+
+Tu dois retourner la liste des chantiers les plus pertinents pour cette requête, triés par pertinence décroissante.
+Ta réponse sera parsée automatiquement comme structured output.
+
+# Glossaire métier
+
+- **Chantier** : projet prioritaire du gouvernement (synonyme : PPG). Identifié par un code CH-XXX.
+- **Axe** : grand axe stratégique d'une politique publique (ex: "Égalité femmes-hommes", "Sécurité du quotidien").
+- **PPG (regroupement)** : intitulé du Projet Prioritaire du Gouvernement auquel le chantier appartient.
+- **Ministères** : ministères porteurs du chantier (noms complets).
+
+# Bloc <chantiers>
+
+Chaque entrée a la forme :
+\`\`\`
+{ "id": "CH-XXX", "nom": "...", "axe": "...", "ppg": "...", "ministeres": ["...", "..."] }
+\`\`\`
+
+**REGLE ABSOLUE** : utilise EXCLUSIVEMENT les \`id\` et \`nom\` présents dans le bloc <chantiers>. N'invente AUCUN identifiant, AUCUN nom.
+
+# Stratégie de matching
+
+Recherche sémantique en français, large et tolérante :
+
+1. **Acronymes et abréviations courants** : déplie-les avant de matcher.
+   - VSS → Violences sexuelles et sexistes
+   - VIF → Violences intra-familiales
+   - MNA → Mineurs non accompagnés
+   - ZAN → Zéro artificialisation nette
+   - VSV → Violences sur la voie publique
+   - PMI → Protection maternelle et infantile
+   - APL → Aide personnalisée au logement
+   - Si tu doutes d'un acronyme, considère-le comme une recherche libre.
+
+2. **Champs à scanner** (par ordre d'importance) : \`nom\`, \`axe\`, \`ppg\`, \`ministeres\`.
+
+3. **Tolérance** :
+   - Casse insensible, accents insensibles
+   - Synonymes et reformulations (ex: "handicap" matche "personnes en situation de handicap", "police" matche "sécurité")
+   - Thématiques connexes (ex: "écologie" matche aussi "transition écologique", "biodiversité")
+
+4. **Pertinence** :
+   - Match direct dans le nom > match dans l'axe/ppg > match via ministère
+   - Si plusieurs chantiers matchent, trie du plus pertinent au moins pertinent
+
+5. **Top-K** : retourne **au maximum 10 chantiers**. Si la requête est très précise et qu'il y a un seul match évident, retourne-le seul.
+
+6. **Pas de match** : si rien ne correspond clairement, retourne un tableau \`chantiers\` vide et explique pourquoi dans \`reasoning\`.
+
+# Format de sortie
+
+\`\`\`json
+{
+  "chantiers": [
+    { "id": "CH-064", "nom": "Lutter contre les violences faites aux femmes" }
+  ],
+  "reasoning": "Le terme « VSS » désigne les violences sexuelles et sexistes ; CH-064 est l'unique chantier traitant directement de cette thématique."
+}
+\`\`\`
+
+Le champ \`reasoning\` doit être court (1-3 phrases) et expliquer pourquoi les chantiers retenus correspondent à la requête.
+
+# Protocole
+
+1. Lis la requête utilisateur
+2. Déplie les acronymes éventuels
+3. Scanne le bloc <chantiers> et identifie les correspondances
+4. Trie par pertinence décroissante, plafonne à 10
+5. Produis la sortie JSON conforme au schéma`;
+}

--- a/apps/pilote-ppg/src/server/albert/subagents/searchChantiersSystemPrompt.ts
+++ b/apps/pilote-ppg/src/server/albert/subagents/searchChantiersSystemPrompt.ts
@@ -10,19 +10,14 @@ Tu reçois :
 Tu dois retourner la liste des chantiers les plus pertinents pour cette requête, triés par pertinence décroissante.
 Ta réponse sera parsée automatiquement comme structured output.
 
-# Glossaire métier
-
-- **Chantier** : projet prioritaire du gouvernement (synonyme : PPG). Identifié par un code CH-XXX.
-- **Axe** : grand axe stratégique d'une politique publique (ex: "Égalité femmes-hommes", "Sécurité du quotidien").
-- **PPG (regroupement)** : intitulé du Projet Prioritaire du Gouvernement auquel le chantier appartient.
-- **Ministères** : ministères porteurs du chantier (noms complets).
-
 # Bloc <chantiers>
 
 Chaque entrée a la forme :
 \`\`\`
 { "id": "CH-XXX", "nom": "...", "axe": "...", "ppg": "...", "ministeres": ["...", "..."] }
 \`\`\`
+
+Le champ \`ppg\` contient le libellé du regroupement parent du chantier ; plusieurs chantiers peuvent partager le même \`ppg\`. Utilise-le comme un signal de pertinence supplémentaire (au même titre que \`axe\`), pas comme un identifiant.
 
 **REGLE ABSOLUE** : utilise EXCLUSIVEMENT les \`id\` et \`nom\` présents dans le bloc <chantiers>. N'invente AUCUN identifiant, AUCUN nom.
 

--- a/apps/pilote-ppg/src/server/albert/subagents/searchIndicateursSystemPrompt.ts
+++ b/apps/pilote-ppg/src/server/albert/subagents/searchIndicateursSystemPrompt.ts
@@ -1,0 +1,88 @@
+export function buildSearchIndicateursSystemPrompt(): string {
+  return `Tu es un agent spécialisé dans l'identification d'indicateurs de suivi PILOTE à partir d'une requête utilisateur en langage naturel.
+
+# Ta mission
+
+Tu reçois :
+- Une **requête** utilisateur en langage naturel (ex: « le taux d'équipement », « l'indicateur sur les délais », « combien de femmes formées »)
+- Un bloc <indicateurs> listant tous les indicateurs disponibles avec leur identité et leur chantier de rattachement
+
+Tu dois retourner la liste des indicateurs les plus pertinents pour cette requête, triés par pertinence décroissante.
+Ta réponse sera parsée automatiquement comme structured output.
+
+# Glossaire métier
+
+- **Indicateur** : mesure de suivi d'un chantier (synonyme : KPI). Identifié par un id court (ex: « IND-001 »).
+- Chaque indicateur appartient à un **chantier** (PPG) unique, fourni dans le bloc <indicateurs>.
+- **type_nom** : catégorie de l'indicateur (ex: « Impact », « Résultat », « Réalisation »).
+- **est_phare** : indicateur mis en avant (vrai = phare).
+- **est_barometre** : indicateur du baromètre national.
+
+# Bloc <indicateurs>
+
+Chaque entrée a la forme :
+\`\`\`
+{
+  "id": "IND-001",
+  "nom": "...",
+  "description": "..." | null,
+  "type_nom": "..." | null,
+  "est_phare": false,
+  "est_barometre": false,
+  "chantier": { "id": "CH-XXX", "nom": "..." }
+}
+\`\`\`
+
+**REGLE ABSOLUE** : utilise EXCLUSIVEMENT les \`id\`, \`nom\` et \`chantier\` présents dans le bloc <indicateurs>. N'invente AUCUN identifiant, AUCUN nom, AUCUNE association indicateur-chantier.
+
+# Stratégie de matching
+
+Recherche sémantique en français, large et tolérante :
+
+1. **Champs à scanner** (par ordre d'importance) : \`nom\`, \`description\`, \`type_nom\`, \`chantier.nom\`.
+
+2. **Acronymes courants** : déplie-les avant de matcher (ex: VSS → violences sexuelles et sexistes, MNA → mineurs non accompagnés, PMR → personnes à mobilité réduite).
+
+3. **Reformulations métier** :
+   - « combien de … », « nombre de … » → cherche un indicateur de comptage (« Nombre de … »)
+   - « taux de … », « pourcentage de … » → cherche un indicateur en pourcentage
+   - « délai de … » → cherche un indicateur de durée
+
+4. **Désambiguïsation par chantier** : si la requête mentionne un thème associé à un chantier précis (ex: « les indicateurs sur les VSS »), restreins-toi aux indicateurs des chantiers correspondants.
+
+5. **Tolérance** : casse insensible, accents insensibles, synonymes courants.
+
+6. **Pertinence** :
+   - Match direct dans le \`nom\` > match dans la \`description\` > match via \`chantier.nom\`
+   - Indicateurs \`est_phare: true\` à privilégier en cas d'égalité de pertinence
+   - Si plusieurs indicateurs matchent, trie du plus pertinent au moins pertinent
+
+7. **Top-K** : retourne **au maximum 10 indicateurs**. Si la requête est très précise et qu'il y a un seul match évident, retourne-le seul.
+
+8. **Pas de match** : si rien ne correspond clairement, retourne un tableau \`indicateurs\` vide et explique pourquoi dans \`reasoning\`.
+
+# Format de sortie
+
+\`\`\`json
+{
+  "indicateurs": [
+    {
+      "id": "IND-001",
+      "nom": "Nombre de femmes formées",
+      "chantier": { "id": "CH-064", "nom": "Lutter contre les violences faites aux femmes" }
+    }
+  ],
+  "reasoning": "L'indicateur IND-001 mesure directement la formation des femmes dans le chantier de lutte contre les violences faites aux femmes."
+}
+\`\`\`
+
+Le champ \`reasoning\` doit être court (1-3 phrases). Il explique le lien entre la requête et les indicateurs retenus, en mentionnant le chantier parent si utile à la désambiguïsation.
+
+# Protocole
+
+1. Lis la requête utilisateur
+2. Identifie les concepts clés (thème, type de mesure, chantier cible si mentionné)
+3. Scanne le bloc <indicateurs> et identifie les correspondances
+4. Trie par pertinence décroissante, plafonne à 10
+5. Produis la sortie JSON conforme au schéma`;
+}

--- a/apps/pilote-ppg/src/server/albert/subagents/searchIndicateursSystemPrompt.ts
+++ b/apps/pilote-ppg/src/server/albert/subagents/searchIndicateursSystemPrompt.ts
@@ -16,7 +16,6 @@ Ta réponse sera parsée automatiquement comme structured output.
 - Chaque indicateur appartient à un **chantier** (PPG) unique, fourni dans le bloc <indicateurs>.
 - **type_nom** : catégorie de l'indicateur (ex: « Impact », « Résultat », « Réalisation »).
 - **est_phare** : indicateur mis en avant (vrai = phare).
-- **est_barometre** : indicateur du baromètre national.
 
 # Bloc <indicateurs>
 
@@ -28,7 +27,6 @@ Chaque entrée a la forme :
   "description": "..." | null,
   "type_nom": "..." | null,
   "est_phare": false,
-  "est_barometre": false,
   "chantier": { "id": "CH-XXX", "nom": "..." }
 }
 \`\`\`

--- a/apps/pilote-ppg/src/server/albert/subagents/searchTerritoiresSystemPrompt.ts
+++ b/apps/pilote-ppg/src/server/albert/subagents/searchTerritoiresSystemPrompt.ts
@@ -1,0 +1,92 @@
+export function buildSearchTerritoiresSystemPrompt(): string {
+  return `Tu es un agent spécialisé dans l'identification de territoires français (national, régions, départements) à partir d'une requête utilisateur en langage naturel.
+
+# Ta mission
+
+Tu reçois :
+- Une **requête** utilisateur en langage naturel (ex: « la Normandie », « le 75 », « les départements bretons », « les DOM », « France entière »)
+- Un bloc <territoires> listant tous les territoires disponibles avec leur identité
+
+Tu dois retourner la liste des territoires les plus pertinents pour cette requête, triés par pertinence décroissante.
+Ta réponse sera parsée automatiquement comme structured output.
+
+# Glossaire métier
+
+- **Maille NAT** : niveau national (code NAT-FR, nom "France")
+- **Maille REG** : régions françaises (code REG-XX, ex: REG-32 pour Hauts-de-France)
+- **Maille DEPT** : départements (code DEPT-XX, ex: DEPT-75 pour Paris)
+- **code_insee** : code INSEE du territoire (ex: "75" pour Paris, "11" pour Île-de-France)
+- **code_parent** : code du territoire parent (un département a pour parent une région, une région a pour parent NAT-FR)
+
+# Bloc <territoires>
+
+Chaque entrée a la forme :
+\`\`\`
+{ "code": "DEPT-75", "nom": "Paris", "maille": "DEPT", "code_parent": "REG-11" }
+\`\`\`
+
+**REGLE ABSOLUE** : utilise EXCLUSIVEMENT les \`code\` et \`nom\` présents dans le bloc <territoires>. N'invente AUCUN code, AUCUN nom.
+
+# Stratégie de matching
+
+Recherche sémantique en français, large et tolérante :
+
+1. **Numéro de département en langage courant** :
+   - « le 75 », « dans le 75 », « 75 » → DEPT-75 (Paris)
+   - « le 13 » → DEPT-13 (Bouches-du-Rhône)
+   - « le 974 » → DEPT-974 (La Réunion)
+   - Match via le \`code_insee\` du territoire de maille DEPT.
+
+2. **National** : « national », « France entière », « la France », « tout le pays », « niveau national » → NAT-FR
+
+3. **Anciennes régions et regroupements courants** (avant fusion 2016) :
+   - « Auvergne », « Rhône-Alpes » seuls (sans tiret) → REG-84 (Auvergne-Rhône-Alpes)
+   - « Aquitaine », « Limousin », « Poitou-Charentes » → REG-75 (Nouvelle-Aquitaine)
+   - « Languedoc-Roussillon », « Midi-Pyrénées » → REG-76 (Occitanie)
+   - « Nord-Pas-de-Calais », « Picardie » → REG-32 (Hauts-de-France)
+   - « Basse-Normandie », « Haute-Normandie » → REG-28 (Normandie)
+   - « Bourgogne », « Franche-Comté » → REG-27 (Bourgogne-Franche-Comté)
+   - « Champagne-Ardenne », « Lorraine », « Alsace » → REG-44 (Grand Est)
+   - Si l'utilisateur cite une de ces anciennes régions seule, propose la région fusionnée.
+
+4. **Groupes géographiques et thématiques** :
+   - « les DOM », « DROM », « outre-mer », « territoires ultramarins » → les départements et régions d'outre-mer (DEPT-971 Guadeloupe, DEPT-972 Martinique, DEPT-973 Guyane, DEPT-974 La Réunion, DEPT-976 Mayotte, et leurs régions équivalentes)
+   - « région parisienne », « Île-de-France » → REG-11
+   - « les départements bretons », « les départements de Bretagne » → tous les départements ayant pour \`code_parent\` la région Bretagne (REG-53)
+   - « les départements normands » → tous les départements ayant pour \`code_parent\` REG-28 (Normandie)
+   - Pour ces requêtes "tous les départements de X", utilise le \`code_parent\` pour identifier les enfants.
+
+5. **Habitants / gentilés** : « les Bretons » → REG-53, « les Normands » → REG-28, « les Corses » → REG-94, etc. Mais ne déduis QUE si le mapping est non ambigu.
+
+6. **Tolérance** : casse insensible, accents insensibles. « bretagne », « Bretagne », « BRETAGNE » matchent tous REG-53.
+
+7. **Pertinence** :
+   - Match exact sur \`nom\` ou \`code_insee\` → priorité absolue
+   - Match via maille parent → secondaire
+   - Si plusieurs candidats, trie du plus pertinent au moins pertinent
+
+8. **Top-K** : retourne **au maximum 10 territoires**. Si la requête est très précise et qu'il y a un seul match évident, retourne-le seul. Pour « les départements bretons », retourne tous les 4 départements bretons (max 10).
+
+9. **Pas de match** : si rien ne correspond clairement, retourne un tableau \`territoires\` vide et explique pourquoi dans \`reasoning\`.
+
+# Format de sortie
+
+\`\`\`json
+{
+  "territoires": [
+    { "code": "DEPT-75", "nom": "Paris", "maille": "DEPT" }
+  ],
+  "reasoning": "« Le 75 » désigne le département de Paris, identifié via son code_insee."
+}
+\`\`\`
+
+Le champ \`reasoning\` doit être court (1-3 phrases).
+
+# Protocole
+
+1. Lis la requête utilisateur
+2. Identifie le type de demande : code INSEE, nom de territoire, ancienne région, groupe, gentilé, etc.
+3. Scanne le bloc <territoires> et identifie les correspondances
+4. Trie par pertinence décroissante, plafonne à 10
+5. Produis la sortie JSON conforme au schéma`;
+}

--- a/apps/pilote-ppg/src/server/albert/systemPrompt.ts
+++ b/apps/pilote-ppg/src/server/albert/systemPrompt.ts
@@ -411,6 +411,19 @@ Si NAT-FR est aussi demandé, ajouter +1 appel par jalon avec territoire_code=NA
 3. Appelle export_rapport avec les données structurées
 4. Réponds "Votre rapport est disponible au téléchargement."
 
+## search_chantiers
+Utilise \`search_chantiers\` quand l'utilisateur mentionne un chantier par **thématique, acronyme ou mot-clé** sans donner d'identifiant CH-XXX (ex: « les chantiers sur les VSS », « le chantier handicap », « tout ce qui touche à la sécurité routière »).
+
+Le tool retourne au maximum 10 chantiers triés par pertinence, avec uniquement leur \`id\` et leur \`nom\`. Aucune donnée d'avancement, météo ou indicateur — ces données s'obtiennent via les autres outils.
+
+Workflow :
+1. Appelle \`search_chantiers({ query })\` avec la formulation de l'utilisateur (acronyme inclus)
+2. Si **un seul** chantier ressort clairement, enchaîne directement avec l'outil de données pertinent (\`get_chantiers\`, \`get_indicateurs\`, …) avec son \`chantier_ids\`
+3. Si **plusieurs** chantiers ressortent, présente la liste à l'utilisateur au format **CH-XXX — Nom du chantier** et demande-lui de préciser lequel l'intéresse avant de poursuivre
+4. Si **aucun** chantier ne ressort, indique-le et invite à reformuler
+
+**N'utilise PAS** \`search_chantiers\` quand l'utilisateur a déjà donné un ou plusieurs CH-XXX explicites : appelle directement \`get_chantiers\` avec \`chantier_ids\`.
+
 ## create_dashboard
 Quand l'utilisateur demande de visualiser des données (dashboard, cockpit, tableau de bord,
 indicateurs d'un chantier, cartographie, comparaison visuelle), appelle \`create_dashboard\` avec :

--- a/apps/pilote-ppg/src/server/albert/systemPrompt.ts
+++ b/apps/pilote-ppg/src/server/albert/systemPrompt.ts
@@ -412,7 +412,7 @@ Si NAT-FR est aussi demandé, ajouter +1 appel par jalon avec territoire_code=NA
 4. Réponds "Votre rapport est disponible au téléchargement."
 
 ## search_chantiers / search_indicateurs / search_territoires
-Trois outils de résolution complémentaires, à utiliser quand l'utilisateur ne donne pas un identifiant explicite (CH-XXX, IND-XXX, NAT-FR/REG-XX/DEPT-XX) mais le décrit en langage naturel. Tous retournent au maximum 10 résultats triés par pertinence, avec uniquement les identifiants — utilise ensuite les outils de données (\`get_chantiers\`, \`get_indicateurs\`, \`get_taux_avancement_territoire\`) pour récupérer les valeurs.
+Trois outils de résolution complémentaires, à utiliser quand l'utilisateur ne donne pas un identifiant explicite (CH-XXX, IND-XXX, NAT-FR/REG-XX/DEPT-XX) mais le décrit en langage naturel. Tous retournent au maximum 10 résultats triés par pertinence, avec leur identifiant et un libellé court — utilise ensuite les outils de données (\`get_chantiers\`, \`get_indicateurs\`, \`get_taux_avancement_territoire\`) pour récupérer les valeurs.
 
 **Workflow type** (à adapter à chaque tool) :
 1. Appelle l'outil de recherche avec la formulation de l'utilisateur (acronyme inclus)

--- a/apps/pilote-ppg/src/server/albert/systemPrompt.ts
+++ b/apps/pilote-ppg/src/server/albert/systemPrompt.ts
@@ -411,6 +411,17 @@ Si NAT-FR est aussi demandé, ajouter +1 appel par jalon avec territoire_code=NA
 3. Appelle export_rapport avec les données structurées
 4. Réponds "Votre rapport est disponible au téléchargement."
 
+## search_chantiers / search_indicateurs / search_territoires
+Trois outils de résolution complémentaires, à utiliser quand l'utilisateur ne donne pas un identifiant explicite (CH-XXX, IND-XXX, NAT-FR/REG-XX/DEPT-XX) mais le décrit en langage naturel. Tous retournent au maximum 10 résultats triés par pertinence, avec uniquement les identifiants — utilise ensuite les outils de données (\`get_chantiers\`, \`get_indicateurs\`, \`get_taux_avancement_territoire\`) pour récupérer les valeurs.
+
+**Workflow type** (à adapter à chaque tool) :
+1. Appelle l'outil de recherche avec la formulation de l'utilisateur (acronyme inclus)
+2. Si **un seul** résultat ressort clairement, enchaîne directement avec l'outil de données pertinent
+3. Si **plusieurs** résultats, présente la liste à l'utilisateur et demande-lui de préciser avant de poursuivre
+4. Si **aucun** résultat, indique-le et invite à reformuler
+
+**N'utilise PAS** ces outils quand l'utilisateur a déjà fourni un identifiant explicite : passe directement à l'outil de données.
+
 ## search_chantiers
 Utilise \`search_chantiers\` quand l'utilisateur mentionne un chantier par **thématique, acronyme ou mot-clé** sans donner d'identifiant CH-XXX (ex: « les chantiers sur les VSS », « le chantier handicap », « tout ce qui touche à la sécurité routière »).
 
@@ -423,6 +434,18 @@ Workflow :
 4. Si **aucun** chantier ne ressort, indique-le et invite à reformuler
 
 **N'utilise PAS** \`search_chantiers\` quand l'utilisateur a déjà donné un ou plusieurs CH-XXX explicites : appelle directement \`get_chantiers\` avec \`chantier_ids\`.
+
+## search_indicateurs
+Utilise \`search_indicateurs\` quand l'utilisateur mentionne un indicateur par **thématique, métrique ou libellé approximatif** sans donner son identifiant (ex: « combien de femmes formées », « le taux d'équipement », « les délais »).
+
+**Pré-scope par chantier** (recommandé) : si tu as déjà ciblé un ou plusieurs chantiers (via \`search_chantiers\` ou un CH-XXX explicite), passe-les dans \`chantier_ids\` pour réduire le contexte et améliorer la pertinence. Sans ce filtre, la recherche porte sur tous les indicateurs accessibles.
+
+La sortie inclut le chantier de rattachement (\`chantier: { id, nom }\`) — utilise-le pour désambiguïser et pour appeler \`get_indicateurs\` avec le bon \`chantier_id\`.
+
+## search_territoires
+Utilise \`search_territoires\` quand l'utilisateur mentionne un territoire par **nom, numéro de département, ancienne région, gentilé ou regroupement géographique** sans donner son code (ex: « la Normandie », « le 75 », « les départements bretons », « les DOM », « France entière »).
+
+**N'utilise PAS** \`search_territoires\` quand l'utilisateur a déjà fourni un code (NAT-FR, REG-XX, DEPT-XX) : passe-le directement à \`get_taux_avancement_territoire\` ou \`get_chantiers\`.
 
 ## create_dashboard
 Quand l'utilisateur demande de visualiser des données (dashboard, cockpit, tableau de bord,

--- a/apps/pilote-ppg/src/server/albert/tools/searchChantiers.ts
+++ b/apps/pilote-ppg/src/server/albert/tools/searchChantiers.ts
@@ -1,6 +1,7 @@
 import { tool } from "ai";
 import { z } from "zod";
 import { Albert } from "@/server/albert/Albert";
+import { filtrerHallucinations } from "@/server/albert/subagents/filtrerHallucinations";
 import { buildSearchChantiersSystemPrompt } from "@/server/albert/subagents/searchChantiersSystemPrompt";
 import type {
   ChantierIdentiteResult,
@@ -92,15 +93,16 @@ Le tool retourne au maximum 10 chantiers triés par pertinence, avec leur id et 
           abortSignal,
         });
 
-        const accessibleSet = new Set(chantiersAccessibles);
         const chantiersById = new Map(chantiers.map((c) => [c.id, c]));
 
-        const resultats = output.chantiers
-          .filter((c) => accessibleSet.has(c.id) && chantiersById.has(c.id))
-          .map((c) => ({
-            id: c.id,
-            nom: chantiersById.get(c.id)?.nom ?? c.nom,
-          }));
+        const resultats = filtrerHallucinations({
+          items: output.chantiers,
+          references: chantiersById,
+          getId: (c) => c.id,
+        }).map((c) => ({
+          id: c.id,
+          nom: c.nom,
+        }));
 
         return {
           chantiers: resultats,

--- a/apps/pilote-ppg/src/server/albert/tools/searchChantiers.ts
+++ b/apps/pilote-ppg/src/server/albert/tools/searchChantiers.ts
@@ -1,0 +1,116 @@
+import { tool } from "ai";
+import { z } from "zod";
+import { Albert } from "@/server/albert/Albert";
+import { buildSearchChantiersSystemPrompt } from "@/server/albert/subagents/searchChantiersSystemPrompt";
+import type {
+  ChantierIdentiteResult,
+  GetChantiersIdentiteQuery,
+} from "@/server/chantiers/query/GetChantiersIdentiteQuery";
+
+export const searchChantiersInputSchema = z.object({
+  query: z
+    .string()
+    .min(1)
+    .describe(
+      "Requête utilisateur en langage naturel pour identifier des chantiers (ex: « les chantiers sur les VSS », « chantier handicap », « sécurité routière »). Peut contenir un acronyme, un mot-clé thématique, un nom de politique publique ou un ministère.",
+    ),
+});
+
+const searchChantiersSubagentOutputSchema = z.object({
+  chantiers: z
+    .array(
+      z.object({
+        id: z.string(),
+        nom: z.string(),
+      }),
+    )
+    .max(10),
+  reasoning: z.string(),
+});
+
+export type SearchChantiersOutput = {
+  chantiers: { id: string; nom: string }[];
+  reasoning: string;
+  _output_instructions: string;
+};
+
+const OUTPUT_INSTRUCTIONS = `Présente à l'utilisateur la liste des chantiers identifiés au format **CH-XXX — Nom du chantier**.
+Si plusieurs chantiers correspondent, demande à l'utilisateur de préciser celui qui l'intéresse avant d'appeler get_chantiers ou get_indicateurs.
+Si un seul chantier correspond clairement, tu peux directement enchaîner avec l'outil de données approprié sans demander confirmation.
+Si la liste est vide, indique-le et invite l'utilisateur à reformuler ou préciser sa demande. Ne reproduis pas le champ \`reasoning\` mot pour mot.`;
+
+const OUTPUT_INSTRUCTIONS_VIDE = `Aucun chantier ne correspond à la requête. Indique-le clairement à l'utilisateur et propose-lui de reformuler ou de préciser sa demande. Mentionne, si pertinent, le motif (acronyme inconnu, thématique non couverte, etc.) sans reproduire \`reasoning\` mot pour mot.`;
+
+function buildSubagentPrompt(
+  query: string,
+  chantiers: ChantierIdentiteResult[],
+): string {
+  return `${query}
+
+<chantiers>
+${JSON.stringify(chantiers)}
+</chantiers>`;
+}
+
+export function createSearchChantiersTool({
+  getChantiersIdentiteQuery,
+}: {
+  getChantiersIdentiteQuery: GetChantiersIdentiteQuery;
+}) {
+  return ({ chantiersAccessibles }: { chantiersAccessibles: string[] }) => {
+    return tool({
+      description: `Identifie des chantiers (CH-XXX) à partir d'une requête en langage naturel quand l'utilisateur ne connaît pas leur identifiant.
+
+Utilise ce tool quand :
+- l'utilisateur mentionne une thématique, un acronyme ou un mot-clé sans donner de CH-XXX (ex: « les chantiers sur les VSS », « chantier handicap », « sécurité routière »)
+- tu as besoin de résoudre un nom de chantier vers un identifiant avant d'appeler get_chantiers, get_indicateurs ou get_chantier_commentaires
+
+N'utilise PAS ce tool quand l'utilisateur a déjà fourni un ou plusieurs CH-XXX explicites — appelle directement get_chantiers avec \`chantier_ids\`.
+
+Le tool retourne au maximum 10 chantiers triés par pertinence, avec leur id et leur nom uniquement. Aucune donnée d'avancement, météo ou indicateur — utilise les autres tools pour ça.`,
+      inputSchema: searchChantiersInputSchema,
+      execute: async (
+        { query },
+        { abortSignal },
+      ): Promise<SearchChantiersOutput> => {
+        const chantiers = await getChantiersIdentiteQuery.execute({
+          chantierIds: chantiersAccessibles,
+        });
+
+        if (chantiers.length === 0) {
+          return {
+            chantiers: [],
+            reasoning: "Aucun chantier accessible pour cet utilisateur.",
+            _output_instructions: OUTPUT_INSTRUCTIONS_VIDE,
+          };
+        }
+
+        const output = await Albert.generateStructuredOutput({
+          systemPrompt: buildSearchChantiersSystemPrompt(),
+          prompt: buildSubagentPrompt(query, chantiers),
+          schema: searchChantiersSubagentOutputSchema,
+          abortSignal,
+        });
+
+        const accessibleSet = new Set(chantiersAccessibles);
+        const chantiersById = new Map(chantiers.map((c) => [c.id, c]));
+
+        const resultats = output.chantiers
+          .filter((c) => accessibleSet.has(c.id) && chantiersById.has(c.id))
+          .map((c) => ({
+            id: c.id,
+            nom: chantiersById.get(c.id)?.nom ?? c.nom,
+          }));
+
+        return {
+          chantiers: resultats,
+          reasoning: output.reasoning,
+          _output_instructions:
+            resultats.length === 0
+              ? OUTPUT_INSTRUCTIONS_VIDE
+              : OUTPUT_INSTRUCTIONS,
+        };
+      },
+    });
+  };
+}

--- a/apps/pilote-ppg/src/server/albert/tools/searchIndicateurs.ts
+++ b/apps/pilote-ppg/src/server/albert/tools/searchIndicateurs.ts
@@ -1,6 +1,7 @@
 import { tool } from "ai";
 import { z } from "zod";
 import { Albert } from "@/server/albert/Albert";
+import { filtrerHallucinations } from "@/server/albert/subagents/filtrerHallucinations";
 import { buildSearchIndicateursSystemPrompt } from "@/server/albert/subagents/searchIndicateursSystemPrompt";
 import type {
   GetIndicateursIdentiteQuery,
@@ -94,18 +95,23 @@ Le tool retourne au maximum 10 indicateurs triés par pertinence, avec leur id, 
             ? chantier_ids.filter((id) => accessibleSet.has(id))
             : chantiersAccessibles;
 
+        if (chantier_ids !== undefined && chantierIdsScope.length === 0) {
+          return {
+            indicateurs: [],
+            reasoning:
+              "Aucun des chantiers demandés n'est accessible pour cet utilisateur.",
+            _output_instructions: OUTPUT_INSTRUCTIONS_VIDE,
+          };
+        }
+
         const indicateurs = await getIndicateursIdentiteQuery.execute({
           chantierIds: chantierIdsScope,
         });
 
         if (indicateurs.length === 0) {
-          const reasoning =
-            chantier_ids !== undefined && chantierIdsScope.length === 0
-              ? "Aucun des chantiers demandés n'est accessible pour cet utilisateur."
-              : "Aucun indicateur accessible dans le périmètre demandé.";
           return {
             indicateurs: [],
-            reasoning,
+            reasoning: "Aucun indicateur accessible dans le périmètre demandé.",
             _output_instructions: OUTPUT_INSTRUCTIONS_VIDE,
           };
         }
@@ -119,21 +125,18 @@ Le tool retourne au maximum 10 indicateurs triés par pertinence, avec leur id, 
 
         const indicateursById = new Map(indicateurs.map((i) => [i.id, i]));
 
-        const resultats = output.indicateurs
-          .map((i) => {
-            const reference = indicateursById.get(i.id);
-            if (!reference) return null;
-            if (!accessibleSet.has(reference.chantier.id)) return null;
-            return {
-              id: reference.id,
-              nom: reference.nom,
-              chantier: {
-                id: reference.chantier.id,
-                nom: reference.chantier.nom,
-              },
-            };
-          })
-          .filter((i): i is NonNullable<typeof i> => i !== null);
+        const resultats = filtrerHallucinations({
+          items: output.indicateurs,
+          references: indicateursById,
+          getId: (i) => i.id,
+        }).map((i) => ({
+          id: i.id,
+          nom: i.nom,
+          chantier: {
+            id: i.chantier.id,
+            nom: i.chantier.nom,
+          },
+        }));
 
         return {
           indicateurs: resultats,

--- a/apps/pilote-ppg/src/server/albert/tools/searchIndicateurs.ts
+++ b/apps/pilote-ppg/src/server/albert/tools/searchIndicateurs.ts
@@ -1,0 +1,149 @@
+import { tool } from "ai";
+import { z } from "zod";
+import { Albert } from "@/server/albert/Albert";
+import { buildSearchIndicateursSystemPrompt } from "@/server/albert/subagents/searchIndicateursSystemPrompt";
+import type {
+  GetIndicateursIdentiteQuery,
+  IndicateurIdentiteResult,
+} from "@/server/chantiers/query/GetIndicateursIdentiteQuery";
+
+export const searchIndicateursInputSchema = z.object({
+  query: z
+    .string()
+    .min(1)
+    .describe(
+      "Requête utilisateur en langage naturel pour identifier des indicateurs (ex: « le taux d'équipement », « combien de femmes formées », « les délais »).",
+    ),
+  chantier_ids: z
+    .array(z.string())
+    .optional()
+    .describe(
+      "Restreint la recherche aux indicateurs des chantiers spécifiés (ex: ['CH-064']). À utiliser quand l'utilisateur a déjà ciblé un ou plusieurs chantiers (via search_chantiers ou un CH-XXX explicite). Réduit le contexte et améliore la pertinence.",
+    ),
+});
+
+const searchIndicateursSubagentOutputSchema = z.object({
+  indicateurs: z
+    .array(
+      z.object({
+        id: z.string(),
+        nom: z.string(),
+        chantier: z.object({
+          id: z.string(),
+          nom: z.string(),
+        }),
+      }),
+    )
+    .max(10),
+  reasoning: z.string(),
+});
+
+export type SearchIndicateursOutput = {
+  indicateurs: {
+    id: string;
+    nom: string;
+    chantier: { id: string; nom: string };
+  }[];
+  reasoning: string;
+  _output_instructions: string;
+};
+
+const OUTPUT_INSTRUCTIONS = `Présente à l'utilisateur la liste des indicateurs identifiés avec leur id, leur nom, et leur chantier de rattachement au format **CH-XXX — Nom du chantier**.
+Si un seul indicateur correspond clairement, tu peux directement enchaîner avec get_indicateurs sans demander confirmation.
+Si plusieurs indicateurs correspondent, demande à l'utilisateur de préciser celui qui l'intéresse avant d'enchaîner.
+Si la liste est vide, indique-le et invite l'utilisateur à reformuler. Ne reproduis pas le champ \`reasoning\` mot pour mot.`;
+
+const OUTPUT_INSTRUCTIONS_VIDE = `Aucun indicateur ne correspond à la requête. Indique-le clairement à l'utilisateur et propose-lui de reformuler ou de cibler d'abord un chantier via search_chantiers. Ne reproduis pas \`reasoning\` mot pour mot.`;
+
+function buildSubagentPrompt(
+  query: string,
+  indicateurs: IndicateurIdentiteResult[],
+): string {
+  return `${query}
+
+<indicateurs>
+${JSON.stringify(indicateurs)}
+</indicateurs>`;
+}
+
+export function createSearchIndicateursTool({
+  getIndicateursIdentiteQuery,
+}: {
+  getIndicateursIdentiteQuery: GetIndicateursIdentiteQuery;
+}) {
+  return ({ chantiersAccessibles }: { chantiersAccessibles: string[] }) => {
+    return tool({
+      description: `Identifie des indicateurs PILOTE à partir d'une requête en langage naturel quand l'utilisateur ne donne pas leur identifiant.
+
+Utilise ce tool quand :
+- l'utilisateur mentionne un indicateur par thématique, libellé approximatif ou métrique (ex: « le taux d'équipement », « combien de femmes formées », « les délais »)
+- tu as besoin de résoudre un nom d'indicateur vers un identifiant avant d'appeler get_indicateurs
+
+Si tu as déjà ciblé un ou plusieurs chantiers (via search_chantiers ou un CH-XXX explicite), passe leurs identifiants dans \`chantier_ids\` pour scoper la recherche et améliorer la pertinence.
+
+Le tool retourne au maximum 10 indicateurs triés par pertinence, avec leur id, leur nom et leur chantier de rattachement. Aucune donnée chiffrée — utilise get_indicateurs pour ça.`,
+      inputSchema: searchIndicateursInputSchema,
+      execute: async (
+        { query, chantier_ids },
+        { abortSignal },
+      ): Promise<SearchIndicateursOutput> => {
+        const accessibleSet = new Set(chantiersAccessibles);
+
+        const chantierIdsScope =
+          chantier_ids !== undefined
+            ? chantier_ids.filter((id) => accessibleSet.has(id))
+            : chantiersAccessibles;
+
+        const indicateurs = await getIndicateursIdentiteQuery.execute({
+          chantierIds: chantierIdsScope,
+        });
+
+        if (indicateurs.length === 0) {
+          const reasoning =
+            chantier_ids !== undefined && chantierIdsScope.length === 0
+              ? "Aucun des chantiers demandés n'est accessible pour cet utilisateur."
+              : "Aucun indicateur accessible dans le périmètre demandé.";
+          return {
+            indicateurs: [],
+            reasoning,
+            _output_instructions: OUTPUT_INSTRUCTIONS_VIDE,
+          };
+        }
+
+        const output = await Albert.generateStructuredOutput({
+          systemPrompt: buildSearchIndicateursSystemPrompt(),
+          prompt: buildSubagentPrompt(query, indicateurs),
+          schema: searchIndicateursSubagentOutputSchema,
+          abortSignal,
+        });
+
+        const indicateursById = new Map(indicateurs.map((i) => [i.id, i]));
+
+        const resultats = output.indicateurs
+          .map((i) => {
+            const reference = indicateursById.get(i.id);
+            if (!reference) return null;
+            if (!accessibleSet.has(reference.chantier.id)) return null;
+            return {
+              id: reference.id,
+              nom: reference.nom,
+              chantier: {
+                id: reference.chantier.id,
+                nom: reference.chantier.nom,
+              },
+            };
+          })
+          .filter((i): i is NonNullable<typeof i> => i !== null);
+
+        return {
+          indicateurs: resultats,
+          reasoning: output.reasoning,
+          _output_instructions:
+            resultats.length === 0
+              ? OUTPUT_INSTRUCTIONS_VIDE
+              : OUTPUT_INSTRUCTIONS,
+        };
+      },
+    });
+  };
+}

--- a/apps/pilote-ppg/src/server/albert/tools/searchTerritoires.ts
+++ b/apps/pilote-ppg/src/server/albert/tools/searchTerritoires.ts
@@ -1,0 +1,107 @@
+import { tool } from "ai";
+import { z } from "zod";
+import { Albert } from "@/server/albert/Albert";
+import { buildSearchTerritoiresSystemPrompt } from "@/server/albert/subagents/searchTerritoiresSystemPrompt";
+import type {
+  GetTerritoiresIdentiteQuery,
+  TerritoireIdentiteResult,
+} from "@/server/chantiers/query/GetTerritoiresIdentiteQuery";
+
+export const searchTerritoiresInputSchema = z.object({
+  query: z
+    .string()
+    .min(1)
+    .describe(
+      "Requête utilisateur en langage naturel pour identifier des territoires (ex: « la Normandie », « le 75 », « les départements bretons », « les DOM », « France entière »). Peut contenir un numéro de département, un nom de région (ancienne ou actuelle), un gentilé ou un regroupement géographique.",
+    ),
+});
+
+const searchTerritoiresSubagentOutputSchema = z.object({
+  territoires: z
+    .array(
+      z.object({
+        code: z.string(),
+        nom: z.string(),
+        maille: z.string(),
+      }),
+    )
+    .max(10),
+  reasoning: z.string(),
+});
+
+export type SearchTerritoiresOutput = {
+  territoires: { code: string; nom: string; maille: string }[];
+  reasoning: string;
+  _output_instructions: string;
+};
+
+const OUTPUT_INSTRUCTIONS = `Présente à l'utilisateur la liste des territoires identifiés en utilisant leur code (NAT-FR, REG-XX, DEPT-XX) et leur nom.
+Si un seul territoire correspond clairement, tu peux directement enchaîner avec get_taux_avancement_territoire ou get_chantiers sans demander confirmation.
+Si plusieurs territoires correspondent, demande à l'utilisateur de préciser celui qui l'intéresse avant d'enchaîner.
+Si la liste est vide, indique-le et invite l'utilisateur à reformuler. Ne reproduis pas le champ \`reasoning\` mot pour mot.`;
+
+const OUTPUT_INSTRUCTIONS_VIDE = `Aucun territoire ne correspond à la requête. Indique-le clairement à l'utilisateur et propose-lui de reformuler (avec un code REG-XX/DEPT-XX, un nom de région, ou un numéro de département). Ne reproduis pas \`reasoning\` mot pour mot.`;
+
+function buildSubagentPrompt(
+  query: string,
+  territoires: TerritoireIdentiteResult[],
+): string {
+  return `${query}
+
+<territoires>
+${JSON.stringify(territoires)}
+</territoires>`;
+}
+
+export function createSearchTerritoiresTool({
+  getTerritoiresIdentiteQuery,
+}: {
+  getTerritoiresIdentiteQuery: GetTerritoiresIdentiteQuery;
+}) {
+  return () =>
+    tool({
+      description: `Identifie des territoires (NAT-FR, REG-XX, DEPT-XX) à partir d'une requête en langage naturel quand l'utilisateur ne donne pas leur code.
+
+Utilise ce tool quand l'utilisateur mentionne un territoire par nom, numéro de département, ancienne région, gentilé ou regroupement géographique (ex: « la Normandie », « le 75 », « les départements bretons », « les DOM », « tous les départements de la région X »).
+
+N'utilise PAS ce tool quand l'utilisateur a déjà fourni un code explicite (NAT-FR, REG-XX, DEPT-XX) — passe-le directement à get_taux_avancement_territoire ou get_chantiers.
+
+Le tool retourne au maximum 10 territoires triés par pertinence, avec leur code, leur nom et leur maille. Aucune donnée d'avancement — utilise les autres tools pour ça.`,
+      inputSchema: searchTerritoiresInputSchema,
+      execute: async (
+        { query },
+        { abortSignal },
+      ): Promise<SearchTerritoiresOutput> => {
+        const territoires = await getTerritoiresIdentiteQuery.execute();
+
+        const output = await Albert.generateStructuredOutput({
+          systemPrompt: buildSearchTerritoiresSystemPrompt(),
+          prompt: buildSubagentPrompt(query, territoires),
+          schema: searchTerritoiresSubagentOutputSchema,
+          abortSignal,
+        });
+
+        const territoiresByCode = new Map(territoires.map((t) => [t.code, t]));
+
+        const resultats = output.territoires
+          .filter((t) => territoiresByCode.has(t.code))
+          .map((t) => {
+            const referenceTerritoire = territoiresByCode.get(t.code);
+            return {
+              code: t.code,
+              nom: referenceTerritoire?.nom ?? t.nom,
+              maille: referenceTerritoire?.maille ?? t.maille,
+            };
+          });
+
+        return {
+          territoires: resultats,
+          reasoning: output.reasoning,
+          _output_instructions:
+            resultats.length === 0
+              ? OUTPUT_INSTRUCTIONS_VIDE
+              : OUTPUT_INSTRUCTIONS,
+        };
+      },
+    });
+}

--- a/apps/pilote-ppg/src/server/albert/tools/searchTerritoires.ts
+++ b/apps/pilote-ppg/src/server/albert/tools/searchTerritoires.ts
@@ -1,6 +1,7 @@
 import { tool } from "ai";
 import { z } from "zod";
 import { Albert } from "@/server/albert/Albert";
+import { filtrerHallucinations } from "@/server/albert/subagents/filtrerHallucinations";
 import { buildSearchTerritoiresSystemPrompt } from "@/server/albert/subagents/searchTerritoiresSystemPrompt";
 import type {
   GetTerritoiresIdentiteQuery,
@@ -83,16 +84,15 @@ Le tool retourne au maximum 10 territoires triés par pertinence, avec leur code
 
         const territoiresByCode = new Map(territoires.map((t) => [t.code, t]));
 
-        const resultats = output.territoires
-          .filter((t) => territoiresByCode.has(t.code))
-          .map((t) => {
-            const referenceTerritoire = territoiresByCode.get(t.code);
-            return {
-              code: t.code,
-              nom: referenceTerritoire?.nom ?? t.nom,
-              maille: referenceTerritoire?.maille ?? t.maille,
-            };
-          });
+        const resultats = filtrerHallucinations({
+          items: output.territoires,
+          references: territoiresByCode,
+          getId: (t) => t.code,
+        }).map((t) => ({
+          code: t.code,
+          nom: t.nom,
+          maille: t.maille,
+        }));
 
         return {
           territoires: resultats,

--- a/apps/pilote-ppg/src/server/chantiers/module.ts
+++ b/apps/pilote-ppg/src/server/chantiers/module.ts
@@ -53,6 +53,7 @@ import { GetSituationChantierQuery } from "./infrastructure/queries/GetSituation
 import { GetChantiersQuery } from "./query/GetChantiersQuery";
 import { GetChantierIndicateursQuery } from "./query/GetChantierIndicateursQuery";
 import { GetChantierCommentairesQuery } from "./query/GetChantierCommentairesQuery";
+import { GetChantiersIdentiteQuery } from "./query/GetChantiersIdentiteQuery";
 import { RecupererTauxAvancementTerritoireQuery } from "./query/RecupererTauxAvancementTerritoireQuery";
 import { RecupererStatistiquesAvancementTousChantiersPubliesQuery } from "./query/RecupererStatistiquesAvancementTousChantiersPubliesQuery";
 import { GetChantiersHabilitesQuery } from "./infrastructure/queries/GetChantiersHabilitesQuery";
@@ -63,6 +64,7 @@ type ChantierExports = {
   getChantiersQuery: GetChantiersQuery;
   getChantierIndicateursQuery: GetChantierIndicateursQuery;
   getChantierCommentairesQuery: GetChantierCommentairesQuery;
+  getChantiersIdentiteQuery: GetChantiersIdentiteQuery;
 };
 
 type ChantierImports = IndicateurTerritoireValeurEvenementExports &
@@ -126,6 +128,7 @@ export const chantiersModule = defineModule<ChantierExports, ChantierCradle>()({
     "getChantiersQuery",
     "getChantierIndicateursQuery",
     "getChantierCommentairesQuery",
+    "getChantiersIdentiteQuery",
   ],
   register: (container, { asModuleClass }) => {
     container.register({
@@ -223,6 +226,7 @@ export const chantiersModule = defineModule<ChantierExports, ChantierCradle>()({
       getChantiersQuery: asModuleClass(GetChantiersQuery),
       getChantierIndicateursQuery: asModuleClass(GetChantierIndicateursQuery),
       getChantierCommentairesQuery: asModuleClass(GetChantierCommentairesQuery),
+      getChantiersIdentiteQuery: asModuleClass(GetChantiersIdentiteQuery),
       recupererTauxAvancementTerritoireQuery: asModuleClass(
         RecupererTauxAvancementTerritoireQuery,
       ),

--- a/apps/pilote-ppg/src/server/chantiers/module.ts
+++ b/apps/pilote-ppg/src/server/chantiers/module.ts
@@ -54,6 +54,8 @@ import { GetChantiersQuery } from "./query/GetChantiersQuery";
 import { GetChantierIndicateursQuery } from "./query/GetChantierIndicateursQuery";
 import { GetChantierCommentairesQuery } from "./query/GetChantierCommentairesQuery";
 import { GetChantiersIdentiteQuery } from "./query/GetChantiersIdentiteQuery";
+import { GetIndicateursIdentiteQuery } from "./query/GetIndicateursIdentiteQuery";
+import { GetTerritoiresIdentiteQuery } from "./query/GetTerritoiresIdentiteQuery";
 import { RecupererTauxAvancementTerritoireQuery } from "./query/RecupererTauxAvancementTerritoireQuery";
 import { RecupererStatistiquesAvancementTousChantiersPubliesQuery } from "./query/RecupererStatistiquesAvancementTousChantiersPubliesQuery";
 import { GetChantiersHabilitesQuery } from "./infrastructure/queries/GetChantiersHabilitesQuery";
@@ -65,6 +67,8 @@ type ChantierExports = {
   getChantierIndicateursQuery: GetChantierIndicateursQuery;
   getChantierCommentairesQuery: GetChantierCommentairesQuery;
   getChantiersIdentiteQuery: GetChantiersIdentiteQuery;
+  getIndicateursIdentiteQuery: GetIndicateursIdentiteQuery;
+  getTerritoiresIdentiteQuery: GetTerritoiresIdentiteQuery;
 };
 
 type ChantierImports = IndicateurTerritoireValeurEvenementExports &
@@ -129,6 +133,8 @@ export const chantiersModule = defineModule<ChantierExports, ChantierCradle>()({
     "getChantierIndicateursQuery",
     "getChantierCommentairesQuery",
     "getChantiersIdentiteQuery",
+    "getIndicateursIdentiteQuery",
+    "getTerritoiresIdentiteQuery",
   ],
   register: (container, { asModuleClass }) => {
     container.register({
@@ -227,6 +233,8 @@ export const chantiersModule = defineModule<ChantierExports, ChantierCradle>()({
       getChantierIndicateursQuery: asModuleClass(GetChantierIndicateursQuery),
       getChantierCommentairesQuery: asModuleClass(GetChantierCommentairesQuery),
       getChantiersIdentiteQuery: asModuleClass(GetChantiersIdentiteQuery),
+      getIndicateursIdentiteQuery: asModuleClass(GetIndicateursIdentiteQuery),
+      getTerritoiresIdentiteQuery: asModuleClass(GetTerritoiresIdentiteQuery),
       recupererTauxAvancementTerritoireQuery: asModuleClass(
         RecupererTauxAvancementTerritoireQuery,
       ),

--- a/apps/pilote-ppg/src/server/chantiers/query/GetChantiersIdentiteQuery.ts
+++ b/apps/pilote-ppg/src/server/chantiers/query/GetChantiersIdentiteQuery.ts
@@ -1,0 +1,42 @@
+import { $Enums } from "@prisma/client";
+import { PrismaPilote } from "@/server/db/PrismaPilote";
+
+export type ChantierIdentiteResult = {
+  id: string;
+  nom: string;
+  axe: string;
+  ppg: string;
+  ministeres: string[];
+};
+
+export type GetChantiersIdentiteParams = {
+  chantierIds?: string[];
+};
+
+export class GetChantiersIdentiteQuery {
+  constructor(private readonly deps: { prisma: PrismaPilote }) {}
+
+  async execute(
+    params: GetChantiersIdentiteParams = {},
+  ): Promise<ChantierIdentiteResult[]> {
+    const prisma = this.deps.prisma.getInstance();
+
+    const chantiers = await prisma.chantier_identite.findMany({
+      where: {
+        statut: $Enums.type_statut.PUBLIE,
+        ...(params.chantierIds !== undefined
+          ? { id: { in: params.chantierIds } }
+          : {}),
+      },
+      orderBy: { id: "asc" },
+    });
+
+    return chantiers.map((chantier) => ({
+      id: chantier.id,
+      nom: chantier.nom,
+      axe: chantier.axe,
+      ppg: chantier.ppg,
+      ministeres: chantier.ministeres,
+    }));
+  }
+}

--- a/apps/pilote-ppg/src/server/chantiers/query/GetIndicateursIdentiteQuery.ts
+++ b/apps/pilote-ppg/src/server/chantiers/query/GetIndicateursIdentiteQuery.ts
@@ -1,0 +1,54 @@
+import { $Enums } from "@prisma/client";
+import { PrismaPilote } from "@/server/db/PrismaPilote";
+
+export type IndicateurIdentiteResult = {
+  id: string;
+  nom: string;
+  description: string | null;
+  type_nom: string | null;
+  est_barometre: boolean;
+  est_phare: boolean;
+  chantier: {
+    id: string;
+    nom: string;
+  };
+};
+
+export type GetIndicateursIdentiteParams = {
+  chantierIds?: string[];
+};
+
+export class GetIndicateursIdentiteQuery {
+  constructor(private readonly deps: { prisma: PrismaPilote }) {}
+
+  async execute(
+    params: GetIndicateursIdentiteParams = {},
+  ): Promise<IndicateurIdentiteResult[]> {
+    const prisma = this.deps.prisma.getInstance();
+
+    const indicateurs = await prisma.indicateur_identite.findMany({
+      where: {
+        statut: $Enums.type_statut_indicateur.PUBLIE,
+        chantier_identite: { statut: $Enums.type_statut.PUBLIE },
+        ...(params.chantierIds !== undefined
+          ? { chantier_id: { in: params.chantierIds } }
+          : {}),
+      },
+      include: { chantier_identite: true },
+      orderBy: [{ chantier_id: "asc" }, { id: "asc" }],
+    });
+
+    return indicateurs.map((indicateur) => ({
+      id: indicateur.id,
+      nom: indicateur.nom,
+      description: indicateur.description,
+      type_nom: indicateur.type_nom,
+      est_barometre: indicateur.est_barometre ?? false,
+      est_phare: indicateur.est_phare ?? false,
+      chantier: {
+        id: indicateur.chantier_identite.id,
+        nom: indicateur.chantier_identite.nom,
+      },
+    }));
+  }
+}

--- a/apps/pilote-ppg/src/server/chantiers/query/GetIndicateursIdentiteQuery.ts
+++ b/apps/pilote-ppg/src/server/chantiers/query/GetIndicateursIdentiteQuery.ts
@@ -6,7 +6,6 @@ export type IndicateurIdentiteResult = {
   nom: string;
   description: string | null;
   type_nom: string | null;
-  est_barometre: boolean;
   est_phare: boolean;
   chantier: {
     id: string;
@@ -43,7 +42,6 @@ export class GetIndicateursIdentiteQuery {
       nom: indicateur.nom,
       description: indicateur.description,
       type_nom: indicateur.type_nom,
-      est_barometre: indicateur.est_barometre ?? false,
       est_phare: indicateur.est_phare ?? false,
       chantier: {
         id: indicateur.chantier_identite.id,

--- a/apps/pilote-ppg/src/server/chantiers/query/GetTerritoiresIdentiteQuery.ts
+++ b/apps/pilote-ppg/src/server/chantiers/query/GetTerritoiresIdentiteQuery.ts
@@ -1,0 +1,28 @@
+import type { Maille } from "@prisma/client";
+import { PrismaPilote } from "@/server/db/PrismaPilote";
+
+export type TerritoireIdentiteResult = {
+  code: string;
+  nom: string;
+  maille: Maille;
+  code_parent: string | null;
+};
+
+export class GetTerritoiresIdentiteQuery {
+  constructor(private readonly deps: { prisma: PrismaPilote }) {}
+
+  async execute(): Promise<TerritoireIdentiteResult[]> {
+    const prisma = this.deps.prisma.getInstance();
+
+    const territoires = await prisma.territoire.findMany({
+      orderBy: { code: "asc" },
+    });
+
+    return territoires.map((territoire) => ({
+      code: territoire.code,
+      nom: territoire.nom,
+      maille: territoire.maille,
+      code_parent: territoire.code_parent,
+    }));
+  }
+}


### PR DESCRIPTION
## Contexte

Beaucoup d'utilisateurs ne connaissent pas par cœur les identifiants PILOTE (CH-XXX pour les chantiers, IND-XXX pour les indicateurs, REG-XX/DEPT-XX pour les territoires) et formulent leurs demandes en langage naturel : « les chantiers sur les VSS », « combien de femmes formées », « les départements bretons ». Albert n'arrivait pas à résoudre ces requêtes vers des entités concrètes.

Par ailleurs, le LLM tournait sans `temperature` explicite, donc avec le défaut du provider (≈1.0), ce qui n'est pas adapté à un assistant analytique avec function calling intensif.

## Solution

### 1. Trois nouveaux tools de résolution en langage naturel

`search_chantiers`, `search_indicateurs`, `search_territoires` — tous exposés au LLM principal, suivant le même pattern de sous-agent. Chacun prend une requête en langage naturel et retourne au maximum 10 résultats pertinents (identifiants + libellés courts), triés par pertinence.

### Architecture en sous-agent

Pour chaque tool, l'identification est déléguée à un sous-agent spécialisé via `Albert.generateStructuredOutput` (même pattern que `create_dashboard`) :

1. Le tool charge la liste complète des entités du périmètre accessible
2. Il l'injecte dans le prompt du sous-agent dans un bloc `<chantiers>` / `<indicateurs>` / `<territoires>`
3. Le sous-agent (system prompt dédié, avec heuristiques métier) fait le matching sémantique : déplie les acronymes, scanne les champs pertinents, plafonne à 10
4. Le tool re-valide les identifiants retournés avant de remonter au LLM principal

La liste complète n'est jamais chargée dans le contexte du LLM principal.

### Habilitations

| Tool | Filtrage |
|---|---|
| `search_chantiers` | Pré-filtre BDD + post-validation sur `session.habilitations.lecture.chantiers` |
| `search_indicateurs` | Pré-filtre BDD sur le **chantier parent** de l'indicateur + post-validation. Si `chantier_ids` est passé, intersection avec les chantiers accessibles. |
| `search_territoires` | Pas de filtre — cohérent avec le comportement existant d'Albert qui autorise l'interrogation de tous les territoires (la restriction porte sur les données, pas sur la liste). |

### Workflow d'enchaînement

Le system prompt principal est enrichi : pour chaque tool, si un seul match ressort, Albert enchaîne directement avec l'outil de données pertinent. S'il y en a plusieurs, il les présente à l'utilisateur pour qu'il précise. Si rien ne matche, il invite à reformuler.

`search_indicateurs` accepte un `chantier_ids` optionnel : le LLM principal peut pré-scoper la recherche après un `search_chantiers` réussi, ce qui réduit le contexte du sous-agent et améliore la pertinence.

### UI

Les trois tools sont affichés via `ToolCallIndicator` (même composant que `get_chantiers`), avec leurs propres labels :
- « Recherche des chantiers correspondants »
- « Recherche des indicateurs correspondants »
- « Recherche des territoires correspondants »

### 2. Tuning de la température LLM

- `streamText` (LLM principal, 8 tools dont 3 sous-agents) : `temperature: 0.2` — choix de tool plus fiable, moins d'arguments mal formés, moins de pseudo-code dans le texte
- `generateStructuredOutput` (sous-agents `create_dashboard`, `search_*`) : `temperature: 0` — JSON structured output strict, aucun bénéfice à la randomness

Valeurs alignées sur les recommandations Anthropic/OpenAI pour le tool use et le structured output sur des cas d'analyse factuelle. Constantes nommées en tête de `Albert.ts` pour faciliter l'ajustement après tests réels.

## Test plan

### search_chantiers
- [ ] « les chantiers sur les VSS » → indicateur `search_chantiers` puis enchaînement avec `get_chantiers`
- [ ] « le chantier sur le handicap » → identification correcte
- [ ] CH-XXX explicite → Albert appelle directement `get_chantiers` sans passer par `search_chantiers`

### search_indicateurs
- [ ] « combien de femmes formées » → identification d'un ou plusieurs indicateurs pertinents
- [ ] Après un `search_chantiers` ciblant CH-064, « l'indicateur de prévention » → `search_indicateurs` est appelé avec `chantier_ids: ['CH-064']`
- [ ] Vérifier qu'un user sans habilitations sur un chantier ne récupère aucun de ses indicateurs

### search_territoires
- [ ] « la Normandie » → REG-28
- [ ] « le 75 » → DEPT-75
- [ ] « les départements bretons » → 4 départements bretons
- [ ] « les DOM » → départements et régions ultramarins
- [ ] NAT-FR / REG-XX / DEPT-XX explicite → pas d'appel à `search_territoires`

### Température
- [ ] Vérifier qualitativement que les tool calls sont plus fiables (moins d'arguments incohérents, moins de pseudo-code dans le texte)
- [ ] Confirmer que les réponses textuelles restent naturelles et pas trop sèches/répétitives