### PR TITLE
chore: passer les sous-domaines de dev sous .modernisation.localhost

### DIFF
--- a/apps/mb-api/.env.example
+++ b/apps/mb-api/.env.example
@@ -1,5 +1,5 @@
 DATABASE_URL=postgresql://postgres:postgres@localhost:5434/postgres
-CORS_ORIGINS=https://mb-webapp.localhost
+CORS_ORIGINS=https://pmb.modernisation.localhost
 OIDC_ISSUER_URL=https://fca.integ01.dev-agentconnect.fr/api/v2
 OIDC_USERINFO_URL=https://fca.integ01.dev-agentconnect.fr/api/v2/userinfo
 OIDC_JWKS_URI=https://fca.integ01.dev-agentconnect.fr/api/v2/jwks

--- a/apps/mb-api/.env.test
+++ b/apps/mb-api/.env.test
@@ -1,5 +1,5 @@
 DATABASE_URL=postgresql://postgres:postgres@localhost:5435/postgres
-CORS_ORIGINS=https://mb-webapp.localhost
+CORS_ORIGINS=https://pmb.modernisation.localhost
 OIDC_ISSUER_URL=https://example.com/api/v2
 OIDC_USERINFO_URL=https://example.com/api/v2/userinfo
 OIDC_JWKS_URI=https://example.com/api/v2/jwks

--- a/apps/mb-api/package.json
+++ b/apps/mb-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pilote/mb-api",
-  "portless": "mb-api",
+  "portless": "pmb-api.modernisation",
   "version": "0.1.0",
   "private": true,
   "type": "module",

--- a/apps/mb-webapp/.env.example
+++ b/apps/mb-webapp/.env.example
@@ -1,13 +1,13 @@
-VITE_API_URL=https://mb-api.localhost
+VITE_API_URL=https://pmb-api.modernisation.localhost
 # URL de mb-api côté serveur (peut différer de VITE_API_URL en prod, ex: http://mb-api:3000 sur réseau interne)
-API_BASE_URL=https://mb-api.localhost
+API_BASE_URL=https://pmb-api.modernisation.localhost
 
 # BFF (server-side only)
 OIDC_ISSUER_URL=https://fca.integ01.dev-agentconnect.fr/api/v2
 OIDC_CLIENT_ID=4ce2e36ceeb69c4a9ede20b52bad46470bc95bfaf5fdf0afedd9815e336d52da
 OIDC_CLIENT_SECRET=
-OIDC_REDIRECT_URI=https://mb-webapp.localhost/auth/callback
-OIDC_POST_LOGOUT_REDIRECT_URI=https://mb-webapp.localhost/
+OIDC_REDIRECT_URI=https://pmb.modernisation.localhost/auth/callback
+OIDC_POST_LOGOUT_REDIRECT_URI=https://pmb.modernisation.localhost/
 SESSION_SECRET=
-PUBLIC_BASE_URL=https://mb-webapp.localhost
+PUBLIC_BASE_URL=https://pmb.modernisation.localhost
 LOG_LEVEL=info

--- a/apps/mb-webapp/.env.test
+++ b/apps/mb-webapp/.env.test
@@ -1,1 +1,1 @@
-VITE_API_URL=https://mb-api.localhost
+VITE_API_URL=https://pmb-api.modernisation.localhost

--- a/apps/mb-webapp/package.json
+++ b/apps/mb-webapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pilote/mb-webapp",
-  "portless": "mb-webapp",
+  "portless": "pmb.modernisation",
   "version": "0.1.0",
   "private": true,
   "type": "module",

--- a/apps/pilote-ppg/.env.example
+++ b/apps/pilote-ppg/.env.example
@@ -8,7 +8,7 @@
 # Misc
 ## 
 
-NEXTAUTH_URL=http://localhost:3000 # ou http://pilote.localhost avec Traefik
+NEXTAUTH_URL=http://localhost:3000 # ou https://pilote.modernisation.localhost avec Traefik
 LOG_LEVEL=info
 
 NEXT_PUBLIC_MATOMO_URL=TBD # Matomo Analytics

--- a/apps/pilote-ppg/next.config.js
+++ b/apps/pilote-ppg/next.config.js
@@ -23,7 +23,10 @@ const nextConfig = {
   outputFileTracingRoot: path.join(__dirname, '../..'),
   bundlePagesRouterDependencies: true,
   pageExtensions: ["js", "jsx", "ts", "tsx", "md", "mdx"],
-  allowedDevOrigins: ["*.pilote-ppg.localhost", "pilote-ppg.localhost"],
+  allowedDevOrigins: [
+    "*.pilote.modernisation.localhost",
+    "pilote.modernisation.localhost",
+  ],
   turbopack: {
     rules: {
       "*.yaml": {

--- a/apps/pilote-ppg/package.json
+++ b/apps/pilote-ppg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pilote/ppg",
-  "portless": "pilote-ppg",
+  "portless": "pilote.modernisation",
   "version": "0.1.0",
   "private": true,
   "packageManager": "pnpm@10.28.2",
@@ -8,7 +8,7 @@
     "node": "24.9.0"
   },
   "scripts": {
-    "dev": "portless ${PORTLESS_NAME:-}pilote-ppg next dev",
+    "dev": "portless ${PORTLESS_NAME:-}pilote.modernisation next dev",
     "deploy:prepare": "bash deploy-prepare.sh",
     "build": "prisma generate && bash scripts/clone_centre_aide.sh && next build && pnpm exec pagefind --site .next/server/app --output-path public/_pagefind && node copy-assets.js && prisma migrate deploy && prisma db seed",
     "build:dev": "prisma generate && next build && pnpm exec pagefind --site .next/server/app --output-path public/_pagefind && node copy-assets.js && prisma migrate deploy && prisma db seed",


### PR DESCRIPTION
## Summary

- Aligne les apps locales sur la convention cible : sous-domaines `*.modernisation.localhost`
  - `mb-webapp.localhost` → `pmb.modernisation.localhost`
  - `mb-api.localhost` → `pmb-api.modernisation.localhost`
  - `pilote-ppg.localhost` → `pilote.modernisation.localhost`
- Maj des `.env.example` / `.env.test` (mb-api, mb-webapp, pilote-ppg), de la clé `portless` dans les `package.json`, et de `allowedDevOrigins` dans `apps/pilote-ppg/next.config.js`.
- Pas de changement applicatif : portless tunnellise les nouveaux hosts automatiquement, les certs sont régénérés au premier `pnpm dev`.

## Action côté équipe après merge

Mettre à jour son `.env` local (les anciens hosts ne seront plus servis par portless) :
- `apps/mb-webapp/.env` : `VITE_API_URL`, `API_BASE_URL`, `OIDC_REDIRECT_URI`, `OIDC_POST_LOGOUT_REDIRECT_URI`, `PUBLIC_BASE_URL`
- `apps/mb-api/.env` : `CORS_ORIGINS`
- `apps/pilote-ppg/.env` : `NEXTAUTH_URL` / `BASE_URL` si pointés sur l'ancien sous-domaine

Si flow OIDC testé en local, vérifier que les nouvelles redirect URIs sont whitelistées côté provider.

## Test plan

- [ ] `pnpm dev` sur `mb-api` → accessible sur `https://pmb-api.modernisation.localhost`
- [ ] `pnpm dev` sur `mb-webapp` → accessible sur `https://pmb.modernisation.localhost`, appels API OK
- [ ] `pnpm dev` sur `pilote-ppg` → accessible sur `https://pilote.modernisation.localhost`
- [ ] Flow login OIDC bout-en-bout sur mb-webapp

🤖 Generated with [Claude Code](https://claude.com/claude-code)