### PR TITLE
feat(auth): SSO automatique PPG → PMB via cookie pmb-ppg (PIL-1603)

### DIFF
--- a/apps/mb-webapp/src/main.tsx
+++ b/apps/mb-webapp/src/main.tsx
@@ -29,7 +29,18 @@ declare module '@tanstack/react-router' {
 
 const root = createRoot(rootElement)
 
+const hasPpgCookie = () => document.cookie.split(';').some((c) => c.trim().startsWith('pmb-ppg='))
+
 void auth.bootstrap().then(() => {
+  if (!auth.isAuthenticated && hasPpgCookie()) {
+    const params = new URLSearchParams({
+      provider: 'keycloak',
+      redirect: location.pathname + location.search + location.hash,
+    })
+    window.location.assign(`/auth/login?${params.toString()}`)
+    return
+  }
+
   root.render(
     <StrictMode>
       <QueryClientProvider client={queryClient}>

--- a/apps/pilote-ppg/next.config.js
+++ b/apps/pilote-ppg/next.config.js
@@ -20,7 +20,7 @@ if (hasSubmodule) {
 const nextConfig = {
   reactStrictMode: true,
   output: "standalone",
-  outputFileTracingRoot: path.join(__dirname, '../..'),
+  outputFileTracingRoot: path.join(__dirname, "../.."),
   bundlePagesRouterDependencies: true,
   pageExtensions: ["js", "jsx", "ts", "tsx", "md", "mdx"],
   allowedDevOrigins: [

--- a/apps/pilote-ppg/src/client/components/_commons/MiseEnPage/EnTete/Utilisateur/Utilisateur.tsx
+++ b/apps/pilote-ppg/src/client/components/_commons/MiseEnPage/EnTete/Utilisateur/Utilisateur.tsx
@@ -10,6 +10,7 @@ import { Dropdown } from "@/components/shared/Dropdown";
 import { useProfilUtilisateurConnecte } from "@/client/hooks/useProfilUtilisateurConnecte";
 import { useEnv } from "@/client/hooks/useEnv";
 import { Settings1Icon } from "@/components/_commons/Icones/Settings1Icon";
+import { ExternalLink1Icon } from "@/components/_commons/Icones/ExternalLink1Icon";
 import { ProfilEnum } from "@/server/app/enum/profil.enum";
 
 const peutAccederPanelAdministrateur = (
@@ -74,6 +75,23 @@ export const Utilisateur = () => {
             </Link>
           </Dropdown.Item>
         ) : null}
+
+        <Dropdown.Divider />
+
+        <Dropdown.Item asChild>
+          <button
+            type="button"
+            onClick={() => {
+              document.cookie =
+                "pmb-ppg=true; Domain=.modernisation.localhost; Path=/; Secure; SameSite=Lax";
+              window.location.href =
+                "https://pmb.modernisation.localhost/indicateurs";
+            }}
+          >
+            <Dropdown.Icone icone={ExternalLink1Icon} />
+            Pilote Marque Blanche
+          </button>
+        </Dropdown.Item>
 
         <Dropdown.Divider />
 

--- a/apps/pilote-ppg/src/proxy.ts
+++ b/apps/pilote-ppg/src/proxy.ts
@@ -130,10 +130,13 @@ export async function proxy(request: NextRequest) {
     routesTrpcPubliques.some((route) => pathname.startsWith(route));
 
   if (!estRoutePublique) {
+    const useSecureCookies =
+      process.env.NEXTAUTH_URL?.startsWith("https://") ?? false;
+
     const token = await getToken({
       req: request,
       secret: process.env.NEXTAUTH_SECRET,
-      secureCookie: process.env.NEXTAUTH_URL?.startsWith("https://") ?? false,
+      secureCookie: useSecureCookies,
     });
 
     if (!token) {
@@ -169,7 +172,11 @@ export async function proxy(request: NextRequest) {
               expires: new Date(0),
               path: "/",
               httpOnly: true,
-              secure: process.env.NODE_ENV === "production",
+              // Doit matcher les attributs d'origine : les cookies `__Secure-` exigent Secure,
+              // et NextAuth les pose dès que NEXTAUTH_URL est en https. Sans ça le navigateur
+              // ignore le clear et on tombe en boucle de redirections quand Keycloak révoque
+              // la session (ex. SSO logout depuis une autre app du realm).
+              secure: useSecureCookies,
               sameSite: "lax",
             });
           }


### PR DESCRIPTION
## Summary
- **pilote-ppg** : lien « Pilote Marque Blanche » dans le menu utilisateur — pose un cookie `pmb-ppg=true` sur `.modernisation.localhost` puis redirige vers PMB
- **mb-webapp** : au bootstrap, si non authentifié et cookie `pmb-ppg` présent, lance automatiquement le flow OIDC avec `provider=keycloak`
- **pilote-ppg `proxy.ts`** : fix du clear des cookies `__Secure-authjs.session-token.*` quand Keycloak révoque la session — `secure` doit matcher l'attribut d'origine, sinon le navigateur ignore le clear et on tombe en boucle de redirections (cas typique : SSO logout depuis une autre app du même realm)

## Test plan
- [ ] Depuis pilote-ppg authentifié, cliquer « Pilote Marque Blanche » → arrive sur PMB authentifié sans saisir d'identifiants
- [ ] Le cookie `pmb-ppg` n'a pas d'effet quand l'utilisateur est déjà authentifié côté PMB
- [ ] Si Keycloak n'a pas de session active, fallback gracieux sur l'écran de login Keycloak
- [ ] Pas de boucle de redirection
- [ ] Après un logout PMB (SSO end-session Keycloak), retour sur pilote-ppg : la session révoquée est correctement nettoyée → page d'accueil sans boucle

🤖 Generated with [Claude Code](https://claude.com/claude-code)