### PR TITLE
[DITP-pilotage/pilote-2] bugfix: supprime les flaky deadlock des test…

### DIFF
--- a/apps/mb-api/src/indicateur/commands/upsertIndicateur.test.ts
+++ b/apps/mb-api/src/indicateur/commands/upsertIndicateur.test.ts
@@ -5,7 +5,7 @@ import { db } from '@/framework/persistence/dbStore'
 import { upsertIndicateur } from '@/indicateur/commands/upsertIndicateur'
 import { fixtures } from '@/test/fixtures'
 import { integrationTest } from '@/test/integrationTest'
-import { testIndicateurId } from '@/test/randomIds'
+import { testIndicateurId, testReferentielId } from '@/test/randomIds'
 import { runAsPrincipal } from '@/test/runAsPrincipal'
 
 const getConfigurationsReferentiels = async (publicId: string) => {
@@ -26,9 +26,11 @@ describe.concurrent('upsertIndicateur', () => {
     'crée un indicateur avec ses référentiels configurés et auto-grant READ+WRITE au créateur',
     integrationTest(async () => {
       const indId = testIndicateurId()
+      const refCreateA = testReferentielId()
+      const refCreateB = testReferentielId()
       const apiKey = await fixtures.apiKey()
-      const refA = await fixtures.referentiel({ publicId: 'REF-CREATE-A' })
-      const refB = await fixtures.referentiel({ publicId: 'REF-CREATE-B' })
+      const refA = await fixtures.referentiel({ publicId: refCreateA })
+      const refB = await fixtures.referentiel({ publicId: refCreateB })
 
       const result = await runAsPrincipal(apiKey.id, () =>
         upsertIndicateur(indId, {
@@ -43,10 +45,11 @@ describe.concurrent('upsertIndicateur', () => {
       )
 
       expect(result.isOk()).toBe(true)
-      expect(await getConfigurationsReferentiels(indId)).toEqual([
-        { referentielPublicId: 'REF-CREATE-A', fonctionAgregation: 'SUM' },
-        { referentielPublicId: 'REF-CREATE-B', fonctionAgregation: 'NONE' },
-      ])
+      const configurationsTriees = [
+        { referentielPublicId: refCreateA, fonctionAgregation: 'SUM' as const },
+        { referentielPublicId: refCreateB, fonctionAgregation: 'NONE' as const },
+      ].sort((a, b) => a.referentielPublicId.localeCompare(b.referentielPublicId))
+      expect(await getConfigurationsReferentiels(indId)).toEqual(configurationsTriees)
       const grants = await db().indicateurPermission.findMany({
         where: { principalId: apiKey.id, indicateur: { publicId: indId } },
         orderBy: { action: 'asc' },
@@ -133,10 +136,13 @@ describe.concurrent('upsertIndicateur', () => {
     "remplace l'ensemble des configurations à chaque PUT (ajout + suppression)",
     integrationTest(async () => {
       const indId = testIndicateurId()
+      const refReplaceA = testReferentielId()
+      const refReplaceB = testReferentielId()
+      const refReplaceC = testReferentielId()
       await fixtures.referentiel(
-        { publicId: 'REF-REPLACE-A' },
-        { publicId: 'REF-REPLACE-B' },
-        { publicId: 'REF-REPLACE-C' },
+        { publicId: refReplaceA },
+        { publicId: refReplaceB },
+        { publicId: refReplaceC },
       )
       const apiKey = await fixtures.apiKey()
       await runAsPrincipal(apiKey.id, () =>
@@ -145,8 +151,8 @@ describe.concurrent('upsertIndicateur', () => {
           visibilite: 'PRIVE',
           unite: null,
           referentiels: [
-            { referentielPublicId: 'REF-REPLACE-A', fonctionAgregation: 'SUM' },
-            { referentielPublicId: 'REF-REPLACE-B', fonctionAgregation: 'SUM' },
+            { referentielPublicId: refReplaceA, fonctionAgregation: 'SUM' },
+            { referentielPublicId: refReplaceB, fonctionAgregation: 'SUM' },
           ],
         }),
       )
@@ -157,16 +163,17 @@ describe.concurrent('upsertIndicateur', () => {
           visibilite: 'PRIVE',
           unite: null,
           referentiels: [
-            { referentielPublicId: 'REF-REPLACE-B', fonctionAgregation: 'SUM' },
-            { referentielPublicId: 'REF-REPLACE-C', fonctionAgregation: 'SUM' },
+            { referentielPublicId: refReplaceB, fonctionAgregation: 'SUM' },
+            { referentielPublicId: refReplaceC, fonctionAgregation: 'SUM' },
           ],
         }),
       )
 
-      expect(await getConfigurationsReferentiels(indId)).toEqual([
-        { referentielPublicId: 'REF-REPLACE-B', fonctionAgregation: 'SUM' },
-        { referentielPublicId: 'REF-REPLACE-C', fonctionAgregation: 'SUM' },
-      ])
+      const configurationsTriees = [
+        { referentielPublicId: refReplaceB, fonctionAgregation: 'SUM' as const },
+        { referentielPublicId: refReplaceC, fonctionAgregation: 'SUM' as const },
+      ].sort((a, b) => a.referentielPublicId.localeCompare(b.referentielPublicId))
+      expect(await getConfigurationsReferentiels(indId)).toEqual(configurationsTriees)
     }),
   )
 
@@ -174,14 +181,15 @@ describe.concurrent('upsertIndicateur', () => {
     'accepte un tableau vide (supprime toutes les configurations)',
     integrationTest(async () => {
       const indId = testIndicateurId()
-      await fixtures.referentiel({ publicId: 'REF-EMPTY-A' })
+      const refEmptyA = testReferentielId()
+      await fixtures.referentiel({ publicId: refEmptyA })
       const apiKey = await fixtures.apiKey()
       await runAsPrincipal(apiKey.id, () =>
         upsertIndicateur(indId, {
           nom: 'I',
           visibilite: 'PRIVE',
           unite: null,
-          referentiels: [{ referentielPublicId: 'REF-EMPTY-A', fonctionAgregation: 'SUM' }],
+          referentiels: [{ referentielPublicId: refEmptyA, fonctionAgregation: 'SUM' }],
         }),
       )
 
@@ -197,7 +205,8 @@ describe.concurrent('upsertIndicateur', () => {
     'dédoublonne silencieusement les referentielPublicId en double',
     integrationTest(async () => {
       const indId = testIndicateurId()
-      await fixtures.referentiel({ publicId: 'REF-DEDUP-A' })
+      const refDedupA = testReferentielId()
+      await fixtures.referentiel({ publicId: refDedupA })
       const apiKey = await fixtures.apiKey()
 
       const result = await runAsPrincipal(apiKey.id, () =>
@@ -206,15 +215,15 @@ describe.concurrent('upsertIndicateur', () => {
           visibilite: 'PRIVE',
           unite: null,
           referentiels: [
-            { referentielPublicId: 'REF-DEDUP-A', fonctionAgregation: 'SUM' },
-            { referentielPublicId: 'REF-DEDUP-A', fonctionAgregation: 'SUM' },
+            { referentielPublicId: refDedupA, fonctionAgregation: 'SUM' },
+            { referentielPublicId: refDedupA, fonctionAgregation: 'SUM' },
           ],
         }),
       )
 
       expect(result.isOk()).toBe(true)
       expect(await getConfigurationsReferentiels(indId)).toEqual([
-        { referentielPublicId: 'REF-DEDUP-A', fonctionAgregation: 'SUM' },
+        { referentielPublicId: refDedupA, fonctionAgregation: 'SUM' },
       ])
     }),
   )
@@ -223,7 +232,10 @@ describe.concurrent('upsertIndicateur', () => {
     'rejette quand un referentielPublicId est inconnu, avec la liste des IDs manquants',
     integrationTest(async () => {
       const indId = testIndicateurId()
-      await fixtures.referentiel({ publicId: 'REF-UNKNOWN-A' })
+      const refKnownA = testReferentielId()
+      const refUnknownX = testReferentielId()
+      const refUnknownY = testReferentielId()
+      await fixtures.referentiel({ publicId: refKnownA })
       const apiKey = await fixtures.apiKey()
 
       await expect(
@@ -233,15 +245,15 @@ describe.concurrent('upsertIndicateur', () => {
             visibilite: 'PRIVE',
             unite: null,
             referentiels: [
-              { referentielPublicId: 'REF-UNKNOWN-A', fonctionAgregation: 'SUM' },
-              { referentielPublicId: 'REF-UNKNOWN-X', fonctionAgregation: 'SUM' },
-              { referentielPublicId: 'REF-UNKNOWN-Y', fonctionAgregation: 'SUM' },
+              { referentielPublicId: refKnownA, fonctionAgregation: 'SUM' },
+              { referentielPublicId: refUnknownX, fonctionAgregation: 'SUM' },
+              { referentielPublicId: refUnknownY, fonctionAgregation: 'SUM' },
             ],
           }),
         ),
       ).rejects.toMatchObject({
         constructor: ValidationError,
-        details: { unknownReferentielIds: ['REF-UNKNOWN-X', 'REF-UNKNOWN-Y'] },
+        details: { unknownReferentielIds: [refUnknownX, refUnknownY].sort() },
       })
 
       const created = await db().indicateur.findUnique({ where: { publicId: indId } })
@@ -270,7 +282,8 @@ describe.concurrent('upsertIndicateur', () => {
     'met à jour la fonctionAgregation pour une configuration existante',
     integrationTest(async () => {
       const indId = testIndicateurId()
-      await fixtures.referentiel({ publicId: 'REF-UPDATE-A' })
+      const refUpdateA = testReferentielId()
+      await fixtures.referentiel({ publicId: refUpdateA })
       const apiKey = await fixtures.apiKey()
 
       await runAsPrincipal(apiKey.id, () =>
@@ -278,7 +291,7 @@ describe.concurrent('upsertIndicateur', () => {
           nom: 'I',
           visibilite: 'PRIVE',
           unite: null,
-          referentiels: [{ referentielPublicId: 'REF-UPDATE-A', fonctionAgregation: 'SUM' }],
+          referentiels: [{ referentielPublicId: refUpdateA, fonctionAgregation: 'SUM' }],
         }),
       )
 
@@ -287,12 +300,12 @@ describe.concurrent('upsertIndicateur', () => {
           nom: 'I',
           visibilite: 'PRIVE',
           unite: null,
-          referentiels: [{ referentielPublicId: 'REF-UPDATE-A', fonctionAgregation: 'NONE' }],
+          referentiels: [{ referentielPublicId: refUpdateA, fonctionAgregation: 'NONE' }],
         }),
       )
 
       expect(await getConfigurationsReferentiels(indId)).toEqual([
-        { referentielPublicId: 'REF-UPDATE-A', fonctionAgregation: 'NONE' },
+        { referentielPublicId: refUpdateA, fonctionAgregation: 'NONE' },
       ])
     }),
   )
@@ -301,7 +314,8 @@ describe.concurrent('upsertIndicateur', () => {
     "dédoublonne sur referentielPublicId : en cas de fonctions différentes, la dernière l'emporte",
     integrationTest(async () => {
       const indId = testIndicateurId()
-      await fixtures.referentiel({ publicId: 'REF-DEDUP-FN' })
+      const refDedupFn = testReferentielId()
+      await fixtures.referentiel({ publicId: refDedupFn })
       const apiKey = await fixtures.apiKey()
 
       const result = await runAsPrincipal(apiKey.id, () =>
@@ -310,15 +324,15 @@ describe.concurrent('upsertIndicateur', () => {
           visibilite: 'PRIVE',
           unite: null,
           referentiels: [
-            { referentielPublicId: 'REF-DEDUP-FN', fonctionAgregation: 'SUM' },
-            { referentielPublicId: 'REF-DEDUP-FN', fonctionAgregation: 'NONE' },
+            { referentielPublicId: refDedupFn, fonctionAgregation: 'SUM' },
+            { referentielPublicId: refDedupFn, fonctionAgregation: 'NONE' },
           ],
         }),
       )
 
       expect(result.isOk()).toBe(true)
       expect(await getConfigurationsReferentiels(indId)).toEqual([
-        { referentielPublicId: 'REF-DEDUP-FN', fonctionAgregation: 'NONE' },
+        { referentielPublicId: refDedupFn, fonctionAgregation: 'NONE' },
       ])
     }),
   )

--- a/apps/mb-api/src/indicateur/permissions.test.ts
+++ b/apps/mb-api/src/indicateur/permissions.test.ts
@@ -7,7 +7,7 @@ import {
 } from '@/indicateur/permissions'
 import { fixtures } from '@/test/fixtures'
 import { integrationTest } from '@/test/integrationTest'
-import { testIndicateurIds } from '@/test/randomIds'
+import { testIndicateurIds, testPanierId } from '@/test/randomIds'
 
 const listIndicateursWithReadPermission = async (principalId: string) =>
   db().indicateur.findMany({
@@ -77,14 +77,15 @@ describe.concurrent('withIndicateurReadPermission', () => {
     'propage READ depuis un panier (action READ sur le panier)',
     integrationTest(async () => {
       const [viaPanier] = testIndicateurIds(1)
+      const panRpropR = testPanierId()
       await fixtures.indicateur({ publicId: viaPanier, visibilite: 'PRIVE' })
       await fixtures.panier({
-        publicId: 'PAN-PERM-RPROP-R',
+        publicId: panRpropR,
         visibilite: 'PRIVE',
         indicateurs: [{ publicId: viaPanier }],
       })
       const apiKey = await fixtures.apiKey({
-        panierPermissions: [{ panier: { publicId: 'PAN-PERM-RPROP-R' }, action: 'READ' }],
+        panierPermissions: [{ panier: { publicId: panRpropR }, action: 'READ' }],
       })
 
       const rows = await listIndicateursWithReadPermission(apiKey.id)
@@ -97,14 +98,15 @@ describe.concurrent('withIndicateurReadPermission', () => {
     'propage READ depuis un panier (action WRITE sur le panier)',
     integrationTest(async () => {
       const [viaPanier] = testIndicateurIds(1)
+      const panRpropW = testPanierId()
       await fixtures.indicateur({ publicId: viaPanier, visibilite: 'PRIVE' })
       await fixtures.panier({
-        publicId: 'PAN-PERM-RPROP-W',
+        publicId: panRpropW,
         visibilite: 'PRIVE',
         indicateurs: [{ publicId: viaPanier }],
       })
       const apiKey = await fixtures.apiKey({
-        panierPermissions: [{ panier: { publicId: 'PAN-PERM-RPROP-W' }, action: 'WRITE' }],
+        panierPermissions: [{ panier: { publicId: panRpropW }, action: 'WRITE' }],
       })
 
       const rows = await listIndicateursWithReadPermission(apiKey.id)
@@ -117,9 +119,10 @@ describe.concurrent('withIndicateurReadPermission', () => {
     "ne propage rien depuis un panier auquel le principal n'a pas accès",
     integrationTest(async () => {
       const [hidden] = testIndicateurIds(1)
+      const panRpropNone = testPanierId()
       await fixtures.indicateur({ publicId: hidden, visibilite: 'PRIVE' })
       await fixtures.panier({
-        publicId: 'PAN-PERM-RPROP-NONE',
+        publicId: panRpropNone,
         visibilite: 'PRIVE',
         indicateurs: [{ publicId: hidden }],
       })
@@ -208,14 +211,15 @@ describe.concurrent('ensureIndicateurWritePermission', () => {
     "rejette même si le principal a WRITE sur un panier qui contient l'indicateur (WRITE indicateur reste direct, pas de propagation)",
     integrationTest(async () => {
       const [viaPanier] = testIndicateurIds(1)
+      const panWpropNo = testPanierId()
       const indicateur = await fixtures.indicateur({ publicId: viaPanier, visibilite: 'PRIVE' })
       await fixtures.panier({
-        publicId: 'PAN-PERM-WPROP-NO',
+        publicId: panWpropNo,
         visibilite: 'PRIVE',
         indicateurs: [{ publicId: viaPanier }],
       })
       const apiKey = await fixtures.apiKey({
-        panierPermissions: [{ panier: { publicId: 'PAN-PERM-WPROP-NO' }, action: 'WRITE' }],
+        panierPermissions: [{ panier: { publicId: panWpropNo }, action: 'WRITE' }],
       })
 
       await expect(

--- a/apps/mb-api/src/indicateur/queries/getIndicateurByPublicId.test.ts
+++ b/apps/mb-api/src/indicateur/queries/getIndicateurByPublicId.test.ts
@@ -4,7 +4,7 @@ import { db } from '@/framework/persistence/dbStore'
 import { getIndicateurByPublicId } from '@/indicateur/queries/getIndicateurByPublicId'
 import { fixtures } from '@/test/fixtures'
 import { integrationTest } from '@/test/integrationTest'
-import { testIndicateurId } from '@/test/randomIds'
+import { testIndicateurId, testReferentielId } from '@/test/randomIds'
 import { runAsPrincipal } from '@/test/runAsPrincipal'
 
 describe.concurrent('getIndicateurByPublicId', () => {
@@ -12,15 +12,17 @@ describe.concurrent('getIndicateurByPublicId', () => {
     "retourne l'indicateur avec ses référentiels liés triés par publicId",
     integrationTest(async () => {
       const indId = testIndicateurId()
+      const refDetailA = testReferentielId()
+      const refDetailB = testReferentielId()
       const indicateur = await fixtures.indicateur({ publicId: indId, nom: 'Indicateur de test' })
-      const [refA, refB] = await fixtures.referentiel(
-        { publicId: 'REF-DETAIL-B' },
-        { publicId: 'REF-DETAIL-A' },
+      const [ref1, ref2] = await fixtures.referentiel(
+        { publicId: refDetailB },
+        { publicId: refDetailA },
       )
       await db().indicateurReferentiel.createMany({
         data: [
-          { indicateurId: indicateur.id, referentielId: refA!.id, fonctionAgregation: 'SUM' },
-          { indicateurId: indicateur.id, referentielId: refB!.id, fonctionAgregation: 'SUM' },
+          { indicateurId: indicateur.id, referentielId: ref1!.id, fonctionAgregation: 'SUM' },
+          { indicateurId: indicateur.id, referentielId: ref2!.id, fonctionAgregation: 'SUM' },
         ],
       })
       const apiKey = await fixtures.apiKey({
@@ -29,16 +31,18 @@ describe.concurrent('getIndicateurByPublicId', () => {
 
       const result = await runAsPrincipal(apiKey.id, () => getIndicateurByPublicId(indId))
 
+      const referentielsTries = [
+        { referentielPublicId: refDetailA, fonctionAgregation: 'SUM' as const },
+        { referentielPublicId: refDetailB, fonctionAgregation: 'SUM' as const },
+      ].sort((a, b) => a.referentielPublicId.localeCompare(b.referentielPublicId))
+
       expect(result.isOk()).toBe(true)
       expect(result._unsafeUnwrap()).toEqual({
         id: indId,
         nom: 'Indicateur de test',
         visibilite: 'PRIVE',
         unite: null,
-        referentiels: [
-          { referentielPublicId: 'REF-DETAIL-A', fonctionAgregation: 'SUM' },
-          { referentielPublicId: 'REF-DETAIL-B', fonctionAgregation: 'SUM' },
-        ],
+        referentiels: referentielsTries,
         createdAt: indicateur.createdAt.toISOString(),
         updatedAt: indicateur.updatedAt.toISOString(),
       })

--- a/apps/mb-api/src/indicateur/queries/listIndicateurs.test.ts
+++ b/apps/mb-api/src/indicateur/queries/listIndicateurs.test.ts
@@ -5,7 +5,7 @@ import { encodeCursor } from '@/framework/persistence/paginate'
 import { listIndicateurs } from '@/indicateur/queries/listIndicateurs'
 import { fixtures } from '@/test/fixtures'
 import { integrationTest } from '@/test/integrationTest'
-import { testIndicateurIds } from '@/test/randomIds'
+import { testIndicateurIds, testPanierId, testReferentielId } from '@/test/randomIds'
 import { runAsPrincipal } from '@/test/runAsPrincipal'
 
 describe.concurrent('listIndicateurs', () => {
@@ -63,17 +63,18 @@ describe.concurrent('listIndicateurs', () => {
     'propage READ via les permissions panier : un principal qui a accès à un panier voit ses indicateurs PRIVE',
     integrationTest(async () => {
       const [viaPanier, hidden] = testIndicateurIds(2)
+      const panPropag = testPanierId()
       await fixtures.indicateur(
         { publicId: viaPanier, visibilite: 'PRIVE' },
         { publicId: hidden, visibilite: 'PRIVE' },
       )
       await fixtures.panier({
-        publicId: 'PAN-PROPAG-1',
+        publicId: panPropag,
         visibilite: 'PRIVE',
         indicateurs: [{ publicId: viaPanier }],
       })
       const apiKey = await fixtures.apiKey({
-        panierPermissions: [{ panier: { publicId: 'PAN-PROPAG-1' }, action: 'READ' }],
+        panierPermissions: [{ panier: { publicId: panPropag }, action: 'READ' }],
       })
 
       const result = await runAsPrincipal(apiKey.id, () => listIndicateurs({}))
@@ -88,14 +89,15 @@ describe.concurrent('listIndicateurs', () => {
     'la propagation panier → indicateur fonctionne aussi avec WRITE sur le panier',
     integrationTest(async () => {
       const [viaPanier] = testIndicateurIds(1)
+      const panPropag = testPanierId()
       await fixtures.indicateur({ publicId: viaPanier, visibilite: 'PRIVE' })
       await fixtures.panier({
-        publicId: 'PAN-PROPAG-2',
+        publicId: panPropag,
         visibilite: 'PRIVE',
         indicateurs: [{ publicId: viaPanier }],
       })
       const apiKey = await fixtures.apiKey({
-        panierPermissions: [{ panier: { publicId: 'PAN-PROPAG-2' }, action: 'WRITE' }],
+        panierPermissions: [{ panier: { publicId: panPropag }, action: 'WRITE' }],
       })
 
       const result = await runAsPrincipal(apiKey.id, () => listIndicateurs({}))
@@ -292,15 +294,17 @@ describe.concurrent('listIndicateurs', () => {
     'expose referentiels triés par publicId ASC sur chaque item',
     integrationTest(async () => {
       const [accessible] = testIndicateurIds(1)
+      const refListZ = testReferentielId()
+      const refListM = testReferentielId()
       const indicateur = await fixtures.indicateur({ publicId: accessible })
-      const [refA, refB] = await fixtures.referentiel(
-        { publicId: 'REF-LIST-Z' },
-        { publicId: 'REF-LIST-M' },
+      const [ref1, ref2] = await fixtures.referentiel(
+        { publicId: refListZ },
+        { publicId: refListM },
       )
       await db().indicateurReferentiel.createMany({
         data: [
-          { indicateurId: indicateur.id, referentielId: refA!.id, fonctionAgregation: 'SUM' },
-          { indicateurId: indicateur.id, referentielId: refB!.id, fonctionAgregation: 'SUM' },
+          { indicateurId: indicateur.id, referentielId: ref1!.id, fonctionAgregation: 'SUM' },
+          { indicateurId: indicateur.id, referentielId: ref2!.id, fonctionAgregation: 'SUM' },
         ],
       })
       const apiKey = await fixtures.apiKey({
@@ -309,11 +313,13 @@ describe.concurrent('listIndicateurs', () => {
 
       const result = await runAsPrincipal(apiKey.id, () => listIndicateurs({}))
 
+      const referentielsTries = [
+        { referentielPublicId: refListM, fonctionAgregation: 'SUM' as const },
+        { referentielPublicId: refListZ, fonctionAgregation: 'SUM' as const },
+      ].sort((a, b) => a.referentielPublicId.localeCompare(b.referentielPublicId))
+
       const value = result._unsafeUnwrap()
-      expect(value.items.find((i) => i.id === accessible)?.referentiels).toEqual([
-        { referentielPublicId: 'REF-LIST-M', fonctionAgregation: 'SUM' },
-        { referentielPublicId: 'REF-LIST-Z', fonctionAgregation: 'SUM' },
-      ])
+      expect(value.items.find((i) => i.id === accessible)?.referentiels).toEqual(referentielsTries)
     }),
   )
 })

--- a/apps/mb-api/src/individu/queries/getIndividuByPublicId.test.ts
+++ b/apps/mb-api/src/individu/queries/getIndividuByPublicId.test.ts
@@ -3,17 +3,18 @@ import { describe, expect, it } from 'vitest'
 import { getIndividuByPublicId } from '@/individu/queries/getIndividuByPublicId'
 import { fixtures } from '@/test/fixtures'
 import { integrationTest } from '@/test/integrationTest'
-import { testDeptId } from '@/test/randomIds'
+import { testDeptId, testReferentielId } from '@/test/randomIds'
 
 describe.concurrent('getIndividuByPublicId', () => {
   it(
     "retourne l'individu avec son référentiel",
     integrationTest(async () => {
       const deptId = testDeptId()
+      const refDept = testReferentielId()
       await fixtures.individu({
         publicId: deptId,
         nom: 'Vaucluse',
-        referentiel: { publicId: 'REF-DEPT', nom: 'Départements' },
+        referentiel: { publicId: refDept, nom: 'Départements' },
       })
 
       const result = await getIndividuByPublicId(deptId)
@@ -22,7 +23,7 @@ describe.concurrent('getIndividuByPublicId', () => {
       expect(value).toMatchObject({
         id: deptId,
         nom: 'Vaucluse',
-        referentiel: 'REF-DEPT',
+        referentiel: refDept,
       })
     }),
   )
@@ -38,11 +39,12 @@ describe.concurrent('getIndividuByPublicId', () => {
     "expose la metadata libre de l'individu",
     integrationTest(async () => {
       const deptId = testDeptId()
+      const refDept = testReferentielId()
       await fixtures.individu({
         publicId: deptId,
         nom: 'Paris',
         metadata: { codeInsee: '75' },
-        referentiel: { publicId: 'REF-DEPT' },
+        referentiel: { publicId: refDept },
       })
 
       const result = await getIndividuByPublicId(deptId)
@@ -55,9 +57,10 @@ describe.concurrent('getIndividuByPublicId', () => {
     'retourne metadata null quand non renseignée',
     integrationTest(async () => {
       const deptId = testDeptId()
+      const refDept = testReferentielId()
       await fixtures.individu({
         publicId: deptId,
-        referentiel: { publicId: 'REF-DEPT' },
+        referentiel: { publicId: refDept },
       })
 
       const result = await getIndividuByPublicId(deptId)

--- a/apps/mb-api/src/panier/permissions.test.ts
+++ b/apps/mb-api/src/panier/permissions.test.ts
@@ -4,6 +4,7 @@ import { db } from '@/framework/persistence/dbStore'
 import { ensurePanierWritePermission, withPanierReadPermission } from '@/panier/permissions'
 import { fixtures } from '@/test/fixtures'
 import { integrationTest } from '@/test/integrationTest'
+import { testPanierId } from '@/test/randomIds'
 
 const listPaniersWithReadPermission = async (principalId: string) =>
   db().panier.findMany({
@@ -16,78 +17,85 @@ describe.concurrent('withPanierReadPermission', () => {
   it(
     'expose un panier PUBLIC à un principal sans aucune permission',
     integrationTest(async () => {
-      await fixtures.panier({ publicId: 'PAN-W-PUB-001', visibilite: 'PUBLIC' })
+      const panPub = testPanierId()
+      await fixtures.panier({ publicId: panPub, visibilite: 'PUBLIC' })
       const apiKey = await fixtures.apiKey()
 
       const rows = await listPaniersWithReadPermission(apiKey.id)
 
-      expect(rows.map((r) => r.publicId)).toContain('PAN-W-PUB-001')
+      expect(rows.map((r) => r.publicId)).toContain(panPub)
     }),
   )
 
   it(
     'cache un panier PRIVE à un principal sans permission',
     integrationTest(async () => {
-      await fixtures.panier({ publicId: 'PAN-W-PRI-001', visibilite: 'PRIVE' })
+      const panPri = testPanierId()
+      await fixtures.panier({ publicId: panPri, visibilite: 'PRIVE' })
       const apiKey = await fixtures.apiKey()
 
       const rows = await listPaniersWithReadPermission(apiKey.id)
 
-      expect(rows.map((r) => r.publicId)).not.toContain('PAN-W-PRI-001')
+      expect(rows.map((r) => r.publicId)).not.toContain(panPri)
     }),
   )
 
   it(
     'expose un panier PRIVE à un principal avec permission READ directe',
     integrationTest(async () => {
-      await fixtures.panier({ publicId: 'PAN-W-PRI-READ', visibilite: 'PRIVE' })
+      const panPriRead = testPanierId()
+      await fixtures.panier({ publicId: panPriRead, visibilite: 'PRIVE' })
       const apiKey = await fixtures.apiKey({
-        panierPermissions: [{ panier: { publicId: 'PAN-W-PRI-READ' }, action: 'READ' }],
+        panierPermissions: [{ panier: { publicId: panPriRead }, action: 'READ' }],
       })
 
       const rows = await listPaniersWithReadPermission(apiKey.id)
 
-      expect(rows.map((r) => r.publicId)).toContain('PAN-W-PRI-READ')
+      expect(rows.map((r) => r.publicId)).toContain(panPriRead)
     }),
   )
 
   it(
     'expose un panier PRIVE à un principal avec permission WRITE directe (WRITE implique READ)',
     integrationTest(async () => {
-      await fixtures.panier({ publicId: 'PAN-W-PRI-WRITE', visibilite: 'PRIVE' })
+      const panPriWrite = testPanierId()
+      await fixtures.panier({ publicId: panPriWrite, visibilite: 'PRIVE' })
       const apiKey = await fixtures.apiKey({
-        panierPermissions: [{ panier: { publicId: 'PAN-W-PRI-WRITE' }, action: 'WRITE' }],
+        panierPermissions: [{ panier: { publicId: panPriWrite }, action: 'WRITE' }],
       })
 
       const rows = await listPaniersWithReadPermission(apiKey.id)
 
-      expect(rows.map((r) => r.publicId)).toContain('PAN-W-PRI-WRITE')
+      expect(rows.map((r) => r.publicId)).toContain(panPriWrite)
     }),
   )
 
   it(
     'isole les permissions par principal : un panier PRIVE accessible à A reste caché à B',
     integrationTest(async () => {
-      await fixtures.panier({ publicId: 'PAN-W-ISO-001', visibilite: 'PRIVE' })
+      const panIso = testPanierId()
+      await fixtures.panier({ publicId: panIso, visibilite: 'PRIVE' })
       const [a, b] = await fixtures.apiKey(
-        { panierPermissions: [{ panier: { publicId: 'PAN-W-ISO-001' }, action: 'READ' }] },
+        { panierPermissions: [{ panier: { publicId: panIso }, action: 'READ' }] },
         {},
       )
 
       const rowsA = await listPaniersWithReadPermission(a!.id)
       const rowsB = await listPaniersWithReadPermission(b!.id)
 
-      expect(rowsA.map((r) => r.publicId)).toContain('PAN-W-ISO-001')
-      expect(rowsB.map((r) => r.publicId)).not.toContain('PAN-W-ISO-001')
+      expect(rowsA.map((r) => r.publicId)).toContain(panIso)
+      expect(rowsB.map((r) => r.publicId)).not.toContain(panIso)
     }),
   )
 
   it(
     'préserve le where externe (AND avec la clause de permission)',
     integrationTest(async () => {
+      const panAndCible = testPanierId()
+      const panAndAutre = testPanierId()
       await fixtures.panier(
-        { publicId: 'PAN-W-AND-A', nom: 'Cible', visibilite: 'PUBLIC' },
-        { publicId: 'PAN-W-AND-B', nom: 'Autre', visibilite: 'PUBLIC' },
+        { publicId: panAndCible, nom: 'Cible', visibilite: 'PUBLIC' },
+        { publicId: panAndAutre, nom: 'Autre', visibilite: 'PUBLIC' },
       )
       const apiKey = await fixtures.apiKey()
 
@@ -96,7 +104,7 @@ describe.concurrent('withPanierReadPermission', () => {
         select: { publicId: true },
       })
 
-      expect(rows.map((r) => r.publicId)).toEqual(['PAN-W-AND-A'])
+      expect(rows.map((r) => r.publicId)).toEqual([panAndCible])
     }),
   )
 })
@@ -105,9 +113,10 @@ describe.concurrent('ensurePanierWritePermission', () => {
   it(
     'passe quand le principal a la permission WRITE directe',
     integrationTest(async () => {
-      const panier = await fixtures.panier({ publicId: 'PAN-EW-OK', visibilite: 'PRIVE' })
+      const panEwOk = testPanierId()
+      const panier = await fixtures.panier({ publicId: panEwOk, visibilite: 'PRIVE' })
       const apiKey = await fixtures.apiKey({
-        panierPermissions: [{ panier: { publicId: 'PAN-EW-OK' }, action: 'WRITE' }],
+        panierPermissions: [{ panier: { publicId: panEwOk }, action: 'WRITE' }],
       })
 
       const result = await ensurePanierWritePermission({
@@ -122,7 +131,8 @@ describe.concurrent('ensurePanierWritePermission', () => {
   it(
     "rejette quand le principal n'a aucune permission",
     integrationTest(async () => {
-      const panier = await fixtures.panier({ publicId: 'PAN-EW-NONE', visibilite: 'PRIVE' })
+      const panEwNone = testPanierId()
+      const panier = await fixtures.panier({ publicId: panEwNone, visibilite: 'PRIVE' })
       const apiKey = await fixtures.apiKey()
 
       await expect(
@@ -134,9 +144,10 @@ describe.concurrent('ensurePanierWritePermission', () => {
   it(
     "rejette quand le principal n'a que la permission READ (READ n'implique pas WRITE)",
     integrationTest(async () => {
-      const panier = await fixtures.panier({ publicId: 'PAN-EW-RONLY', visibilite: 'PRIVE' })
+      const panEwRonly = testPanierId()
+      const panier = await fixtures.panier({ publicId: panEwRonly, visibilite: 'PRIVE' })
       const apiKey = await fixtures.apiKey({
-        panierPermissions: [{ panier: { publicId: 'PAN-EW-RONLY' }, action: 'READ' }],
+        panierPermissions: [{ panier: { publicId: panEwRonly }, action: 'READ' }],
       })
 
       await expect(
@@ -148,7 +159,8 @@ describe.concurrent('ensurePanierWritePermission', () => {
   it(
     'rejette quand le panier est PUBLIC mais sans permission WRITE explicite (PUBLIC ne couvre que la lecture)',
     integrationTest(async () => {
-      const panier = await fixtures.panier({ publicId: 'PAN-EW-PUB', visibilite: 'PUBLIC' })
+      const panEwPub = testPanierId()
+      const panier = await fixtures.panier({ publicId: panEwPub, visibilite: 'PUBLIC' })
       const apiKey = await fixtures.apiKey()
 
       await expect(

--- a/apps/mb-api/src/panier/queries/getPanierByPublicId.test.ts
+++ b/apps/mb-api/src/panier/queries/getPanierByPublicId.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest'
 import { getPanierByPublicId } from '@/panier/queries/getPanierByPublicId'
 import { fixtures } from '@/test/fixtures'
 import { integrationTest } from '@/test/integrationTest'
-import { testIndicateurIds } from '@/test/randomIds'
+import { testIndicateurIds, testPanierId } from '@/test/randomIds'
 import { runAsPrincipal } from '@/test/runAsPrincipal'
 
 describe.concurrent('getPanierByPublicId', () => {
@@ -11,8 +11,9 @@ describe.concurrent('getPanierByPublicId', () => {
     "retourne le panier PUBLIC avec ses indicateurs triés par ordre d'insertion",
     integrationTest(async () => {
       const [indA, indB] = testIndicateurIds(2)
+      const panDetail = testPanierId()
       const panier = await fixtures.panier({
-        publicId: 'PAN-DETAIL-1',
+        publicId: panDetail,
         nom: 'Panier de détail',
         description: 'Une description',
         visibilite: 'PUBLIC',
@@ -20,11 +21,11 @@ describe.concurrent('getPanierByPublicId', () => {
       })
       const apiKey = await fixtures.apiKey()
 
-      const result = await runAsPrincipal(apiKey.id, () => getPanierByPublicId('PAN-DETAIL-1'))
+      const result = await runAsPrincipal(apiKey.id, () => getPanierByPublicId(panDetail))
 
       expect(result.isOk()).toBe(true)
       expect(result._unsafeUnwrap()).toEqual({
-        id: 'PAN-DETAIL-1',
+        id: panDetail,
         nom: 'Panier de détail',
         description: 'Une description',
         visibilite: 'PUBLIC',
@@ -38,17 +39,18 @@ describe.concurrent('getPanierByPublicId', () => {
   it(
     'retourne un panier sans indicateurs avec un tableau vide',
     integrationTest(async () => {
+      const panEmpty = testPanierId()
       await fixtures.panier({
-        publicId: 'PAN-DETAIL-EMPTY',
+        publicId: panEmpty,
         nom: 'Sans indicateurs',
         visibilite: 'PUBLIC',
       })
       const apiKey = await fixtures.apiKey()
 
-      const result = await runAsPrincipal(apiKey.id, () => getPanierByPublicId('PAN-DETAIL-EMPTY'))
+      const result = await runAsPrincipal(apiKey.id, () => getPanierByPublicId(panEmpty))
 
       expect(result._unsafeUnwrap()).toMatchObject({
-        id: 'PAN-DETAIL-EMPTY',
+        id: panEmpty,
         indicateurIds: [],
         description: null,
       })
@@ -58,37 +60,36 @@ describe.concurrent('getPanierByPublicId', () => {
   it(
     "retourne un panier PRIVE quand le principal dispose d'une permission",
     integrationTest(async () => {
-      await fixtures.panier({ publicId: 'PAN-DETAIL-PRIV', visibilite: 'PRIVE' })
+      const panPriv = testPanierId()
+      await fixtures.panier({ publicId: panPriv, visibilite: 'PRIVE' })
       const apiKey = await fixtures.apiKey({
-        panierPermissions: [{ panier: { publicId: 'PAN-DETAIL-PRIV' }, action: 'READ' }],
+        panierPermissions: [{ panier: { publicId: panPriv }, action: 'READ' }],
       })
 
-      const result = await runAsPrincipal(apiKey.id, () => getPanierByPublicId('PAN-DETAIL-PRIV'))
+      const result = await runAsPrincipal(apiKey.id, () => getPanierByPublicId(panPriv))
 
-      expect(result._unsafeUnwrap().id).toBe('PAN-DETAIL-PRIV')
+      expect(result._unsafeUnwrap().id).toBe(panPriv)
     }),
   )
 
   it(
     'lève une erreur quand un panier PRIVE est demandé sans permission',
     integrationTest(async () => {
-      await fixtures.panier({ publicId: 'PAN-DETAIL-NOACL', visibilite: 'PRIVE' })
+      const panNoacl = testPanierId()
+      await fixtures.panier({ publicId: panNoacl, visibilite: 'PRIVE' })
       const apiKey = await fixtures.apiKey()
 
-      await expect(
-        runAsPrincipal(apiKey.id, () => getPanierByPublicId('PAN-DETAIL-NOACL')),
-      ).rejects.toThrow()
+      await expect(runAsPrincipal(apiKey.id, () => getPanierByPublicId(panNoacl))).rejects.toThrow()
     }),
   )
 
   it(
     'lève une erreur quand aucun panier ne correspond',
     integrationTest(async () => {
+      const panNope = testPanierId()
       const apiKey = await fixtures.apiKey()
 
-      await expect(
-        runAsPrincipal(apiKey.id, () => getPanierByPublicId('PAN-NOPE-001')),
-      ).rejects.toThrow()
+      await expect(runAsPrincipal(apiKey.id, () => getPanierByPublicId(panNope))).rejects.toThrow()
     }),
   )
 })

--- a/apps/mb-api/src/panier/queries/listPaniers.test.ts
+++ b/apps/mb-api/src/panier/queries/listPaniers.test.ts
@@ -4,7 +4,7 @@ import { encodeCursor } from '@/framework/persistence/paginate'
 import { listPaniers } from '@/panier/queries/listPaniers'
 import { fixtures } from '@/test/fixtures'
 import { integrationTest } from '@/test/integrationTest'
-import { testIndicateurIds } from '@/test/randomIds'
+import { testIndicateurIds, testPanierId } from '@/test/randomIds'
 import { runAsPrincipal } from '@/test/runAsPrincipal'
 
 describe.concurrent('listPaniers', () => {
@@ -26,17 +26,21 @@ describe.concurrent('listPaniers', () => {
   it(
     'retourne tous les paniers PUBLIC quand leur nombre est inférieur à la taille de page',
     integrationTest(async () => {
+      // Ordre de création = ordre attendu (orderBy id interne uuidv7).
+      const panList1 = testPanierId()
+      const panList2 = testPanierId()
+      const panList3 = testPanierId()
       await fixtures.panier(
-        { publicId: 'PAN-LIST-1', nom: 'Panier 1', visibilite: 'PUBLIC' },
-        { publicId: 'PAN-LIST-2', nom: 'Panier 2', visibilite: 'PUBLIC' },
-        { publicId: 'PAN-LIST-3', nom: 'Panier 3', visibilite: 'PUBLIC' },
+        { publicId: panList1, nom: 'Panier 1', visibilite: 'PUBLIC' },
+        { publicId: panList2, nom: 'Panier 2', visibilite: 'PUBLIC' },
+        { publicId: panList3, nom: 'Panier 3', visibilite: 'PUBLIC' },
       )
       const apiKey = await fixtures.apiKey()
 
       const result = await runAsPrincipal(apiKey.id, () => listPaniers({}))
 
       const value = result._unsafeUnwrap()
-      expect(value.items.map((p) => p.id)).toEqual(['PAN-LIST-1', 'PAN-LIST-2', 'PAN-LIST-3'])
+      expect(value.items.map((p) => p.id)).toEqual([panList1, panList2, panList3])
       expect(value.pagination).toEqual({ cursor: null, hasMore: false })
       expect(value.total).toBe(3)
     }),
@@ -45,18 +49,20 @@ describe.concurrent('listPaniers', () => {
   it(
     "n'inclut que les paniers sur lesquels le principal a une permission",
     integrationTest(async () => {
+      const panPermAcc = testPanierId()
+      const panPermHid = testPanierId()
       await fixtures.panier(
-        { publicId: 'PAN-PERM-ACC', visibilite: 'PRIVE' },
-        { publicId: 'PAN-PERM-HID', visibilite: 'PRIVE' },
+        { publicId: panPermAcc, visibilite: 'PRIVE' },
+        { publicId: panPermHid, visibilite: 'PRIVE' },
       )
       const apiKey = await fixtures.apiKey({
-        panierPermissions: [{ panier: { publicId: 'PAN-PERM-ACC' }, action: 'READ' }],
+        panierPermissions: [{ panier: { publicId: panPermAcc }, action: 'READ' }],
       })
 
       const result = await runAsPrincipal(apiKey.id, () => listPaniers({}))
 
       const value = result._unsafeUnwrap()
-      expect(value.items.map((p) => p.id)).toEqual(['PAN-PERM-ACC'])
+      expect(value.items.map((p) => p.id)).toEqual([panPermAcc])
       expect(value.total).toBe(1)
     }),
   )
@@ -64,16 +70,18 @@ describe.concurrent('listPaniers', () => {
   it(
     "inclut les paniers PUBLIC sur lesquels le principal n'a aucune permission",
     integrationTest(async () => {
+      const panVisPub = testPanierId()
+      const panVisPri = testPanierId()
       await fixtures.panier(
-        { publicId: 'PAN-VIS-PUB', visibilite: 'PUBLIC' },
-        { publicId: 'PAN-VIS-PRI', visibilite: 'PRIVE' },
+        { publicId: panVisPub, visibilite: 'PUBLIC' },
+        { publicId: panVisPri, visibilite: 'PRIVE' },
       )
       const apiKey = await fixtures.apiKey()
 
       const result = await runAsPrincipal(apiKey.id, () => listPaniers({}))
 
       const value = result._unsafeUnwrap()
-      expect(value.items.map((p) => p.id)).toEqual(['PAN-VIS-PUB'])
+      expect(value.items.map((p) => p.id)).toEqual([panVisPub])
       expect(value.items.map((p) => p.visibilite)).toEqual(['PUBLIC'])
     }),
   )
@@ -82,8 +90,9 @@ describe.concurrent('listPaniers', () => {
     "expose les indicateurs du panier triés par ordre d'insertion (createdAt ASC)",
     integrationTest(async () => {
       const [indA, indB, indC] = testIndicateurIds(3)
+      const panOrder = testPanierId()
       await fixtures.panier({
-        publicId: 'PAN-ORDER-001',
+        publicId: panOrder,
         visibilite: 'PUBLIC',
         indicateurs: [{ publicId: indA }, { publicId: indB }, { publicId: indC }],
       })
@@ -92,7 +101,7 @@ describe.concurrent('listPaniers', () => {
       const result = await runAsPrincipal(apiKey.id, () => listPaniers({}))
 
       const value = result._unsafeUnwrap()
-      const panier = value.items.find((p) => p.id === 'PAN-ORDER-001')
+      const panier = value.items.find((p) => p.id === panOrder)
       expect(panier?.indicateurIds).toEqual([indA, indB, indC])
     }),
   )
@@ -100,13 +109,14 @@ describe.concurrent('listPaniers', () => {
   it(
     'retourne un panier sans indicateurs avec un tableau vide',
     integrationTest(async () => {
-      await fixtures.panier({ publicId: 'PAN-EMPTY-001', visibilite: 'PUBLIC' })
+      const panEmpty = testPanierId()
+      await fixtures.panier({ publicId: panEmpty, visibilite: 'PUBLIC' })
       const apiKey = await fixtures.apiKey()
 
       const result = await runAsPrincipal(apiKey.id, () => listPaniers({}))
 
       const value = result._unsafeUnwrap()
-      const panier = value.items.find((p) => p.id === 'PAN-EMPTY-001')
+      const panier = value.items.find((p) => p.id === panEmpty)
       expect(panier?.indicateurIds).toEqual([])
     }),
   )
@@ -114,13 +124,20 @@ describe.concurrent('listPaniers', () => {
   it(
     'pagine quand le nombre de paniers dépasse la taille de page',
     integrationTest(async () => {
+      // Ordre de création = ordre attendu (orderBy id interne uuidv7).
+      const panPage1 = testPanierId()
+      const panPage2 = testPanierId()
+      const panPage3 = testPanierId()
+      const panPage4 = testPanierId()
+      const panPage5 = testPanierId()
+      const panPage6 = testPanierId()
       const created = await fixtures.panier(
-        { publicId: 'PAN-PAGE-1', visibilite: 'PUBLIC' },
-        { publicId: 'PAN-PAGE-2', visibilite: 'PUBLIC' },
-        { publicId: 'PAN-PAGE-3', visibilite: 'PUBLIC' },
-        { publicId: 'PAN-PAGE-4', visibilite: 'PUBLIC' },
-        { publicId: 'PAN-PAGE-5', visibilite: 'PUBLIC' },
-        { publicId: 'PAN-PAGE-6', visibilite: 'PUBLIC' },
+        { publicId: panPage1, visibilite: 'PUBLIC' },
+        { publicId: panPage2, visibilite: 'PUBLIC' },
+        { publicId: panPage3, visibilite: 'PUBLIC' },
+        { publicId: panPage4, visibilite: 'PUBLIC' },
+        { publicId: panPage5, visibilite: 'PUBLIC' },
+        { publicId: panPage6, visibilite: 'PUBLIC' },
       )
       const apiKey = await fixtures.apiKey()
 
@@ -128,11 +145,11 @@ describe.concurrent('listPaniers', () => {
 
       const value = result._unsafeUnwrap()
       expect(value.items.map((p) => p.id)).toEqual([
-        'PAN-PAGE-1',
-        'PAN-PAGE-2',
-        'PAN-PAGE-3',
-        'PAN-PAGE-4',
-        'PAN-PAGE-5',
+        panPage1,
+        panPage2,
+        panPage3,
+        panPage4,
+        panPage5,
       ])
       expect(value.pagination).toEqual({ cursor: encodeCursor(created[4]!.id), hasMore: true })
       expect(value.total).toBe(6)
@@ -142,13 +159,20 @@ describe.concurrent('listPaniers', () => {
   it(
     'retourne la page suivante en utilisant le cursor',
     integrationTest(async () => {
+      // Ordre de création = ordre attendu (orderBy id interne uuidv7).
+      const panCursor1 = testPanierId()
+      const panCursor2 = testPanierId()
+      const panCursor3 = testPanierId()
+      const panCursor4 = testPanierId()
+      const panCursor5 = testPanierId()
+      const panCursor6 = testPanierId()
       const created = await fixtures.panier(
-        { publicId: 'PAN-CURSOR-1', visibilite: 'PUBLIC' },
-        { publicId: 'PAN-CURSOR-2', visibilite: 'PUBLIC' },
-        { publicId: 'PAN-CURSOR-3', visibilite: 'PUBLIC' },
-        { publicId: 'PAN-CURSOR-4', visibilite: 'PUBLIC' },
-        { publicId: 'PAN-CURSOR-5', visibilite: 'PUBLIC' },
-        { publicId: 'PAN-CURSOR-6', visibilite: 'PUBLIC' },
+        { publicId: panCursor1, visibilite: 'PUBLIC' },
+        { publicId: panCursor2, visibilite: 'PUBLIC' },
+        { publicId: panCursor3, visibilite: 'PUBLIC' },
+        { publicId: panCursor4, visibilite: 'PUBLIC' },
+        { publicId: panCursor5, visibilite: 'PUBLIC' },
+        { publicId: panCursor6, visibilite: 'PUBLIC' },
       )
       const apiKey = await fixtures.apiKey()
 
@@ -157,7 +181,7 @@ describe.concurrent('listPaniers', () => {
       )
 
       const value = result._unsafeUnwrap()
-      expect(value.items.map((p) => p.id)).toEqual(['PAN-CURSOR-6'])
+      expect(value.items.map((p) => p.id)).toEqual([panCursor6])
       expect(value.pagination).toEqual({ cursor: null, hasMore: false })
       expect(value.total).toBe(6)
     }),

--- a/apps/mb-api/src/referentiel/commands/upsertReferentiel.test.ts
+++ b/apps/mb-api/src/referentiel/commands/upsertReferentiel.test.ts
@@ -4,21 +4,22 @@ import { db } from '@/framework/persistence/dbStore'
 import { upsertReferentiel } from '@/referentiel/commands/upsertReferentiel'
 import { fixtures } from '@/test/fixtures'
 import { integrationTest } from '@/test/integrationTest'
-import { testDeptIds } from '@/test/randomIds'
+import { testDeptIds, testReferentielId } from '@/test/randomIds'
 
 describe.concurrent('upsertReferentiel', () => {
   it(
     'crée un référentiel quand le publicId est libre',
     integrationTest(async () => {
       // When
-      const result = await upsertReferentiel('REF-NEW', {
+      const refNew = testReferentielId()
+      const result = await upsertReferentiel(refNew, {
         nom: 'Nouveau référentiel',
         description: 'Description initiale',
       })
 
       // Then
       expect(result.isOk()).toBe(true)
-      const persisted = await db().referentiel.findUniqueOrThrow({ where: { publicId: 'REF-NEW' } })
+      const persisted = await db().referentiel.findUniqueOrThrow({ where: { publicId: refNew } })
       expect(persisted.nom).toBe('Nouveau référentiel')
       expect(persisted.description).toBe('Description initiale')
     }),
@@ -28,21 +29,22 @@ describe.concurrent('upsertReferentiel', () => {
     'met à jour nom, description et updatedAt quand le référentiel existe déjà',
     integrationTest(async () => {
       // Given
+      const refUpd = testReferentielId()
       const original = await fixtures.referentiel({
-        publicId: 'REF-UPD',
+        publicId: refUpd,
         nom: 'Ancien nom',
         description: 'Ancienne description',
       })
 
       // When
-      const result = await upsertReferentiel('REF-UPD', {
+      const result = await upsertReferentiel(refUpd, {
         nom: 'Nouveau nom',
         description: null,
       })
 
       // Then
       expect(result.isOk()).toBe(true)
-      const persisted = await db().referentiel.findUniqueOrThrow({ where: { publicId: 'REF-UPD' } })
+      const persisted = await db().referentiel.findUniqueOrThrow({ where: { publicId: refUpd } })
       expect(persisted.nom).toBe('Nouveau nom')
       expect(persisted.description).toBeNull()
       expect(persisted.createdAt).toEqual(original.createdAt)
@@ -55,9 +57,10 @@ describe.concurrent('upsertReferentiel', () => {
     integrationTest(async () => {
       // Given
       const [dept1, dept2] = testDeptIds(2)
+      const refInds = testReferentielId()
 
       // When
-      await upsertReferentiel('REF-INDS', {
+      await upsertReferentiel(refInds, {
         nom: 'Avec individus',
         description: null,
         individus: [
@@ -72,9 +75,9 @@ describe.concurrent('upsertReferentiel', () => {
         include: { referentiel: { select: { publicId: true } } },
       })
       expect(persistedDept1.nom).toBe('Premier')
-      expect(persistedDept1.referentiel.publicId).toBe('REF-INDS')
+      expect(persistedDept1.referentiel.publicId).toBe(refInds)
       const individusForRef = await db().individu.findMany({
-        where: { referentiel: { publicId: 'REF-INDS' } },
+        where: { referentiel: { publicId: refInds } },
       })
       expect(individusForRef).toHaveLength(2)
     }),
@@ -85,14 +88,15 @@ describe.concurrent('upsertReferentiel', () => {
     integrationTest(async () => {
       // Given
       const [dept1] = testDeptIds(1)
+      const refLink = testReferentielId()
       await fixtures.individu({
         publicId: dept1,
         nom: 'Ancien nom individu',
-        referentiel: { publicId: 'REF-LINK' },
+        referentiel: { publicId: refLink },
       })
 
       // When
-      const result = await upsertReferentiel('REF-LINK', {
+      const result = await upsertReferentiel(refLink, {
         nom: 'Référentiel',
         description: null,
         individus: [{ publicId: dept1, nom: 'Nouveau nom individu' }],
@@ -105,7 +109,7 @@ describe.concurrent('upsertReferentiel', () => {
         include: { referentiel: { select: { publicId: true } } },
       })
       expect(persisted.nom).toBe('Nouveau nom individu')
-      expect(persisted.referentiel.publicId).toBe('REF-LINK')
+      expect(persisted.referentiel.publicId).toBe(refLink)
     }),
   )
 
@@ -114,13 +118,16 @@ describe.concurrent('upsertReferentiel', () => {
     integrationTest(async () => {
       // Given
       const [dept1, dept2, dept3] = testDeptIds(3)
+      const refOtherA = testReferentielId()
+      const refOtherB = testReferentielId()
+      const refNew2 = testReferentielId()
       await fixtures.individu(
-        { publicId: dept1, referentiel: { publicId: 'REF-OTHER-A' } },
-        { publicId: dept2, referentiel: { publicId: 'REF-OTHER-B' } },
+        { publicId: dept1, referentiel: { publicId: refOtherA } },
+        { publicId: dept2, referentiel: { publicId: refOtherB } },
       )
 
       // When
-      const result = await upsertReferentiel('REF-NEW2', {
+      const result = await upsertReferentiel(refNew2, {
         nom: 'Nouveau référentiel',
         description: null,
         individus: [
@@ -136,7 +143,7 @@ describe.concurrent('upsertReferentiel', () => {
         type: 'INDIVIDUS_ALREADY_ATTACHED',
         individuIds: [dept1, dept2].sort(),
       })
-      const created = await db().referentiel.findUnique({ where: { publicId: 'REF-NEW2' } })
+      const created = await db().referentiel.findUnique({ where: { publicId: refNew2 } })
       expect(created).toBeNull()
     }),
   )
@@ -145,7 +152,8 @@ describe.concurrent('upsertReferentiel', () => {
     'fonctionne sans individus (champ omis)',
     integrationTest(async () => {
       // When
-      const result = await upsertReferentiel('REF-EMPTY', {
+      const refEmpty = testReferentielId()
+      const result = await upsertReferentiel(refEmpty, {
         nom: 'Sans individus',
         description: null,
       })
@@ -153,7 +161,7 @@ describe.concurrent('upsertReferentiel', () => {
       // Then
       expect(result.isOk()).toBe(true)
       const persisted = await db().referentiel.findUniqueOrThrow({
-        where: { publicId: 'REF-EMPTY' },
+        where: { publicId: refEmpty },
       })
       expect(persisted.nom).toBe('Sans individus')
     }),

--- a/apps/mb-api/src/referentiel/queries/getReferentielByPublicId.test.ts
+++ b/apps/mb-api/src/referentiel/queries/getReferentielByPublicId.test.ts
@@ -3,33 +3,34 @@ import { describe, expect, it } from 'vitest'
 import { getReferentielByPublicId } from '@/referentiel/queries/getReferentielByPublicId'
 import { fixtures } from '@/test/fixtures'
 import { integrationTest } from '@/test/integrationTest'
-import { testDeptIds } from '@/test/randomIds'
+import { testDeptIds, testReferentielId, testWidgetId } from '@/test/randomIds'
 
 describe.concurrent('getReferentielByPublicId', () => {
   it(
     'retourne le référentiel avec sa population',
     integrationTest(async () => {
       const [dept1, dept2] = testDeptIds(2)
+      const refTest = testReferentielId()
       await fixtures.individu(
         {
           publicId: dept1,
           referentiel: {
-            publicId: 'REF-TEST',
+            publicId: refTest,
             nom: 'Référentiel de test',
             description: 'Description test',
           },
         },
         {
           publicId: dept2,
-          referentiel: { publicId: 'REF-TEST' },
+          referentiel: { publicId: refTest },
         },
       )
 
-      const result = await getReferentielByPublicId('REF-TEST')
+      const result = await getReferentielByPublicId(refTest)
 
       const value = result._unsafeUnwrap()
       expect(value).toMatchObject({
-        id: 'REF-TEST',
+        id: refTest,
         nom: 'Référentiel de test',
         description: 'Description test',
         nombreIndividus: 2,
@@ -47,22 +48,24 @@ describe.concurrent('getReferentielByPublicId', () => {
   it(
     'inclut les widgets rattachés au référentiel',
     integrationTest(async () => {
+      const refCarto = testReferentielId()
+      const widCarto = testWidgetId()
       await fixtures.referentielWidget({
-        referentiel: { publicId: 'REF-CARTO' },
+        referentiel: { publicId: refCarto },
         widget: {
-          publicId: 'WID-CARTO-TEST',
+          publicId: widCarto,
           type: 'carte-france-departements',
           nom: 'Carte des départements',
           joinKey: 'codeInsee',
         },
       })
 
-      const result = await getReferentielByPublicId('REF-CARTO')
+      const result = await getReferentielByPublicId(refCarto)
 
       const value = result._unsafeUnwrap()
       expect(value.widgets).toEqual([
         {
-          id: 'WID-CARTO-TEST',
+          id: widCarto,
           type: 'carte-france-departements',
           nom: 'Carte des départements',
           joinKey: 'codeInsee',
@@ -74,9 +77,10 @@ describe.concurrent('getReferentielByPublicId', () => {
   it(
     "retourne un tableau widgets vide quand aucun widget n'est rattaché",
     integrationTest(async () => {
-      await fixtures.referentiel({ publicId: 'REF-NO-WID' })
+      const refNoWid = testReferentielId()
+      await fixtures.referentiel({ publicId: refNoWid })
 
-      const result = await getReferentielByPublicId('REF-NO-WID')
+      const result = await getReferentielByPublicId(refNoWid)
 
       expect(result._unsafeUnwrap().widgets).toEqual([])
     }),

--- a/apps/mb-api/src/referentiel/queries/listIndividusForReferentiel.test.ts
+++ b/apps/mb-api/src/referentiel/queries/listIndividusForReferentiel.test.ts
@@ -3,46 +3,52 @@ import { describe, expect, it } from 'vitest'
 import { listIndividusForReferentiel } from '@/referentiel/queries/listIndividusForReferentiel'
 import { fixtures } from '@/test/fixtures'
 import { integrationTest } from '@/test/integrationTest'
+import { testIndividuId, testReferentielId } from '@/test/randomIds'
 
 describe.concurrent('listIndividusForReferentiel', () => {
   it(
     'retourne les individus de la population du référentiel',
     integrationTest(async () => {
+      const refPop = testReferentielId()
+      const refOther = testReferentielId()
+      const p1 = testIndividuId()
+      const p2 = testIndividuId()
+      const o1 = testIndividuId()
       await fixtures.individu(
         {
-          publicId: 'P-1',
+          publicId: p1,
           nom: 'Premier',
-          referentiel: { publicId: 'REF-POP', nom: 'Pop' },
+          referentiel: { publicId: refPop, nom: 'Pop' },
         },
         {
-          publicId: 'P-2',
+          publicId: p2,
           nom: 'Second',
-          referentiel: { publicId: 'REF-POP' },
+          referentiel: { publicId: refPop },
         },
         {
-          publicId: 'O-1',
+          publicId: o1,
           nom: 'Hors population',
-          referentiel: { publicId: 'REF-OTHER', nom: 'Other' },
+          referentiel: { publicId: refOther, nom: 'Other' },
         },
       )
 
-      const result = await listIndividusForReferentiel('REF-POP', {})
+      const result = await listIndividusForReferentiel(refPop, {})
 
       expect(result._unsafeUnwrap()).toEqual({
         items: [
           {
-            id: 'P-1',
+            id: p1,
             nom: 'Premier',
-            referentiel: 'REF-POP',
+            referentiel: refPop,
             parents: [],
             metadata: null,
             createdAt: expect.any(String),
             updatedAt: expect.any(String),
           },
           {
-            id: 'P-2',
+            id: p2,
             nom: 'Second',
-            referentiel: 'REF-POP',
+            referentiel: refPop,
             parents: [],
             metadata: null,
             createdAt: expect.any(String),
@@ -58,41 +64,45 @@ describe.concurrent('listIndividusForReferentiel', () => {
   it(
     'filtre par recherche sur le nom',
     integrationTest(async () => {
+      const refSearch = testReferentielId()
+      const a1 = testIndividuId()
+      const a2 = testIndividuId()
+      const a3 = testIndividuId()
       await fixtures.individu(
         {
-          publicId: 'A-1',
+          publicId: a1,
           nom: 'Alpha',
-          referentiel: { publicId: 'REF-SEARCH', nom: 'Search' },
+          referentiel: { publicId: refSearch, nom: 'Search' },
         },
         {
-          publicId: 'A-2',
+          publicId: a2,
           nom: 'Bravo',
-          referentiel: { publicId: 'REF-SEARCH' },
+          referentiel: { publicId: refSearch },
         },
         {
-          publicId: 'A-3',
+          publicId: a3,
           nom: 'ALPHA majuscule',
-          referentiel: { publicId: 'REF-SEARCH' },
+          referentiel: { publicId: refSearch },
         },
       )
 
-      const result = await listIndividusForReferentiel('REF-SEARCH', { recherche: 'alpha' })
+      const result = await listIndividusForReferentiel(refSearch, { recherche: 'alpha' })
 
       expect(result._unsafeUnwrap()).toEqual({
         items: [
           {
-            id: 'A-1',
+            id: a1,
             nom: 'Alpha',
-            referentiel: 'REF-SEARCH',
+            referentiel: refSearch,
             parents: [],
             metadata: null,
             createdAt: expect.any(String),
             updatedAt: expect.any(String),
           },
           {
-            id: 'A-3',
+            id: a3,
             nom: 'ALPHA majuscule',
-            referentiel: 'REF-SEARCH',
+            referentiel: refSearch,
             parents: [],
             metadata: null,
             createdAt: expect.any(String),
@@ -108,20 +118,22 @@ describe.concurrent('listIndividusForReferentiel', () => {
   it(
     "renvoie le metadata JSON quand l'individu en a un",
     integrationTest(async () => {
+      const refMeta = testReferentielId()
+      const m1 = testIndividuId()
       await fixtures.individu({
-        publicId: 'M-1',
+        publicId: m1,
         nom: 'Avec metadata',
-        referentiel: { publicId: 'REF-META', nom: 'Meta' },
+        referentiel: { publicId: refMeta, nom: 'Meta' },
         metadata: { codeInsee: '75', region: 'IDF' },
       })
 
-      const result = await listIndividusForReferentiel('REF-META', {})
+      const result = await listIndividusForReferentiel(refMeta, {})
 
       expect(result._unsafeUnwrap().items).toEqual([
         {
-          id: 'M-1',
+          id: m1,
           nom: 'Avec metadata',
-          referentiel: 'REF-META',
+          referentiel: refMeta,
           parents: [],
           metadata: { codeInsee: '75', region: 'IDF' },
           createdAt: expect.any(String),

--- a/apps/mb-api/src/referentiel/queries/listReferentiels.test.ts
+++ b/apps/mb-api/src/referentiel/queries/listReferentiels.test.ts
@@ -4,6 +4,7 @@ import { encodeCursor } from '@/framework/persistence/paginate'
 import { listReferentiels } from '@/referentiel/queries/listReferentiels'
 import { fixtures } from '@/test/fixtures'
 import { integrationTest } from '@/test/integrationTest'
+import { testIndividuId, testReferentielId, testWidgetId } from '@/test/randomIds'
 
 describe.concurrent('listReferentiels', () => {
   it(
@@ -23,24 +24,28 @@ describe.concurrent('listReferentiels', () => {
   it(
     "retourne les référentiels avec leur nombre d'individus",
     integrationTest(async () => {
+      const refAlpha = testReferentielId()
+      const refBeta = testReferentielId()
+      const a1 = testIndividuId()
+      const a2 = testIndividuId()
       await fixtures.individu(
         {
-          publicId: 'A-1',
-          referentiel: { publicId: 'REF-ALPHA', nom: 'Alpha' },
+          publicId: a1,
+          referentiel: { publicId: refAlpha, nom: 'Alpha' },
         },
         {
-          publicId: 'A-2',
-          referentiel: { publicId: 'REF-ALPHA' },
+          publicId: a2,
+          referentiel: { publicId: refAlpha },
         },
       )
-      await fixtures.referentiel({ publicId: 'REF-BETA', nom: 'Beta' })
+      await fixtures.referentiel({ publicId: refBeta, nom: 'Beta' })
 
       const result = await listReferentiels({})
 
       expect(result._unsafeUnwrap()).toEqual({
         items: [
           {
-            id: 'REF-ALPHA',
+            id: refAlpha,
             nom: 'Alpha',
             description: null,
             nombreIndividus: 2,
@@ -49,7 +54,7 @@ describe.concurrent('listReferentiels', () => {
             updatedAt: expect.any(String),
           },
           {
-            id: 'REF-BETA',
+            id: refBeta,
             nom: 'Beta',
             description: null,
             nombreIndividus: 0,
@@ -67,10 +72,12 @@ describe.concurrent('listReferentiels', () => {
   it(
     'inclut les widgets rattachés à chaque référentiel',
     integrationTest(async () => {
+      const refWidList = testReferentielId()
+      const widCartoList = testWidgetId()
       await fixtures.referentielWidget({
-        referentiel: { publicId: 'REF-WID-LIST', nom: 'Référentiel avec widget' },
+        referentiel: { publicId: refWidList, nom: 'Référentiel avec widget' },
         widget: {
-          publicId: 'WID-CARTO-LIST',
+          publicId: widCartoList,
           type: 'carte-france-departements',
           nom: 'Carte des départements',
           joinKey: 'codeInsee',
@@ -81,10 +88,10 @@ describe.concurrent('listReferentiels', () => {
 
       expect(result._unsafeUnwrap().items).toEqual([
         expect.objectContaining({
-          id: 'REF-WID-LIST',
+          id: refWidList,
           widgets: [
             {
-              id: 'WID-CARTO-LIST',
+              id: widCartoList,
               type: 'carte-france-departements',
               nom: 'Carte des départements',
               joinKey: 'codeInsee',
@@ -98,10 +105,13 @@ describe.concurrent('listReferentiels', () => {
   it(
     'filtre par recherche case-insensitive',
     integrationTest(async () => {
+      const refDept = testReferentielId()
+      const refReg = testReferentielId()
+      const refNat = testReferentielId()
       await fixtures.referentiel(
-        { publicId: 'REF-DEPT', nom: 'Départements de France' },
-        { publicId: 'REF-REG', nom: 'Régions de France' },
-        { publicId: 'REF-NAT', nom: 'France national' },
+        { publicId: refDept, nom: 'Départements de France' },
+        { publicId: refReg, nom: 'Régions de France' },
+        { publicId: refNat, nom: 'France national' },
       )
 
       const result = await listReferentiels({ recherche: 'régions' })
@@ -109,7 +119,7 @@ describe.concurrent('listReferentiels', () => {
       expect(result._unsafeUnwrap()).toEqual({
         items: [
           {
-            id: 'REF-REG',
+            id: refReg,
             nom: 'Régions de France',
             description: null,
             nombreIndividus: 0,
@@ -127,20 +137,26 @@ describe.concurrent('listReferentiels', () => {
   it(
     'pagine au-delà de la taille de page',
     integrationTest(async () => {
+      const ref1 = testReferentielId()
+      const ref2 = testReferentielId()
+      const ref3 = testReferentielId()
+      const ref4 = testReferentielId()
+      const ref5 = testReferentielId()
+      const ref6 = testReferentielId()
       const created = await fixtures.referentiel(
-        { publicId: 'REF-1', nom: 'R1' },
-        { publicId: 'REF-2', nom: 'R2' },
-        { publicId: 'REF-3', nom: 'R3' },
-        { publicId: 'REF-4', nom: 'R4' },
-        { publicId: 'REF-5', nom: 'R5' },
-        { publicId: 'REF-6', nom: 'R6' },
+        { publicId: ref1, nom: 'R1' },
+        { publicId: ref2, nom: 'R2' },
+        { publicId: ref3, nom: 'R3' },
+        { publicId: ref4, nom: 'R4' },
+        { publicId: ref5, nom: 'R5' },
+        { publicId: ref6, nom: 'R6' },
       )
 
       const result = await listReferentiels({ pageSize: 5 })
 
       const value = result._unsafeUnwrap()
       expect(value.items).toHaveLength(5)
-      expect(value.items.map((r) => r.id)).toEqual(['REF-1', 'REF-2', 'REF-3', 'REF-4', 'REF-5'])
+      expect(value.items.map((r) => r.id)).toEqual([ref1, ref2, ref3, ref4, ref5])
       expect(value.pagination).toEqual({ cursor: encodeCursor(created[4]!.id), hasMore: true })
       expect(value.total).toBe(6)
     }),

--- a/apps/mb-api/src/test/randomIds.ts
+++ b/apps/mb-api/src/test/randomIds.ts
@@ -1,133 +1,3 @@
-// Codes INSEE de régions françaises (https://www.insee.fr/fr/information/2114819)
-const REG_CODES = [
-  '01',
-  '02',
-  '03',
-  '04',
-  '06', // DROM (Guadeloupe, Martinique, Guyane, La Réunion, Mayotte)
-  '11', // Île-de-France
-  '24', // Centre-Val de Loire
-  '27', // Bourgogne-Franche-Comté
-  '28', // Normandie
-  '32', // Hauts-de-France
-  '44', // Grand Est
-  '52', // Pays de la Loire
-  '53', // Bretagne
-  '75', // Nouvelle-Aquitaine
-  '76', // Occitanie
-  '84', // Auvergne-Rhône-Alpes
-  '93', // Provence-Alpes-Côte d'Azur
-  '94', // Corse
-] as const
-
-// Codes INSEE de départements français (métropolitains 01-95 + 2A/2B + DOM 971-976)
-const DEPT_CODES = [
-  '01',
-  '02',
-  '03',
-  '04',
-  '05',
-  '06',
-  '07',
-  '08',
-  '09',
-  '10',
-  '11',
-  '12',
-  '13',
-  '14',
-  '15',
-  '16',
-  '17',
-  '18',
-  '19',
-  '2A',
-  '2B',
-  '21',
-  '22',
-  '23',
-  '24',
-  '25',
-  '26',
-  '27',
-  '28',
-  '29',
-  '30',
-  '31',
-  '32',
-  '33',
-  '34',
-  '35',
-  '36',
-  '37',
-  '38',
-  '39',
-  '40',
-  '41',
-  '42',
-  '43',
-  '44',
-  '45',
-  '46',
-  '47',
-  '48',
-  '49',
-  '50',
-  '51',
-  '52',
-  '53',
-  '54',
-  '55',
-  '56',
-  '57',
-  '58',
-  '59',
-  '60',
-  '61',
-  '62',
-  '63',
-  '64',
-  '65',
-  '66',
-  '67',
-  '68',
-  '69',
-  '70',
-  '71',
-  '72',
-  '73',
-  '74',
-  '75',
-  '76',
-  '77',
-  '78',
-  '79',
-  '80',
-  '81',
-  '82',
-  '83',
-  '84',
-  '85',
-  '86',
-  '87',
-  '88',
-  '89',
-  '90',
-  '91',
-  '92',
-  '93',
-  '94',
-  '95',
-  '971',
-  '972',
-  '973',
-  '974',
-  '976',
-] as const
-
-const pickRandom = <T>(items: ReadonlyArray<T>): T =>
-  items[Math.floor(Math.random() * items.length)]!
-
 type FixedTuple<N extends number, T, Acc extends T[] = []> = Acc['length'] extends N
   ? Acc
   : FixedTuple<N, T, [T, ...Acc]>
@@ -157,9 +27,12 @@ export const testWidgetId = (): string => `WID-${randomToken(12).toUpperCase()}`
 
 export const testPanierId = (): string => `PAN-${randomToken(12)}`
 
-export const testDeptId = (): string => `DEPT-${pickRandom(DEPT_CODES)}`
+// Suffixe aléatoire (et non un code INSEE tiré d'un petit pool) : avec jusqu'à
+// 10 transactions concurrentes, piocher parmi 18 régions / ~100 départements
+// provoquait des collisions de publicId entre tests → contention de row-locks.
+export const testDeptId = (): string => `DEPT-${randomToken(12).toUpperCase()}`
 
-export const testRegId = (): string => `REG-${pickRandom(REG_CODES)}`
+export const testRegId = (): string => `REG-${randomToken(12).toUpperCase()}`
 
 export const testEmail = (): string => `utilisateur-${randomToken(12)}@example.com`
 

--- a/apps/mb-api/src/valeurAvancement/queries/listDernieresValeursForIndividu.test.ts
+++ b/apps/mb-api/src/valeurAvancement/queries/listDernieresValeursForIndividu.test.ts
@@ -2,7 +2,13 @@ import { describe, expect, it } from 'vitest'
 
 import { fixtures } from '@/test/fixtures'
 import { integrationTest } from '@/test/integrationTest'
-import { testDeptId, testIndicateurId, testIndicateurIds, testRegId } from '@/test/randomIds'
+import {
+  testDeptId,
+  testIndicateurId,
+  testIndicateurIds,
+  testReferentielId,
+  testRegId,
+} from '@/test/randomIds'
 import { runAsPrincipal } from '@/test/runAsPrincipal'
 import { listDernieresValeursForIndividu } from '@/valeurAvancement/queries/listDernieresValeursForIndividu'
 
@@ -12,11 +18,12 @@ describe.concurrent('listDernieresValeursForIndividu', () => {
     integrationTest(async () => {
       const indId = testIndicateurId()
       const deptId = testDeptId()
+      const refA = testReferentielId()
       await fixtures.indicateur({ publicId: indId, nom: 'T', visibilite: 'PUBLIC' })
       await fixtures.valeurAvancement(
         {
           indicateur: { publicId: indId },
-          individu: { publicId: deptId, referentiel: { publicId: 'REF-A', nom: 'A' } },
+          individu: { publicId: deptId, referentiel: { publicId: refA, nom: 'A' } },
           date: '2026-01-01',
           valeur: 10,
         },
@@ -50,8 +57,9 @@ describe.concurrent('listDernieresValeursForIndividu', () => {
     integrationTest(async () => {
       const indId = testIndicateurId()
       const deptId = testDeptId()
+      const refA = testReferentielId()
       await fixtures.indicateur({ publicId: indId, nom: 'T', visibilite: 'PUBLIC' })
-      await fixtures.individu({ publicId: deptId, referentiel: { publicId: 'REF-A', nom: 'A' } })
+      await fixtures.individu({ publicId: deptId, referentiel: { publicId: refA, nom: 'A' } })
       const apiKey = await fixtures.apiKey()
 
       const result = await runAsPrincipal(apiKey.id, () =>
@@ -82,13 +90,14 @@ describe.concurrent('listDernieresValeursForIndividu', () => {
     integrationTest(async () => {
       const [indAvecValeur, indSansValeur] = testIndicateurIds(2)
       const deptId = testDeptId()
+      const refA = testReferentielId()
       await fixtures.indicateur(
         { publicId: indAvecValeur, nom: 'A', visibilite: 'PUBLIC' },
         { publicId: indSansValeur, nom: 'B', visibilite: 'PUBLIC' },
       )
       await fixtures.valeurAvancement({
         indicateur: { publicId: indAvecValeur },
-        individu: { publicId: deptId, referentiel: { publicId: 'REF-A', nom: 'A' } },
+        individu: { publicId: deptId, referentiel: { publicId: refA, nom: 'A' } },
         date: '2026-01-01',
         valeur: 42,
       })
@@ -111,6 +120,7 @@ describe.concurrent('listDernieresValeursForIndividu', () => {
     integrationTest(async () => {
       const [indPublic, indPrive] = testIndicateurIds(2)
       const deptId = testDeptId()
+      const refA = testReferentielId()
       await fixtures.indicateur(
         { publicId: indPublic, nom: 'Public', visibilite: 'PUBLIC' },
         { publicId: indPrive, nom: 'Privé', visibilite: 'PRIVE' },
@@ -118,7 +128,7 @@ describe.concurrent('listDernieresValeursForIndividu', () => {
       await fixtures.valeurAvancement(
         {
           indicateur: { publicId: indPublic },
-          individu: { publicId: deptId, referentiel: { publicId: 'REF-A', nom: 'A' } },
+          individu: { publicId: deptId, referentiel: { publicId: refA, nom: 'A' } },
           date: '2026-01-01',
           valeur: 10,
         },
@@ -147,19 +157,21 @@ describe.concurrent('listDernieresValeursForIndividu', () => {
       const indId = testIndicateurId()
       const regId = testRegId()
       const deptId = testDeptId()
+      const refReg = testReferentielId()
+      const refDept = testReferentielId()
       await fixtures.indicateur({ publicId: indId, nom: 'T', visibilite: 'PUBLIC' })
       await fixtures.indicateurReferentiel({
         indicateur: { publicId: indId },
-        referentiel: { publicId: 'REF-REG', nom: 'Régions' },
+        referentiel: { publicId: refReg, nom: 'Régions' },
         fonctionAgregation: 'SUM',
       })
       await fixtures.indicateurReferentiel({
         indicateur: { publicId: indId },
-        referentiel: { publicId: 'REF-DEPT', nom: 'Départements' },
+        referentiel: { publicId: refDept, nom: 'Départements' },
       })
       await fixtures.relation({
-        parent: { publicId: regId, referentiel: { publicId: 'REF-REG' } },
-        child: { publicId: deptId, referentiel: { publicId: 'REF-DEPT' } },
+        parent: { publicId: regId, referentiel: { publicId: refReg } },
+        child: { publicId: deptId, referentiel: { publicId: refDept } },
       })
       await fixtures.valeurAvancement({
         indicateur: { publicId: indId },

--- a/apps/mb-api/src/valeurAvancement/queries/listIndividusWithValeurs.test.ts
+++ b/apps/mb-api/src/valeurAvancement/queries/listIndividusWithValeurs.test.ts
@@ -2,7 +2,13 @@ import { describe, expect, it } from 'vitest'
 
 import { fixtures } from '@/test/fixtures'
 import { integrationTest } from '@/test/integrationTest'
-import { testDeptId, testDeptIds, testIndicateurId, testRegId } from '@/test/randomIds'
+import {
+  testDeptId,
+  testDeptIds,
+  testIndicateurId,
+  testReferentielId,
+  testRegId,
+} from '@/test/randomIds'
 import { runAsPrincipal } from '@/test/runAsPrincipal'
 import { listIndividusWithValeurs } from '@/valeurAvancement/queries/listIndividusWithValeurs'
 
@@ -12,21 +18,22 @@ describe.concurrent('listIndividusWithValeurs', () => {
     integrationTest(async () => {
       const indId = testIndicateurId()
       const [dept1, dept2, dept3] = testDeptIds(3)
+      const refDept = testReferentielId()
       await fixtures.individu(
         {
           publicId: dept1,
           nom: 'Vaucluse',
-          referentiel: { publicId: 'REF-DEPT', nom: 'Dept' },
+          referentiel: { publicId: refDept, nom: 'Dept' },
         },
         {
           publicId: dept2,
           nom: 'BdR',
-          referentiel: { publicId: 'REF-DEPT' },
+          referentiel: { publicId: refDept },
         },
         {
           publicId: dept3,
           nom: 'AM',
-          referentiel: { publicId: 'REF-DEPT' },
+          referentiel: { publicId: refDept },
         },
       )
       await fixtures.valeurAvancement(
@@ -61,7 +68,7 @@ describe.concurrent('listIndividusWithValeurs', () => {
             individu: {
               id: dept1,
               nom: 'Vaucluse',
-              referentiel: 'REF-DEPT',
+              referentiel: refDept,
               parents: [],
               metadata: null,
               createdAt: expect.any(String),
@@ -74,7 +81,7 @@ describe.concurrent('listIndividusWithValeurs', () => {
             individu: {
               id: dept2,
               nom: 'BdR',
-              referentiel: 'REF-DEPT',
+              referentiel: refDept,
               parents: [],
               metadata: null,
               createdAt: expect.any(String),
@@ -96,16 +103,18 @@ describe.concurrent('listIndividusWithValeurs', () => {
       const indId = testIndicateurId()
       const deptId = testDeptId()
       const regId = testRegId()
+      const refDept = testReferentielId()
+      const refReg = testReferentielId()
       await fixtures.individu(
         {
           publicId: deptId,
           nom: 'Vaucluse',
-          referentiel: { publicId: 'REF-DEPT', nom: 'Dept' },
+          referentiel: { publicId: refDept, nom: 'Dept' },
         },
         {
           publicId: regId,
           nom: 'PACA',
-          referentiel: { publicId: 'REF-REG', nom: 'Reg' },
+          referentiel: { publicId: refReg, nom: 'Reg' },
         },
       )
       await fixtures.valeurAvancement(
@@ -127,7 +136,7 @@ describe.concurrent('listIndividusWithValeurs', () => {
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>
-        listIndividusWithValeurs(indId, { referentiel: 'REF-REG' }),
+        listIndividusWithValeurs(indId, { referentiel: refReg }),
       )
 
       expect(result._unsafeUnwrap()).toEqual({
@@ -136,7 +145,7 @@ describe.concurrent('listIndividusWithValeurs', () => {
             individu: {
               id: regId,
               nom: 'PACA',
-              referentiel: 'REF-REG',
+              referentiel: refReg,
               parents: [],
               metadata: null,
               createdAt: expect.any(String),

--- a/apps/mb-api/src/valeurAvancement/queries/listSyntheseIndividus.test.ts
+++ b/apps/mb-api/src/valeurAvancement/queries/listSyntheseIndividus.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import { fixtures } from '@/test/fixtures'
 import { integrationTest } from '@/test/integrationTest'
-import { testDeptId, testDeptIds, testIndicateurId } from '@/test/randomIds'
+import { testDeptId, testDeptIds, testIndicateurId, testReferentielId } from '@/test/randomIds'
 import { runAsPrincipal } from '@/test/runAsPrincipal'
 import { listSyntheseIndividus } from '@/valeurAvancement/queries/listSyntheseIndividus'
 
@@ -12,8 +12,9 @@ describe.concurrent('listSyntheseIndividus', () => {
     integrationTest(async () => {
       const indId = testIndicateurId()
       const deptId = testDeptId()
+      const refA = testReferentielId()
       await fixtures.indicateur({ publicId: indId, nom: 'T', visibilite: 'PUBLIC' })
-      await fixtures.individu({ publicId: deptId, referentiel: { publicId: 'REF-A', nom: 'A' } })
+      await fixtures.individu({ publicId: deptId, referentiel: { publicId: refA, nom: 'A' } })
       const apiKey = await fixtures.apiKey()
 
       const result = await runAsPrincipal(apiKey.id, () =>
@@ -31,11 +32,12 @@ describe.concurrent('listSyntheseIndividus', () => {
     integrationTest(async () => {
       const indId = testIndicateurId()
       const [dept1, dept2] = testDeptIds(2)
+      const refA = testReferentielId()
       await fixtures.indicateur({ publicId: indId, nom: 'T', visibilite: 'PUBLIC' })
-      await fixtures.individu({ publicId: dept1, referentiel: { publicId: 'REF-A', nom: 'A' } })
+      await fixtures.individu({ publicId: dept1, referentiel: { publicId: refA, nom: 'A' } })
       await fixtures.valeurAvancement({
         indicateur: { publicId: indId },
-        individu: { publicId: dept2, referentiel: { publicId: 'REF-A' } },
+        individu: { publicId: dept2, referentiel: { publicId: refA } },
         date: '2026-01-01',
         valeur: 42,
       })
@@ -56,10 +58,11 @@ describe.concurrent('listSyntheseIndividus', () => {
     integrationTest(async () => {
       const indId = testIndicateurId()
       const deptId = testDeptId()
+      const refA = testReferentielId()
       await fixtures.indicateur({ publicId: indId, nom: 'T', visibilite: 'PUBLIC' })
       await fixtures.valeurAvancement({
         indicateur: { publicId: indId },
-        individu: { publicId: deptId, referentiel: { publicId: 'REF-A', nom: 'A' } },
+        individu: { publicId: deptId, referentiel: { publicId: refA, nom: 'A' } },
         date: '2026-01-01',
         valeur: 50,
       })
@@ -80,11 +83,12 @@ describe.concurrent('listSyntheseIndividus', () => {
     integrationTest(async () => {
       const indId = testIndicateurId()
       const deptId = testDeptId()
+      const refA = testReferentielId()
       await fixtures.indicateur({ publicId: indId, nom: 'T', visibilite: 'PUBLIC' })
       await fixtures.valeurAvancement(
         {
           indicateur: { publicId: indId },
-          individu: { publicId: deptId, referentiel: { publicId: 'REF-A', nom: 'A' } },
+          individu: { publicId: deptId, referentiel: { publicId: refA, nom: 'A' } },
           date: '2026-01-01',
           valeur: 50,
         },
@@ -118,11 +122,12 @@ describe.concurrent('listSyntheseIndividus', () => {
     integrationTest(async () => {
       const indId = testIndicateurId()
       const deptId = testDeptId()
+      const refA = testReferentielId()
       await fixtures.indicateur({ publicId: indId, nom: 'T', visibilite: 'PUBLIC' })
       await fixtures.valeurAvancement(
         {
           indicateur: { publicId: indId },
-          individu: { publicId: deptId, referentiel: { publicId: 'REF-A', nom: 'A' } },
+          individu: { publicId: deptId, referentiel: { publicId: refA, nom: 'A' } },
           date: '2026-02-01',
           valeur: 10,
         },
@@ -156,6 +161,7 @@ describe.concurrent('listSyntheseIndividus', () => {
     integrationTest(async () => {
       const indId = testIndicateurId()
       const [dept1, dept2, dept3] = testDeptIds(3)
+      const refA = testReferentielId()
       await fixtures.indicateur({ publicId: indId, nom: 'T', visibilite: 'PUBLIC' })
       await fixtures.valeurAvancement(
         {
@@ -163,7 +169,7 @@ describe.concurrent('listSyntheseIndividus', () => {
           individu: {
             publicId: dept1,
             nom: 'A',
-            referentiel: { publicId: 'REF-A', nom: 'A' },
+            referentiel: { publicId: refA, nom: 'A' },
           },
           date: '2026-01-01',
           valeur: 10,
@@ -176,7 +182,7 @@ describe.concurrent('listSyntheseIndividus', () => {
         },
         {
           indicateur: { publicId: indId },
-          individu: { publicId: dept2, nom: 'B', referentiel: { publicId: 'REF-A' } },
+          individu: { publicId: dept2, nom: 'B', referentiel: { publicId: refA } },
           date: '2026-01-01',
           valeur: 5,
         },
@@ -184,7 +190,7 @@ describe.concurrent('listSyntheseIndividus', () => {
       await fixtures.individu({
         publicId: dept3,
         nom: 'C',
-        referentiel: { publicId: 'REF-A' },
+        referentiel: { publicId: refA },
       })
       const apiKey = await fixtures.apiKey()
 
@@ -207,11 +213,12 @@ describe.concurrent('listSyntheseIndividus', () => {
     integrationTest(async () => {
       const [indId, autreIndId] = [testIndicateurId(), testIndicateurId()]
       const deptId = testDeptId()
+      const refA = testReferentielId()
       await fixtures.indicateur({ publicId: indId, nom: 'T', visibilite: 'PUBLIC' })
       await fixtures.valeurAvancement(
         {
           indicateur: { publicId: indId },
-          individu: { publicId: deptId, referentiel: { publicId: 'REF-A', nom: 'A' } },
+          individu: { publicId: deptId, referentiel: { publicId: refA, nom: 'A' } },
           date: '2026-01-01',
           valeur: 100,
         },
@@ -240,10 +247,11 @@ describe.concurrent('listSyntheseIndividus', () => {
       const indId = testIndicateurId()
       const deptId = testDeptId()
       const inconnu = testDeptId()
+      const refA = testReferentielId()
       await fixtures.indicateur({ publicId: indId, nom: 'T', visibilite: 'PUBLIC' })
       await fixtures.valeurAvancement({
         indicateur: { publicId: indId },
-        individu: { publicId: deptId, referentiel: { publicId: 'REF-A', nom: 'A' } },
+        individu: { publicId: deptId, referentiel: { publicId: refA, nom: 'A' } },
         date: '2026-01-01',
         valeur: 42,
       })
@@ -264,11 +272,12 @@ describe.concurrent('listSyntheseIndividus', () => {
     integrationTest(async () => {
       const indId = testIndicateurId()
       const deptId = testDeptId()
+      const refA = testReferentielId()
       await fixtures.indicateur({ publicId: indId, nom: 'T', visibilite: 'PUBLIC' })
       await fixtures.valeurAvancement(
         {
           indicateur: { publicId: indId },
-          individu: { publicId: deptId, referentiel: { publicId: 'REF-A', nom: 'A' } },
+          individu: { publicId: deptId, referentiel: { publicId: refA, nom: 'A' } },
           date: '2026-01-01',
           valeur: 0.15,
         },
@@ -296,23 +305,24 @@ describe.concurrent('listSyntheseIndividus', () => {
     integrationTest(async () => {
       const indId = testIndicateurId()
       const [dept1, dept2, dept3] = testDeptIds(3)
+      const refA = testReferentielId()
       await fixtures.indicateur({ publicId: indId, nom: 'T', visibilite: 'PUBLIC' })
       await fixtures.valeurAvancement(
         {
           indicateur: { publicId: indId },
-          individu: { publicId: dept1, referentiel: { publicId: 'REF-A', nom: 'A' } },
+          individu: { publicId: dept1, referentiel: { publicId: refA, nom: 'A' } },
           date: '2026-01-01',
           valeur: 0.3,
         },
         {
           indicateur: { publicId: indId },
-          individu: { publicId: dept2, referentiel: { publicId: 'REF-A' } },
+          individu: { publicId: dept2, referentiel: { publicId: refA } },
           date: '2026-01-01',
           valeur: 0.15,
         },
         {
           indicateur: { publicId: indId },
-          individu: { publicId: dept3, referentiel: { publicId: 'REF-A' } },
+          individu: { publicId: dept3, referentiel: { publicId: refA } },
           date: '2026-01-01',
           valeur: 0.45,
         },
@@ -334,11 +344,12 @@ describe.concurrent('listSyntheseIndividus', () => {
     integrationTest(async () => {
       const indId = testIndicateurId()
       const [dept1, dept2, dept3] = testDeptIds(3)
+      const refA = testReferentielId()
       await fixtures.indicateur({ publicId: indId, nom: 'T', visibilite: 'PUBLIC' })
       await fixtures.valeurAvancement(
         {
           indicateur: { publicId: indId },
-          individu: { publicId: dept1, referentiel: { publicId: 'REF-A', nom: 'A' } },
+          individu: { publicId: dept1, referentiel: { publicId: refA, nom: 'A' } },
           date: '2026-01-01',
           valeur: 100,
         },
@@ -350,13 +361,13 @@ describe.concurrent('listSyntheseIndividus', () => {
         },
         {
           indicateur: { publicId: indId },
-          individu: { publicId: dept2, referentiel: { publicId: 'REF-A' } },
+          individu: { publicId: dept2, referentiel: { publicId: refA } },
           date: '2026-01-01',
           valeur: 50,
         },
         {
           indicateur: { publicId: indId },
-          individu: { publicId: dept3, referentiel: { publicId: 'REF-A' } },
+          individu: { publicId: dept3, referentiel: { publicId: refA } },
           date: '2026-01-01',
           valeur: 30,
         },
@@ -378,29 +389,31 @@ describe.concurrent('listSyntheseIndividus', () => {
     integrationTest(async () => {
       const indId = testIndicateurId()
       const [deptA, deptB1, deptB2, deptB3] = testDeptIds(4)
+      const refA = testReferentielId()
+      const refB = testReferentielId()
       await fixtures.indicateur({ publicId: indId, nom: 'T', visibilite: 'PUBLIC' })
       await fixtures.valeurAvancement(
         {
           indicateur: { publicId: indId },
-          individu: { publicId: deptA, referentiel: { publicId: 'REF-A', nom: 'A' } },
+          individu: { publicId: deptA, referentiel: { publicId: refA, nom: 'A' } },
           date: '2026-01-01',
           valeur: 100,
         },
         {
           indicateur: { publicId: indId },
-          individu: { publicId: deptB1, referentiel: { publicId: 'REF-B', nom: 'B' } },
+          individu: { publicId: deptB1, referentiel: { publicId: refB, nom: 'B' } },
           date: '2026-01-01',
           valeur: 10,
         },
         {
           indicateur: { publicId: indId },
-          individu: { publicId: deptB2, referentiel: { publicId: 'REF-B' } },
+          individu: { publicId: deptB2, referentiel: { publicId: refB } },
           date: '2026-01-01',
           valeur: 50,
         },
         {
           indicateur: { publicId: indId },
-          individu: { publicId: deptB3, referentiel: { publicId: 'REF-B' } },
+          individu: { publicId: deptB3, referentiel: { publicId: refB } },
           date: '2026-01-01',
           valeur: 90,
         },
@@ -422,29 +435,31 @@ describe.concurrent('listSyntheseIndividus', () => {
     integrationTest(async () => {
       const indId = testIndicateurId()
       const [deptA1, deptA2, deptB1, deptB2] = testDeptIds(4)
+      const refA = testReferentielId()
+      const refB = testReferentielId()
       await fixtures.indicateur({ publicId: indId, nom: 'T', visibilite: 'PUBLIC' })
       await fixtures.valeurAvancement(
         {
           indicateur: { publicId: indId },
-          individu: { publicId: deptA1, referentiel: { publicId: 'REF-A', nom: 'A' } },
+          individu: { publicId: deptA1, referentiel: { publicId: refA, nom: 'A' } },
           date: '2026-01-01',
           valeur: 10,
         },
         {
           indicateur: { publicId: indId },
-          individu: { publicId: deptA2, referentiel: { publicId: 'REF-A' } },
+          individu: { publicId: deptA2, referentiel: { publicId: refA } },
           date: '2026-01-01',
           valeur: 30,
         },
         {
           indicateur: { publicId: indId },
-          individu: { publicId: deptB1, referentiel: { publicId: 'REF-B', nom: 'B' } },
+          individu: { publicId: deptB1, referentiel: { publicId: refB, nom: 'B' } },
           date: '2026-01-01',
           valeur: 100,
         },
         {
           indicateur: { publicId: indId },
-          individu: { publicId: deptB2, referentiel: { publicId: 'REF-B' } },
+          individu: { publicId: deptB2, referentiel: { publicId: refB } },
           date: '2026-01-01',
           valeur: 200,
         },
@@ -480,8 +495,9 @@ describe.concurrent('listSyntheseIndividus', () => {
     integrationTest(async () => {
       const indId = testIndicateurId()
       const deptId = testDeptId()
+      const refA = testReferentielId()
       await fixtures.indicateur({ publicId: indId, nom: 'T', visibilite: 'PRIVE' })
-      await fixtures.individu({ publicId: deptId, referentiel: { publicId: 'REF-A', nom: 'A' } })
+      await fixtures.individu({ publicId: deptId, referentiel: { publicId: refA, nom: 'A' } })
       const apiKey = await fixtures.apiKey()
 
       await expect(


### PR DESCRIPTION
…s mb-api (ids statiques)

Les tests d'intégration tournent en concurrence (jusqu'à 10 transactions Postgres simultanées, chacune rollback-ée). Plusieurs tests partageaient des publicId statiques (REF-A, REF-DEPT, PAN-*, WID-*) : des upsert concurrents sur la même ligne provoquaient des deadlocks Postgres intermittents.

Remplace ces publicId statiques par des ids uniques générés par test (testReferentielId/testPanierId/testWidgetId/testIndividuId), en propageant la const dans les fixtures ET les assertions. Rend aussi testDeptId/testRegId aléatoires (avant : pool de ~100 dépts / 18 régions, source de collisions). Les assertions triées par publicId sont rendues robustes au tri.

Suite stable sur runs répétés et ramenée de ~12s à ~1,6s.

Refs:
Project: pilote-2
Client: DITP-pilotage
Category: bugfix
Stack: typescript, vitest, prisma, postgres
Tags: tests, flaky
Files-changed: 16