### PR TITLE
fix(e2e): corriger le redirect HTTPS en dev et la race condition logout

### DIFF
--- a/apps/pilote-ppg/src/proxy.ts
+++ b/apps/pilote-ppg/src/proxy.ts
@@ -68,7 +68,10 @@ export async function proxy(request: NextRequest) {
   const pathname = request.nextUrl.pathname;
   const estAcmeChallenge = pathname.startsWith("/.well-known/acme-challenge/");
 
+  const isDev = process.env.NODE_ENV === "development";
+
   if (
+    !isDev &&
     request.headers.get("x-forwarded-proto") === "http" &&
     !estAcmeChallenge
   ) {
@@ -80,8 +83,6 @@ export async function proxy(request: NextRequest) {
   const nonce = generateNonce();
 
   const response = NextResponse.next();
-
-  const isDev = process.env.NODE_ENV === "development";
 
   response.headers.set("x-nonce", nonce);
 

--- a/apps/pilote-ppg/tests/components/header.component.ts
+++ b/apps/pilote-ppg/tests/components/header.component.ts
@@ -36,11 +36,14 @@ export class HeaderComponent {
 
       await this.logoutButton.click();
 
-      // Le click déclenche next-auth signOut() qui POST /api/auth/signout
-      // puis redirige. On attend que la navigation déclenchée par signOut
-      // soit terminée avant de vérifier l'état des cookies — sinon notre
-      // goto de fallback racerait avec la navigation en cours (ERR_ABORTED).
-      await this.page.waitForLoadState("load");
+      // SignOut déclenche une chaîne de 2 navigations :
+      // 1. NextAuth redirige vers la page courante (ex: /accueil/chantier/NAT-FR)
+      // 2. Le middleware intercepte (plus d'auth) et redirige vers /
+      // waitForLoadState("load") ne couvrait que la 1ère navigation, laissant
+      // la 2ème en cours → race avec le goto("/") de loginAs → ERR_ABORTED.
+      await this.page.waitForURL((url) => url.pathname === "/", {
+        timeout: 30_000,
+      });
 
       // Dans next-auth v5 beta, le cookie de session (authjs.session-token)
       // peut persister après la redirection à cause d'une race avec une


### PR DESCRIPTION
## Problème

Deux bugs bloquaient les tests e2e :

1. **Redirect HTTPS en mode développement** — le middleware (`proxy.ts`) redirectionnait toutes les requêtes HTTP vers HTTPS quand `x-forwarded-proto: http` était présent. En mode e2e, cela transformait les appels tRPC en `TRPCClientError: Failed to fetch` (pas de certificat SSL sur localhost), empêchant le bouton "Se connecter" d'apparaître.

2. **Race condition ERR_ABORTED au logout** — après un `signOut()`, NextAuth déclenche une chaîne de 2 navigations : (1) redirect vers la page courante, (2) le middleware redirige vers `/` l'utilisateur non authentifié. `waitForLoadState("load")` ne couvrait que la première, laissant la deuxième en cours quand `loginAs` appelait `page.goto("/")` → `net::ERR_ABORTED`.

## Changements

- **`src/proxy.ts`** : ajoute `!isDev` dans la condition du redirect HTTP→HTTPS — le redirect reste actif en production uniquement.
- **`tests/components/header.component.ts`** : remplace `waitForLoadState("load")` par `waitForURL(pathname === "/")` qui attend la stabilisation complète de la chaîne de redirections.

## Plan de test

- [ ] Lancer `pnpm test:e2e` — `login.spec.ts` doit passer
- [ ] Lancer `pnpm test:e2e` — `proposition-valeur-avancement.spec.ts` doit passer
- [ ] Vérifier que le redirect HTTP→HTTPS fonctionne toujours en production (`NODE_ENV=production`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)