### PR TITLE
feat(mb-api): rôle CONTRIBUTOR/ADMIN sur les clés API (PIL-1614)

### DIFF
--- a/apps/mb-api/prisma/migrations/20260615143703_add_api_key_role/migration.sql
+++ b/apps/mb-api/prisma/migrations/20260615143703_add_api_key_role/migration.sql
@@ -1,0 +1,5 @@
+-- CreateEnum
+CREATE TYPE "api_key_role_enum" AS ENUM ('CONTRIBUTOR', 'ADMIN');
+
+-- AlterTable
+ALTER TABLE "api_key" ADD COLUMN     "role" "api_key_role_enum" NOT NULL DEFAULT 'CONTRIBUTOR';

--- a/apps/mb-api/prisma/schema.prisma
+++ b/apps/mb-api/prisma/schema.prisma
@@ -54,15 +54,23 @@ model IdentiteExterne {
   @@map("identite_externe")
 }
 
+enum ApiKeyRole {
+  CONTRIBUTOR
+  ADMIN
+
+  @@map("api_key_role_enum")
+}
+
 model ApiKey {
-  id         String    @id @db.Uuid
+  id         String     @id @db.Uuid
   label      String
-  keyHash    String    @unique @map("key_hash")
-  prefix     String    @map("prefix")
-  createdAt  DateTime  @default(now()) @map("created_at")
-  expiresAt  DateTime? @map("expires_at")
-  revokedAt  DateTime? @map("revoked_at")
-  lastUsedAt DateTime? @map("last_used_at")
+  keyHash    String     @unique @map("key_hash")
+  prefix     String     @map("prefix")
+  role       ApiKeyRole @default(CONTRIBUTOR) @map("role")
+  createdAt  DateTime   @default(now()) @map("created_at")
+  expiresAt  DateTime?  @map("expires_at")
+  revokedAt  DateTime?  @map("revoked_at")
+  lastUsedAt DateTime?  @map("last_used_at")
 
   principal Principal @relation(fields: [id], references: [id], onDelete: Cascade)
 

--- a/apps/mb-api/scripts/generate-api-key.ts
+++ b/apps/mb-api/scripts/generate-api-key.ts
@@ -5,10 +5,11 @@ import { buildApiKey } from '@/framework/auth/apiKey'
 const printUsage = () => {
   process.stderr.write(
     [
-      'Usage: tsx scripts/generate-api-key.ts --secret=<hmac-secret> [--label=<label>] [--expires-at=YYYY-MM-DD]',
+      'Usage: tsx scripts/generate-api-key.ts --secret=<hmac-secret> [--label=<label>] [--admin] [--expires-at=YYYY-MM-DD]',
       '',
       '  --secret      Secret HMAC à utiliser pour calculer le hash (obligatoire ; sinon lu depuis API_KEY_HMAC_SECRET).',
       "  --label       Étiquette à utiliser dans la commande SQL d'insertion (optionnel ; défaut: 'à renseigner').",
+      '  --admin       Génère une clé de rôle ADMIN (gestion des indicateurs/référentiels). Défaut : CONTRIBUTOR.',
       "  --expires-at  Date d'expiration ISO (optionnel ; sans cette option, la clé n'expire pas).",
       '',
       'Le script ne touche pas la base : il imprime la clé en clair (à transmettre au client) et',
@@ -35,6 +36,7 @@ const main = (): void => {
     options: {
       secret: { type: 'string' },
       label: { type: 'string' },
+      admin: { type: 'boolean' },
       'expires-at': { type: 'string' },
       help: { type: 'boolean', short: 'h' },
     },
@@ -56,14 +58,16 @@ const main = (): void => {
   }
 
   const label = values.label ?? 'à renseigner'
+  const role = values.admin ? 'ADMIN' : 'CONTRIBUTOR'
   const expiresAt = parseExpiresAt(values['expires-at'])
   const generated = buildApiKey(secret)
 
   const sqlInsert = [
     'BEGIN;',
     `INSERT INTO principal (id) VALUES (${sqlString(generated.id)});`,
-    `INSERT INTO api_key (id, label, key_hash, prefix, expires_at) VALUES (` +
+    `INSERT INTO api_key (id, label, key_hash, prefix, role, expires_at) VALUES (` +
       `${sqlString(generated.id)}, ${sqlString(label)}, ${sqlString(generated.keyHash)}, ${sqlString(generated.prefix)}, ` +
+      `${sqlString(role)}::api_key_role_enum, ` +
       `${expiresAt ? sqlString(expiresAt.toISOString()) : 'NULL'});`,
     `-- Grants READ + WRITE sur les 10 premiers indicateurs (ordre publicId ASC)`,
     `INSERT INTO indicateur_permission (principal_id, indicateur_id, action)`,
@@ -79,6 +83,7 @@ const main = (): void => {
       '== API key générée ==',
       `id        : ${generated.id}`,
       `label     : ${label}`,
+      `role      : ${role}`,
       `prefix    : ${generated.prefix}`,
       `expiresAt : ${expiresAt ? expiresAt.toISOString() : 'jamais'}`,
       '',

--- a/apps/mb-api/src/framework/auth/authContext.test.ts
+++ b/apps/mb-api/src/framework/auth/authContext.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { authContext } from '@/framework/auth/authContext'
 import { UnauthorizedError } from '@/framework/auth/UnauthorizedError'
+import { ApiKeyRole } from '@/generated/prisma/enums'
 import {
   getCurrentPrincipal,
   getCurrentUser,
@@ -174,7 +175,9 @@ describe.sequential('middleware authContext', () => {
   })
 
   it("route les tokens préfixés pilote_live_ vers le vérificateur d'API key", async () => {
-    verifyKey.mockReturnValue(okAsync({ id: 'api-key-id-1', label: 'partner-x' }))
+    verifyKey.mockReturnValue(
+      okAsync({ id: 'api-key-id-1', label: 'partner-x', role: ApiKeyRole.CONTRIBUTOR }),
+    )
     const app = buildApp()
     const response = await app.request('/protected-principal', {
       headers: { Authorization: 'Bearer pilote_live_abc123' },
@@ -182,7 +185,7 @@ describe.sequential('middleware authContext', () => {
     expect(response.status).toBe(200)
     expect(await response.json()).toEqual({
       kind: 'apiKey',
-      apiKey: { id: 'api-key-id-1', label: 'partner-x' },
+      apiKey: { id: 'api-key-id-1', label: 'partner-x', role: ApiKeyRole.CONTRIBUTOR },
     })
     expect(verifyKey).toHaveBeenCalledWith('pilote_live_abc123', expect.any(String))
     expect(verifyJwt).not.toHaveBeenCalled()
@@ -199,7 +202,9 @@ describe.sequential('middleware authContext', () => {
   })
 
   it('fait throw UnauthorizedError sur requireUser() quand le principal est une API key', async () => {
-    verifyKey.mockReturnValue(okAsync({ id: 'api-key-id-1', label: 'partner-x' }))
+    verifyKey.mockReturnValue(
+      okAsync({ id: 'api-key-id-1', label: 'partner-x', role: ApiKeyRole.CONTRIBUTOR }),
+    )
     const app = buildApp()
     const response = await app.request('/protected-user', {
       headers: { Authorization: 'Bearer pilote_live_abc123' },
@@ -208,7 +213,9 @@ describe.sequential('middleware authContext', () => {
   })
 
   it('fait passer requirePrincipal() avec un principal API key', async () => {
-    verifyKey.mockReturnValue(okAsync({ id: 'api-key-id-1', label: 'partner-x' }))
+    verifyKey.mockReturnValue(
+      okAsync({ id: 'api-key-id-1', label: 'partner-x', role: ApiKeyRole.CONTRIBUTOR }),
+    )
     const app = buildApp()
     const response = await app.request('/protected-principal', {
       headers: { Authorization: 'Bearer pilote_live_abc123' },

--- a/apps/mb-api/src/framework/auth/ensureApiKeyAdmin.test.ts
+++ b/apps/mb-api/src/framework/auth/ensureApiKeyAdmin.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+
+import { ensureApiKeyAdmin } from '@/framework/auth/ensureApiKeyAdmin'
+import { UnauthorizedError } from '@/framework/auth/UnauthorizedError'
+import { ForbiddenError } from '@/framework/errors/AppError'
+import { ApiKeyRole } from '@/generated/prisma/enums'
+import { runAsPrincipal, runAsUser } from '@/test/runAsPrincipal'
+
+describe('ensureApiKeyAdmin', () => {
+  it('laisse passer une clé API ADMIN', () => {
+    expect(() =>
+      runAsPrincipal('00000000-0000-0000-0000-000000000001', ensureApiKeyAdmin, ApiKeyRole.ADMIN),
+    ).not.toThrow()
+  })
+
+  it('refuse une clé API CONTRIBUTOR', () => {
+    expect(() =>
+      runAsPrincipal(
+        '00000000-0000-0000-0000-000000000001',
+        ensureApiKeyAdmin,
+        ApiKeyRole.CONTRIBUTOR,
+      ),
+    ).toThrow(ForbiddenError)
+  })
+
+  it('laisse passer un utilisateur OIDC', () => {
+    expect(() => runAsUser('00000000-0000-0000-0000-000000000002', ensureApiKeyAdmin)).not.toThrow()
+  })
+
+  it('refuse en absence de principal', () => {
+    expect(() => ensureApiKeyAdmin()).toThrow(UnauthorizedError)
+  })
+})

--- a/apps/mb-api/src/framework/auth/ensureApiKeyAdmin.test.ts
+++ b/apps/mb-api/src/framework/auth/ensureApiKeyAdmin.test.ts
@@ -3,23 +3,18 @@ import { describe, expect, it } from 'vitest'
 import { ensureApiKeyAdmin } from '@/framework/auth/ensureApiKeyAdmin'
 import { UnauthorizedError } from '@/framework/auth/UnauthorizedError'
 import { ForbiddenError } from '@/framework/errors/AppError'
-import { ApiKeyRole } from '@/generated/prisma/enums'
-import { runAsPrincipal, runAsUser } from '@/test/runAsPrincipal'
+import { runAsAdmin, runAsContributor, runAsUser } from '@/test/runAsPrincipal'
 
 describe('ensureApiKeyAdmin', () => {
   it('laisse passer une clé API ADMIN', () => {
     expect(() =>
-      runAsPrincipal('00000000-0000-0000-0000-000000000001', ensureApiKeyAdmin, ApiKeyRole.ADMIN),
+      runAsAdmin('00000000-0000-0000-0000-000000000001', ensureApiKeyAdmin),
     ).not.toThrow()
   })
 
   it('refuse une clé API CONTRIBUTOR', () => {
     expect(() =>
-      runAsPrincipal(
-        '00000000-0000-0000-0000-000000000001',
-        ensureApiKeyAdmin,
-        ApiKeyRole.CONTRIBUTOR,
-      ),
+      runAsContributor('00000000-0000-0000-0000-000000000001', ensureApiKeyAdmin),
     ).toThrow(ForbiddenError)
   })
 

--- a/apps/mb-api/src/framework/auth/ensureApiKeyAdmin.ts
+++ b/apps/mb-api/src/framework/auth/ensureApiKeyAdmin.ts
@@ -1,0 +1,13 @@
+import { requirePrincipal } from '@/framework/auth/userContext'
+import { ForbiddenError } from '@/framework/errors/AppError'
+import { ApiKeyRole } from '@/generated/prisma/enums'
+
+// Réserve l'opération aux clés API de rôle ADMIN.
+// Les principals utilisateur (OIDC) ne sont pas concernés par ce durcissement.
+export const ensureApiKeyAdmin = (): void => {
+  const principal = requirePrincipal()
+  if (principal.kind === 'user') return
+  if (principal.apiKey.role !== ApiKeyRole.ADMIN) {
+    throw new ForbiddenError('Cette opération requiert une clé API de rôle ADMIN')
+  }
+}

--- a/apps/mb-api/src/framework/auth/requireAuthentication.test.ts
+++ b/apps/mb-api/src/framework/auth/requireAuthentication.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from 'vitest'
 import { UnauthorizedError } from '@/framework/auth/UnauthorizedError'
 import { requireAuthentication } from '@/framework/auth/requireAuthentication'
 import { type Principal, runWithPrincipal } from '@/framework/auth/userContext'
+import { ApiKeyRole } from '@/generated/prisma/enums'
 
 const buildApp = (principal: Principal | null) => {
   const app = new Hono()
@@ -42,7 +43,7 @@ describe.concurrent('middleware requireAuthentication', () => {
   it('laisse passer la requête quand un principal API key est présent', async () => {
     const app = buildApp({
       kind: 'apiKey',
-      apiKey: { id: 'api-key-id-1', label: 'partner-x' },
+      apiKey: { id: 'api-key-id-1', label: 'partner-x', role: ApiKeyRole.CONTRIBUTOR },
     })
     const response = await app.request('/protected')
     expect(response.status).toBe(200)

--- a/apps/mb-api/src/framework/auth/userContext.ts
+++ b/apps/mb-api/src/framework/auth/userContext.ts
@@ -1,6 +1,7 @@
 import { AsyncLocalStorage } from 'node:async_hooks'
 
 import { UnauthorizedError } from '@/framework/auth/UnauthorizedError'
+import type { ApiKeyRole } from '@/generated/prisma/enums'
 
 export type UtilisateurAuthentifie = {
   id: string
@@ -12,6 +13,7 @@ export type UtilisateurAuthentifie = {
 export type ApiKeyAuthentifiee = {
   id: string
   label: string
+  role: ApiKeyRole
 }
 
 export type Principal =

--- a/apps/mb-api/src/framework/auth/verifyApiKey.test.ts
+++ b/apps/mb-api/src/framework/auth/verifyApiKey.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import { env } from '@/env'
 import { verifyApiKey } from '@/framework/auth/verifyApiKey'
+import { ApiKeyRole } from '@/generated/prisma/enums'
 import { fixtures } from '@/test/fixtures'
 import { integrationTest } from '@/test/integrationTest'
 
@@ -12,6 +13,7 @@ describe.concurrent('verifyApiKey', () => {
       const row = await fixtures.apiKey({
         rawKey: 'pilote_live_active_key_for_test_value',
         label: 'partenaire X',
+        role: ApiKeyRole.ADMIN,
       })
 
       const result = await verifyApiKey(
@@ -20,7 +22,11 @@ describe.concurrent('verifyApiKey', () => {
       )
 
       expect(result.isOk()).toBe(true)
-      expect(result._unsafeUnwrap()).toEqual({ id: row.id, label: 'partenaire X' })
+      expect(result._unsafeUnwrap()).toEqual({
+        id: row.id,
+        label: 'partenaire X',
+        role: ApiKeyRole.ADMIN,
+      })
     }),
   )
 

--- a/apps/mb-api/src/framework/auth/verifyApiKey.ts
+++ b/apps/mb-api/src/framework/auth/verifyApiKey.ts
@@ -41,5 +41,5 @@ const resolveApiKey = async (
     )
   }
 
-  return { id: row.id, label: row.label }
+  return { id: row.id, label: row.label, role: row.role }
 }

--- a/apps/mb-api/src/indicateur/commands/upsertIndicateur.test.ts
+++ b/apps/mb-api/src/indicateur/commands/upsertIndicateur.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, it } from 'vitest'
 
-import { ValidationError } from '@/framework/errors/AppError'
+import { ForbiddenError, ValidationError } from '@/framework/errors/AppError'
 import { db } from '@/framework/persistence/dbStore'
 import { upsertIndicateur } from '@/indicateur/commands/upsertIndicateur'
 import { fixtures } from '@/test/fixtures'
 import { integrationTest } from '@/test/integrationTest'
 import { testIndicateurId, testReferentielId } from '@/test/randomIds'
-import { runAsPrincipal } from '@/test/runAsPrincipal'
+import { runAsAdmin, runAsContributor, runAsUser } from '@/test/runAsPrincipal'
 
 const getConfigurationsReferentiels = async (publicId: string) => {
   const indicateur = await db().indicateur.findUniqueOrThrow({
@@ -32,7 +32,7 @@ describe.concurrent('upsertIndicateur', () => {
       const refA = await fixtures.referentiel({ publicId: refCreateA })
       const refB = await fixtures.referentiel({ publicId: refCreateB })
 
-      const result = await runAsPrincipal(apiKey.id, () =>
+      const result = await runAsAdmin(apiKey.id, () =>
         upsertIndicateur(indId, {
           nom: 'Nouvel indicateur',
           visibilite: 'PRIVE',
@@ -64,7 +64,7 @@ describe.concurrent('upsertIndicateur', () => {
       const indId = testIndicateurId()
       const apiKey = await fixtures.apiKey()
 
-      await runAsPrincipal(apiKey.id, () =>
+      await runAsAdmin(apiKey.id, () =>
         upsertIndicateur(indId, { nom: 'I', visibilite: 'PUBLIC', unite: null, referentiels: [] }),
       )
 
@@ -79,7 +79,7 @@ describe.concurrent('upsertIndicateur', () => {
       const indId = testIndicateurId()
       const apiKey = await fixtures.apiKey()
 
-      await runAsPrincipal(apiKey.id, () =>
+      await runAsAdmin(apiKey.id, () =>
         upsertIndicateur(indId, {
           nom: 'I',
           visibilite: 'PRIVE',
@@ -90,7 +90,7 @@ describe.concurrent('upsertIndicateur', () => {
       const apresCreation = await db().indicateur.findUniqueOrThrow({ where: { publicId: indId } })
       expect(apresCreation.unite).toBe('POURCENTAGE')
 
-      await runAsPrincipal(apiKey.id, () =>
+      await runAsAdmin(apiKey.id, () =>
         upsertIndicateur(indId, {
           nom: 'I',
           visibilite: 'PRIVE',
@@ -101,7 +101,7 @@ describe.concurrent('upsertIndicateur', () => {
       const apresMaj = await db().indicateur.findUniqueOrThrow({ where: { publicId: indId } })
       expect(apresMaj.unite).toBe('ANNEES')
 
-      await runAsPrincipal(apiKey.id, () =>
+      await runAsAdmin(apiKey.id, () =>
         upsertIndicateur(indId, {
           nom: 'I',
           visibilite: 'PRIVE',
@@ -123,7 +123,7 @@ describe.concurrent('upsertIndicateur', () => {
         permissions: [{ indicateur: { publicId: indId }, action: 'WRITE' }],
       })
 
-      await runAsPrincipal(apiKey.id, () =>
+      await runAsAdmin(apiKey.id, () =>
         upsertIndicateur(indId, { nom: 'I', visibilite: 'PUBLIC', unite: null, referentiels: [] }),
       )
 
@@ -145,7 +145,7 @@ describe.concurrent('upsertIndicateur', () => {
         { publicId: refReplaceC },
       )
       const apiKey = await fixtures.apiKey()
-      await runAsPrincipal(apiKey.id, () =>
+      await runAsAdmin(apiKey.id, () =>
         upsertIndicateur(indId, {
           nom: 'I',
           visibilite: 'PRIVE',
@@ -157,7 +157,7 @@ describe.concurrent('upsertIndicateur', () => {
         }),
       )
 
-      await runAsPrincipal(apiKey.id, () =>
+      await runAsAdmin(apiKey.id, () =>
         upsertIndicateur(indId, {
           nom: 'I',
           visibilite: 'PRIVE',
@@ -184,7 +184,7 @@ describe.concurrent('upsertIndicateur', () => {
       const refEmptyA = testReferentielId()
       await fixtures.referentiel({ publicId: refEmptyA })
       const apiKey = await fixtures.apiKey()
-      await runAsPrincipal(apiKey.id, () =>
+      await runAsAdmin(apiKey.id, () =>
         upsertIndicateur(indId, {
           nom: 'I',
           visibilite: 'PRIVE',
@@ -193,7 +193,7 @@ describe.concurrent('upsertIndicateur', () => {
         }),
       )
 
-      await runAsPrincipal(apiKey.id, () =>
+      await runAsAdmin(apiKey.id, () =>
         upsertIndicateur(indId, { nom: 'I', visibilite: 'PRIVE', unite: null, referentiels: [] }),
       )
 
@@ -209,7 +209,7 @@ describe.concurrent('upsertIndicateur', () => {
       await fixtures.referentiel({ publicId: refDedupA })
       const apiKey = await fixtures.apiKey()
 
-      const result = await runAsPrincipal(apiKey.id, () =>
+      const result = await runAsAdmin(apiKey.id, () =>
         upsertIndicateur(indId, {
           nom: 'I',
           visibilite: 'PRIVE',
@@ -239,7 +239,7 @@ describe.concurrent('upsertIndicateur', () => {
       const apiKey = await fixtures.apiKey()
 
       await expect(
-        runAsPrincipal(apiKey.id, () =>
+        runAsAdmin(apiKey.id, () =>
           upsertIndicateur(indId, {
             nom: 'I',
             visibilite: 'PRIVE',
@@ -271,7 +271,7 @@ describe.concurrent('upsertIndicateur', () => {
       })
 
       await expect(
-        runAsPrincipal(apiKey.id, () =>
+        runAsAdmin(apiKey.id, () =>
           upsertIndicateur(indId, { nom: 'X', visibilite: 'PRIVE', unite: null, referentiels: [] }),
         ),
       ).rejects.toThrow(/permission/i)
@@ -286,7 +286,7 @@ describe.concurrent('upsertIndicateur', () => {
       await fixtures.referentiel({ publicId: refUpdateA })
       const apiKey = await fixtures.apiKey()
 
-      await runAsPrincipal(apiKey.id, () =>
+      await runAsAdmin(apiKey.id, () =>
         upsertIndicateur(indId, {
           nom: 'I',
           visibilite: 'PRIVE',
@@ -295,7 +295,7 @@ describe.concurrent('upsertIndicateur', () => {
         }),
       )
 
-      await runAsPrincipal(apiKey.id, () =>
+      await runAsAdmin(apiKey.id, () =>
         upsertIndicateur(indId, {
           nom: 'I',
           visibilite: 'PRIVE',
@@ -318,7 +318,7 @@ describe.concurrent('upsertIndicateur', () => {
       await fixtures.referentiel({ publicId: refDedupFn })
       const apiKey = await fixtures.apiKey()
 
-      const result = await runAsPrincipal(apiKey.id, () =>
+      const result = await runAsAdmin(apiKey.id, () =>
         upsertIndicateur(indId, {
           nom: 'I',
           visibilite: 'PRIVE',
@@ -334,6 +334,50 @@ describe.concurrent('upsertIndicateur', () => {
       expect(await getConfigurationsReferentiels(indId)).toEqual([
         { referentielPublicId: refDedupFn, fonctionAgregation: 'NONE' },
       ])
+    }),
+  )
+})
+
+describe.concurrent('upsertIndicateur — garde ADMIN', () => {
+  const body = { nom: 'Nouveau nom', visibilite: 'PRIVE' as const, unite: null, referentiels: [] }
+
+  it(
+    'refuse une clé CONTRIBUTOR (403)',
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const apiKey = await fixtures.apiKey({
+        permissions: [{ indicateur: { publicId: indId }, action: 'WRITE' }],
+      })
+
+      await expect(
+        runAsContributor(apiKey.id, () => upsertIndicateur(indId, body)),
+      ).rejects.toBeInstanceOf(ForbiddenError)
+    }),
+  )
+
+  it(
+    'autorise une clé ADMIN à créer un indicateur',
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const apiKey = await fixtures.apiKey()
+
+      const result = await runAsAdmin(apiKey.id, () => upsertIndicateur(indId, body))
+
+      expect(result.isOk()).toBe(true)
+      const row = await db().indicateur.findUnique({ where: { publicId: indId } })
+      expect(row?.nom).toBe('Nouveau nom')
+    }),
+  )
+
+  it(
+    'autorise un utilisateur OIDC à créer un indicateur',
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const utilisateur = await fixtures.utilisateur()
+
+      const result = await runAsUser(utilisateur.id, () => upsertIndicateur(indId, body))
+
+      expect(result.isOk()).toBe(true)
     }),
   )
 })

--- a/apps/mb-api/src/indicateur/commands/upsertIndicateur.ts
+++ b/apps/mb-api/src/indicateur/commands/upsertIndicateur.ts
@@ -5,6 +5,7 @@ import {
 import { ResultAsync } from 'neverthrow'
 import { uuidv7 } from 'uuidv7'
 
+import { ensureApiKeyAdmin } from '@/framework/auth/ensureApiKeyAdmin'
 import { requireCurrentPrincipalId } from '@/framework/auth/userContext'
 import { ForbiddenError, ValidationError } from '@/framework/errors/AppError'
 import { db } from '@/framework/persistence/dbStore'
@@ -163,6 +164,7 @@ const createIndicateurAvecGrants = async (
 }
 
 const performUpsert = async (publicId: string, body: UpsertIndicateurBody): Promise<void> => {
+  ensureApiKeyAdmin()
   const principalId = requireCurrentPrincipalId()
   const existant = await db().indicateur.findUnique({ where: { publicId } })
   if (existant) {

--- a/apps/mb-api/src/indicateur/routes.ts
+++ b/apps/mb-api/src/indicateur/routes.ts
@@ -80,7 +80,7 @@ const upsertIndicateurRoute = createRoute({
   tags: ['Indicateur', 'Admin'],
   summary: 'Créer ou remplacer un indicateur (nom + référentiels liés)',
   description:
-    "Réservé aux clés API de rôle `ADMIN`. Crée l'indicateur s'il n'existe pas, ou met à jour son `nom` si déjà présent. Le champ `referentielIds` est obligatoire et applique une sémantique replace-all : l'ensemble des liens devient strictement celui décrit dans le body (tableau vide pour aucun lien). Les doublons sont silencieusement dédupliqués. Si un `referentielId` n'existe pas, l'appel échoue avec 400 `VALIDATION_ERROR` et `details.unknownReferentielIds`. L'opération est atomique (transaction unique).",
+    "Réservé aux clés API de rôle `ADMIN` (les utilisateurs OIDC authentifiés restent autorisés). Crée l'indicateur s'il n'existe pas, ou met à jour son `nom` si déjà présent. Le champ `referentielIds` est obligatoire et applique une sémantique replace-all : l'ensemble des liens devient strictement celui décrit dans le body (tableau vide pour aucun lien). Les doublons sont silencieusement dédupliqués. Si un `referentielId` n'existe pas, l'appel échoue avec 400 `VALIDATION_ERROR` et `details.unknownReferentielIds`. L'opération est atomique (transaction unique).",
   middleware: [requireAuthentication],
   request: {
     params: detailParamsSchema,

--- a/apps/mb-api/src/indicateur/routes.ts
+++ b/apps/mb-api/src/indicateur/routes.ts
@@ -77,10 +77,10 @@ const getIndicateurByIdRoute = createRoute({
 const upsertIndicateurRoute = createRoute({
   method: 'put',
   path: '/indicateurs/{id}',
-  tags: ['Indicateur'],
+  tags: ['Indicateur', 'Admin'],
   summary: 'Créer ou remplacer un indicateur (nom + référentiels liés)',
   description:
-    "Crée l'indicateur s'il n'existe pas, ou met à jour son `nom` si déjà présent. Le champ `referentielIds` est obligatoire et applique une sémantique replace-all : l'ensemble des liens devient strictement celui décrit dans le body (tableau vide pour aucun lien). Les doublons sont silencieusement dédupliqués. Si un `referentielId` n'existe pas, l'appel échoue avec 400 `VALIDATION_ERROR` et `details.unknownReferentielIds`. L'opération est atomique (transaction unique).",
+    "Réservé aux clés API de rôle `ADMIN`. Crée l'indicateur s'il n'existe pas, ou met à jour son `nom` si déjà présent. Le champ `referentielIds` est obligatoire et applique une sémantique replace-all : l'ensemble des liens devient strictement celui décrit dans le body (tableau vide pour aucun lien). Les doublons sont silencieusement dédupliqués. Si un `referentielId` n'existe pas, l'appel échoue avec 400 `VALIDATION_ERROR` et `details.unknownReferentielIds`. L'opération est atomique (transaction unique).",
   middleware: [requireAuthentication],
   request: {
     params: detailParamsSchema,
@@ -97,6 +97,10 @@ const upsertIndicateurRoute = createRoute({
     400: {
       content: { 'application/json': { schema: ErrorApiModelSchema } },
       description: 'Requête invalide (body ou référentiels inconnus)',
+    },
+    403: {
+      content: { 'application/json': { schema: ErrorApiModelSchema } },
+      description: 'Clé API sans le rôle ADMIN requis',
     },
   },
 })

--- a/apps/mb-api/src/referentiel/commands/upsertReferentiel.test.ts
+++ b/apps/mb-api/src/referentiel/commands/upsertReferentiel.test.ts
@@ -1,10 +1,18 @@
 import { describe, expect, it } from 'vitest'
 
+import { ForbiddenError } from '@/framework/errors/AppError'
 import { db } from '@/framework/persistence/dbStore'
 import { upsertReferentiel } from '@/referentiel/commands/upsertReferentiel'
 import { fixtures } from '@/test/fixtures'
 import { integrationTest } from '@/test/integrationTest'
 import { testDeptIds, testReferentielId } from '@/test/randomIds'
+import { runAsAdmin, runAsContributor, runAsUser } from '@/test/runAsPrincipal'
+
+// La gestion d'un référentiel est réservée aux clés ADMIN : les cas nominaux
+// s'exécutent donc sous un principal ADMIN.
+const ADMIN_PRINCIPAL_ID = '00000000-0000-0000-0000-0000000000aa'
+const upsertReferentielAsAdmin: typeof upsertReferentiel = (publicId, body) =>
+  runAsAdmin(ADMIN_PRINCIPAL_ID, () => upsertReferentiel(publicId, body))
 
 describe.concurrent('upsertReferentiel', () => {
   it(
@@ -12,7 +20,7 @@ describe.concurrent('upsertReferentiel', () => {
     integrationTest(async () => {
       // When
       const refNew = testReferentielId()
-      const result = await upsertReferentiel(refNew, {
+      const result = await upsertReferentielAsAdmin(refNew, {
         nom: 'Nouveau référentiel',
         description: 'Description initiale',
       })
@@ -37,7 +45,7 @@ describe.concurrent('upsertReferentiel', () => {
       })
 
       // When
-      const result = await upsertReferentiel(refUpd, {
+      const result = await upsertReferentielAsAdmin(refUpd, {
         nom: 'Nouveau nom',
         description: null,
       })
@@ -60,7 +68,7 @@ describe.concurrent('upsertReferentiel', () => {
       const refInds = testReferentielId()
 
       // When
-      await upsertReferentiel(refInds, {
+      await upsertReferentielAsAdmin(refInds, {
         nom: 'Avec individus',
         description: null,
         individus: [
@@ -96,7 +104,7 @@ describe.concurrent('upsertReferentiel', () => {
       })
 
       // When
-      const result = await upsertReferentiel(refLink, {
+      const result = await upsertReferentielAsAdmin(refLink, {
         nom: 'Référentiel',
         description: null,
         individus: [{ publicId: dept1, nom: 'Nouveau nom individu' }],
@@ -127,7 +135,7 @@ describe.concurrent('upsertReferentiel', () => {
       )
 
       // When
-      const result = await upsertReferentiel(refNew2, {
+      const result = await upsertReferentielAsAdmin(refNew2, {
         nom: 'Nouveau référentiel',
         description: null,
         individus: [
@@ -153,7 +161,7 @@ describe.concurrent('upsertReferentiel', () => {
     integrationTest(async () => {
       // When
       const refEmpty = testReferentielId()
-      const result = await upsertReferentiel(refEmpty, {
+      const result = await upsertReferentielAsAdmin(refEmpty, {
         nom: 'Sans individus',
         description: null,
       })
@@ -164,6 +172,48 @@ describe.concurrent('upsertReferentiel', () => {
         where: { publicId: refEmpty },
       })
       expect(persisted.nom).toBe('Sans individus')
+    }),
+  )
+})
+
+describe.concurrent('upsertReferentiel — garde ADMIN', () => {
+  const body = { nom: 'Référentiel', description: null, individus: [] }
+
+  it(
+    'refuse une clé CONTRIBUTOR (403)',
+    integrationTest(async () => {
+      const refId = testReferentielId()
+      const apiKey = await fixtures.apiKey()
+
+      await expect(
+        runAsContributor(apiKey.id, () => upsertReferentiel(refId, body)),
+      ).rejects.toBeInstanceOf(ForbiddenError)
+    }),
+  )
+
+  it(
+    'autorise une clé ADMIN',
+    integrationTest(async () => {
+      const refId = testReferentielId()
+      const apiKey = await fixtures.apiKey()
+
+      const result = await runAsAdmin(apiKey.id, () => upsertReferentiel(refId, body))
+
+      expect(result.isOk()).toBe(true)
+      const row = await db().referentiel.findUnique({ where: { publicId: refId } })
+      expect(row?.nom).toBe('Référentiel')
+    }),
+  )
+
+  it(
+    'autorise un utilisateur OIDC',
+    integrationTest(async () => {
+      const refId = testReferentielId()
+      const utilisateur = await fixtures.utilisateur()
+
+      const result = await runAsUser(utilisateur.id, () => upsertReferentiel(refId, body))
+
+      expect(result.isOk()).toBe(true)
     }),
   )
 })

--- a/apps/mb-api/src/referentiel/commands/upsertReferentiel.ts
+++ b/apps/mb-api/src/referentiel/commands/upsertReferentiel.ts
@@ -2,6 +2,7 @@ import { type UpsertReferentielBody } from '@pilote/mb-shared/referentiel'
 import { err, ok, type Result, ResultAsync } from 'neverthrow'
 import { uuidv7 } from 'uuidv7'
 
+import { ensureApiKeyAdmin } from '@/framework/auth/ensureApiKeyAdmin'
 import { db } from '@/framework/persistence/dbStore'
 
 export type UpsertReferentielError = {
@@ -29,6 +30,7 @@ const performUpsert = async (
   publicId: string,
   body: UpsertReferentielBody,
 ): Promise<Result<void, UpsertReferentielError>> => {
+  ensureApiKeyAdmin()
   const existingReferentiel = await db().referentiel.findUnique({
     where: { publicId },
     select: { id: true },

--- a/apps/mb-api/src/referentiel/routes.ts
+++ b/apps/mb-api/src/referentiel/routes.ts
@@ -83,7 +83,7 @@ const upsertReferentielRoute = createRoute({
   tags: ['Referentiel', 'Admin'],
   summary: 'Créer ou mettre à jour un référentiel',
   description:
-    "Réservé aux clés API de rôle `ADMIN`. Crée le référentiel s'il n'existe pas, ou met à jour son `nom` et sa `description` quand le référentiel existe déjà. Le tableau `individus` est optionnel : chaque individu est créé et rattaché au référentiel, ou son nom est mis à jour s'il existe déjà et qu'il est déjà rattaché à ce même référentiel. Si un individu listé existe et est rattaché à un autre référentiel, la requête est rejetée (409). Opération idempotente, exécutée dans une transaction.",
+    "Réservé aux clés API de rôle `ADMIN` (les utilisateurs OIDC authentifiés restent autorisés). Crée le référentiel s'il n'existe pas, ou met à jour son `nom` et sa `description` quand le référentiel existe déjà. Le tableau `individus` est optionnel : chaque individu est créé et rattaché au référentiel, ou son nom est mis à jour s'il existe déjà et qu'il est déjà rattaché à ce même référentiel. Si un individu listé existe et est rattaché à un autre référentiel, la requête est rejetée (409). Opération idempotente, exécutée dans une transaction.",
   middleware: [requireAuthentication],
   request: {
     params: detailParamsSchema,

--- a/apps/mb-api/src/referentiel/routes.ts
+++ b/apps/mb-api/src/referentiel/routes.ts
@@ -80,10 +80,10 @@ const getReferentielByIdRoute = createRoute({
 const upsertReferentielRoute = createRoute({
   method: 'put',
   path: '/referentiels/{id}',
-  tags: ['Referentiel'],
+  tags: ['Referentiel', 'Admin'],
   summary: 'Créer ou mettre à jour un référentiel',
   description:
-    "Crée le référentiel s'il n'existe pas, ou met à jour son `nom` et sa `description` quand le référentiel existe déjà. Le tableau `individus` est optionnel : chaque individu est créé et rattaché au référentiel, ou son nom est mis à jour s'il existe déjà et qu'il est déjà rattaché à ce même référentiel. Si un individu listé existe et est rattaché à un autre référentiel, la requête est rejetée (409). Opération idempotente, exécutée dans une transaction.",
+    "Réservé aux clés API de rôle `ADMIN`. Crée le référentiel s'il n'existe pas, ou met à jour son `nom` et sa `description` quand le référentiel existe déjà. Le tableau `individus` est optionnel : chaque individu est créé et rattaché au référentiel, ou son nom est mis à jour s'il existe déjà et qu'il est déjà rattaché à ce même référentiel. Si un individu listé existe et est rattaché à un autre référentiel, la requête est rejetée (409). Opération idempotente, exécutée dans une transaction.",
   middleware: [requireAuthentication],
   request: {
     params: detailParamsSchema,
@@ -100,6 +100,10 @@ const upsertReferentielRoute = createRoute({
     400: {
       content: { 'application/json': { schema: ErrorApiModelSchema } },
       description: 'Corps de requête ou paramètres invalides',
+    },
+    403: {
+      content: { 'application/json': { schema: ErrorApiModelSchema } },
+      description: 'Clé API sans le rôle ADMIN requis',
     },
     409: {
       content: { 'application/json': { schema: ErrorApiModelSchema } },

--- a/apps/mb-api/src/test/fixtures.ts
+++ b/apps/mb-api/src/test/fixtures.ts
@@ -30,6 +30,7 @@ import {
   type WidgetModel,
 } from '@/generated/prisma/models'
 import {
+  ApiKeyRole,
   PermissionAction,
   ProviderType,
   Visibilite,
@@ -528,6 +529,7 @@ type ApiKeyOverrides = Partial<{
   label: string
   rawKey: string
   prefix: string
+  role: ApiKeyRole
   expiresAt: Date | null
   revokedAt: Date | null
   lastUsedAt: Date | null
@@ -563,6 +565,7 @@ const upsertApiKey = async (o: ApiKeyOverrides = {}) => {
     label: o.label ?? 'API key de test',
     keyHash,
     prefix: o.prefix ?? rawKey.slice(0, 20),
+    role: o.role ?? ApiKeyRole.CONTRIBUTOR,
     expiresAt: o.expiresAt ?? null,
     revokedAt: o.revokedAt ?? null,
     lastUsedAt: o.lastUsedAt ?? null,

--- a/apps/mb-api/src/test/runAsPrincipal.ts
+++ b/apps/mb-api/src/test/runAsPrincipal.ts
@@ -1,11 +1,20 @@
 import { runWithPrincipal } from '@/framework/auth/userContext'
 import { ApiKeyRole } from '@/generated/prisma/enums'
 
+// Défaut CONTRIBUTOR : reflète le défaut de la colonne `role` en base (moindre
+// privilège). Utiliser runAsAdmin pour les opérations de gestion réservées aux
+// clés ADMIN, afin que chaque test déclare explicitement son niveau de droit.
 export const runAsPrincipal = <T>(
   principalId: string,
   fn: () => T,
   role: ApiKeyRole = ApiKeyRole.CONTRIBUTOR,
 ): T => runWithPrincipal({ kind: 'apiKey', apiKey: { id: principalId, label: 'test', role } }, fn)
+
+export const runAsAdmin = <T>(principalId: string, fn: () => T): T =>
+  runAsPrincipal(principalId, fn, ApiKeyRole.ADMIN)
+
+export const runAsContributor = <T>(principalId: string, fn: () => T): T =>
+  runAsPrincipal(principalId, fn, ApiKeyRole.CONTRIBUTOR)
 
 export const runAsUser = <T>(userId: string, fn: () => T): T =>
   runWithPrincipal(

--- a/apps/mb-api/src/test/runAsPrincipal.ts
+++ b/apps/mb-api/src/test/runAsPrincipal.ts
@@ -1,4 +1,14 @@
 import { runWithPrincipal } from '@/framework/auth/userContext'
+import { ApiKeyRole } from '@/generated/prisma/enums'
 
-export const runAsPrincipal = <T>(principalId: string, fn: () => T): T =>
-  runWithPrincipal({ kind: 'apiKey', apiKey: { id: principalId, label: 'test' } }, fn)
+export const runAsPrincipal = <T>(
+  principalId: string,
+  fn: () => T,
+  role: ApiKeyRole = ApiKeyRole.CONTRIBUTOR,
+): T => runWithPrincipal({ kind: 'apiKey', apiKey: { id: principalId, label: 'test', role } }, fn)
+
+export const runAsUser = <T>(userId: string, fn: () => T): T =>
+  runWithPrincipal(
+    { kind: 'user', user: { id: userId, email: 'test@example.com', prenom: 'Test', nom: 'User' } },
+    fn,
+  )


### PR DESCRIPTION
## Contexte

Toutes les clés API de `mb-api` avaient les mêmes capacités. L'action de permission `WRITE` (par indicateur) était **surchargée** : elle autorisait à la fois la **gestion de définition** (`PUT /indicateurs/{id}`) et la **saisie de valeurs** (`PUT/DELETE /indicateurs/{id}/valeurs`, `:batch`, objectifs). On découple ces deux capacités.

Deux trous de sécurité sont fermés au passage :
- `PUT /referentiels/{id}` n'était gardé par **aucune** permission ;
- la **création** d'indicateur via `PUT /indicateurs/{id}` n'était pas gardée.

## Solution

Un **rôle sur la clé API**, orthogonal à l'ACL par ressource existante :

- `enum ApiKeyRole { CONTRIBUTOR, ADMIN }`, colonne `role` sur `ApiKey`, **défaut `CONTRIBUTOR`** ;
- garde `ensureApiKeyAdmin` sur `PUT /indicateurs/{id}` et `PUT /referentiels/{id}` (création + mise à jour) ;
- **saisie de valeurs inchangée** (toujours gouvernée par l'ACL `WRITE` par indicateur) ;
- les principals **utilisateur (OIDC) restent autorisés** — le durcissement vise les clés API ;
- Swagger : tag `Admin` + réponse `403` documentée sur les routes de gestion.


## ⚠️ Exploitation (à ne pas oublier)

La migration met **toutes** les clés existantes en `CONTRIBUTOR`. Après déploiement, **promouvoir manuellement en `ADMIN`** les clés légitimes (typiquement mb-admin), **env par env** — sinon leurs écritures de définition/référentiel renverront 403. Le script `generate-api-key.ts` accepte désormais `--admin`.

## Tests

- `ensureApiKeyAdmin` : ADMIN ✅, CONTRIBUTOR → 403, user OIDC ✅, sans principal → 401.
- `upsertIndicateur` / `upsertReferentiel` : CONTRIBUTOR → 403, ADMIN ✅, user OIDC ✅.
- Suite complète mb-api : **328 tests verts**, lint (eslint + tsc + prettier) vert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)