### PR TITLE
refacto(pmb): navigation par switch dans la page Tableau de bord

### DIFF
--- a/apps/mb-webapp/src/components/DashboardSwitch.tsx
+++ b/apps/mb-webapp/src/components/DashboardSwitch.tsx
@@ -1,0 +1,35 @@
+import { useLocation, useNavigate, useSearch } from '@tanstack/react-router'
+import { FolderClosed, LineChart } from 'lucide-react'
+
+import { SegmentedControl } from '@/components/ui/SegmentedControl'
+
+const ROUTE_BY_VUE = {
+  indicateurs: '/indicateurs',
+  dossiers: '/paniers',
+} as const
+
+type VueTableauDeBord = keyof typeof ROUTE_BY_VUE
+
+export function DashboardSwitch() {
+  const navigate = useNavigate()
+  const search = useSearch({ strict: false })
+  const { pathname } = useLocation()
+  const vue: VueTableauDeBord = pathname.startsWith('/paniers') ? 'dossiers' : 'indicateurs'
+
+  return (
+    <SegmentedControl
+      aria-label="Basculer entre indicateurs et dossiers"
+      value={vue}
+      onValueChange={(prochaineVue) => {
+        void navigate({
+          to: ROUTE_BY_VUE[prochaineVue],
+          search: { individu: search.individu, referentiel: search.referentiel },
+        })
+      }}
+      options={[
+        { value: 'indicateurs', label: 'Indicateurs', icon: <LineChart /> },
+        { value: 'dossiers', label: 'Mes dossiers', icon: <FolderClosed /> },
+      ]}
+    />
+  )
+}

--- a/apps/mb-webapp/src/components/ui/SegmentedControl.tsx
+++ b/apps/mb-webapp/src/components/ui/SegmentedControl.tsx
@@ -1,0 +1,59 @@
+import { ToggleGroup as ToggleGroupPrimitive } from 'radix-ui'
+import type { ReactNode } from 'react'
+
+import { clsxm } from '@/lib/clsxm'
+
+export type SegmentedControlOption<TValue extends string> = {
+  value: TValue
+  label: ReactNode
+  icon?: ReactNode
+}
+
+type SegmentedControlProps<TValue extends string> = {
+  value: TValue
+  onValueChange: (value: TValue) => void
+  options: SegmentedControlOption<TValue>[]
+  'aria-label': string
+  className?: string
+}
+
+export function SegmentedControl<TValue extends string>({
+  value,
+  onValueChange,
+  options,
+  className,
+  ...props
+}: SegmentedControlProps<TValue>) {
+  return (
+    <ToggleGroupPrimitive.Root
+      type="single"
+      value={value}
+      onValueChange={(next) => {
+        // Radix renvoie une chaîne vide quand on reclique le segment actif : on ignore pour rester non-déselectionnable
+        if (next) onValueChange(next as TValue)
+      }}
+      aria-label={props['aria-label']}
+      className={clsxm(
+        'inline-flex items-center gap-1 rounded-lg border border-border bg-surface-tinted p-1',
+        className,
+      )}
+    >
+      {options.map((option) => (
+        <ToggleGroupPrimitive.Item
+          key={option.value}
+          value={option.value}
+          className={clsxm(
+            'inline-flex items-center gap-2 rounded-md px-3 py-1.5 text-sm font-medium text-text-muted transition-colors',
+            'hover:text-text',
+            'focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary',
+            'data-[state=on]:bg-primary data-[state=on]:text-primary-foreground data-[state=on]:font-semibold data-[state=on]:shadow-sm',
+            '[&_svg]:size-4 [&_svg]:shrink-0',
+          )}
+        >
+          {option.icon}
+          {option.label}
+        </ToggleGroupPrimitive.Item>
+      ))}
+    </ToggleGroupPrimitive.Root>
+  )
+}

--- a/apps/mb-webapp/src/routes/__root.tsx
+++ b/apps/mb-webapp/src/routes/__root.tsx
@@ -3,6 +3,7 @@ import {
   createRootRouteWithContext,
   Link,
   Outlet,
+  useLocation,
   useNavigate,
   useSearch,
 } from '@tanstack/react-router'
@@ -49,8 +50,7 @@ function RootComponent() {
           </Link>
 
           <nav className="flex items-center gap-1 sm:gap-2">
-            <NavLink to="/indicateurs">Indicateurs</NavLink>
-            <NavLink to="/paniers">Paniers</NavLink>
+            <NavLink>Tableau de bord</NavLink>
 
             <div className="mx-2 hidden h-6 w-px bg-border sm:block" />
 
@@ -90,14 +90,16 @@ function RootComponent() {
   )
 }
 
-function NavLink({ to, children }: { to: '/indicateurs' | '/paniers'; children: ReactNode }) {
+function NavLink({ children }: { children: ReactNode }) {
   const search = useSearch({ strict: false })
+  const { pathname } = useLocation()
+  const isActive = pathname.startsWith('/indicateurs') || pathname.startsWith('/paniers')
   return (
     <Link
-      to={to}
+      to="/indicateurs"
       search={{ individu: search.individu, referentiel: search.referentiel }}
+      data-status={isActive ? 'active' : undefined}
       className="rounded-md px-3 py-2 text-sm font-medium text-text-muted transition-colors hover:bg-surface-tinted hover:text-primary data-[status=active]:bg-primary-tinted data-[status=active]:text-primary"
-      activeProps={{ 'data-status': 'active' }}
     >
       {children}
     </Link>

--- a/apps/mb-webapp/src/routes/_authenticated/indicateurs/index.tsx
+++ b/apps/mb-webapp/src/routes/_authenticated/indicateurs/index.tsx
@@ -5,6 +5,7 @@ import { createFileRoute, redirect, useNavigate } from '@tanstack/react-router'
 import { startTransition, useId } from 'react'
 import { z } from 'zod'
 
+import { DashboardSwitch } from '@/components/DashboardSwitch'
 import { RouteError } from '@/components/RouteError'
 import { RouteLoading } from '@/components/RouteLoading'
 import { IndicateurCard } from '@/components/indicateurs/IndicateurCard'
@@ -63,7 +64,10 @@ function IndicateursListComponent() {
   const referentielIds = referentiels.map((r) => r.id)
 
   return (
-    <Page kicker="Catalogue" title="Indicateurs">
+    <Page
+      title="Tableau de bord"
+      description="Consultez et gérez l'ensemble de vos indicateurs par valeur ou par dossier."
+    >
       <div className="flex flex-col gap-6">
         {search.individu ? (
           <div className="max-w-md">
@@ -88,15 +92,18 @@ function IndicateursListComponent() {
           <Text as="span" variant="kicker" tone="muted">
             {data.total} indicateur{data.total > 1 ? 's' : ''}
           </Text>
-          <SearchField
-            label="Rechercher un indicateur par nom"
-            placeholder="Rechercher un indicateur…"
-            value={search.recherche ?? ''}
-            onChange={(value) => {
-              const recherche = value || undefined
-              void navigate({ search: (prev) => ({ ...prev, recherche, cursor: undefined }) })
-            }}
-          />
+          <div className="flex flex-wrap items-center gap-4">
+            <SearchField
+              label="Rechercher un indicateur par nom"
+              placeholder="Rechercher un indicateur…"
+              value={search.recherche ?? ''}
+              onChange={(value) => {
+                const recherche = value || undefined
+                void navigate({ search: (prev) => ({ ...prev, recherche, cursor: undefined }) })
+              }}
+            />
+            <DashboardSwitch />
+          </div>
         </div>
 
         {data.items.length === 0 ? (

--- a/apps/mb-webapp/src/routes/_authenticated/indicateurs/index.tsx
+++ b/apps/mb-webapp/src/routes/_authenticated/indicateurs/index.tsx
@@ -69,41 +69,43 @@ function IndicateursListComponent() {
       description="Consultez et gérez l'ensemble de vos indicateurs par valeur ou par dossier."
     >
       <div className="flex flex-col gap-6">
-        {search.individu ? (
-          <div className="max-w-md">
-            <FormField label="Individu observé" htmlFor={selectId}>
-              <IndividuSelect
-                id={selectId}
-                referentielIds={referentielIds}
-                value={search.individu}
-                onChange={({ individu, referentiel }) => {
-                  startTransition(() => {
-                    void navigate({
-                      search: (prev) => ({ ...prev, individu, referentiel }),
+        <div className="flex flex-wrap items-end justify-between gap-4">
+          {search.individu ? (
+            <div className="max-w-md flex-1">
+              <FormField label="Individu observé" htmlFor={selectId}>
+                <IndividuSelect
+                  id={selectId}
+                  referentielIds={referentielIds}
+                  value={search.individu}
+                  onChange={({ individu, referentiel }) => {
+                    startTransition(() => {
+                      void navigate({
+                        search: (prev) => ({ ...prev, individu, referentiel }),
+                      })
                     })
-                  })
-                }}
-              />
-            </FormField>
-          </div>
-        ) : null}
+                  }}
+                />
+              </FormField>
+            </div>
+          ) : (
+            <div />
+          )}
+          <DashboardSwitch />
+        </div>
 
         <div className="flex flex-wrap items-center justify-between gap-4">
           <Text as="span" variant="kicker" tone="muted">
             {data.total} indicateur{data.total > 1 ? 's' : ''}
           </Text>
-          <div className="flex flex-wrap items-center gap-4">
-            <SearchField
-              label="Rechercher un indicateur par nom"
-              placeholder="Rechercher un indicateur…"
-              value={search.recherche ?? ''}
-              onChange={(value) => {
-                const recherche = value || undefined
-                void navigate({ search: (prev) => ({ ...prev, recherche, cursor: undefined }) })
-              }}
-            />
-            <DashboardSwitch />
-          </div>
+          <SearchField
+            label="Rechercher un indicateur par nom"
+            placeholder="Rechercher un indicateur…"
+            value={search.recherche ?? ''}
+            onChange={(value) => {
+              const recherche = value || undefined
+              void navigate({ search: (prev) => ({ ...prev, recherche, cursor: undefined }) })
+            }}
+          />
         </div>
 
         {data.items.length === 0 ? (

--- a/apps/mb-webapp/src/routes/_authenticated/paniers/index.tsx
+++ b/apps/mb-webapp/src/routes/_authenticated/paniers/index.tsx
@@ -5,6 +5,7 @@ import { createFileRoute, redirect, useNavigate } from '@tanstack/react-router'
 import { startTransition, useId } from 'react'
 import { z } from 'zod'
 
+import { DashboardSwitch } from '@/components/DashboardSwitch'
 import { RouteError } from '@/components/RouteError'
 import { RouteLoading } from '@/components/RouteLoading'
 import { IndividuSelect } from '@/components/indicateurs/IndividuSelect'
@@ -71,7 +72,10 @@ function PaniersListComponent() {
       : undefined
 
   return (
-    <Page kicker="Collections thématiques" title="Paniers">
+    <Page
+      title="Tableau de bord"
+      description="Consultez et gérez l'ensemble de vos indicateurs par valeur ou par dossier."
+    >
       <div className="flex flex-col gap-6">
         {search.individu ? (
           <div className="max-w-md">
@@ -92,9 +96,12 @@ function PaniersListComponent() {
           </div>
         ) : null}
 
-        <Text as="span" variant="kicker" tone="muted">
-          {data.total} panier{data.total > 1 ? 's' : ''}
-        </Text>
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <Text as="span" variant="kicker" tone="muted">
+            {data.total} dossier{data.total > 1 ? 's' : ''}
+          </Text>
+          <DashboardSwitch />
+        </div>
 
         {data.items.length === 0 ? (
           <EmptyState title="Aucun panier disponible" />

--- a/apps/mb-webapp/src/routes/_authenticated/paniers/index.tsx
+++ b/apps/mb-webapp/src/routes/_authenticated/paniers/index.tsx
@@ -77,31 +77,33 @@ function PaniersListComponent() {
       description="Consultez et gérez l'ensemble de vos indicateurs par valeur ou par dossier."
     >
       <div className="flex flex-col gap-6">
-        {search.individu ? (
-          <div className="max-w-md">
-            <FormField label="Individu observé" htmlFor={selectId}>
-              <IndividuSelect
-                id={selectId}
-                referentielIds={referentielIds}
-                value={search.individu}
-                onChange={({ individu, referentiel }) => {
-                  startTransition(() => {
-                    void navigate({
-                      search: (prev) => ({ ...prev, individu, referentiel }),
+        <div className="flex flex-wrap items-end justify-between gap-4">
+          {search.individu ? (
+            <div className="max-w-md flex-1">
+              <FormField label="Individu observé" htmlFor={selectId}>
+                <IndividuSelect
+                  id={selectId}
+                  referentielIds={referentielIds}
+                  value={search.individu}
+                  onChange={({ individu, referentiel }) => {
+                    startTransition(() => {
+                      void navigate({
+                        search: (prev) => ({ ...prev, individu, referentiel }),
+                      })
                     })
-                  })
-                }}
-              />
-            </FormField>
-          </div>
-        ) : null}
-
-        <div className="flex flex-wrap items-center justify-between gap-4">
-          <Text as="span" variant="kicker" tone="muted">
-            {data.total} dossier{data.total > 1 ? 's' : ''}
-          </Text>
+                  }}
+                />
+              </FormField>
+            </div>
+          ) : (
+            <div />
+          )}
           <DashboardSwitch />
         </div>
+
+        <Text as="span" variant="kicker" tone="muted">
+          {data.total} dossier{data.total > 1 ? 's' : ''}
+        </Text>
 
         {data.items.length === 0 ? (
           <EmptyState title="Aucun panier disponible" />

--- a/apps/mb-webapp/src/tests/routing.test.tsx
+++ b/apps/mb-webapp/src/tests/routing.test.tsx
@@ -61,13 +61,13 @@ describe('routing', () => {
   it('ne rend pas /indicateurs sans être authentifié (le beforeLoad bloque le rendu)', async () => {
     renderAt('/indicateurs', stubAuth(null))
     await new Promise((resolve) => setTimeout(resolve, 50))
-    expect(screen.queryByRole('heading', { level: 1, name: 'Indicateurs' })).toBeNull()
+    expect(screen.queryByRole('heading', { level: 1, name: 'Tableau de bord' })).toBeNull()
   })
 
   it("permet d'accéder à /indicateurs après login", async () => {
     renderAt('/indicateurs', stubAuth({ userId: 'sub-1', prenom: 'Admin', nom: 'DITP' }))
     await waitFor(() => {
-      expect(screen.getByRole('heading', { level: 1, name: 'Indicateurs' })).toBeInTheDocument()
+      expect(screen.getByRole('heading', { level: 1, name: 'Tableau de bord' })).toBeInTheDocument()
     })
   })
 })


### PR DESCRIPTION
## Contexte

La webapp PMB exposait deux onglets dans la navbar (**Indicateurs** et **Paniers**) menant à deux pages distinctes. On passe à une entrée de navbar unique **Tableau de bord** + un **switch `Indicateurs | Mes dossiers`** dans la page, conformément au modèle.

## Approche (volontairement minimale)

Pas de fusion de routes/loaders/schemas : on **garde l'archi existante**, le switch ne fait que **naviguer** entre `/indicateurs` et `/paniers`.
- Vue active **dérivée de la route courante** (`useLocation`) — pas d'état local ni de param d'URL en plus.
- Params `individu`/`referentiel` **préservés** au changement de vue (même comportement que l'ancien `NavLink`).

## Changements

**Nouveaux composants**
- `ui/SegmentedControl.tsx` — segmented control générique réutilisable (Radix `ToggleGroup`, style pill, non-déselectionnable).
- `DashboardSwitch.tsx` — câble le switch aux deux routes.

**Modifs**
- `routes/_authenticated/indicateurs/index.tsx` — titre → « Tableau de bord » + description, switch à droite de la ligne compteur.
- `routes/_authenticated/paniers/index.tsx` — même titre/description, compteur « dossier(s) », switch à droite.
- `routes/__root.tsx` — 2 `NavLink` → entrée unique « Tableau de bord », active sur les deux routes.

## Hors périmètre (PR ultérieures)

- Rename complet `panier` → `dossier` dans le code/API/routes.
- Filtres du modèle (Thématiques, Périmètres ministériels).
- Recherche côté dossiers.

## Vérifs

- `pnpm lint` (tsr generate + eslint + `tsc --noEmit` + prettier) ✅