### PR TITLE
feat(webapp): libellé "Valeur d'avancement" + écart à la médiane (PIL-1561 / PIL-1564)

### DIFF
--- a/apps/mb-webapp/src/components/indicateurs/IndicateurValeursRemarquables.tsx
+++ b/apps/mb-webapp/src/components/indicateurs/IndicateurValeursRemarquables.tsx
@@ -8,6 +8,7 @@ import {
   formatDateFr,
   formatNumberAvecUniteFr,
   formatNumberFr,
+  formatVariationAvecUniteFr,
   formatVariationFr,
 } from '@/lib/format'
 import {
@@ -52,12 +53,14 @@ export function IndicateurValeursRemarquables({
 
   const derniereValeur = derniereValeurFromItems(valeurs.items)
   const variation = synthese.items[0]?.variation ?? null
+  const ecartMediane = synthese.items[0]?.ecartMediane ?? null
 
   const dernierPoint = tauxProgression.items[tauxProgression.items.length - 1]
   const hasTaux = dernierPoint !== undefined
+  const columns = hasTaux ? 4 : 3
 
   return (
-    <StatGrid columns={hasTaux ? 3 : 2}>
+    <StatGrid columns={columns}>
       <StatCard
         label="Valeur d'avancement"
         tone={derniereValeur ? 'neutral' : 'muted'}
@@ -68,6 +71,11 @@ export function IndicateurValeursRemarquables({
         label="Variation depuis la dernière MAJ"
         tone={variationTone(variation)}
         value={variation === null ? '—' : formatVariationFr(variation)}
+      />
+      <StatCard
+        label="Écart à la médiane"
+        tone={ecartMediane === null ? 'muted' : 'neutral'}
+        value={ecartMediane === null ? '—' : formatVariationAvecUniteFr(ecartMediane, unite)}
       />
       {hasTaux && (
         <StatCard

--- a/apps/mb-webapp/src/components/indicateurs/IndicateurValeursRemarquables.tsx
+++ b/apps/mb-webapp/src/components/indicateurs/IndicateurValeursRemarquables.tsx
@@ -59,7 +59,7 @@ export function IndicateurValeursRemarquables({
   return (
     <StatGrid columns={hasTaux ? 3 : 2}>
       <StatCard
-        label="Valeur la plus récente"
+        label="Valeur d'avancement"
         tone={derniereValeur ? 'neutral' : 'muted'}
         value={derniereValeur ? formatNumberAvecUniteFr(derniereValeur.valeur, unite) : '—'}
         caption={derniereValeur ? `au ${formatDateFr(derniereValeur.date)}` : undefined}

--- a/apps/mb-webapp/src/lib/format.ts
+++ b/apps/mb-webapp/src/lib/format.ts
@@ -29,7 +29,9 @@ export const formatVariationAvecUniteFr = (
   value: number,
   unite: UniteIndicateurApiModel | null,
 ): string =>
-  unite ? `${variationFr.format(value)}${NBSP_FINE}${unite.abbreviation}` : variationFr.format(value)
+  unite
+    ? `${variationFr.format(value)}${NBSP_FINE}${unite.abbreviation}`
+    : variationFr.format(value)
 
 export const formatDateFr = (value: Date | string): string => dateFr.format(toDate(value))
 

--- a/apps/mb-webapp/src/lib/format.ts
+++ b/apps/mb-webapp/src/lib/format.ts
@@ -25,6 +25,12 @@ export const formatNumberAvecUniteFr = (
 
 export const formatVariationFr = (value: number): string => variationFr.format(value)
 
+export const formatVariationAvecUniteFr = (
+  value: number,
+  unite: UniteIndicateurApiModel | null,
+): string =>
+  unite ? `${variationFr.format(value)}${NBSP_FINE}${unite.abbreviation}` : variationFr.format(value)
+
 export const formatDateFr = (value: Date | string): string => dateFr.format(toDate(value))
 
 export const formatDateTimeFr = (value: Date | string): string =>


### PR DESCRIPTION
## Summary
- **PIL-1561** — Renomme le libellé de la StatCard "Valeur la plus récente" → "Valeur d'avancement" dans `IndicateurValeursRemarquables` pour s'aligner sur la spec (libellé exact attendu côté utilisateur).
- **PIL-1564** — Ajoute une StatCard "Écart à la médiane" alimentée par `synthese.items[0].ecartMediane` (déjà exposé par `/synthese-individus` côté mb-api). Le grid passe à 3 colonnes (sans taux de progression) ou 4 (avec). La valeur est affichée brute (signe + unité, pas d'arrondi), pour rester cohérent avec les autres champs numériques de l'API.
- Min/max/médiane de la maille étaient déjà rendus par `IndicateurStatsPanel`. La maille de comparaison correspond au référentiel de l'individu observé, déjà résolu via `IndividuSelect`.

## Test plan
- [ ] `/indicateurs/$id`, sélectionner un individu : les cards "Valeur d'avancement", "Variation depuis la dernière MAJ" et "Écart à la médiane" sont affichées.
- [ ] Sélectionner un individu sans valeur : les 3 cards affichent "—".
- [ ] Changer d'individu : valeur, variation et écart à la médiane sont mis à jour ; min/max/médiane du \`IndicateurStatsPanel\` aussi (référentiel synchronisé).
- [ ] Indicateur avec une cible : la 4ᵉ card "Taux de progression" reste affichée, layout en 4 colonnes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PIL-1561]: https://data-ditp.atlassian.net/browse/PIL-1561
[PIL-1564]: https://data-ditp.atlassian.net/browse/PIL-1564