### PR TITLE
feat: autoriser la MAJ des indicateurs sur les chantiers archivés (PIL-1620)

### DIFF
--- a/apps/pilote-ppg/src/client/components/PageChantier/usePageChantier.ts
+++ b/apps/pilote-ppg/src/client/components/PageChantier/usePageChantier.ts
@@ -80,8 +80,7 @@ export const usePageChantier = () => {
   const estAutoriseAImporterDesIndicateurs =
     peutToujoursImporterDesIndicateurs ||
     (estAutoriséAImporterDesIndicateurs(session!.profil) &&
-      estAutoriseAImporterSurLeChantier &&
-      chantier.statut !== "ARCHIVE");
+      estAutoriseAImporterSurLeChantier);
 
   const estAutoriseAVoirLeBoutonFicheConducteur =
     !!ffFicheConducteur &&


### PR DESCRIPTION
## Contexte

Ticket Jira : [PIL-1620](https://data-ditp.atlassian.net/jira/software/c/projects/PIL/boards/3?selectedIssue=PIL-1620)

## Changements

Suppression de la condition `chantier.statut !== "ARCHIVE"` dans le calcul de `estAutoriseAImporterDesIndicateurs`.

Auparavant, les utilisateurs autorisés à importer des indicateurs ne pouvaient pas le faire sur les chantiers archivés. Ce changement lève cette restriction pour permettre la mise à jour des PPG archivés.

[PIL-1620]: https://data-ditp.atlassian.net/browse/PIL-1620?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ