### PR TITLE
fix(gestion-utilisateur): dédier un email système pour la désactivation automatique (PIL-1551)

### DIFF
--- a/apps/pilote-ppg/scripts/anonymisation_utilisateurs.sh
+++ b/apps/pilote-ppg/scripts/anonymisation_utilisateurs.sh
@@ -4,5 +4,5 @@ echo ">> Anonymisation des utilisateurs..."
 time psql -d "$DATABASE_URL" -c "
 UPDATE utilisateur
 SET email = REPLACE(CONCAT(id, '@example.com'), ' ', '')
-WHERE email NOT LIKE '%@example%' AND email <> 'import.csv@modernisation.gouv.fr';
+WHERE email NOT LIKE '%@example%' AND email NOT IN ('import.csv@modernisation.gouv.fr', 'desactivation.automatique@modernisation.gouv.fr');
 "

--- a/apps/pilote-ppg/src/server/gestion-utilisateur/usecases/DesactiverLesComptesInactifsUseCase.ts
+++ b/apps/pilote-ppg/src/server/gestion-utilisateur/usecases/DesactiverLesComptesInactifsUseCase.ts
@@ -16,7 +16,8 @@ export interface DesactiverLesComptesInactifsResultat {
   erreurs: number;
 }
 
-const EMAIL_UTILISATEUR_SYSTEME = "import.csv@modernisation.gouv.fr";
+const EMAIL_UTILISATEUR_SYSTEME =
+  "desactivation.automatique@modernisation.gouv.fr";
 
 export class DesactiverLesComptesInactifsUseCase {
   private utilisateurRepository: UtilisateurRepository;


### PR DESCRIPTION
## Contexte

[PIL-1551](https://ditp-pilotage.atlassian.net/browse/PIL-1551)

L'email utilisé comme identifiant de l'utilisateur système dans le use case `DesactiverLesComptesInactifsUseCase` était `import.csv@modernisation.gouv.fr`, partagé avec le process d'import CSV. Cela posait un problème de lisibilité et de séparation des responsabilités.

## Changements

- **`DesactiverLesComptesInactifsUseCase.ts`** — `EMAIL_UTILISATEUR_SYSTEME` passe à `desactivation.automatique@modernisation.gouv.fr`
- **`anonymisation_utilisateurs.sh`** — le script exclut désormais les deux emails système de l'anonymisation (`NOT IN` au lieu de `<>`)

[PIL-1551]: https://data-ditp.atlassian.net/browse/PIL-1551?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ