### PR TITLE
feat(cron): ajouter le paramètre force au cron rapports-pva

### DIFF
--- a/apps/pilote-ppg/src/pages/api/admin/cron/rapports-pva.ts
+++ b/apps/pilote-ppg/src/pages/api/admin/cron/rapports-pva.ts
@@ -1,22 +1,33 @@
 import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
 import { onlyCron } from "@/server/infrastructure/api/cron/onlyCron";
 import { getContainer } from "@/server/dependances";
 import logger from "@/server/infrastructure/Logger";
 import { envoieMessageTchap } from "@/server/utils/notification-tchap";
 import { configuration } from "@/config";
 
+const querySchema = z.object({
+  force: z
+    .enum(["true", "false"])
+    .optional()
+    .transform((val) => val === "true"),
+});
+
 async function handler(req: NextApiRequest, res: NextApiResponse) {
   const baseUrl = configuration().tchap.baseUrl;
   const roomId = configuration().tchap.roomIdRapportPva;
   const accessToken = configuration().tchap.accessToken;
+
+  const { force } = querySchema.parse(req.query);
 
   const featureFlips = await getContainer("legacy")
     .resolve("recupererFeatureFlipsUseCase")
     .run();
 
   if (
-    !featureFlips["NEXT_PUBLIC_FF_RAPPORT_PVA"] ||
-    configuration().scalingoEnvironment !== "PROD"
+    !force &&
+    (!featureFlips["NEXT_PUBLIC_FF_RAPPORT_PVA"] ||
+      configuration().scalingoEnvironment !== "PROD")
   ) {
     return res.status(200).json({
       skipped: true,


### PR DESCRIPTION
## Contexte

Le cron `rapports-coordinateurs` supporte un paramètre `?force=true` permettant de bypasser les vérifications de feature flag et d'environnement. Le cron `rapports-pva` ne disposait pas de cette possibilité.

## Changements

Ajout du paramètre query `force` sur `/api/admin/cron/rapports-pva`, calqué sur l'implémentation existante de `rapports-coordinateurs` :

- Parsing via Zod (`force=true` → booléen)
- Quand `force=true`, les checks feature flag (`NEXT_PUBLIC_FF_RAPPORT_PVA`) et environnement (`PROD`) sont ignorés