### PR TITLE
feat(panier): ajouter le bloc Contacts utiles dans l'onglet Gouvernance

### DIFF
--- a/apps/mb-api/prisma/migrations/20260622000000_panier_gouvernance/migration.sql
+++ b/apps/mb-api/prisma/migrations/20260622000000_panier_gouvernance/migration.sql
@@ -1,9 +1,9 @@
 -- AlterTable
 ALTER TABLE "utilisateur"
-  ADD COLUMN "nom"      TEXT,
-  ADD COLUMN "prenom"   TEXT,
-  ADD COLUMN "service"  TEXT,
-  ADD COLUMN "fonction" TEXT;
+  ADD COLUMN "nom"      TEXT NOT NULL,
+  ADD COLUMN "prenom"   TEXT NOT NULL,
+  ADD COLUMN "service"  TEXT NOT NULL,
+  ADD COLUMN "fonction" TEXT NOT NULL;
 
 -- CreateTable
 CREATE TABLE "panier_responsable" (

--- a/apps/mb-api/prisma/migrations/20260622000000_panier_gouvernance/migration.sql
+++ b/apps/mb-api/prisma/migrations/20260622000000_panier_gouvernance/migration.sql
@@ -1,0 +1,29 @@
+-- AlterTable
+ALTER TABLE "utilisateur"
+  ADD COLUMN "nom"      TEXT,
+  ADD COLUMN "prenom"   TEXT,
+  ADD COLUMN "service"  TEXT,
+  ADD COLUMN "fonction" TEXT;
+
+-- CreateTable
+CREATE TABLE "panier_responsable" (
+  "panier_id"      UUID        NOT NULL,
+  "utilisateur_id" UUID        NOT NULL,
+  "created_at"     TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+  CONSTRAINT "panier_responsable_pkey" PRIMARY KEY ("panier_id", "utilisateur_id")
+);
+
+-- CreateIndex
+CREATE INDEX "panier_responsable_panier_id_created_at_idx"
+  ON "panier_responsable" ("panier_id", "created_at");
+
+-- AddForeignKey
+ALTER TABLE "panier_responsable"
+  ADD CONSTRAINT "panier_responsable_panier_id_fkey"
+  FOREIGN KEY ("panier_id") REFERENCES "panier"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "panier_responsable"
+  ADD CONSTRAINT "panier_responsable_utilisateur_id_fkey"
+  FOREIGN KEY ("utilisateur_id") REFERENCES "utilisateur"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/mb-api/prisma/migrations/20260622100000_contacts_utiles/migration.sql
+++ b/apps/mb-api/prisma/migrations/20260622100000_contacts_utiles/migration.sql
@@ -1,0 +1,28 @@
+CREATE TABLE "organisme" (
+  "id" UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  "nom" TEXT NOT NULL,
+  "created_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+  "updated_at" TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE "contact_utile" (
+  "id" UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  "organisme_id" UUID NOT NULL REFERENCES "organisme"("id") ON DELETE RESTRICT,
+  "nom" TEXT NOT NULL,
+  "description" TEXT,
+  "telephone" TEXT,
+  "email" TEXT,
+  "url" TEXT,
+  "adresse" TEXT,
+  "created_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+  "updated_at" TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE "panier_contact_utile" (
+  "panier_id" UUID NOT NULL REFERENCES "panier"("id") ON DELETE CASCADE,
+  "contact_utile_id" UUID NOT NULL REFERENCES "contact_utile"("id") ON DELETE CASCADE,
+  "created_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY ("panier_id", "contact_utile_id")
+);
+
+CREATE INDEX "panier_contact_utile_panier_id_idx" ON "panier_contact_utile"("panier_id");

--- a/apps/mb-api/prisma/schema.prisma
+++ b/apps/mb-api/prisma/schema.prisma
@@ -278,9 +278,10 @@ model Panier {
   createdAt   DateTime   @default(now()) @map("created_at")
   updatedAt   DateTime   @updatedAt      @map("updated_at")
 
-  indicateurs  PanierIndicateur[]
-  permissions  PanierPermission[]
-  responsables PanierResponsable[]
+  indicateurs    PanierIndicateur[]
+  permissions    PanierPermission[]
+  responsables   PanierResponsable[]
+  contactsUtiles PanierContactUtile[]
 
   @@map("panier")
 }
@@ -324,6 +325,48 @@ model PanierResponsable {
   @@id([panierId, utilisateurId])
   @@index([panierId, createdAt])
   @@map("panier_responsable")
+}
+
+model Organisme {
+  id        String   @id @default(uuid()) @db.Uuid
+  nom       String
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt       @map("updated_at")
+
+  contacts  ContactUtile[]
+
+  @@map("organisme")
+}
+
+model ContactUtile {
+  id          String   @id @default(uuid()) @db.Uuid
+  organismeId String   @map("organisme_id") @db.Uuid
+  nom         String
+  description String?
+  telephone   String?
+  email       String?
+  url         String?
+  adresse     String?
+  createdAt   DateTime @default(now()) @map("created_at")
+  updatedAt   DateTime @updatedAt       @map("updated_at")
+
+  organisme Organisme            @relation(fields: [organismeId], references: [id])
+  paniers   PanierContactUtile[]
+
+  @@map("contact_utile")
+}
+
+model PanierContactUtile {
+  panierId       String   @map("panier_id")        @db.Uuid
+  contactUtileId String   @map("contact_utile_id") @db.Uuid
+  createdAt      DateTime @default(now())           @map("created_at")
+
+  panier       Panier       @relation(fields: [panierId],       references: [id], onDelete: Cascade)
+  contactUtile ContactUtile @relation(fields: [contactUtileId], references: [id], onDelete: Cascade)
+
+  @@id([panierId, contactUtileId])
+  @@index([panierId])
+  @@map("panier_contact_utile")
 }
 
 enum ApplicationLogLevel {

--- a/apps/mb-api/prisma/schema.prisma
+++ b/apps/mb-api/prisma/schema.prisma
@@ -32,10 +32,10 @@ enum ProviderType {
 model Utilisateur {
   id        String   @id @db.Uuid
   email     String   @unique
-  nom       String?
-  prenom    String?
-  service   String?
-  fonction  String?
+  nom       String
+  prenom    String
+  service   String
+  fonction  String
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt      @map("updated_at")
 

--- a/apps/mb-api/prisma/schema.prisma
+++ b/apps/mb-api/prisma/schema.prisma
@@ -32,11 +32,16 @@ enum ProviderType {
 model Utilisateur {
   id        String   @id @db.Uuid
   email     String   @unique
+  nom       String?
+  prenom    String?
+  service   String?
+  fonction  String?
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt      @map("updated_at")
 
-  principal  Principal         @relation(fields: [id], references: [id], onDelete: Cascade)
-  identites  IdentiteExterne[]
+  principal       Principal          @relation(fields: [id], references: [id], onDelete: Cascade)
+  identites       IdentiteExterne[]
+  responsabilites PanierResponsable[]
 
   @@map("utilisateur")
 }
@@ -273,8 +278,9 @@ model Panier {
   createdAt   DateTime   @default(now()) @map("created_at")
   updatedAt   DateTime   @updatedAt      @map("updated_at")
 
-  indicateurs PanierIndicateur[]
-  permissions PanierPermission[]
+  indicateurs  PanierIndicateur[]
+  permissions  PanierPermission[]
+  responsables PanierResponsable[]
 
   @@map("panier")
 }
@@ -305,6 +311,19 @@ model PanierIndicateur {
   @@id([panierId, indicateurId])
   @@index([panierId, createdAt])
   @@map("panier_indicateur")
+}
+
+model PanierResponsable {
+  panierId      String   @map("panier_id")      @db.Uuid
+  utilisateurId String   @map("utilisateur_id") @db.Uuid
+  createdAt     DateTime @default(now())         @map("created_at")
+
+  panier      Panier      @relation(fields: [panierId],      references: [id], onDelete: Cascade)
+  utilisateur Utilisateur @relation(fields: [utilisateurId], references: [id], onDelete: Cascade)
+
+  @@id([panierId, utilisateurId])
+  @@index([panierId, createdAt])
+  @@map("panier_responsable")
 }
 
 enum ApplicationLogLevel {

--- a/apps/mb-api/prisma/seed.ts
+++ b/apps/mb-api/prisma/seed.ts
@@ -740,6 +740,7 @@ const main = async () => {
 
   // Responsables panier : ditp.admin et claire.dupont sont responsables de PAN-005.
   const pan005 = paniersByPublicId.get('PAN-005')
+  const pan004 = paniersByPublicId.get('PAN-004')
   const claireDupont = await prisma.utilisateur.findUniqueOrThrow({
     where: { email: 'claire.dupont@example.com' },
     select: { id: true },
@@ -755,10 +756,109 @@ const main = async () => {
   }
   const panierResponsablesCount = 2
 
+  // ── Organismes ────────────────────────────────────────────────────────────────
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const prismaAny = prisma as any
+
+  const ditp = await prismaAny.organisme.upsert({
+    where:  { id: 'a1b2c3d4-0000-0000-0000-000000000001' },
+    update: {},
+    create: {
+      id:  'a1b2c3d4-0000-0000-0000-000000000001',
+      nom: 'Direction interministérielle de la transformation publique (DITP)',
+    },
+  })
+
+  const dinum = await prismaAny.organisme.upsert({
+    where:  { id: 'a1b2c3d4-0000-0000-0000-000000000002' },
+    update: {},
+    create: {
+      id:  'a1b2c3d4-0000-0000-0000-000000000002',
+      nom: 'Direction interministérielle du numérique (DINUM)',
+    },
+  })
+
+  // ── Contacts utiles ────────────────────────────────────────────────────────────
+
+  const supportMethodo = await prismaAny.contactUtile.upsert({
+    where:  { id: 'b0000000-0000-0000-0000-000000000001' },
+    update: {},
+    create: {
+      id:          'b0000000-0000-0000-0000-000000000001',
+      organismeId: ditp.id,
+      nom:         'Support méthodologique et accompagnement',
+      description: 'Accompagnement des équipes projet dans la démarche de pilotage par les résultats',
+      telephone:   '01 23 45 67 89',
+      email:       'support.methodologie@ditp.gouv.fr',
+      url:         'https://www.modernisation.gouv.fr',
+      adresse:     '20 avenue de Ségur, 75007 Paris',
+    },
+  })
+
+  const celluleFormation = await prismaAny.contactUtile.upsert({
+    where:  { id: 'b0000000-0000-0000-0000-000000000002' },
+    update: {},
+    create: {
+      id:          'b0000000-0000-0000-0000-000000000002',
+      organismeId: ditp.id,
+      nom:         'Cellule formation et montée en compétences',
+      description: 'Formations au pilotage par les résultats, ateliers et webinaires',
+      telephone:   '01 23 45 67 90',
+      email:       'formation@ditp.gouv.fr',
+    },
+  })
+
+  const supportTechnique = await prismaAny.contactUtile.upsert({
+    where:  { id: 'b0000000-0000-0000-0000-000000000003' },
+    update: {},
+    create: {
+      id:          'b0000000-0000-0000-0000-000000000003',
+      organismeId: dinum.id,
+      nom:         'Support technique Pilote',
+      email:       'support@pilote.gouv.fr',
+      url:         'https://pilote.numerique.gouv.fr',
+    },
+  })
+
+  const ouvertureDonnees = await prismaAny.contactUtile.upsert({
+    where:  { id: 'b0000000-0000-0000-0000-000000000004' },
+    update: {},
+    create: {
+      id:          'b0000000-0000-0000-0000-000000000004',
+      organismeId: dinum.id,
+      nom:         'Département ouverture des données',
+      description: "Accompagnement à l'ouverture et au partage des données publiques",
+      email:       'data@numerique.gouv.fr',
+      url:         'https://data.gouv.fr',
+    },
+  })
+
+  // ── Rattachements ──────────────────────────────────────────────────────────────
+
+  if (pan005) {
+    for (const contact of [supportMethodo, celluleFormation, supportTechnique, ouvertureDonnees]) {
+      await prismaAny.panierContactUtile.upsert({
+        where:  { panierId_contactUtileId: { panierId: pan005.id, contactUtileId: contact.id } },
+        update: {},
+        create: { panierId: pan005.id, contactUtileId: contact.id },
+      })
+    }
+  }
+
+  if (pan004) {
+    await prismaAny.panierContactUtile.upsert({
+      where:  { panierId_contactUtileId: { panierId: pan004.id, contactUtileId: ouvertureDonnees.id } },
+      update: {},
+      create: { panierId: pan004.id, contactUtileId: ouvertureDonnees.id },
+    })
+  }
+
+  const contactsUtilesCount = 4
+
   const permissionsCount = 8 * 2
   const widgetLiaisonsCount = widgetsSeed.reduce((acc, w) => acc + w.referentielPublicIds.length, 0)
   console.log(
-    `Seed terminé : ${indicateursSeed.length} indicateurs, ${utilisateursSeed.length} utilisateurs, ${permissionsCount} permissions indicateur, ${referentielsSeed.length} référentiels, ${individusSeed.length} individus, ${liaisonsCount} liaisons indicateur-référentiel, ${relationsSeed.length} relations, ${valeursCount} valeurs insérées, ${objectifsCount} objectifs insérés (les doublons ont été ignorés), ${widgetsSeed.length} widgets, ${widgetLiaisonsCount} liaisons référentiel-widget, ${paniersSeed.length} paniers (${panierLiaisonsCount} liaisons panier-indicateur, ${panierPermissionsCount} permissions panier, ${panierResponsablesCount} responsable panier).`,
+    `Seed terminé : ${indicateursSeed.length} indicateurs, ${utilisateursSeed.length} utilisateurs, ${permissionsCount} permissions indicateur, ${referentielsSeed.length} référentiels, ${individusSeed.length} individus, ${liaisonsCount} liaisons indicateur-référentiel, ${relationsSeed.length} relations, ${valeursCount} valeurs insérées, ${objectifsCount} objectifs insérés (les doublons ont été ignorés), ${widgetsSeed.length} widgets, ${widgetLiaisonsCount} liaisons référentiel-widget, ${paniersSeed.length} paniers (${panierLiaisonsCount} liaisons panier-indicateur, ${panierPermissionsCount} permissions panier, ${panierResponsablesCount} responsable panier, ${contactsUtilesCount} contacts utiles).`,
   )
 }
 

--- a/apps/mb-api/prisma/seed.ts
+++ b/apps/mb-api/prisma/seed.ts
@@ -761,19 +761,19 @@ const main = async () => {
   const prismaAny = prisma as any
 
   const ditp = await prismaAny.organisme.upsert({
-    where:  { id: 'a1b2c3d4-0000-0000-0000-000000000001' },
+    where: { id: 'a1b2c3d4-0000-0000-0000-000000000001' },
     update: {},
     create: {
-      id:  'a1b2c3d4-0000-0000-0000-000000000001',
+      id: 'a1b2c3d4-0000-0000-0000-000000000001',
       nom: 'Direction interministérielle de la transformation publique (DITP)',
     },
   })
 
   const dinum = await prismaAny.organisme.upsert({
-    where:  { id: 'a1b2c3d4-0000-0000-0000-000000000002' },
+    where: { id: 'a1b2c3d4-0000-0000-0000-000000000002' },
     update: {},
     create: {
-      id:  'a1b2c3d4-0000-0000-0000-000000000002',
+      id: 'a1b2c3d4-0000-0000-0000-000000000002',
       nom: 'Direction interministérielle du numérique (DINUM)',
     },
   })
@@ -781,55 +781,56 @@ const main = async () => {
   // ── Contacts utiles ────────────────────────────────────────────────────────────
 
   const supportMethodo = await prismaAny.contactUtile.upsert({
-    where:  { id: 'b0000000-0000-0000-0000-000000000001' },
+    where: { id: 'b0000000-0000-0000-0000-000000000001' },
     update: {},
     create: {
-      id:          'b0000000-0000-0000-0000-000000000001',
+      id: 'b0000000-0000-0000-0000-000000000001',
       organismeId: ditp.id,
-      nom:         'Support méthodologique et accompagnement',
-      description: 'Accompagnement des équipes projet dans la démarche de pilotage par les résultats',
-      telephone:   '01 23 45 67 89',
-      email:       'support.methodologie@ditp.gouv.fr',
-      url:         'https://www.modernisation.gouv.fr',
-      adresse:     '20 avenue de Ségur, 75007 Paris',
+      nom: 'Support méthodologique et accompagnement',
+      description:
+        'Accompagnement des équipes projet dans la démarche de pilotage par les résultats',
+      telephone: '01 23 45 67 89',
+      email: 'support.methodologie@ditp.gouv.fr',
+      url: 'https://www.modernisation.gouv.fr',
+      adresse: '20 avenue de Ségur, 75007 Paris',
     },
   })
 
   const celluleFormation = await prismaAny.contactUtile.upsert({
-    where:  { id: 'b0000000-0000-0000-0000-000000000002' },
+    where: { id: 'b0000000-0000-0000-0000-000000000002' },
     update: {},
     create: {
-      id:          'b0000000-0000-0000-0000-000000000002',
+      id: 'b0000000-0000-0000-0000-000000000002',
       organismeId: ditp.id,
-      nom:         'Cellule formation et montée en compétences',
+      nom: 'Cellule formation et montée en compétences',
       description: 'Formations au pilotage par les résultats, ateliers et webinaires',
-      telephone:   '01 23 45 67 90',
-      email:       'formation@ditp.gouv.fr',
+      telephone: '01 23 45 67 90',
+      email: 'formation@ditp.gouv.fr',
     },
   })
 
   const supportTechnique = await prismaAny.contactUtile.upsert({
-    where:  { id: 'b0000000-0000-0000-0000-000000000003' },
+    where: { id: 'b0000000-0000-0000-0000-000000000003' },
     update: {},
     create: {
-      id:          'b0000000-0000-0000-0000-000000000003',
+      id: 'b0000000-0000-0000-0000-000000000003',
       organismeId: dinum.id,
-      nom:         'Support technique Pilote',
-      email:       'support@pilote.gouv.fr',
-      url:         'https://pilote.numerique.gouv.fr',
+      nom: 'Support technique Pilote',
+      email: 'support@pilote.gouv.fr',
+      url: 'https://pilote.numerique.gouv.fr',
     },
   })
 
   const ouvertureDonnees = await prismaAny.contactUtile.upsert({
-    where:  { id: 'b0000000-0000-0000-0000-000000000004' },
+    where: { id: 'b0000000-0000-0000-0000-000000000004' },
     update: {},
     create: {
-      id:          'b0000000-0000-0000-0000-000000000004',
+      id: 'b0000000-0000-0000-0000-000000000004',
       organismeId: dinum.id,
-      nom:         'Département ouverture des données',
+      nom: 'Département ouverture des données',
       description: "Accompagnement à l'ouverture et au partage des données publiques",
-      email:       'data@numerique.gouv.fr',
-      url:         'https://data.gouv.fr',
+      email: 'data@numerique.gouv.fr',
+      url: 'https://data.gouv.fr',
     },
   })
 
@@ -838,7 +839,7 @@ const main = async () => {
   if (pan005) {
     for (const contact of [supportMethodo, celluleFormation, supportTechnique, ouvertureDonnees]) {
       await prismaAny.panierContactUtile.upsert({
-        where:  { panierId_contactUtileId: { panierId: pan005.id, contactUtileId: contact.id } },
+        where: { panierId_contactUtileId: { panierId: pan005.id, contactUtileId: contact.id } },
         update: {},
         create: { panierId: pan005.id, contactUtileId: contact.id },
       })
@@ -847,7 +848,9 @@ const main = async () => {
 
   if (pan004) {
     await prismaAny.panierContactUtile.upsert({
-      where:  { panierId_contactUtileId: { panierId: pan004.id, contactUtileId: ouvertureDonnees.id } },
+      where: {
+        panierId_contactUtileId: { panierId: pan004.id, contactUtileId: ouvertureDonnees.id },
+      },
       update: {},
       create: { panierId: pan004.id, contactUtileId: ouvertureDonnees.id },
     })

--- a/apps/mb-api/prisma/seed.ts
+++ b/apps/mb-api/prisma/seed.ts
@@ -96,10 +96,10 @@ const indicateursSeed: ReadonlyArray<{
 
 const utilisateursSeed: ReadonlyArray<{
   email: string
-  nom: string | null
-  prenom: string | null
-  service: string | null
-  fonction: string | null
+  nom: string
+  prenom: string
+  service: string
+  fonction: string
 }> = [
   {
     email: 'ditp.admin@example.com',

--- a/apps/mb-api/prisma/seed.ts
+++ b/apps/mb-api/prisma/seed.ts
@@ -94,7 +94,28 @@ const indicateursSeed: ReadonlyArray<{
   },
 ]
 
-const utilisateursSeed: ReadonlyArray<{ email: string }> = [{ email: 'ditp.admin@example.com' }]
+const utilisateursSeed: ReadonlyArray<{
+  email: string
+  nom: string | null
+  prenom: string | null
+  service: string | null
+  fonction: string | null
+}> = [
+  {
+    email: 'ditp.admin@example.com',
+    nom: 'Admin',
+    prenom: 'DITP',
+    service: 'DITP',
+    fonction: 'Administrateur',
+  },
+  {
+    email: 'claire.dupont@example.com',
+    nom: 'Dupont',
+    prenom: 'Claire',
+    service: 'Bureau des indicateurs',
+    fonction: 'Chargée de mission',
+  },
+]
 
 // Clusters de mise à jour : plusieurs indicateurs peuvent partager la même
 // date de mise à jour (réaliste : on bouge plusieurs fiches le même jour).
@@ -188,11 +209,31 @@ const main = async () => {
   }
   for (const item of utilisateursSeed) {
     const existing = await prisma.utilisateur.findUnique({ where: { email: item.email } })
-    if (existing) continue
+    if (existing) {
+      await prisma.utilisateur.update({
+        where: { email: item.email },
+        data: {
+          nom: item.nom,
+          prenom: item.prenom,
+          service: item.service,
+          fonction: item.fonction,
+        },
+      })
+      continue
+    }
     const id = uuidv7()
     await prisma.$transaction([
       prisma.principal.create({ data: { id } }),
-      prisma.utilisateur.create({ data: { id, email: item.email } }),
+      prisma.utilisateur.create({
+        data: {
+          id,
+          email: item.email,
+          nom: item.nom,
+          prenom: item.prenom,
+          service: item.service,
+          fonction: item.fonction,
+        },
+      }),
     ])
   }
 
@@ -697,10 +738,27 @@ const main = async () => {
   }
   const panierPermissionsCount = 2
 
+  // Responsables panier : ditp.admin et claire.dupont sont responsables de PAN-005.
+  const pan005 = paniersByPublicId.get('PAN-005')
+  const claireDupont = await prisma.utilisateur.findUniqueOrThrow({
+    where: { email: 'claire.dupont@example.com' },
+    select: { id: true },
+  })
+  if (pan005) {
+    for (const utilisateurId of [ditpAdmin.id, claireDupont.id]) {
+      await prisma.panierResponsable.upsert({
+        where: { panierId_utilisateurId: { panierId: pan005.id, utilisateurId } },
+        update: {},
+        create: { panierId: pan005.id, utilisateurId },
+      })
+    }
+  }
+  const panierResponsablesCount = 2
+
   const permissionsCount = 8 * 2
   const widgetLiaisonsCount = widgetsSeed.reduce((acc, w) => acc + w.referentielPublicIds.length, 0)
   console.log(
-    `Seed terminé : ${indicateursSeed.length} indicateurs, ${utilisateursSeed.length} utilisateurs, ${permissionsCount} permissions indicateur, ${referentielsSeed.length} référentiels, ${individusSeed.length} individus, ${liaisonsCount} liaisons indicateur-référentiel, ${relationsSeed.length} relations, ${valeursCount} valeurs insérées, ${objectifsCount} objectifs insérés (les doublons ont été ignorés), ${widgetsSeed.length} widgets, ${widgetLiaisonsCount} liaisons référentiel-widget, ${paniersSeed.length} paniers (${panierLiaisonsCount} liaisons panier-indicateur, ${panierPermissionsCount} permissions panier).`,
+    `Seed terminé : ${indicateursSeed.length} indicateurs, ${utilisateursSeed.length} utilisateurs, ${permissionsCount} permissions indicateur, ${referentielsSeed.length} référentiels, ${individusSeed.length} individus, ${liaisonsCount} liaisons indicateur-référentiel, ${relationsSeed.length} relations, ${valeursCount} valeurs insérées, ${objectifsCount} objectifs insérés (les doublons ont été ignorés), ${widgetsSeed.length} widgets, ${widgetLiaisonsCount} liaisons référentiel-widget, ${paniersSeed.length} paniers (${panierLiaisonsCount} liaisons panier-indicateur, ${panierPermissionsCount} permissions panier, ${panierResponsablesCount} responsable panier).`,
   )
 }
 

--- a/apps/mb-api/prisma/seed.ts
+++ b/apps/mb-api/prisma/seed.ts
@@ -761,19 +761,19 @@ const main = async () => {
   const prismaAny = prisma as any
 
   const ditp = await prismaAny.organisme.upsert({
-    where: { id: 'a1b2c3d4-0000-0000-0000-000000000001' },
+    where: { id: 'a1b2c3d4-e5f6-4a7b-8c9d-e0f1a2b3c401' },
     update: {},
     create: {
-      id: 'a1b2c3d4-0000-0000-0000-000000000001',
+      id: 'a1b2c3d4-e5f6-4a7b-8c9d-e0f1a2b3c401',
       nom: 'Direction interministérielle de la transformation publique (DITP)',
     },
   })
 
   const dinum = await prismaAny.organisme.upsert({
-    where: { id: 'a1b2c3d4-0000-0000-0000-000000000002' },
+    where: { id: 'a1b2c3d4-e5f6-4a7b-8c9d-e0f1a2b3c402' },
     update: {},
     create: {
-      id: 'a1b2c3d4-0000-0000-0000-000000000002',
+      id: 'a1b2c3d4-e5f6-4a7b-8c9d-e0f1a2b3c402',
       nom: 'Direction interministérielle du numérique (DINUM)',
     },
   })
@@ -781,10 +781,10 @@ const main = async () => {
   // ── Contacts utiles ────────────────────────────────────────────────────────────
 
   const supportMethodo = await prismaAny.contactUtile.upsert({
-    where: { id: 'b0000000-0000-0000-0000-000000000001' },
+    where: { id: 'b1c2d3e4-f5a6-4b7c-8d9e-f0a1b2c3d401' },
     update: {},
     create: {
-      id: 'b0000000-0000-0000-0000-000000000001',
+      id: 'b1c2d3e4-f5a6-4b7c-8d9e-f0a1b2c3d401',
       organismeId: ditp.id,
       nom: 'Support méthodologique et accompagnement',
       description:
@@ -797,10 +797,10 @@ const main = async () => {
   })
 
   const celluleFormation = await prismaAny.contactUtile.upsert({
-    where: { id: 'b0000000-0000-0000-0000-000000000002' },
+    where: { id: 'b1c2d3e4-f5a6-4b7c-8d9e-f0a1b2c3d402' },
     update: {},
     create: {
-      id: 'b0000000-0000-0000-0000-000000000002',
+      id: 'b1c2d3e4-f5a6-4b7c-8d9e-f0a1b2c3d402',
       organismeId: ditp.id,
       nom: 'Cellule formation et montée en compétences',
       description: 'Formations au pilotage par les résultats, ateliers et webinaires',
@@ -810,10 +810,10 @@ const main = async () => {
   })
 
   const supportTechnique = await prismaAny.contactUtile.upsert({
-    where: { id: 'b0000000-0000-0000-0000-000000000003' },
+    where: { id: 'b1c2d3e4-f5a6-4b7c-8d9e-f0a1b2c3d403' },
     update: {},
     create: {
-      id: 'b0000000-0000-0000-0000-000000000003',
+      id: 'b1c2d3e4-f5a6-4b7c-8d9e-f0a1b2c3d403',
       organismeId: dinum.id,
       nom: 'Support technique Pilote',
       email: 'support@pilote.gouv.fr',
@@ -822,10 +822,10 @@ const main = async () => {
   })
 
   const ouvertureDonnees = await prismaAny.contactUtile.upsert({
-    where: { id: 'b0000000-0000-0000-0000-000000000004' },
+    where: { id: 'b1c2d3e4-f5a6-4b7c-8d9e-f0a1b2c3d404' },
     update: {},
     create: {
-      id: 'b0000000-0000-0000-0000-000000000004',
+      id: 'b1c2d3e4-f5a6-4b7c-8d9e-f0a1b2c3d404',
       organismeId: dinum.id,
       nom: 'Département ouverture des données',
       description: "Accompagnement à l'ouverture et au partage des données publiques",

--- a/apps/mb-api/src/panier/queries/getPanierContactsUtiles.test.ts
+++ b/apps/mb-api/src/panier/queries/getPanierContactsUtiles.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, it } from 'vitest'
+
+import { getPanierContactsUtiles } from '@/panier/queries/getPanierContactsUtiles'
+import { fixtures } from '@/test/fixtures'
+import { integrationTest } from '@/test/integrationTest'
+import { testPanierId } from '@/test/randomIds'
+import { runAsPrincipal } from '@/test/runAsPrincipal'
+
+describe.concurrent('getPanierContactsUtiles', () => {
+  it(
+    'retourne une liste vide quand le panier na aucun contact',
+    integrationTest(async () => {
+      const panVide = testPanierId()
+      await fixtures.panier({ publicId: panVide, visibilite: 'PUBLIC' })
+      const apiKey = await fixtures.apiKey()
+
+      const result = await runAsPrincipal(apiKey.id, () => getPanierContactsUtiles(panVide))
+
+      expect(result.isOk()).toBe(true)
+      expect(result._unsafeUnwrap()).toEqual({ items: [] })
+    }),
+  )
+
+  it(
+    'retourne tous les champs dun contact quand ils sont tous renseignés',
+    integrationTest(async () => {
+      const panComplet = testPanierId()
+      await fixtures.panierContactUtile({
+        panier: { publicId: panComplet, visibilite: 'PUBLIC' },
+        contactUtile: {
+          nom: 'Contact complet',
+          description: 'Une description',
+          telephone: '01 23 45 67 89',
+          email: 'contact@example.com',
+          url: 'https://example.com',
+          adresse: '1 rue de la Paix, 75001 Paris',
+          organisme: { nom: 'Organisme A' },
+        },
+      })
+      const apiKey = await fixtures.apiKey()
+
+      const result = await runAsPrincipal(apiKey.id, () => getPanierContactsUtiles(panComplet))
+      const item = result._unsafeUnwrap().items[0]
+
+      expect(item).toBeDefined()
+      expect(item!.organisme.nom).toBe('Organisme A')
+      expect(item!.contacts[0]).toMatchObject({
+        nom:         'Contact complet',
+        description: 'Une description',
+        telephone:   '01 23 45 67 89',
+        email:       'contact@example.com',
+        url:         'https://example.com',
+        adresse:     '1 rue de la Paix, 75001 Paris',
+      })
+    }),
+  )
+
+  it(
+    'retourne null pour les champs absents dun contact minimal',
+    integrationTest(async () => {
+      const panMinimal = testPanierId()
+      await fixtures.panierContactUtile({
+        panier: { publicId: panMinimal, visibilite: 'PUBLIC' },
+        contactUtile: { nom: 'Contact minimal' },
+      })
+      const apiKey = await fixtures.apiKey()
+
+      const result = await runAsPrincipal(apiKey.id, () => getPanierContactsUtiles(panMinimal))
+      const contact = result._unsafeUnwrap().items[0]!.contacts[0]!
+
+      expect(contact.nom).toBe('Contact minimal')
+      expect(contact.description).toBeNull()
+      expect(contact.telephone).toBeNull()
+      expect(contact.email).toBeNull()
+      expect(contact.url).toBeNull()
+      expect(contact.adresse).toBeNull()
+    }),
+  )
+
+  it(
+    'regroupe plusieurs contacts du même organisme dans un seul item',
+    integrationTest(async () => {
+      const panGroupé = testPanierId()
+      const panierRow = await fixtures.panier({ publicId: panGroupé, visibilite: 'PUBLIC' })
+      const org = await fixtures.organisme({ nom: 'Organisme Unique' })
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const prismaDb = (await import('@/framework/persistence/dbStore')).db() as any
+      const c1 = await prismaDb.contactUtile.create({
+        data: { organismeId: org.id, nom: 'Alpha' },
+      })
+      const c2 = await prismaDb.contactUtile.create({
+        data: { organismeId: org.id, nom: 'Beta' },
+      })
+      await prismaDb.panierContactUtile.createMany({
+        data: [
+          { panierId: panierRow.id, contactUtileId: c1.id },
+          { panierId: panierRow.id, contactUtileId: c2.id },
+        ],
+      })
+      const apiKey = await fixtures.apiKey()
+
+      const result = await runAsPrincipal(apiKey.id, () => getPanierContactsUtiles(panGroupé))
+      const items = result._unsafeUnwrap().items
+
+      expect(items).toHaveLength(1)
+      expect(items[0]!.organisme.nom).toBe('Organisme Unique')
+      expect(items[0]!.contacts).toHaveLength(2)
+    }),
+  )
+
+  it(
+    'retourne plusieurs organismes triés alphabétiquement',
+    integrationTest(async () => {
+      const panTri = testPanierId()
+      const panierRow = await fixtures.panier({ publicId: panTri, visibilite: 'PUBLIC' })
+      const orgZ = await fixtures.organisme({ nom: 'Zzz Organisation' })
+      const orgA = await fixtures.organisme({ nom: 'Aaa Organisation' })
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const prismaDb = (await import('@/framework/persistence/dbStore')).db() as any
+      const cZ = await prismaDb.contactUtile.create({ data: { organismeId: orgZ.id, nom: 'Contact Z' } })
+      const cA = await prismaDb.contactUtile.create({ data: { organismeId: orgA.id, nom: 'Contact A' } })
+      await prismaDb.panierContactUtile.createMany({
+        data: [
+          { panierId: panierRow.id, contactUtileId: cZ.id },
+          { panierId: panierRow.id, contactUtileId: cA.id },
+        ],
+      })
+      const apiKey = await fixtures.apiKey()
+
+      const result = await runAsPrincipal(apiKey.id, () => getPanierContactsUtiles(panTri))
+      const noms = result._unsafeUnwrap().items.map((i) => i.organisme.nom)
+
+      expect(noms).toEqual(['Aaa Organisation', 'Zzz Organisation'])
+    }),
+  )
+
+  it(
+    'trie les contacts dun organisme alphabétiquement par nom',
+    integrationTest(async () => {
+      const panContactsTri = testPanierId()
+      const panierRow = await fixtures.panier({ publicId: panContactsTri, visibilite: 'PUBLIC' })
+      const org = await fixtures.organisme({ nom: 'Organisme Tri' })
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const prismaDb = (await import('@/framework/persistence/dbStore')).db() as any
+      const cZ = await prismaDb.contactUtile.create({ data: { organismeId: org.id, nom: 'Zebra' } })
+      const cA = await prismaDb.contactUtile.create({ data: { organismeId: org.id, nom: 'Alpha' } })
+      await prismaDb.panierContactUtile.createMany({
+        data: [
+          { panierId: panierRow.id, contactUtileId: cZ.id },
+          { panierId: panierRow.id, contactUtileId: cA.id },
+        ],
+      })
+      const apiKey = await fixtures.apiKey()
+
+      const result = await runAsPrincipal(apiKey.id, () => getPanierContactsUtiles(panContactsTri))
+      const nomsContacts = result._unsafeUnwrap().items[0]!.contacts.map((c) => c.nom)
+
+      expect(nomsContacts).toEqual(['Alpha', 'Zebra'])
+    }),
+  )
+
+  it(
+    'est accessible sur un panier PRIVE avec permission READ',
+    integrationTest(async () => {
+      const panPrive = testPanierId()
+      await fixtures.panierContactUtile({
+        panier: { publicId: panPrive, visibilite: 'PRIVE' },
+        contactUtile: { nom: 'Contact privé' },
+      })
+      const apiKey = await fixtures.apiKey({
+        panierPermissions: [{ panier: { publicId: panPrive }, action: 'READ' }],
+      })
+
+      const result = await runAsPrincipal(apiKey.id, () => getPanierContactsUtiles(panPrive))
+
+      expect(result.isOk()).toBe(true)
+      expect(result._unsafeUnwrap().items[0]!.contacts).toHaveLength(1)
+    }),
+  )
+
+  it(
+    'lève une erreur sur un panier PRIVE sans permission',
+    integrationTest(async () => {
+      const panPriveSans = testPanierId()
+      await fixtures.panier({ publicId: panPriveSans, visibilite: 'PRIVE' })
+      const apiKey = await fixtures.apiKey()
+
+      await expect(
+        runAsPrincipal(apiKey.id, () => getPanierContactsUtiles(panPriveSans)),
+      ).rejects.toThrow()
+    }),
+  )
+
+  it(
+    'lève une erreur si le panier nexiste pas',
+    integrationTest(async () => {
+      const panInexistant = testPanierId()
+      const apiKey = await fixtures.apiKey()
+
+      await expect(
+        runAsPrincipal(apiKey.id, () => getPanierContactsUtiles(panInexistant)),
+      ).rejects.toThrow()
+    }),
+  )
+
+  it(
+    'un contact rattaché à deux paniers est visible dans chacun indépendamment',
+    integrationTest(async () => {
+      const pan1 = testPanierId()
+      const pan2 = testPanierId()
+      const panierRow1 = await fixtures.panier({ publicId: pan1, visibilite: 'PUBLIC' })
+      const panierRow2 = await fixtures.panier({ publicId: pan2, visibilite: 'PUBLIC' })
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const prismaDb = (await import('@/framework/persistence/dbStore')).db() as any
+      const org = await fixtures.organisme({ nom: 'Organisme Partagé' })
+      const contact = await prismaDb.contactUtile.create({
+        data: { organismeId: org.id, nom: 'Contact Partagé' },
+      })
+      await prismaDb.panierContactUtile.createMany({
+        data: [
+          { panierId: panierRow1.id, contactUtileId: contact.id },
+          { panierId: panierRow2.id, contactUtileId: contact.id },
+        ],
+      })
+      const apiKey = await fixtures.apiKey()
+
+      const result1 = await runAsPrincipal(apiKey.id, () => getPanierContactsUtiles(pan1))
+      const result2 = await runAsPrincipal(apiKey.id, () => getPanierContactsUtiles(pan2))
+
+      expect(result1._unsafeUnwrap().items[0]!.contacts[0]!.nom).toBe('Contact Partagé')
+      expect(result2._unsafeUnwrap().items[0]!.contacts[0]!.nom).toBe('Contact Partagé')
+    }),
+  )
+})

--- a/apps/mb-api/src/panier/queries/getPanierContactsUtiles.test.ts
+++ b/apps/mb-api/src/panier/queries/getPanierContactsUtiles.test.ts
@@ -45,12 +45,12 @@ describe.concurrent('getPanierContactsUtiles', () => {
       expect(item).toBeDefined()
       expect(item!.organisme.nom).toBe('Organisme A')
       expect(item!.contacts[0]).toMatchObject({
-        nom:         'Contact complet',
+        nom: 'Contact complet',
         description: 'Une description',
-        telephone:   '01 23 45 67 89',
-        email:       'contact@example.com',
-        url:         'https://example.com',
-        adresse:     '1 rue de la Paix, 75001 Paris',
+        telephone: '01 23 45 67 89',
+        email: 'contact@example.com',
+        url: 'https://example.com',
+        adresse: '1 rue de la Paix, 75001 Paris',
       })
     }),
   )
@@ -117,8 +117,12 @@ describe.concurrent('getPanierContactsUtiles', () => {
       const orgA = await fixtures.organisme({ nom: 'Aaa Organisation' })
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const prismaDb = (await import('@/framework/persistence/dbStore')).db() as any
-      const cZ = await prismaDb.contactUtile.create({ data: { organismeId: orgZ.id, nom: 'Contact Z' } })
-      const cA = await prismaDb.contactUtile.create({ data: { organismeId: orgA.id, nom: 'Contact A' } })
+      const cZ = await prismaDb.contactUtile.create({
+        data: { organismeId: orgZ.id, nom: 'Contact Z' },
+      })
+      const cA = await prismaDb.contactUtile.create({
+        data: { organismeId: orgA.id, nom: 'Contact A' },
+      })
       await prismaDb.panierContactUtile.createMany({
         data: [
           { panierId: panierRow.id, contactUtileId: cZ.id },

--- a/apps/mb-api/src/panier/queries/getPanierContactsUtiles.ts
+++ b/apps/mb-api/src/panier/queries/getPanierContactsUtiles.ts
@@ -31,7 +31,13 @@ export const getPanierContactsUtiles = (
       },
     }),
   ).map((panier) => {
-    const grouped = new Map<string, { organisme: { id: string; nom: string }; contacts: typeof panier.contactsUtiles[0]['contactUtile'][] }>()
+    const grouped = new Map<
+      string,
+      {
+        organisme: { id: string; nom: string }
+        contacts: (typeof panier.contactsUtiles)[0]['contactUtile'][]
+      }
+    >()
 
     for (const joinRow of panier.contactsUtiles) {
       const c = joinRow.contactUtile
@@ -46,13 +52,13 @@ export const getPanierContactsUtiles = (
       items: Array.from(grouped.values()).map(({ organisme, contacts }) => ({
         organisme,
         contacts: contacts.map((c) => ({
-          id:          c.id,
-          nom:         c.nom,
+          id: c.id,
+          nom: c.nom,
           description: c.description,
-          telephone:   c.telephone,
-          email:       c.email,
-          url:         c.url,
-          adresse:     c.adresse,
+          telephone: c.telephone,
+          email: c.email,
+          url: c.url,
+          adresse: c.adresse,
         })),
       })),
     }

--- a/apps/mb-api/src/panier/queries/getPanierContactsUtiles.ts
+++ b/apps/mb-api/src/panier/queries/getPanierContactsUtiles.ts
@@ -1,0 +1,60 @@
+import { type PanierContactsUtilesApiModel } from '@pilote/mb-shared/panierContactUtile'
+import { ResultAsync } from 'neverthrow'
+
+import { requireCurrentPrincipalId } from '@/framework/auth/userContext'
+import { db } from '@/framework/persistence/dbStore'
+import { withPanierReadPermission } from '@/panier/permissions'
+
+export const getPanierContactsUtiles = (
+  panierPublicId: string,
+): ResultAsync<PanierContactsUtilesApiModel, never> => {
+  const principalId = requireCurrentPrincipalId()
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const prismaDb = db() as any
+  return ResultAsync.fromSafePromise(
+    prismaDb.panier.findFirstOrThrow({
+      where: withPanierReadPermission({ publicId: panierPublicId }, principalId),
+      include: {
+        contactsUtiles: {
+          include: {
+            contactUtile: {
+              include: {
+                organisme: true,
+              },
+            },
+          },
+          orderBy: [
+            { contactUtile: { organisme: { nom: 'asc' } } },
+            { contactUtile: { nom: 'asc' } },
+          ],
+        },
+      },
+    }),
+  ).map((panier) => {
+    const grouped = new Map<string, { organisme: { id: string; nom: string }; contacts: typeof panier.contactsUtiles[0]['contactUtile'][] }>()
+
+    for (const joinRow of panier.contactsUtiles) {
+      const c = joinRow.contactUtile
+      const o = c.organisme
+      if (!grouped.has(o.id)) {
+        grouped.set(o.id, { organisme: { id: o.id, nom: o.nom }, contacts: [] })
+      }
+      grouped.get(o.id)!.contacts.push(c)
+    }
+
+    return {
+      items: Array.from(grouped.values()).map(({ organisme, contacts }) => ({
+        organisme,
+        contacts: contacts.map((c) => ({
+          id:          c.id,
+          nom:         c.nom,
+          description: c.description,
+          telephone:   c.telephone,
+          email:       c.email,
+          url:         c.url,
+          adresse:     c.adresse,
+        })),
+      })),
+    }
+  })
+}

--- a/apps/mb-api/src/panier/queries/getPanierResponsables.test.ts
+++ b/apps/mb-api/src/panier/queries/getPanierResponsables.test.ts
@@ -54,32 +54,6 @@ describe.concurrent('getPanierResponsables', () => {
   )
 
   it(
-    'retourne les champs null pour un responsable sans profil renseigné',
-    integrationTest(async () => {
-      const panNull = testPanierId()
-      await fixtures.panierResponsable({
-        panier: { publicId: panNull, visibilite: 'PUBLIC' },
-        utilisateur: { email: `bob-${panNull}@example.com` },
-      })
-      const apiKey = await fixtures.apiKey()
-
-      const result = await runAsPrincipal(apiKey.id, () => getPanierResponsables(panNull))
-
-      expect(result._unsafeUnwrap()).toEqual({
-        items: [
-          {
-            email: `bob-${panNull}@example.com`,
-            nom: null,
-            prenom: null,
-            service: null,
-            fonction: null,
-          },
-        ],
-      })
-    }),
-  )
-
-  it(
     'retourne les responsables triés par ordre dassignation (createdAt ASC)',
     integrationTest(async () => {
       const panOrdre = testPanierId()

--- a/apps/mb-api/src/panier/queries/getPanierResponsables.test.ts
+++ b/apps/mb-api/src/panier/queries/getPanierResponsables.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from 'vitest'
+
+import { getPanierResponsables } from '@/panier/queries/getPanierResponsables'
+import { fixtures } from '@/test/fixtures'
+import { integrationTest } from '@/test/integrationTest'
+import { testPanierId } from '@/test/randomIds'
+import { runAsPrincipal } from '@/test/runAsPrincipal'
+
+describe.concurrent('getPanierResponsables', () => {
+  it(
+    'retourne une liste vide quand le panier PUBLIC na aucun responsable',
+    integrationTest(async () => {
+      const panVide = testPanierId()
+      await fixtures.panier({ publicId: panVide, visibilite: 'PUBLIC' })
+      const apiKey = await fixtures.apiKey()
+
+      const result = await runAsPrincipal(apiKey.id, () => getPanierResponsables(panVide))
+
+      expect(result.isOk()).toBe(true)
+      expect(result._unsafeUnwrap()).toEqual({ items: [] })
+    }),
+  )
+
+  it(
+    'retourne les champs complets dun responsable avec profil renseigné',
+    integrationTest(async () => {
+      const panComplet = testPanierId()
+      await fixtures.panierResponsable({
+        panier: { publicId: panComplet, visibilite: 'PUBLIC' },
+        utilisateur: {
+          email: `alice-${panComplet}@example.com`,
+          nom: 'Martin',
+          prenom: 'Alice',
+          service: 'DITP',
+          fonction: 'Chargée de mission',
+        },
+      })
+      const apiKey = await fixtures.apiKey()
+
+      const result = await runAsPrincipal(apiKey.id, () => getPanierResponsables(panComplet))
+
+      expect(result._unsafeUnwrap()).toEqual({
+        items: [
+          {
+            email: `alice-${panComplet}@example.com`,
+            nom: 'Martin',
+            prenom: 'Alice',
+            service: 'DITP',
+            fonction: 'Chargée de mission',
+          },
+        ],
+      })
+    }),
+  )
+
+  it(
+    'retourne les champs null pour un responsable sans profil renseigné',
+    integrationTest(async () => {
+      const panNull = testPanierId()
+      await fixtures.panierResponsable({
+        panier: { publicId: panNull, visibilite: 'PUBLIC' },
+        utilisateur: { email: `bob-${panNull}@example.com` },
+      })
+      const apiKey = await fixtures.apiKey()
+
+      const result = await runAsPrincipal(apiKey.id, () => getPanierResponsables(panNull))
+
+      expect(result._unsafeUnwrap()).toEqual({
+        items: [
+          {
+            email: `bob-${panNull}@example.com`,
+            nom: null,
+            prenom: null,
+            service: null,
+            fonction: null,
+          },
+        ],
+      })
+    }),
+  )
+
+  it(
+    'retourne les responsables triés par ordre dassignation (createdAt ASC)',
+    integrationTest(async () => {
+      const panOrdre = testPanierId()
+      const panierRow = await fixtures.panier({ publicId: panOrdre, visibilite: 'PUBLIC' })
+      const userA = await fixtures.utilisateur({ email: `aa-${panOrdre}@example.com` })
+      const userB = await fixtures.utilisateur({ email: `bb-${panOrdre}@example.com` })
+      // Insertion séquentielle pour garantir un createdAt différent.
+      await fixtures.panierResponsable({
+        panier: { publicId: panierRow.publicId },
+        utilisateur: { email: userA.email },
+      })
+      await fixtures.panierResponsable({
+        panier: { publicId: panierRow.publicId },
+        utilisateur: { email: userB.email },
+      })
+      const apiKey = await fixtures.apiKey()
+
+      const result = await runAsPrincipal(apiKey.id, () => getPanierResponsables(panOrdre))
+      const emails = result._unsafeUnwrap().items.map((r) => r.email)
+
+      expect(emails).toEqual([userA.email, userB.email])
+    }),
+  )
+
+  it(
+    'est accessible sur un panier PRIVE avec permission READ',
+    integrationTest(async () => {
+      const panPrive = testPanierId()
+      await fixtures.panierResponsable({
+        panier: { publicId: panPrive, visibilite: 'PRIVE' },
+        utilisateur: { email: `resp-${panPrive}@example.com` },
+      })
+      const apiKey = await fixtures.apiKey({
+        panierPermissions: [{ panier: { publicId: panPrive }, action: 'READ' }],
+      })
+
+      const result = await runAsPrincipal(apiKey.id, () => getPanierResponsables(panPrive))
+
+      expect(result.isOk()).toBe(true)
+      expect(result._unsafeUnwrap().items).toHaveLength(1)
+    }),
+  )
+
+  it(
+    'lève une erreur sur un panier PRIVE sans permission',
+    integrationTest(async () => {
+      const panPriveSans = testPanierId()
+      await fixtures.panier({ publicId: panPriveSans, visibilite: 'PRIVE' })
+      const apiKey = await fixtures.apiKey()
+
+      await expect(
+        runAsPrincipal(apiKey.id, () => getPanierResponsables(panPriveSans)),
+      ).rejects.toThrow()
+    }),
+  )
+
+  it(
+    'lève une erreur si le panier nexiste pas',
+    integrationTest(async () => {
+      const panInexistant = testPanierId()
+      const apiKey = await fixtures.apiKey()
+
+      await expect(
+        runAsPrincipal(apiKey.id, () => getPanierResponsables(panInexistant)),
+      ).rejects.toThrow()
+    }),
+  )
+})

--- a/apps/mb-api/src/panier/queries/getPanierResponsables.ts
+++ b/apps/mb-api/src/panier/queries/getPanierResponsables.ts
@@ -16,9 +16,7 @@ export const getPanierResponsables = (
         responsables: {
           orderBy: { createdAt: 'asc' },
           include: {
-            utilisateur: {
-              select: { email: true, nom: true, prenom: true, service: true, fonction: true },
-            },
+            utilisateur: true,
           },
         },
       },

--- a/apps/mb-api/src/panier/queries/getPanierResponsables.ts
+++ b/apps/mb-api/src/panier/queries/getPanierResponsables.ts
@@ -1,0 +1,35 @@
+import { type PanierResponsablesApiModel } from '@pilote/mb-shared/panierResponsable'
+import { ResultAsync } from 'neverthrow'
+
+import { requireCurrentPrincipalId } from '@/framework/auth/userContext'
+import { db } from '@/framework/persistence/dbStore'
+import { withPanierReadPermission } from '@/panier/permissions'
+
+export const getPanierResponsables = (
+  panierPublicId: string,
+): ResultAsync<PanierResponsablesApiModel, never> => {
+  const principalId = requireCurrentPrincipalId()
+  return ResultAsync.fromSafePromise(
+    db().panier.findFirstOrThrow({
+      where: withPanierReadPermission({ publicId: panierPublicId }, principalId),
+      include: {
+        responsables: {
+          orderBy: { createdAt: 'asc' },
+          include: {
+            utilisateur: {
+              select: { email: true, nom: true, prenom: true, service: true, fonction: true },
+            },
+          },
+        },
+      },
+    }),
+  ).map((panier) => ({
+    items: panier.responsables.map((r) => ({
+      email: r.utilisateur.email,
+      nom: r.utilisateur.nom,
+      prenom: r.utilisateur.prenom,
+      service: r.utilisateur.service,
+      fonction: r.utilisateur.fonction,
+    })),
+  }))
+}

--- a/apps/mb-api/src/panier/routes.ts
+++ b/apps/mb-api/src/panier/routes.ts
@@ -5,6 +5,7 @@ import {
   panierApiModelSchema,
   panierListApiModelSchema,
 } from '@pilote/mb-shared/panier'
+import { panierResponsablesApiModelSchema } from '@pilote/mb-shared/panierResponsable'
 import {
   getPanierTauxProgressionQuerySchema,
   panierTauxProgressionApiModelSchema,
@@ -15,6 +16,7 @@ import { requireAuthentication } from '@/framework/auth/requireAuthentication'
 import { never } from '@/framework/errors/never'
 import { jsonResponseOk } from '@/framework/openapi/jsonResponse'
 import { getPanierByPublicId } from '@/panier/queries/getPanierByPublicId'
+import { getPanierResponsables } from '@/panier/queries/getPanierResponsables'
 import { getPanierTauxProgression } from '@/panier/queries/getPanierTauxProgression'
 import { listPaniers } from '@/panier/queries/listPaniers'
 
@@ -22,6 +24,9 @@ const PanierApiModelSchema = panierApiModelSchema.openapi('PanierApiModel')
 const PanierListApiModelSchema = panierListApiModelSchema.openapi('PanierListApiModel')
 const PanierTauxProgressionApiModelSchema = panierTauxProgressionApiModelSchema.openapi(
   'PanierTauxProgressionApiModel',
+)
+const PanierResponsablesApiModelSchema = panierResponsablesApiModelSchema.openapi(
+  'PanierResponsablesApiModel',
 )
 const ErrorApiModelSchema = errorApiModelSchema.openapi('ErrorApiModel')
 
@@ -106,6 +111,32 @@ const getPanierTauxProgressionRoute = createRoute({
   },
 })
 
+// --- GET /paniers/:id/responsables -------------------------------------------
+
+const getPanierResponsablesRoute = createRoute({
+  method: 'get',
+  path: '/paniers/{id}/responsables',
+  tags: ['Panier'],
+  summary: "Lister les responsables d'un panier",
+  description:
+    'Retourne la liste des utilisateurs désignés responsables du panier, triés par ordre ' +
+    "d'assignation (createdAt ASC). Accessible à tout principal pouvant lire le panier " +
+    '(visibilite PUBLIC ou permission READ/WRITE explicite). ' +
+    'Renvoie 404 (`ENTITY_NOT_FOUND`) si le panier est introuvable ou inaccessible.',
+  middleware: [requireAuthentication],
+  request: { params: detailParamsSchema },
+  responses: {
+    200: {
+      content: { 'application/json': { schema: PanierResponsablesApiModelSchema } },
+      description: 'Liste des responsables du panier',
+    },
+    404: {
+      content: { 'application/json': { schema: ErrorApiModelSchema } },
+      description: 'Panier introuvable',
+    },
+  },
+})
+
 // --- App registration --------------------------------------------------------
 
 export const panierRoutes = new OpenAPIHono()
@@ -150,6 +181,21 @@ panierRoutes.openapi(getPanierTauxProgressionRoute, async (context) => {
         context,
         data,
         schema: PanierTauxProgressionApiModelSchema,
+        status: 200,
+      }),
+    never,
+  )
+})
+
+panierRoutes.openapi(getPanierResponsablesRoute, async (context) => {
+  const { id } = context.req.valid('param')
+
+  return getPanierResponsables(id).match(
+    (data) =>
+      jsonResponseOk({
+        context,
+        data,
+        schema: PanierResponsablesApiModelSchema,
         status: 200,
       }),
     never,

--- a/apps/mb-api/src/panier/routes.ts
+++ b/apps/mb-api/src/panier/routes.ts
@@ -5,6 +5,7 @@ import {
   panierApiModelSchema,
   panierListApiModelSchema,
 } from '@pilote/mb-shared/panier'
+import { panierContactsUtilesApiModelSchema } from '@pilote/mb-shared/panierContactUtile'
 import { panierResponsablesApiModelSchema } from '@pilote/mb-shared/panierResponsable'
 import {
   getPanierTauxProgressionQuerySchema,
@@ -16,6 +17,7 @@ import { requireAuthentication } from '@/framework/auth/requireAuthentication'
 import { never } from '@/framework/errors/never'
 import { jsonResponseOk } from '@/framework/openapi/jsonResponse'
 import { getPanierByPublicId } from '@/panier/queries/getPanierByPublicId'
+import { getPanierContactsUtiles } from '@/panier/queries/getPanierContactsUtiles'
 import { getPanierResponsables } from '@/panier/queries/getPanierResponsables'
 import { getPanierTauxProgression } from '@/panier/queries/getPanierTauxProgression'
 import { listPaniers } from '@/panier/queries/listPaniers'
@@ -27,6 +29,9 @@ const PanierTauxProgressionApiModelSchema = panierTauxProgressionApiModelSchema.
 )
 const PanierResponsablesApiModelSchema = panierResponsablesApiModelSchema.openapi(
   'PanierResponsablesApiModel',
+)
+const PanierContactsUtilesApiModelSchema = panierContactsUtilesApiModelSchema.openapi(
+  'PanierContactsUtilesApiModel',
 )
 const ErrorApiModelSchema = errorApiModelSchema.openapi('ErrorApiModel')
 
@@ -137,6 +142,32 @@ const getPanierResponsablesRoute = createRoute({
   },
 })
 
+// --- GET /paniers/:id/contacts-utiles ----------------------------------------
+
+const getPanierContactsUtilesRoute = createRoute({
+  method: 'get',
+  path: '/paniers/{id}/contacts-utiles',
+  tags: ['Panier'],
+  summary: "Lister les contacts utiles d'un panier",
+  description:
+    'Retourne les contacts utiles du panier, regroupés par organisme et triés alphabétiquement. ' +
+    'Accessible à tout principal pouvant lire le panier ' +
+    '(visibilite PUBLIC ou permission READ/WRITE explicite). ' +
+    'Renvoie 404 (`ENTITY_NOT_FOUND`) si le panier est introuvable ou inaccessible.',
+  middleware: [requireAuthentication],
+  request: { params: detailParamsSchema },
+  responses: {
+    200: {
+      content: { 'application/json': { schema: PanierContactsUtilesApiModelSchema } },
+      description: 'Contacts utiles du panier groupés par organisme',
+    },
+    404: {
+      content: { 'application/json': { schema: ErrorApiModelSchema } },
+      description: 'Panier introuvable',
+    },
+  },
+})
+
 // --- App registration --------------------------------------------------------
 
 export const panierRoutes = new OpenAPIHono()
@@ -196,6 +227,21 @@ panierRoutes.openapi(getPanierResponsablesRoute, async (context) => {
         context,
         data,
         schema: PanierResponsablesApiModelSchema,
+        status: 200,
+      }),
+    never,
+  )
+})
+
+panierRoutes.openapi(getPanierContactsUtilesRoute, async (context) => {
+  const { id } = context.req.valid('param')
+
+  return getPanierContactsUtiles(id).match(
+    (data) =>
+      jsonResponseOk({
+        context,
+        data,
+        schema: PanierContactsUtilesApiModelSchema,
         status: 200,
       }),
     never,

--- a/apps/mb-api/src/test/fixtures.ts
+++ b/apps/mb-api/src/test/fixtures.ts
@@ -605,10 +605,10 @@ async function apiKey(...overrides: ApiKeyOverrides[]): Promise<ApiKeyModel | Ap
 type UtilisateurOverrides = Partial<{
   id: string
   email: string
-  nom: string | null
-  prenom: string | null
-  service: string | null
-  fonction: string | null
+  nom: string
+  prenom: string
+  service: string
+  fonction: string
   identite: { provider: ProviderType; providerSub: string }
   permissions: PrincipalIndicateurPermissionOverrides[]
   panierPermissions: PrincipalPanierPermissionOverrides[]
@@ -628,10 +628,10 @@ const upsertUtilisateur = async (o: UtilisateurOverrides = {}) => {
     data: {
       id,
       email,
-      nom: o.nom ?? null,
-      prenom: o.prenom ?? null,
-      service: o.service ?? null,
-      fonction: o.fonction ?? null,
+      nom: o.nom ?? 'Doe',
+      prenom: o.prenom ?? 'John',
+      service: o.service ?? 'DITP',
+      fonction: o.fonction ?? 'Agent',
     },
   })
   if (o.identite) {

--- a/apps/mb-api/src/test/fixtures.ts
+++ b/apps/mb-api/src/test/fixtures.ts
@@ -22,6 +22,7 @@ import {
   type ObjectifIndicateurIndividuModel,
   type PanierModel,
   type PanierPermissionModel,
+  type PanierResponsableModel,
   type ReferentielModel,
   type ReferentielWidgetModel,
   type RelationModel,
@@ -604,6 +605,10 @@ async function apiKey(...overrides: ApiKeyOverrides[]): Promise<ApiKeyModel | Ap
 type UtilisateurOverrides = Partial<{
   id: string
   email: string
+  nom: string | null
+  prenom: string | null
+  service: string | null
+  fonction: string | null
   identite: { provider: ProviderType; providerSub: string }
   permissions: PrincipalIndicateurPermissionOverrides[]
   panierPermissions: PrincipalPanierPermissionOverrides[]
@@ -619,7 +624,16 @@ const upsertUtilisateur = async (o: UtilisateurOverrides = {}) => {
   }
   const id = o.id ?? uuidv7()
   await db().principal.create({ data: { id } })
-  const created = await db().utilisateur.create({ data: { id, email } })
+  const created = await db().utilisateur.create({
+    data: {
+      id,
+      email,
+      nom: o.nom ?? null,
+      prenom: o.prenom ?? null,
+      service: o.service ?? null,
+      fonction: o.fonction ?? null,
+    },
+  })
   if (o.identite) {
     await db().identiteExterne.create({
       data: {
@@ -736,6 +750,43 @@ async function panierPermission(
   return results
 }
 
+// --- PanierResponsable (deps requises) ----------------------------------------
+
+type PanierResponsableOverrides = {
+  panier: PanierOverrides
+  utilisateur: UtilisateurOverrides
+}
+
+const upsertPanierResponsable = async (o: PanierResponsableOverrides) => {
+  const panierRow = await upsertPanier(o.panier)
+  const utilisateurRow = await upsertUtilisateur(o.utilisateur)
+  return db().panierResponsable.upsert({
+    where: {
+      panierId_utilisateurId: {
+        panierId: panierRow.id,
+        utilisateurId: utilisateurRow.id,
+      },
+    },
+    update: {},
+    create: { panierId: panierRow.id, utilisateurId: utilisateurRow.id },
+  })
+}
+
+function panierResponsable(override: PanierResponsableOverrides): Promise<PanierResponsableModel>
+function panierResponsable(
+  o1: PanierResponsableOverrides,
+  o2: PanierResponsableOverrides,
+  ...rest: PanierResponsableOverrides[]
+): Promise<PanierResponsableModel[]>
+async function panierResponsable(
+  ...overrides: PanierResponsableOverrides[]
+): Promise<PanierResponsableModel | PanierResponsableModel[]> {
+  if (overrides.length === 1) return upsertPanierResponsable(overrides[0]!)
+  const results: PanierResponsableModel[] = []
+  for (const o of overrides) results.push(await upsertPanierResponsable(o))
+  return results
+}
+
 export const fixtures = {
   indicateur,
   referentiel,
@@ -751,4 +802,5 @@ export const fixtures = {
   utilisateur,
   indicateurPermission,
   panierPermission,
+  panierResponsable,
 }

--- a/apps/mb-api/src/test/fixtures.ts
+++ b/apps/mb-api/src/test/fixtures.ts
@@ -895,9 +895,7 @@ const upsertPanierContactUtile = async (
   })
 }
 
-function panierContactUtile(
-  override: PanierContactUtileOverrides,
-): Promise<PanierContactUtileModel>
+function panierContactUtile(override: PanierContactUtileOverrides): Promise<PanierContactUtileModel>
 async function panierContactUtile(
   override: PanierContactUtileOverrides,
 ): Promise<PanierContactUtileModel> {

--- a/apps/mb-api/src/test/fixtures.ts
+++ b/apps/mb-api/src/test/fixtures.ts
@@ -30,6 +30,21 @@ import {
   type ValeurAvancementModel,
   type WidgetModel,
 } from '@/generated/prisma/models'
+
+type OrganismeModel = { id: string; nom: string; createdAt: Date; updatedAt: Date }
+type ContactUtileModel = {
+  id: string
+  organismeId: string
+  nom: string
+  description: string | null
+  telephone: string | null
+  email: string | null
+  url: string | null
+  adresse: string | null
+  createdAt: Date
+  updatedAt: Date
+}
+type PanierContactUtileModel = { panierId: string; contactUtileId: string; createdAt: Date }
 import {
   ApiKeyRole,
   PermissionAction,
@@ -787,6 +802,108 @@ async function panierResponsable(
   return results
 }
 
+// --- Organisme ---------------------------------------------------------------
+
+type OrganismeOverrides = Partial<{
+  id: string
+  nom: string
+}>
+
+const upsertOrganisme = async (o: OrganismeOverrides = {}): Promise<OrganismeModel> => {
+  const id = o.id ?? uuidv7()
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const prismaDb = db() as any
+  return prismaDb.organisme.upsert({
+    where: { id },
+    update: { nom: o.nom ?? 'Organisme Test' },
+    create: {
+      id,
+      nom: o.nom ?? 'Organisme Test',
+    },
+  })
+}
+
+function organisme(): Promise<OrganismeModel>
+function organisme(override: OrganismeOverrides): Promise<OrganismeModel>
+async function organisme(override?: OrganismeOverrides): Promise<OrganismeModel> {
+  return upsertOrganisme(override)
+}
+
+// --- ContactUtile ------------------------------------------------------------
+
+type ContactUtileOverrides = Partial<{
+  id: string
+  nom: string
+  description: string | null
+  telephone: string | null
+  email: string | null
+  url: string | null
+  adresse: string | null
+  organisme: OrganismeOverrides
+}>
+
+const upsertContactUtile = async (o: ContactUtileOverrides = {}): Promise<ContactUtileModel> => {
+  const organismeRow = await upsertOrganisme(o.organisme)
+  const id = o.id ?? uuidv7()
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const prismaDb = db() as any
+  return prismaDb.contactUtile.upsert({
+    where: { id },
+    update: {},
+    create: {
+      id,
+      organismeId: organismeRow.id,
+      nom: o.nom ?? 'Contact Test',
+      description: o.description ?? null,
+      telephone: o.telephone ?? null,
+      email: o.email ?? null,
+      url: o.url ?? null,
+      adresse: o.adresse ?? null,
+    },
+  })
+}
+
+function contactUtile(): Promise<ContactUtileModel>
+function contactUtile(override: ContactUtileOverrides): Promise<ContactUtileModel>
+async function contactUtile(override?: ContactUtileOverrides): Promise<ContactUtileModel> {
+  return upsertContactUtile(override)
+}
+
+// --- PanierContactUtile ------------------------------------------------------
+
+type PanierContactUtileOverrides = {
+  panier?: PanierOverrides
+  contactUtile?: ContactUtileOverrides
+}
+
+const upsertPanierContactUtile = async (
+  o: PanierContactUtileOverrides,
+): Promise<PanierContactUtileModel> => {
+  const panierRow = await upsertPanier(o.panier)
+  const contactUtileRow = await upsertContactUtile(o.contactUtile)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const prismaDb = db() as any
+  return prismaDb.panierContactUtile.upsert({
+    where: {
+      panierId_contactUtileId: {
+        panierId: panierRow.id,
+        contactUtileId: contactUtileRow.id,
+      },
+    },
+    update: {},
+    create: { panierId: panierRow.id, contactUtileId: contactUtileRow.id },
+  })
+}
+
+function panierContactUtile(
+  override: PanierContactUtileOverrides,
+): Promise<PanierContactUtileModel>
+async function panierContactUtile(
+  override: PanierContactUtileOverrides,
+): Promise<PanierContactUtileModel> {
+  return upsertPanierContactUtile(override)
+}
+
 export const fixtures = {
   indicateur,
   referentiel,
@@ -803,4 +920,7 @@ export const fixtures = {
   indicateurPermission,
   panierPermission,
   panierResponsable,
+  organisme,
+  contactUtile,
+  panierContactUtile,
 }

--- a/apps/mb-webapp/src/api/paniers.ts
+++ b/apps/mb-webapp/src/api/paniers.ts
@@ -6,6 +6,10 @@ import {
   panierListApiModelSchema,
 } from '@pilote/mb-shared/panier'
 import {
+  type PanierContactsUtilesApiModel,
+  panierContactsUtilesApiModelSchema,
+} from '@pilote/mb-shared/panierContactUtile'
+import {
   type PanierResponsablesApiModel,
   panierResponsablesApiModelSchema,
 } from '@pilote/mb-shared/panierResponsable'
@@ -44,4 +48,11 @@ export const fetchPanierResponsables = async (
 ): Promise<PanierResponsablesApiModel> => {
   const json = await apiClient.get(`paniers/${panierId}/responsables`).json()
   return panierResponsablesApiModelSchema.parse(json)
+}
+
+export const fetchPanierContactsUtiles = async (
+  panierId: string,
+): Promise<PanierContactsUtilesApiModel> => {
+  const json = await apiClient.get(`paniers/${panierId}/contacts-utiles`).json()
+  return panierContactsUtilesApiModelSchema.parse(json)
 }

--- a/apps/mb-webapp/src/api/paniers.ts
+++ b/apps/mb-webapp/src/api/paniers.ts
@@ -6,6 +6,10 @@ import {
   panierListApiModelSchema,
 } from '@pilote/mb-shared/panier'
 import {
+  type PanierResponsablesApiModel,
+  panierResponsablesApiModelSchema,
+} from '@pilote/mb-shared/panierResponsable'
+import {
   type PanierTauxProgressionApiModel,
   panierTauxProgressionApiModelSchema,
 } from '@pilote/mb-shared/panierTauxProgression'
@@ -33,4 +37,11 @@ export const fetchPanierTauxProgression = async ({
     .get(`paniers/${panierId}/taux-progression`, { searchParams: { individu } })
     .json()
   return panierTauxProgressionApiModelSchema.parse(json)
+}
+
+export const fetchPanierResponsables = async (
+  panierId: string,
+): Promise<PanierResponsablesApiModel> => {
+  const json = await apiClient.get(`paniers/${panierId}/responsables`).json()
+  return panierResponsablesApiModelSchema.parse(json)
 }

--- a/apps/mb-webapp/src/components/paniers/PanierContactsUtiles.tsx
+++ b/apps/mb-webapp/src/components/paniers/PanierContactsUtiles.tsx
@@ -27,7 +27,10 @@ export function PanierContactsUtiles({ panierId }: { panierId: string }) {
 
           <ul className="space-y-2">
             {contacts.map((contact) => (
-              <li key={contact.id} className="rounded-lg border border-gray-200 bg-white p-4 space-y-2">
+              <li
+                key={contact.id}
+                className="rounded-lg border border-gray-200 bg-white p-4 space-y-2"
+              >
                 <p className="text-sm font-semibold text-gray-900">{contact.nom}</p>
                 {contact.description && (
                   <p className="text-sm text-gray-500 italic">{contact.description}</p>
@@ -41,13 +44,20 @@ export function PanierContactsUtiles({ panierId }: { panierId: string }) {
                 {contact.email && (
                   <div className="flex items-center gap-2 text-sm text-gray-600">
                     <Mail size={14} className="shrink-0 text-gray-400" />
-                    <a href={`mailto:${contact.email}`} className="hover:underline">{contact.email}</a>
+                    <a href={`mailto:${contact.email}`} className="hover:underline">
+                      {contact.email}
+                    </a>
                   </div>
                 )}
                 {contact.url && (
                   <div className="flex items-center gap-2 text-sm text-gray-600">
                     <Globe size={14} className="shrink-0 text-gray-400" />
-                    <a href={contact.url} target="_blank" rel="noopener noreferrer" className="hover:underline truncate max-w-xs">
+                    <a
+                      href={contact.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="hover:underline truncate max-w-xs"
+                    >
                       {contact.url.length > 50 ? contact.url.slice(0, 50) + '…' : contact.url}
                     </a>
                   </div>

--- a/apps/mb-webapp/src/components/paniers/PanierContactsUtiles.tsx
+++ b/apps/mb-webapp/src/components/paniers/PanierContactsUtiles.tsx
@@ -1,0 +1,68 @@
+import { Globe, Mail, MapPin, Phone } from 'lucide-react'
+import { useSuspenseQuery } from '@tanstack/react-query'
+
+import { EmptyState } from '@/components/ui/EmptyState'
+import { Heading } from '@/components/ui/Typography'
+import { panierContactsUtilesQueryOptions } from '@/queries/paniers'
+
+export function PanierContactsUtiles({ panierId }: { panierId: string }) {
+  const { data } = useSuspenseQuery(panierContactsUtilesQueryOptions(panierId))
+
+  if (data.items.length === 0) {
+    return <EmptyState title="Aucun contact utile pour ce panier." />
+  }
+
+  return (
+    <div className="space-y-6">
+      <Heading size="sm">Contacts utiles</Heading>
+
+      {data.items.map(({ organisme, contacts }) => (
+        <div key={organisme.id} className="space-y-3">
+          <div className="flex items-center gap-3">
+            <span className="text-xs font-semibold uppercase tracking-widest text-gray-400 whitespace-nowrap">
+              {organisme.nom}
+            </span>
+            <hr className="flex-1 border-gray-200" />
+          </div>
+
+          <ul className="space-y-2">
+            {contacts.map((contact) => (
+              <li key={contact.id} className="rounded-lg border border-gray-200 bg-white p-4 space-y-2">
+                <p className="text-sm font-semibold text-gray-900">{contact.nom}</p>
+                {contact.description && (
+                  <p className="text-sm text-gray-500 italic">{contact.description}</p>
+                )}
+                {contact.telephone && (
+                  <div className="flex items-center gap-2 text-sm text-gray-600">
+                    <Phone size={14} className="shrink-0 text-gray-400" />
+                    <span>{contact.telephone}</span>
+                  </div>
+                )}
+                {contact.email && (
+                  <div className="flex items-center gap-2 text-sm text-gray-600">
+                    <Mail size={14} className="shrink-0 text-gray-400" />
+                    <a href={`mailto:${contact.email}`} className="hover:underline">{contact.email}</a>
+                  </div>
+                )}
+                {contact.url && (
+                  <div className="flex items-center gap-2 text-sm text-gray-600">
+                    <Globe size={14} className="shrink-0 text-gray-400" />
+                    <a href={contact.url} target="_blank" rel="noopener noreferrer" className="hover:underline truncate max-w-xs">
+                      {contact.url.length > 50 ? contact.url.slice(0, 50) + '…' : contact.url}
+                    </a>
+                  </div>
+                )}
+                {contact.adresse && (
+                  <div className="flex items-center gap-2 text-sm text-gray-600">
+                    <MapPin size={14} className="shrink-0 text-gray-400" />
+                    <span>{contact.adresse}</span>
+                  </div>
+                )}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/apps/mb-webapp/src/components/paniers/PanierGouvernanceTab.tsx
+++ b/apps/mb-webapp/src/components/paniers/PanierGouvernanceTab.tsx
@@ -1,8 +1,22 @@
+import { Mail } from 'lucide-react'
 import { useSuspenseQuery } from '@tanstack/react-query'
 
 import { EmptyState } from '@/components/ui/EmptyState'
 import { Heading, Text } from '@/components/ui/Typography'
 import { panierResponsablesQueryOptions } from '@/queries/paniers'
+
+function Initiales({ nom, prenom }: { nom: string | null; prenom: string | null }) {
+  const initiales = [prenom, nom]
+    .filter(Boolean)
+    .map((s) => s![0]!.toUpperCase())
+    .join('')
+    .slice(0, 2)
+  return (
+    <div className="flex size-10 shrink-0 items-center justify-center rounded-full bg-primary/10 text-sm font-semibold text-primary select-none">
+      {initiales || '?'}
+    </div>
+  )
+}
 
 export function PanierGouvernanceTab({ panierId }: { panierId: string }) {
   const { data } = useSuspenseQuery(panierResponsablesQueryOptions(panierId))
@@ -13,20 +27,28 @@ export function PanierGouvernanceTab({ panierId }: { panierId: string }) {
       {data.items.length === 0 ? (
         <EmptyState title="Aucun responsable désigné pour ce panier." />
       ) : (
-        <ul className="flex flex-col gap-3">
+        <ul className="divide-y divide-border rounded-xl border border-border">
           {data.items.map((r) => {
             const nomComplet = [r.prenom, r.nom].filter(Boolean).join(' ')
+            const meta = [r.fonction, r.service].filter(Boolean).join(' · ')
             return (
-              <li key={r.email} className="rounded-lg border border-border p-4 flex flex-col gap-1">
-                <Text weight="medium">{nomComplet || r.email}</Text>
-                {r.fonction && <Text tone="muted">Fonction : {r.fonction}</Text>}
-                {r.service && <Text tone="muted">Service : {r.service}</Text>}
-                <Text tone="muted">
-                  Email :{' '}
-                  <a href={`mailto:${r.email}`} className="underline hover:text-text">
-                    {r.email}
-                  </a>
-                </Text>
+              <li key={r.email} className="flex items-center gap-4 px-5 py-4">
+                <Initiales nom={r.nom} prenom={r.prenom} />
+                <div className="flex min-w-0 flex-1 flex-col">
+                  <Text weight="medium">{nomComplet || r.email}</Text>
+                  {meta && (
+                    <Text variant="caption" tone="muted">
+                      {meta}
+                    </Text>
+                  )}
+                </div>
+                <a
+                  href={`mailto:${r.email}`}
+                  className="flex shrink-0 items-center gap-1.5 text-sm text-text-muted hover:text-text transition-colors"
+                >
+                  <Mail className="size-4" aria-hidden />
+                  <span className="hidden sm:inline">{r.email}</span>
+                </a>
               </li>
             )
           })}

--- a/apps/mb-webapp/src/components/paniers/PanierGouvernanceTab.tsx
+++ b/apps/mb-webapp/src/components/paniers/PanierGouvernanceTab.tsx
@@ -1,0 +1,37 @@
+import { useSuspenseQuery } from '@tanstack/react-query'
+
+import { EmptyState } from '@/components/ui/EmptyState'
+import { Heading, Text } from '@/components/ui/Typography'
+import { panierResponsablesQueryOptions } from '@/queries/paniers'
+
+export function PanierGouvernanceTab({ panierId }: { panierId: string }) {
+  const { data } = useSuspenseQuery(panierResponsablesQueryOptions(panierId))
+
+  return (
+    <div className="flex flex-col gap-4">
+      <Heading size="sm">Responsables</Heading>
+      {data.items.length === 0 ? (
+        <EmptyState title="Aucun responsable désigné pour ce panier." />
+      ) : (
+        <ul className="flex flex-col gap-3">
+          {data.items.map((r) => {
+            const nomComplet = [r.prenom, r.nom].filter(Boolean).join(' ')
+            return (
+              <li key={r.email} className="rounded-lg border border-border p-4 flex flex-col gap-1">
+                <Text weight="medium">{nomComplet || r.email}</Text>
+                {r.fonction && <Text tone="muted">Fonction : {r.fonction}</Text>}
+                {r.service && <Text tone="muted">Service : {r.service}</Text>}
+                <Text tone="muted">
+                  Email :{' '}
+                  <a href={`mailto:${r.email}`} className="underline hover:text-text">
+                    {r.email}
+                  </a>
+                </Text>
+              </li>
+            )
+          })}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/apps/mb-webapp/src/components/paniers/PanierGouvernanceTab.tsx
+++ b/apps/mb-webapp/src/components/paniers/PanierGouvernanceTab.tsx
@@ -1,6 +1,8 @@
 import { Mail } from 'lucide-react'
 import { useSuspenseQuery } from '@tanstack/react-query'
+import { Suspense } from 'react'
 
+import { PanierContactsUtiles } from '@/components/paniers/PanierContactsUtiles'
 import { EmptyState } from '@/components/ui/EmptyState'
 import { Heading, Text } from '@/components/ui/Typography'
 import { panierResponsablesQueryOptions } from '@/queries/paniers'
@@ -22,38 +24,44 @@ export function PanierGouvernanceTab({ panierId }: { panierId: string }) {
   const { data } = useSuspenseQuery(panierResponsablesQueryOptions(panierId))
 
   return (
-    <div className="flex flex-col gap-4">
-      <Heading size="sm">Responsables</Heading>
-      {data.items.length === 0 ? (
-        <EmptyState title="Aucun responsable désigné pour ce panier." />
-      ) : (
-        <ul className="divide-y divide-border rounded-xl border border-border">
-          {data.items.map((r) => {
-            const nomComplet = [r.prenom, r.nom].filter(Boolean).join(' ')
-            const meta = [r.fonction, r.service].filter(Boolean).join(' · ')
-            return (
-              <li key={r.email} className="flex items-center gap-4 px-5 py-4">
-                <Initiales nom={r.nom} prenom={r.prenom} />
-                <div className="flex min-w-0 flex-1 flex-col">
-                  <Text weight="medium">{nomComplet || r.email}</Text>
-                  {meta && (
-                    <Text variant="caption" tone="muted">
-                      {meta}
-                    </Text>
-                  )}
-                </div>
-                <a
-                  href={`mailto:${r.email}`}
-                  className="flex shrink-0 items-center gap-1.5 text-sm text-text-muted hover:text-text transition-colors"
-                >
-                  <Mail className="size-4" aria-hidden />
-                  <span className="hidden sm:inline">{r.email}</span>
-                </a>
-              </li>
-            )
-          })}
-        </ul>
-      )}
+    <div className="flex flex-col gap-8">
+      <div className="flex flex-col gap-4">
+        <Heading size="sm">Responsables</Heading>
+        {data.items.length === 0 ? (
+          <EmptyState title="Aucun responsable désigné pour ce panier." />
+        ) : (
+          <ul className="divide-y divide-border rounded-xl border border-border">
+            {data.items.map((r) => {
+              const nomComplet = [r.prenom, r.nom].filter(Boolean).join(' ')
+              const meta = [r.fonction, r.service].filter(Boolean).join(' · ')
+              return (
+                <li key={r.email} className="flex items-center gap-4 px-5 py-4">
+                  <Initiales nom={r.nom} prenom={r.prenom} />
+                  <div className="flex min-w-0 flex-1 flex-col">
+                    <Text weight="medium">{nomComplet || r.email}</Text>
+                    {meta && (
+                      <Text variant="caption" tone="muted">
+                        {meta}
+                      </Text>
+                    )}
+                  </div>
+                  <a
+                    href={`mailto:${r.email}`}
+                    className="flex shrink-0 items-center gap-1.5 text-sm text-text-muted hover:text-text transition-colors"
+                  >
+                    <Mail className="size-4" aria-hidden />
+                    <span className="hidden sm:inline">{r.email}</span>
+                  </a>
+                </li>
+              )
+            })}
+          </ul>
+        )}
+      </div>
+
+      <Suspense>
+        <PanierContactsUtiles panierId={panierId} />
+      </Suspense>
     </div>
   )
 }

--- a/apps/mb-webapp/src/components/paniers/PanierGouvernanceTab.tsx
+++ b/apps/mb-webapp/src/components/paniers/PanierGouvernanceTab.tsx
@@ -5,10 +5,10 @@ import { EmptyState } from '@/components/ui/EmptyState'
 import { Heading, Text } from '@/components/ui/Typography'
 import { panierResponsablesQueryOptions } from '@/queries/paniers'
 
-function Initiales({ nom, prenom }: { nom: string | null; prenom: string | null }) {
+function Initiales({ nom, prenom }: { nom: string; prenom: string }) {
   const initiales = [prenom, nom]
     .filter(Boolean)
-    .map((s) => s![0]!.toUpperCase())
+    .map((s) => s[0]!.toUpperCase())
     .join('')
     .slice(0, 2)
   return (

--- a/apps/mb-webapp/src/queries/paniers.ts
+++ b/apps/mb-webapp/src/queries/paniers.ts
@@ -1,7 +1,12 @@
 import { type ListPaniersQuery } from '@pilote/mb-shared/panier'
 import { type QueryClient, queryOptions } from '@tanstack/react-query'
 
-import { fetchPanierById, fetchPaniers, fetchPanierTauxProgression } from '@/api/paniers'
+import {
+  fetchPanierById,
+  fetchPanierResponsables,
+  fetchPaniers,
+  fetchPanierTauxProgression,
+} from '@/api/paniers'
 
 import { DEFAULT_STALE_TIME } from './utils'
 
@@ -45,5 +50,12 @@ export const panierTauxProgressionQueryOptions = ({
   queryOptions({
     queryKey: ['panier', panierId, 'taux-progression', individu],
     queryFn: () => fetchPanierTauxProgression({ panierId, individu }),
+    staleTime: DEFAULT_STALE_TIME,
+  })
+
+export const panierResponsablesQueryOptions = (panierId: string) =>
+  queryOptions({
+    queryKey: ['panier', panierId, 'responsables'],
+    queryFn: () => fetchPanierResponsables(panierId),
     staleTime: DEFAULT_STALE_TIME,
   })

--- a/apps/mb-webapp/src/queries/paniers.ts
+++ b/apps/mb-webapp/src/queries/paniers.ts
@@ -3,6 +3,7 @@ import { type QueryClient, queryOptions } from '@tanstack/react-query'
 
 import {
   fetchPanierById,
+  fetchPanierContactsUtiles,
   fetchPanierResponsables,
   fetchPaniers,
   fetchPanierTauxProgression,
@@ -57,5 +58,12 @@ export const panierResponsablesQueryOptions = (panierId: string) =>
   queryOptions({
     queryKey: ['panier', panierId, 'responsables'],
     queryFn: () => fetchPanierResponsables(panierId),
+    staleTime: DEFAULT_STALE_TIME,
+  })
+
+export const panierContactsUtilesQueryOptions = (panierId: string) =>
+  queryOptions({
+    queryKey: ['panier', panierId, 'contacts-utiles'],
+    queryFn: () => fetchPanierContactsUtiles(panierId),
     staleTime: DEFAULT_STALE_TIME,
   })

--- a/apps/mb-webapp/src/routes/_authenticated/paniers/$id.tsx
+++ b/apps/mb-webapp/src/routes/_authenticated/paniers/$id.tsx
@@ -23,6 +23,7 @@ import { ensureIndividuReferentielPair } from '@/lib/individus/pair'
 import { indicateursQueryOptions } from '@/queries/indicateurs'
 import {
   loadPanier,
+  panierContactsUtilesQueryOptions,
   panierQueryOptions,
   panierResponsablesQueryOptions,
   panierTauxProgressionQueryOptions,
@@ -74,6 +75,7 @@ export const Route = createFileRoute('/_authenticated/paniers/$id')({
     }
 
     void queryClient.prefetchQuery(panierResponsablesQueryOptions(params.id))
+    void queryClient.prefetchQuery(panierContactsUtilesQueryOptions(params.id))
 
     return { panier }
   },

--- a/apps/mb-webapp/src/routes/_authenticated/paniers/$id.tsx
+++ b/apps/mb-webapp/src/routes/_authenticated/paniers/$id.tsx
@@ -3,25 +3,28 @@ import { referentielPublicIdSchema } from '@pilote/mb-shared/referentiel'
 import { panierPublicIdSchema } from '@pilote/mb-shared/publicIds'
 import { useSuspenseQuery } from '@tanstack/react-query'
 import { createFileRoute, Link, redirect, useNavigate } from '@tanstack/react-router'
-import { startTransition, useId } from 'react'
+import { startTransition, Suspense, useId } from 'react'
 import { z } from 'zod'
 
 import { RouteError } from '@/components/RouteError'
 import { RouteLoading } from '@/components/RouteLoading'
 import { IndicateurCard } from '@/components/indicateurs/IndicateurCard'
 import { IndividuSelect } from '@/components/indicateurs/IndividuSelect'
+import { PanierGouvernanceTab } from '@/components/paniers/PanierGouvernanceTab'
 import { PanierTauxProgression } from '@/components/paniers/PanierTauxProgression'
 import { BackLink } from '@/components/ui/BackLink'
 import { CardGrid } from '@/components/ui/CardGrid'
 import { EmptyState } from '@/components/ui/EmptyState'
 import { FormField } from '@/components/ui/FormField'
 import { Page } from '@/components/ui/Page'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/Tabs'
 import { Text } from '@/components/ui/Typography'
 import { ensureIndividuReferentielPair } from '@/lib/individus/pair'
 import { indicateursQueryOptions } from '@/queries/indicateurs'
 import {
   loadPanier,
   panierQueryOptions,
+  panierResponsablesQueryOptions,
   panierTauxProgressionQueryOptions,
 } from '@/queries/paniers'
 import { allReferentielsQueryOptions, loadAllReferentielIds } from '@/queries/referentiels'
@@ -70,6 +73,8 @@ export const Route = createFileRoute('/_authenticated/paniers/$id')({
       )
     }
 
+    void queryClient.prefetchQuery(panierResponsablesQueryOptions(params.id))
+
     return { panier }
   },
   pendingComponent: () => <RouteLoading message="Chargement du panier…" />,
@@ -111,48 +116,63 @@ function PanierDetailComponent() {
 
   return (
     <Page title={panier.nom} description={panier.description ?? undefined} back={back}>
-      <div className="flex flex-col gap-6">
-        {search.individu ? (
-          <div className="flex flex-col gap-6">
-            <div className="max-w-md">
-              <FormField label="Individu observé" htmlFor={selectId}>
-                <IndividuSelect
-                  id={selectId}
-                  referentielIds={referentielIds}
-                  value={search.individu}
-                  onChange={({ individu, referentiel }) => {
-                    startTransition(() => {
-                      void navigate({
-                        search: (prev) => ({ ...prev, individu, referentiel }),
-                      })
-                    })
-                  }}
-                />
-              </FormField>
-            </div>
-            <div className="max-w-xs">
-              <PanierTauxProgression panierId={id} individu={search.individu} />
-            </div>
-          </div>
-        ) : null}
+      <Tabs defaultValue="resultats">
+        <TabsList>
+          <TabsTrigger value="resultats">Résultats</TabsTrigger>
+          <TabsTrigger value="gouvernance">Gouvernance</TabsTrigger>
+        </TabsList>
 
-        <Text as="span" variant="kicker" tone="muted">
-          {orderedIndicateurs.length} indicateur{orderedIndicateurs.length > 1 ? 's' : ''}
-        </Text>
-        {orderedIndicateurs.length === 0 ? (
-          <EmptyState title="Ce panier ne contient aucun indicateur." />
-        ) : (
-          <CardGrid>
-            {orderedIndicateurs.map((indicateur) => (
-              <IndicateurCard
-                key={indicateur.id}
-                indicateur={indicateur}
-                {...(cardContext ? { context: cardContext } : {})}
-              />
-            ))}
-          </CardGrid>
-        )}
-      </div>
+        <TabsContent value="resultats">
+          <div className="flex flex-col gap-6">
+            {search.individu ? (
+              <div className="flex flex-col gap-6">
+                <div className="max-w-md">
+                  <FormField label="Individu observé" htmlFor={selectId}>
+                    <IndividuSelect
+                      id={selectId}
+                      referentielIds={referentielIds}
+                      value={search.individu}
+                      onChange={({ individu, referentiel }) => {
+                        startTransition(() => {
+                          void navigate({
+                            search: (prev) => ({ ...prev, individu, referentiel }),
+                          })
+                        })
+                      }}
+                    />
+                  </FormField>
+                </div>
+                <div className="max-w-xs">
+                  <PanierTauxProgression panierId={id} individu={search.individu} />
+                </div>
+              </div>
+            ) : null}
+
+            <Text as="span" variant="kicker" tone="muted">
+              {orderedIndicateurs.length} indicateur{orderedIndicateurs.length > 1 ? 's' : ''}
+            </Text>
+            {orderedIndicateurs.length === 0 ? (
+              <EmptyState title="Ce panier ne contient aucun indicateur." />
+            ) : (
+              <CardGrid>
+                {orderedIndicateurs.map((indicateur) => (
+                  <IndicateurCard
+                    key={indicateur.id}
+                    indicateur={indicateur}
+                    {...(cardContext ? { context: cardContext } : {})}
+                  />
+                ))}
+              </CardGrid>
+            )}
+          </div>
+        </TabsContent>
+
+        <TabsContent value="gouvernance">
+          <Suspense fallback={<RouteLoading message="Chargement des responsables…" />}>
+            <PanierGouvernanceTab panierId={id} />
+          </Suspense>
+        </TabsContent>
+      </Tabs>
     </Page>
   )
 }

--- a/packages/mb-shared/package.json
+++ b/packages/mb-shared/package.json
@@ -63,6 +63,10 @@
     "./panierTauxProgression": {
       "types": "./src/panierTauxProgression.ts",
       "default": "./src/panierTauxProgression.ts"
+    },
+    "./panierResponsable": {
+      "types": "./src/panierResponsable.ts",
+      "default": "./src/panierResponsable.ts"
     }
   },
   "files": [

--- a/packages/mb-shared/package.json
+++ b/packages/mb-shared/package.json
@@ -67,6 +67,10 @@
     "./panierResponsable": {
       "types": "./src/panierResponsable.ts",
       "default": "./src/panierResponsable.ts"
+    },
+    "./panierContactUtile": {
+      "types": "./src/panierContactUtile.ts",
+      "default": "./src/panierContactUtile.ts"
     }
   },
   "files": [

--- a/packages/mb-shared/src/panierContactUtile.ts
+++ b/packages/mb-shared/src/panierContactUtile.ts
@@ -1,0 +1,27 @@
+import { z } from 'zod'
+
+export const contactUtileApiModelSchema = z.object({
+  id:          z.string().uuid(),
+  nom:         z.string(),
+  description: z.string().nullable(),
+  telephone:   z.string().nullable(),
+  email:       z.string().nullable(),
+  url:         z.string().nullable(),
+  adresse:     z.string().nullable(),
+})
+
+export const organismeAvecContactsApiModelSchema = z.object({
+  organisme: z.object({
+    id:  z.string().uuid(),
+    nom: z.string(),
+  }),
+  contacts: z.array(contactUtileApiModelSchema),
+})
+
+export const panierContactsUtilesApiModelSchema = z.object({
+  items: z.array(organismeAvecContactsApiModelSchema),
+})
+
+export type ContactUtileApiModel          = z.infer<typeof contactUtileApiModelSchema>
+export type OrganismeAvecContactsApiModel = z.infer<typeof organismeAvecContactsApiModelSchema>
+export type PanierContactsUtilesApiModel  = z.infer<typeof panierContactsUtilesApiModelSchema>

--- a/packages/mb-shared/src/panierResponsable.ts
+++ b/packages/mb-shared/src/panierResponsable.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod'
+
+export const panierResponsableApiModelSchema = z.object({
+  email:    z.string().email(),
+  nom:      z.string().nullable(),
+  prenom:   z.string().nullable(),
+  service:  z.string().nullable(),
+  fonction: z.string().nullable(),
+})
+export type PanierResponsableApiModel = z.infer<typeof panierResponsableApiModelSchema>
+
+export const panierResponsablesApiModelSchema = z.object({
+  items: z.array(panierResponsableApiModelSchema),
+})
+export type PanierResponsablesApiModel = z.infer<typeof panierResponsablesApiModelSchema>

--- a/packages/mb-shared/src/panierResponsable.ts
+++ b/packages/mb-shared/src/panierResponsable.ts
@@ -2,10 +2,10 @@ import { z } from 'zod'
 
 export const panierResponsableApiModelSchema = z.object({
   email:    z.string().email(),
-  nom:      z.string().nullable(),
-  prenom:   z.string().nullable(),
-  service:  z.string().nullable(),
-  fonction: z.string().nullable(),
+  nom:      z.string(),
+  prenom:   z.string(),
+  service:  z.string(),
+  fonction: z.string(),
 })
 export type PanierResponsableApiModel = z.infer<typeof panierResponsableApiModelSchema>
 


### PR DESCRIPTION
## Résumé

- Ajoute un bloc **Contacts utiles** sous le bloc Responsables dans l'onglet Gouvernance du détail d'un panier
- Les contacts sont regroupés par organisme (entité normalisée), triés alphabétiquement
- Chaque contact peut afficher : nom (obligatoire), description, téléphone, email, URL, adresse postale

## Modèle de données

3 nouvelles tables :
- `organisme` — entité partagée entre paniers (id, nom)
- `contact_utile` — service/point de contact avec champs optionnels
- `panier_contact_utile` — jointure M-N entre paniers et contacts

## Périmètre technique

- **Shared** : types Zod `panierContactUtile` + entry point package
- **API** : `GET /paniers/{id}/contacts-utiles` — mêmes règles de permission que `/responsables`, réponse pré-groupée par organisme côté serveur
- **Tests** : 10 cas couverts (liste vide, champs complets, contact minimal, groupement, tri, permissions, multi-panier)
- **Frontend** : composant `PanierContactsUtiles` avec séparateurs d'organisme, cartes de contact, icônes lucide-react, rendu conditionnel des champs nuls
- **Seed** : 2 organismes (DITP, DINUM), 4 contacts dont 2 sous la DITP, rattachés à PAN-005

## Test plan

- [ ] Appliquer la migration : `pnpm prisma migrate dev`
- [ ] Relancer le seed : `pnpm prisma db seed`
- [ ] Vérifier l'affichage sur PAN-005 : 2 groupes DITP + DINUM avec leurs contacts respectifs
- [ ] Vérifier l'empty state sur un panier sans contacts
- [ ] Vérifier qu'un panier PRIVÉ sans permission ne retourne pas les contacts (`404`)
- [ ] Lancer les tests : `pnpm vitest run getPanierContactsUtiles`

🤖 Generated with [Claude Code](https://claude.com/claude-code)