### PR TITLE
feat(commentaires): socle + satellites, niveau de confiance & commentaires libres (PIL-1581 → PIL-1593)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,10 +44,11 @@ qodana.yaml
 # uploads
 /uploads
 
-docs/superpowers/
-
-# superpowers specs/plans
-docs/superpowers/
+# superpowers ignoré, sauf le spec commentaires (tracké)
+docs/superpowers/*
+!docs/superpowers/specs/
+docs/superpowers/specs/*
+!docs/superpowers/specs/2026-06-23-commentaires-niveau-confiance-design.md
 
 # superpowers visual companion (mockups)
 .superpowers/

--- a/apps/mb-api/prisma/migrations/20260624120000_add_commentaires_niveau_confiance/migration.sql
+++ b/apps/mb-api/prisma/migrations/20260624120000_add_commentaires_niveau_confiance/migration.sql
@@ -1,0 +1,77 @@
+-- Socle Commentaire + satellites par secteur (IndicateurIndividu, PanierIndividu, Panier)
+-- + NiveauConfiance (météo) accroché 1:1 à un commentaire.
+-- Les enums `type` sont seedés avec un placeholder (TYPE_COMMENTAIRE_1) ;
+-- ils seront remplacés quand les vraies valeurs métier seront connues.
+
+-- CreateEnum
+CREATE TYPE "commentaire_statut_enum" AS ENUM ('BROUILLON', 'PUBLIE');
+CREATE TYPE "indice_confiance_enum" AS ENUM ('OBJECTIF_COMPROMIS', 'APPUIS_NECESSAIRE', 'OBJECTIF_ATTEIGNABLE', 'OBJECTIF_SECURISE');
+CREATE TYPE "indicateur_individu_commentaire_type_enum" AS ENUM ('TYPE_COMMENTAIRE_1');
+CREATE TYPE "panier_individu_commentaire_type_enum" AS ENUM ('TYPE_COMMENTAIRE_1');
+CREATE TYPE "panier_commentaire_type_enum" AS ENUM ('TYPE_COMMENTAIRE_1');
+
+-- CreateTable : socle
+CREATE TABLE "commentaire" (
+    "id"            UUID                      NOT NULL,
+    "contenu"       TEXT                      NOT NULL,
+    "contenu_texte" TEXT                      NOT NULL,
+    "statut"        "commentaire_statut_enum" NOT NULL,
+    "created_by"    UUID                      NOT NULL,
+    "updated_by"    UUID                      NOT NULL,
+    "created_at"    TIMESTAMP(3)              NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at"    TIMESTAMP(3)              NOT NULL,
+    CONSTRAINT "commentaire_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "commentaire_created_by_fkey" FOREIGN KEY ("created_by") REFERENCES "principal"("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "commentaire_updated_by_fkey" FOREIGN KEY ("updated_by") REFERENCES "principal"("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+CREATE INDEX "commentaire_created_by_idx" ON "commentaire"("created_by");
+CREATE INDEX "commentaire_updated_by_idx" ON "commentaire"("updated_by");
+
+-- CreateTable : satellite IndicateurIndividu
+CREATE TABLE "indicateur_individu_commentaire" (
+    "commentaire_id" UUID                                NOT NULL,
+    "indicateur_id"  UUID                                NOT NULL,
+    "individu_id"    UUID                                NOT NULL,
+    "type"           "indicateur_individu_commentaire_type_enum" NOT NULL,
+    CONSTRAINT "indicateur_individu_commentaire_pkey" PRIMARY KEY ("commentaire_id"),
+    CONSTRAINT "indicateur_individu_commentaire_commentaire_id_fkey" FOREIGN KEY ("commentaire_id") REFERENCES "commentaire"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "indicateur_individu_commentaire_indicateur_id_fkey" FOREIGN KEY ("indicateur_id") REFERENCES "indicateur"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "indicateur_individu_commentaire_individu_id_fkey" FOREIGN KEY ("individu_id") REFERENCES "individu"("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+CREATE INDEX "indicateur_individu_commentaire_indicateur_id_individu_id_idx" ON "indicateur_individu_commentaire"("indicateur_id", "individu_id");
+
+-- CreateTable : satellite PanierIndividu
+CREATE TABLE "panier_individu_commentaire" (
+    "commentaire_id" UUID                            NOT NULL,
+    "panier_id"      UUID                            NOT NULL,
+    "individu_id"    UUID                            NOT NULL,
+    "type"           "panier_individu_commentaire_type_enum" NOT NULL,
+    CONSTRAINT "panier_individu_commentaire_pkey" PRIMARY KEY ("commentaire_id"),
+    CONSTRAINT "panier_individu_commentaire_commentaire_id_fkey" FOREIGN KEY ("commentaire_id") REFERENCES "commentaire"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "panier_individu_commentaire_panier_id_fkey" FOREIGN KEY ("panier_id") REFERENCES "panier"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "panier_individu_commentaire_individu_id_fkey" FOREIGN KEY ("individu_id") REFERENCES "individu"("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+CREATE INDEX "panier_individu_commentaire_panier_id_individu_id_idx" ON "panier_individu_commentaire"("panier_id", "individu_id");
+
+-- CreateTable : satellite Panier (global, sans individu)
+CREATE TABLE "panier_commentaire" (
+    "commentaire_id" UUID                    NOT NULL,
+    "panier_id"      UUID                    NOT NULL,
+    "type"           "panier_commentaire_type_enum" NOT NULL,
+    CONSTRAINT "panier_commentaire_pkey" PRIMARY KEY ("commentaire_id"),
+    CONSTRAINT "panier_commentaire_commentaire_id_fkey" FOREIGN KEY ("commentaire_id") REFERENCES "commentaire"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "panier_commentaire_panier_id_fkey" FOREIGN KEY ("panier_id") REFERENCES "panier"("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE INDEX "panier_commentaire_panier_id_idx" ON "panier_commentaire"("panier_id");
+
+-- CreateTable : NiveauConfiance (météo), 1:1 sur le commentaire
+CREATE TABLE "niveau_confiance" (
+    "commentaire_id" UUID                    NOT NULL,
+    "indice"         "indice_confiance_enum" NOT NULL,
+    CONSTRAINT "niveau_confiance_pkey" PRIMARY KEY ("commentaire_id"),
+    CONSTRAINT "niveau_confiance_commentaire_id_fkey" FOREIGN KEY ("commentaire_id") REFERENCES "commentaire"("id") ON DELETE CASCADE ON UPDATE CASCADE
+);

--- a/apps/mb-api/prisma/migrations/20260624120000_add_commentaires_niveau_confiance/migration.sql
+++ b/apps/mb-api/prisma/migrations/20260624120000_add_commentaires_niveau_confiance/migration.sql
@@ -1,14 +1,12 @@
 -- Socle Commentaire + satellites par secteur (IndicateurIndividu, PanierIndividu, Panier)
--- + NiveauConfiance (météo) accroché 1:1 à un commentaire.
--- Les enums `type` sont seedés avec un placeholder (TYPE_COMMENTAIRE_1) ;
--- ils seront remplacés quand les vraies valeurs métier seront connues.
+-- + NiveauConfiance (météo) accroché 1:n à un commentaire (historique d'indices + autres usages).
 
 -- CreateEnum
 CREATE TYPE "commentaire_statut_enum" AS ENUM ('BROUILLON', 'PUBLIE');
 CREATE TYPE "indice_confiance_enum" AS ENUM ('OBJECTIF_COMPROMIS', 'APPUIS_NECESSAIRE', 'OBJECTIF_ATTEIGNABLE', 'OBJECTIF_SECURISE');
-CREATE TYPE "indicateur_individu_commentaire_type_enum" AS ENUM ('TYPE_COMMENTAIRE_1');
-CREATE TYPE "panier_individu_commentaire_type_enum" AS ENUM ('TYPE_COMMENTAIRE_1');
-CREATE TYPE "panier_commentaire_type_enum" AS ENUM ('TYPE_COMMENTAIRE_1');
+CREATE TYPE "indicateur_individu_commentaire_type_enum" AS ENUM ('DEFAUT', 'CONFIANCE');
+CREATE TYPE "panier_individu_commentaire_type_enum" AS ENUM ('DEFAUT', 'CONFIANCE');
+CREATE TYPE "panier_commentaire_type_enum" AS ENUM ('DEFAUT', 'CONFIANCE', 'OBJECTIF');
 
 -- CreateTable : socle
 CREATE TABLE "commentaire" (
@@ -68,10 +66,15 @@ CREATE TABLE "panier_commentaire" (
 
 CREATE INDEX "panier_commentaire_panier_id_idx" ON "panier_commentaire"("panier_id");
 
--- CreateTable : NiveauConfiance (météo), 1:1 sur le commentaire
+-- CreateTable : NiveauConfiance (météo), 1:n sur le commentaire (historique d'indices)
 CREATE TABLE "niveau_confiance" (
+    "id"             UUID                    NOT NULL,
     "commentaire_id" UUID                    NOT NULL,
     "indice"         "indice_confiance_enum" NOT NULL,
-    CONSTRAINT "niveau_confiance_pkey" PRIMARY KEY ("commentaire_id"),
+    "created_at"     TIMESTAMP(3)            NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at"     TIMESTAMP(3)            NOT NULL,
+    CONSTRAINT "niveau_confiance_pkey" PRIMARY KEY ("id"),
     CONSTRAINT "niveau_confiance_commentaire_id_fkey" FOREIGN KEY ("commentaire_id") REFERENCES "commentaire"("id") ON DELETE CASCADE ON UPDATE CASCADE
 );
+
+CREATE INDEX "niveau_confiance_commentaire_id_idx" ON "niveau_confiance"("commentaire_id");

--- a/apps/mb-api/prisma/schema.prisma
+++ b/apps/mb-api/prisma/schema.prisma
@@ -306,7 +306,7 @@ model Panier {
   permissions          PanierPermission[]
   responsables         PanierResponsable[]
   individuCommentaires PanierIndividuCommentaire[]
-  commentaires         PanierCommentaire[]
+  panierCommentaires   PanierCommentaire[]
 
   @@map("panier")
 }
@@ -395,19 +395,23 @@ enum IndiceConfiance {
 }
 
 enum IndicateurIndividuCommentaireType {
-  TYPE_COMMENTAIRE_1
+  DEFAUT
+  CONFIANCE
 
   @@map("indicateur_individu_commentaire_type_enum")
 }
 
 enum PanierIndividuCommentaireType {
-  TYPE_COMMENTAIRE_1
+  DEFAUT
+  CONFIANCE
 
   @@map("panier_individu_commentaire_type_enum")
 }
 
 enum PanierCommentaireType {
-  TYPE_COMMENTAIRE_1
+  DEFAUT
+  CONFIANCE
+  OBJECTIF
 
   @@map("panier_commentaire_type_enum")
 }
@@ -428,7 +432,7 @@ model Commentaire {
   indicateurIndividu IndicateurIndividuCommentaire?
   panierIndividu     PanierIndividuCommentaire?
   panier             PanierCommentaire?
-  niveauConfiance    NiveauConfiance?
+  niveauxConfiance   NiveauConfiance[]
 
   @@index([createdBy])
   @@index([updatedBy])
@@ -476,10 +480,14 @@ model PanierCommentaire {
 }
 
 model NiveauConfiance {
-  commentaireId String          @id @map("commentaire_id") @db.Uuid
+  id            String          @id @db.Uuid
+  commentaireId String          @map("commentaire_id") @db.Uuid
   indice        IndiceConfiance
+  createdAt     DateTime        @default(now()) @map("created_at")
+  updatedAt     DateTime        @updatedAt @map("updated_at")
 
   commentaire Commentaire @relation(fields: [commentaireId], references: [id], onDelete: Cascade)
 
+  @@index([commentaireId])
   @@map("niveau_confiance")
 }

--- a/apps/mb-api/prisma/schema.prisma
+++ b/apps/mb-api/prisma/schema.prisma
@@ -18,6 +18,8 @@ model Principal {
   apiKey                ApiKey?
   indicateurPermissions IndicateurPermission[]
   panierPermissions     PanierPermission[]
+  commentairesCrees     Commentaire[]          @relation("commentaireCreatedBy")
+  commentairesModifies  Commentaire[]          @relation("commentaireUpdatedBy")
 
   @@map("principal")
 }
@@ -37,9 +39,9 @@ model Utilisateur {
   service   String
   fonction  String
   createdAt DateTime @default(now()) @map("created_at")
-  updatedAt DateTime @updatedAt      @map("updated_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
 
-  principal       Principal          @relation(fields: [id], references: [id], onDelete: Cascade)
+  principal       Principal           @relation(fields: [id], references: [id], onDelete: Cascade)
   identites       IdentiteExterne[]
   responsabilites PanierResponsable[]
 
@@ -50,7 +52,7 @@ model IdentiteExterne {
   provider      ProviderType
   providerSub   String       @map("provider_sub")
   utilisateurId String       @map("utilisateur_id") @db.Uuid
-  createdAt     DateTime     @default(now())        @map("created_at")
+  createdAt     DateTime     @default(now()) @map("created_at")
 
   utilisateur Utilisateur @relation(fields: [utilisateurId], references: [id], onDelete: Cascade)
 
@@ -84,25 +86,26 @@ model ApiKey {
 }
 
 model Indicateur {
-  id                String            @id @db.Uuid
-  publicId          String            @unique @map("public_id")
-  nom               String
-  visibilite        Visibilite
-  unite             UniteIndicateur?
-  description       String?
-  methodeCalcul     String?           @map("methode_calcul")
-  sourceDonnees     String?           @map("source_donnees")
-  sourceUrl         String?           @map("source_url")
-  periodeMiseAJour  PeriodeMiseAJour? @map("periode_mise_a_jour")
-  jourMiseAJour     Int?              @map("jour_mise_a_jour")
-  createdAt         DateTime          @default(now()) @map("created_at")
-  updatedAt         DateTime          @updatedAt      @map("updated_at")
+  id               String            @id @db.Uuid
+  publicId         String            @unique @map("public_id")
+  nom              String
+  visibilite       Visibilite
+  unite            UniteIndicateur?
+  description      String?
+  methodeCalcul    String?           @map("methode_calcul")
+  sourceDonnees    String?           @map("source_donnees")
+  sourceUrl        String?           @map("source_url")
+  periodeMiseAJour PeriodeMiseAJour? @map("periode_mise_a_jour")
+  jourMiseAJour    Int?              @map("jour_mise_a_jour")
+  createdAt        DateTime          @default(now()) @map("created_at")
+  updatedAt        DateTime          @updatedAt @map("updated_at")
 
-  valeurs      ValeurAvancement[]
-  objectifs    ObjectifIndicateurIndividu[]
-  referentiels IndicateurReferentiel[]
-  permissions  IndicateurPermission[]
-  paniers      PanierIndicateur[]
+  valeurs              ValeurAvancement[]
+  objectifs            ObjectifIndicateurIndividu[]
+  referentiels         IndicateurReferentiel[]
+  permissions          IndicateurPermission[]
+  paniers              PanierIndicateur[]
+  individuCommentaires IndicateurIndividuCommentaire[]
 
   @@map("indicateur")
 }
@@ -143,12 +146,12 @@ enum PeriodeMiseAJour {
 }
 
 model IndicateurReferentiel {
-  indicateurId       String             @map("indicateur_id")  @db.Uuid
+  indicateurId       String             @map("indicateur_id") @db.Uuid
   referentielId      String             @map("referentiel_id") @db.Uuid
   fonctionAgregation FonctionAgregation @map("fonction_agregation")
-  createdAt          DateTime           @default(now())        @map("created_at")
+  createdAt          DateTime           @default(now()) @map("created_at")
 
-  indicateur  Indicateur  @relation(fields: [indicateurId],  references: [id], onDelete: Cascade)
+  indicateur  Indicateur  @relation(fields: [indicateurId], references: [id], onDelete: Cascade)
   referentiel Referentiel @relation(fields: [referentielId], references: [id], onDelete: Cascade)
 
   @@id([indicateurId, referentielId])
@@ -164,12 +167,12 @@ enum PermissionAction {
 }
 
 model IndicateurPermission {
-  principalId  String           @map("principal_id")  @db.Uuid
+  principalId  String           @map("principal_id") @db.Uuid
   indicateurId String           @map("indicateur_id") @db.Uuid
   action       PermissionAction
   createdAt    DateTime         @default(now()) @map("created_at")
 
-  principal  Principal  @relation(fields: [principalId],  references: [id], onDelete: Cascade)
+  principal  Principal  @relation(fields: [principalId], references: [id], onDelete: Cascade)
   indicateur Indicateur @relation(fields: [indicateurId], references: [id], onDelete: Cascade)
 
   @@id([principalId, indicateurId, action])
@@ -183,7 +186,7 @@ model Referentiel {
   nom         String
   description String?
   createdAt   DateTime @default(now()) @map("created_at")
-  updatedAt   DateTime @updatedAt      @map("updated_at")
+  updatedAt   DateTime @updatedAt @map("updated_at")
 
   individus   Individu[]
   indicateurs IndicateurReferentiel[]
@@ -199,26 +202,28 @@ model Individu {
   referentielId String   @map("referentiel_id") @db.Uuid
   metadata      Json?
   createdAt     DateTime @default(now()) @map("created_at")
-  updatedAt     DateTime @updatedAt      @map("updated_at")
+  updatedAt     DateTime @updatedAt @map("updated_at")
 
-  referentiel       Referentiel          @relation(fields: [referentielId], references: [id], onDelete: Restrict)
-  relationsAsParent Relation[]           @relation("relationParent")
-  relationsAsChild  Relation[]           @relation("relationChild")
-  valeurs           ValeurAvancement[]
-  objectifs         ObjectifIndicateurIndividu[]
+  referentiel            Referentiel                     @relation(fields: [referentielId], references: [id], onDelete: Restrict)
+  relationsAsParent      Relation[]                      @relation("relationParent")
+  relationsAsChild       Relation[]                      @relation("relationChild")
+  valeurs                ValeurAvancement[]
+  objectifs              ObjectifIndicateurIndividu[]
+  indicateurCommentaires IndicateurIndividuCommentaire[]
+  panierCommentaires     PanierIndividuCommentaire[]
 
   @@index([referentielId])
   @@map("individu")
 }
 
 model Widget {
-  id            String   @id @db.Uuid
-  publicId      String   @unique @map("public_id")
-  type          String
-  nom           String
-  joinKey       String   @map("join_key")
-  createdAt     DateTime @default(now()) @map("created_at")
-  updatedAt     DateTime @updatedAt      @map("updated_at")
+  id        String   @id @db.Uuid
+  publicId  String   @unique @map("public_id")
+  type      String
+  nom       String
+  joinKey   String   @map("join_key")
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
 
   referentiels ReferentielWidget[]
 
@@ -227,11 +232,11 @@ model Widget {
 
 model ReferentielWidget {
   referentielId String   @map("referentiel_id") @db.Uuid
-  widgetId      String   @map("widget_id")      @db.Uuid
+  widgetId      String   @map("widget_id") @db.Uuid
   createdAt     DateTime @default(now()) @map("created_at")
 
   referentiel Referentiel @relation(fields: [referentielId], references: [id], onDelete: Cascade)
-  widget      Widget      @relation(fields: [widgetId],      references: [id], onDelete: Cascade)
+  widget      Widget      @relation(fields: [widgetId], references: [id], onDelete: Cascade)
 
   @@id([referentielId, widgetId])
   @@index([widgetId])
@@ -241,11 +246,11 @@ model ReferentielWidget {
 model Relation {
   id        String   @id @db.Uuid
   parentId  String   @map("parent_id") @db.Uuid
-  childId   String   @map("child_id")  @db.Uuid
+  childId   String   @map("child_id") @db.Uuid
   createdAt DateTime @default(now()) @map("created_at")
 
   parent Individu @relation("relationParent", fields: [parentId], references: [id], onDelete: Cascade)
-  child  Individu @relation("relationChild",  fields: [childId],  references: [id], onDelete: Cascade)
+  child  Individu @relation("relationChild", fields: [childId], references: [id], onDelete: Cascade)
 
   @@unique([parentId, childId])
   @@index([childId])
@@ -255,14 +260,14 @@ model Relation {
 model ValeurAvancement {
   id           String   @id @db.Uuid
   indicateurId String   @map("indicateur_id") @db.Uuid
-  individuId   String   @map("individu_id")   @db.Uuid
+  individuId   String   @map("individu_id") @db.Uuid
   date         String
   valeur       Decimal  @db.Decimal(20, 2)
   createdAt    DateTime @default(now()) @map("created_at")
-  updatedAt    DateTime @updatedAt      @map("updated_at")
+  updatedAt    DateTime @updatedAt @map("updated_at")
 
   indicateur Indicateur @relation(fields: [indicateurId], references: [id], onDelete: Cascade)
-  individu   Individu   @relation(fields: [individuId],   references: [id], onDelete: Restrict)
+  individu   Individu   @relation(fields: [individuId], references: [id], onDelete: Restrict)
 
   @@unique([indicateurId, individuId, date], name: "valeur_avancement_unique")
   @@index([indicateurId, date])
@@ -273,14 +278,14 @@ model ValeurAvancement {
 model ObjectifIndicateurIndividu {
   id           String   @id @db.Uuid
   indicateurId String   @map("indicateur_id") @db.Uuid
-  individuId   String   @map("individu_id")   @db.Uuid
+  individuId   String   @map("individu_id") @db.Uuid
   dateCible    String   @map("date_cible")
   valeurCible  Decimal  @map("valeur_cible") @db.Decimal(20, 2)
   createdAt    DateTime @default(now()) @map("created_at")
-  updatedAt    DateTime @updatedAt      @map("updated_at")
+  updatedAt    DateTime @updatedAt @map("updated_at")
 
   indicateur Indicateur @relation(fields: [indicateurId], references: [id], onDelete: Cascade)
-  individu   Individu   @relation(fields: [individuId],   references: [id], onDelete: Restrict)
+  individu   Individu   @relation(fields: [individuId], references: [id], onDelete: Restrict)
 
   @@unique([indicateurId, individuId, dateCible], name: "objectif_indicateur_individu_unique")
   @@index([indicateurId, individuId])
@@ -295,23 +300,25 @@ model Panier {
   description String?
   visibilite  Visibilite
   createdAt   DateTime   @default(now()) @map("created_at")
-  updatedAt   DateTime   @updatedAt      @map("updated_at")
+  updatedAt   DateTime   @updatedAt @map("updated_at")
 
-  indicateurs  PanierIndicateur[]
-  permissions  PanierPermission[]
-  responsables PanierResponsable[]
+  indicateurs          PanierIndicateur[]
+  permissions          PanierPermission[]
+  responsables         PanierResponsable[]
+  individuCommentaires PanierIndividuCommentaire[]
+  commentaires         PanierCommentaire[]
 
   @@map("panier")
 }
 
 model PanierPermission {
   principalId String           @map("principal_id") @db.Uuid
-  panierId    String           @map("panier_id")    @db.Uuid
+  panierId    String           @map("panier_id") @db.Uuid
   action      PermissionAction
   createdAt   DateTime         @default(now()) @map("created_at")
 
   principal Principal @relation(fields: [principalId], references: [id], onDelete: Cascade)
-  panier    Panier    @relation(fields: [panierId],    references: [id], onDelete: Cascade)
+  panier    Panier    @relation(fields: [panierId], references: [id], onDelete: Cascade)
 
   @@id([principalId, panierId, action])
   @@index([panierId])
@@ -319,12 +326,12 @@ model PanierPermission {
 }
 
 model PanierIndicateur {
-  panierId     String   @map("panier_id")     @db.Uuid
+  panierId     String   @map("panier_id") @db.Uuid
   indicateurId String   @map("indicateur_id") @db.Uuid
-  ponderation  Decimal  @default(1)           @db.Decimal(20, 2)
-  createdAt    DateTime @default(now())       @map("created_at")
+  ponderation  Decimal  @default(1) @db.Decimal(20, 2)
+  createdAt    DateTime @default(now()) @map("created_at")
 
-  panier     Panier     @relation(fields: [panierId],     references: [id], onDelete: Cascade)
+  panier     Panier     @relation(fields: [panierId], references: [id], onDelete: Cascade)
   indicateur Indicateur @relation(fields: [indicateurId], references: [id], onDelete: Cascade)
 
   @@id([panierId, indicateurId])
@@ -369,4 +376,110 @@ model ApplicationLog {
   @@index([level, date])
   @@index([requestId])
   @@map("application_log")
+}
+
+enum CommentaireStatut {
+  BROUILLON
+  PUBLIE
+
+  @@map("commentaire_statut_enum")
+}
+
+enum IndiceConfiance {
+  OBJECTIF_COMPROMIS
+  APPUIS_NECESSAIRE
+  OBJECTIF_ATTEIGNABLE
+  OBJECTIF_SECURISE
+
+  @@map("indice_confiance_enum")
+}
+
+enum IndicateurIndividuCommentaireType {
+  TYPE_COMMENTAIRE_1
+
+  @@map("indicateur_individu_commentaire_type_enum")
+}
+
+enum PanierIndividuCommentaireType {
+  TYPE_COMMENTAIRE_1
+
+  @@map("panier_individu_commentaire_type_enum")
+}
+
+enum PanierCommentaireType {
+  TYPE_COMMENTAIRE_1
+
+  @@map("panier_commentaire_type_enum")
+}
+
+model Commentaire {
+  id           String            @id @db.Uuid
+  contenu      String
+  contenuTexte String            @map("contenu_texte")
+  statut       CommentaireStatut
+  createdBy    String            @map("created_by") @db.Uuid
+  updatedBy    String            @map("updated_by") @db.Uuid
+  createdAt    DateTime          @default(now()) @map("created_at")
+  updatedAt    DateTime          @updatedAt @map("updated_at")
+
+  auteurCreation     Principal @relation("commentaireCreatedBy", fields: [createdBy], references: [id], onDelete: Restrict)
+  auteurModification Principal @relation("commentaireUpdatedBy", fields: [updatedBy], references: [id], onDelete: Restrict)
+
+  indicateurIndividu IndicateurIndividuCommentaire?
+  panierIndividu     PanierIndividuCommentaire?
+  panier             PanierCommentaire?
+  niveauConfiance    NiveauConfiance?
+
+  @@index([createdBy])
+  @@index([updatedBy])
+  @@map("commentaire")
+}
+
+model IndicateurIndividuCommentaire {
+  commentaireId String                            @id @map("commentaire_id") @db.Uuid
+  indicateurId  String                            @map("indicateur_id") @db.Uuid
+  individuId    String                            @map("individu_id") @db.Uuid
+  type          IndicateurIndividuCommentaireType
+
+  commentaire Commentaire @relation(fields: [commentaireId], references: [id], onDelete: Cascade)
+  indicateur  Indicateur  @relation(fields: [indicateurId], references: [id], onDelete: Cascade)
+  individu    Individu    @relation(fields: [individuId], references: [id], onDelete: Restrict)
+
+  @@index([indicateurId, individuId])
+  @@map("indicateur_individu_commentaire")
+}
+
+model PanierIndividuCommentaire {
+  commentaireId String                        @id @map("commentaire_id") @db.Uuid
+  panierId      String                        @map("panier_id") @db.Uuid
+  individuId    String                        @map("individu_id") @db.Uuid
+  type          PanierIndividuCommentaireType
+
+  commentaire Commentaire @relation(fields: [commentaireId], references: [id], onDelete: Cascade)
+  panier      Panier      @relation(fields: [panierId], references: [id], onDelete: Cascade)
+  individu    Individu    @relation(fields: [individuId], references: [id], onDelete: Restrict)
+
+  @@index([panierId, individuId])
+  @@map("panier_individu_commentaire")
+}
+
+model PanierCommentaire {
+  commentaireId String                @id @map("commentaire_id") @db.Uuid
+  panierId      String                @map("panier_id") @db.Uuid
+  type          PanierCommentaireType
+
+  commentaire Commentaire @relation(fields: [commentaireId], references: [id], onDelete: Cascade)
+  panier      Panier      @relation(fields: [panierId], references: [id], onDelete: Cascade)
+
+  @@index([panierId])
+  @@map("panier_commentaire")
+}
+
+model NiveauConfiance {
+  commentaireId String          @id @map("commentaire_id") @db.Uuid
+  indice        IndiceConfiance
+
+  commentaire Commentaire @relation(fields: [commentaireId], references: [id], onDelete: Cascade)
+
+  @@map("niveau_confiance")
 }

--- a/apps/mb-api/src/app.ts
+++ b/apps/mb-api/src/app.ts
@@ -4,6 +4,7 @@ import { cors } from 'hono/cors'
 
 import { me } from '@/authentication/routes/me'
 import { whoami } from '@/authentication/routes/whoami'
+import { commentaireRoutes } from '@/commentaire/routes'
 import { env } from '@/env'
 import { authContext } from '@/framework/auth/authContext'
 import { registerErrorHandler } from '@/framework/errors/errorHandler'
@@ -39,6 +40,7 @@ app.route('/', objectifIndicateurIndividuRoutes)
 app.route('/', referentielRoutes)
 app.route('/', individuRoutes)
 app.route('/', panierRoutes)
+app.route('/', commentaireRoutes)
 app.route('/', me)
 app.route('/', whoami)
 

--- a/apps/mb-api/src/commentaire/commands/creerCommentaire.test.ts
+++ b/apps/mb-api/src/commentaire/commands/creerCommentaire.test.ts
@@ -32,7 +32,7 @@ describe.concurrent('creerCommentaire', () => {
       const model = result._unsafeUnwrap()
       expect(model.type).toBe('DEFAUT')
       expect(model.individuId).toBe(indivId)
-      expect(model.contenuTexte).toBe('Hello')
+      expect(model.contenu).toBe('<p>Hello</p>')
       expect(model.auteurCreation.id).toBe(apiKey.id)
       const count = await db().commentaire.count({
         where: { indicateurIndividu: { indicateurId: indicateur.id } },

--- a/apps/mb-api/src/commentaire/commands/creerCommentaire.test.ts
+++ b/apps/mb-api/src/commentaire/commands/creerCommentaire.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import { creerCommentaire } from '@/commentaire/commands/creerCommentaire'
-import { indicateurIndividuConfig } from '@/commentaire/sujets'
+import { indicateurIndividuConfig } from '@/indicateur/commands/creerIndicateurIndividuCommentaire'
 import { db } from '@/framework/persistence/dbStore'
 import { PermissionAction } from '@/generated/prisma/enums'
 import { fixtures } from '@/test/fixtures'

--- a/apps/mb-api/src/commentaire/commands/creerCommentaire.test.ts
+++ b/apps/mb-api/src/commentaire/commands/creerCommentaire.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest'
+
+import { creerCommentaire } from '@/commentaire/commands/creerCommentaire'
+import { indicateurIndividuConfig } from '@/commentaire/sujets'
+import { db } from '@/framework/persistence/dbStore'
+import { PermissionAction } from '@/generated/prisma/enums'
+import { fixtures } from '@/test/fixtures'
+import { integrationTest } from '@/test/integrationTest'
+import { testIndicateurId, testIndividuId } from '@/test/randomIds'
+import { runAsPrincipal } from '@/test/runAsPrincipal'
+
+describe.concurrent('creerCommentaire', () => {
+  it(
+    'crée un commentaire DEFAUT rattaché à (indicateur, individu) avec auteur = principal courant',
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const indivId = testIndividuId()
+      const indicateur = await fixtures.indicateur({ publicId: indId })
+      await fixtures.individu({ publicId: indivId })
+      const apiKey = await fixtures.apiKey({
+        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.WRITE }],
+      })
+
+      const result = await runAsPrincipal(apiKey.id, () =>
+        creerCommentaire(indicateurIndividuConfig, {
+          params: { indicateurId: indId, individuId: indivId },
+          body: { type: 'DEFAUT', contenu: '<p>Hello</p>', statut: 'PUBLIE' },
+        }),
+      )
+
+      expect(result.isOk()).toBe(true)
+      const model = result._unsafeUnwrap()
+      expect(model.type).toBe('DEFAUT')
+      expect(model.individuId).toBe(indivId)
+      expect(model.contenuTexte).toBe('Hello')
+      expect(model.auteurCreation.id).toBe(apiKey.id)
+      const count = await db().commentaire.count({
+        where: { indicateurIndividu: { indicateurId: indicateur.id } },
+      })
+      expect(count).toBe(1)
+    }),
+  )
+
+  it(
+    'throw ForbiddenError sans permission WRITE',
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const indivId = testIndividuId()
+      await fixtures.indicateur({ publicId: indId, visibilite: 'PUBLIC' })
+      await fixtures.individu({ publicId: indivId })
+      const apiKey = await fixtures.apiKey() // pas de WRITE
+
+      await expect(
+        runAsPrincipal(apiKey.id, () =>
+          creerCommentaire(indicateurIndividuConfig, {
+            params: { indicateurId: indId, individuId: indivId },
+            body: { type: 'DEFAUT', contenu: '', statut: 'BROUILLON' },
+          }),
+        ),
+      ).rejects.toMatchObject({ code: 'FORBIDDEN' })
+    }),
+  )
+
+  it(
+    'refuse un second brouillon pour le même (scope, auteur) — ConflictError (PIL-1585/1592)',
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const indivId = testIndividuId()
+      await fixtures.indicateur({ publicId: indId })
+      await fixtures.individu({ publicId: indivId })
+      const apiKey = await fixtures.apiKey({
+        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.WRITE }],
+      })
+      const creerBrouillon = () =>
+        runAsPrincipal(apiKey.id, () =>
+          creerCommentaire(indicateurIndividuConfig, {
+            params: { indicateurId: indId, individuId: indivId },
+            body: { type: 'DEFAUT', contenu: '', statut: 'BROUILLON' },
+          }),
+        )
+
+      const premier = await creerBrouillon()
+      expect(premier.isOk()).toBe(true)
+      await expect(creerBrouillon()).rejects.toMatchObject({ code: 'CONFLICT' })
+
+      // Un PUBLIE supplémentaire reste autorisé (la contrainte ne vise que les brouillons).
+      const publie = await runAsPrincipal(apiKey.id, () =>
+        creerCommentaire(indicateurIndividuConfig, {
+          params: { indicateurId: indId, individuId: indivId },
+          body: { type: 'DEFAUT', contenu: '<p>ok</p>', statut: 'PUBLIE' },
+        }),
+      )
+      expect(publie.isOk()).toBe(true)
+    }),
+  )
+})

--- a/apps/mb-api/src/commentaire/commands/creerCommentaire.ts
+++ b/apps/mb-api/src/commentaire/commands/creerCommentaire.ts
@@ -1,0 +1,66 @@
+import { type CommentaireApiModel, type CreerCommentaireBody } from '@pilote/mb-shared/commentaire'
+import { ResultAsync } from 'neverthrow'
+import { uuidv7 } from 'uuidv7'
+
+import { type SujetCommentaireConfig } from '@/commentaire/sujets'
+import { commentaireInclude, htmlToPlainText, toCommentaireApiModel } from '@/commentaire/utils'
+import { ConflictError } from '@/framework/errors/AppError'
+import { db } from '@/framework/persistence/dbStore'
+
+type CreerCommentaireParams<P extends Record<string, string>> = {
+  params: P
+  body: CreerCommentaireBody
+}
+
+export const creerCommentaire = <P extends Record<string, string>>(
+  config: SujetCommentaireConfig<P>,
+  { params, body }: CreerCommentaireParams<P>,
+): ResultAsync<CommentaireApiModel, never> =>
+  config.resoudreCibleEcriture(params).andThen((cible) =>
+    ensureUnSeulBrouillon(config, params, body.statut, cible.principalId).andThen(() =>
+      ResultAsync.fromSafePromise(
+        db().commentaire.create({
+          data: {
+            id: uuidv7(),
+            contenu: body.contenu,
+            contenuTexte: htmlToPlainText(body.contenu),
+            statut: body.statut,
+            createdBy: cible.principalId,
+            updatedBy: cible.principalId,
+            ...cible.satelliteCreate(body.type),
+          },
+          include: commentaireInclude,
+        }),
+      ).map(toCommentaireApiModel),
+    ),
+  )
+
+// Règle PIL-1585/1592 : au plus 1 brouillon par (scope, auteur).
+// `whereLecture` borne au scope exact (sujet + individu) ; on ajoute statut BROUILLON + auteur.
+// Exécuté dans la transaction de la route (withTransaction) → cohérent.
+const ensureUnSeulBrouillon = <P extends Record<string, string>>(
+  config: SujetCommentaireConfig<P>,
+  params: P,
+  statut: CreerCommentaireBody['statut'],
+  principalId: string,
+): ResultAsync<void, never> => {
+  if (statut !== 'BROUILLON') return ResultAsync.fromSafePromise(Promise.resolve())
+  return ResultAsync.fromSafePromise(
+    db()
+      .commentaire.count({
+        where: {
+          AND: [
+            config.whereLecture(params, principalId),
+            { statut: 'BROUILLON', createdBy: principalId },
+          ],
+        },
+      })
+      .then((count) => {
+        if (count > 0) {
+          throw new ConflictError(
+            'Un brouillon existe déjà pour ce scope ; reprenez-le plutôt que d’en créer un autre',
+          )
+        }
+      }),
+  )
+}

--- a/apps/mb-api/src/commentaire/commands/modifierCommentaire.test.ts
+++ b/apps/mb-api/src/commentaire/commands/modifierCommentaire.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+
+import { modifierCommentaire } from '@/commentaire/commands/modifierCommentaire'
+import { db } from '@/framework/persistence/dbStore'
+import { PermissionAction } from '@/generated/prisma/enums'
+import { fixtures } from '@/test/fixtures'
+import { integrationTest } from '@/test/integrationTest'
+import { testIndicateurId, testIndividuId } from '@/test/randomIds'
+import { runAsPrincipal } from '@/test/runAsPrincipal'
+
+describe.concurrent('modifierCommentaire', () => {
+  it(
+    'met à jour contenu + statut + contenuTexte par l’auteur',
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const apiKey = await fixtures.apiKey({
+        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.WRITE }],
+      })
+      const c = await fixtures.commentaire({
+        indicateur: { publicId: indId },
+        individu: { publicId: testIndividuId() },
+        createdBy: apiKey.id,
+        statut: 'BROUILLON',
+      })
+
+      const result = await runAsPrincipal(apiKey.id, () =>
+        modifierCommentaire(c.id, { contenu: '<p>MAJ</p>', statut: 'PUBLIE' }),
+      )
+
+      expect(result.isOk()).toBe(true)
+      const row = await db().commentaire.findUniqueOrThrow({ where: { id: c.id } })
+      expect(row.contenuTexte).toBe('MAJ')
+      expect(row.statut).toBe('PUBLIE')
+    }),
+  )
+
+  it(
+    'throw ForbiddenError si le principal n’est pas l’auteur',
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const auteur = await fixtures.apiKey({
+        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.WRITE }],
+      })
+      const autre = await fixtures.apiKey({
+        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.WRITE }],
+      })
+      const c = await fixtures.commentaire({
+        indicateur: { publicId: indId },
+        individu: { publicId: testIndividuId() },
+        createdBy: auteur.id,
+      })
+
+      await expect(
+        runAsPrincipal(autre.id, () => modifierCommentaire(c.id, { statut: 'PUBLIE' })),
+      ).rejects.toMatchObject({ code: 'FORBIDDEN' })
+    }),
+  )
+})

--- a/apps/mb-api/src/commentaire/commands/modifierCommentaire.ts
+++ b/apps/mb-api/src/commentaire/commands/modifierCommentaire.ts
@@ -1,4 +1,7 @@
-import { type CommentaireApiModel, type ModifierCommentaireBody } from '@pilote/mb-shared/commentaire'
+import {
+  type CommentaireApiModel,
+  type ModifierCommentaireBody,
+} from '@pilote/mb-shared/commentaire'
 import { ResultAsync } from 'neverthrow'
 
 import { resolveCommentairePourEcriture } from '@/commentaire/resolveCommentairePourEcriture'

--- a/apps/mb-api/src/commentaire/commands/modifierCommentaire.ts
+++ b/apps/mb-api/src/commentaire/commands/modifierCommentaire.ts
@@ -1,0 +1,26 @@
+import { type CommentaireApiModel, type ModifierCommentaireBody } from '@pilote/mb-shared/commentaire'
+import { ResultAsync } from 'neverthrow'
+
+import { resolveCommentairePourEcriture } from '@/commentaire/resolveCommentairePourEcriture'
+import { commentaireInclude, htmlToPlainText, toCommentaireApiModel } from '@/commentaire/utils'
+import { db } from '@/framework/persistence/dbStore'
+
+export const modifierCommentaire = (
+  commentaireId: string,
+  body: ModifierCommentaireBody,
+): ResultAsync<CommentaireApiModel, never> =>
+  resolveCommentairePourEcriture(commentaireId).andThen(({ principalId }) =>
+    ResultAsync.fromSafePromise(
+      db().commentaire.update({
+        where: { id: commentaireId },
+        data: {
+          ...(body.contenu !== undefined
+            ? { contenu: body.contenu, contenuTexte: htmlToPlainText(body.contenu) }
+            : {}),
+          ...(body.statut !== undefined ? { statut: body.statut } : {}),
+          updatedBy: principalId,
+        },
+        include: commentaireInclude,
+      }),
+    ).map(toCommentaireApiModel),
+  )

--- a/apps/mb-api/src/commentaire/commands/supprimerCommentaire.test.ts
+++ b/apps/mb-api/src/commentaire/commands/supprimerCommentaire.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+
+import { supprimerCommentaire } from '@/commentaire/commands/supprimerCommentaire'
+import { db } from '@/framework/persistence/dbStore'
+import { PermissionAction } from '@/generated/prisma/enums'
+import { fixtures } from '@/test/fixtures'
+import { integrationTest } from '@/test/integrationTest'
+import { testIndicateurId, testIndividuId } from '@/test/randomIds'
+import { runAsPrincipal } from '@/test/runAsPrincipal'
+
+describe.concurrent('supprimerCommentaire', () => {
+  it(
+    'supprime le commentaire de l’auteur',
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const apiKey = await fixtures.apiKey({
+        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.WRITE }],
+      })
+      const c = await fixtures.commentaire({
+        indicateur: { publicId: indId },
+        individu: { publicId: testIndividuId() },
+        createdBy: apiKey.id,
+      })
+
+      const result = await runAsPrincipal(apiKey.id, () => supprimerCommentaire(c.id))
+
+      expect(result.isOk()).toBe(true)
+      expect(await db().commentaire.findUnique({ where: { id: c.id } })).toBeNull()
+    }),
+  )
+})

--- a/apps/mb-api/src/commentaire/commands/supprimerCommentaire.ts
+++ b/apps/mb-api/src/commentaire/commands/supprimerCommentaire.ts
@@ -1,0 +1,13 @@
+import { ResultAsync } from 'neverthrow'
+
+import { resolveCommentairePourEcriture } from '@/commentaire/resolveCommentairePourEcriture'
+import { db } from '@/framework/persistence/dbStore'
+
+export const supprimerCommentaire = (commentaireId: string): ResultAsync<void, never> =>
+  resolveCommentairePourEcriture(commentaireId).andThen(() =>
+    ResultAsync.fromSafePromise(
+      db()
+        .commentaire.delete({ where: { id: commentaireId } })
+        .then(() => undefined),
+    ),
+  )

--- a/apps/mb-api/src/commentaire/openapi.ts
+++ b/apps/mb-api/src/commentaire/openapi.ts
@@ -1,0 +1,36 @@
+import {
+  commentaireApiModelSchema,
+  commentaireListApiModelSchema,
+} from '@pilote/mb-shared/commentaire'
+import { errorApiModelSchema } from '@pilote/mb-shared/error'
+
+export const CommentaireApiModelSchema = commentaireApiModelSchema.openapi('CommentaireApiModel')
+export const CommentaireListApiModelSchema =
+  commentaireListApiModelSchema.openapi('CommentaireListApiModel')
+const ErrorApiModelSchema = errorApiModelSchema.openapi('ErrorApiModel')
+
+export const reponseCommentaire = {
+  200: {
+    content: { 'application/json': { schema: CommentaireApiModelSchema } },
+    description: 'Commentaire',
+  },
+  400: {
+    content: { 'application/json': { schema: ErrorApiModelSchema } },
+    description: 'Requête invalide',
+  },
+  403: {
+    content: { 'application/json': { schema: ErrorApiModelSchema } },
+    description: 'Permission insuffisante',
+  },
+  404: {
+    content: { 'application/json': { schema: ErrorApiModelSchema } },
+    description: 'Sujet introuvable',
+  },
+}
+
+export const reponseListe = {
+  200: {
+    content: { 'application/json': { schema: CommentaireListApiModelSchema } },
+    description: 'Liste paginée',
+  },
+}

--- a/apps/mb-api/src/commentaire/queries/listerCommentaires.test.ts
+++ b/apps/mb-api/src/commentaire/queries/listerCommentaires.test.ts
@@ -10,7 +10,7 @@ import { runAsPrincipal } from '@/test/runAsPrincipal'
 
 describe.concurrent('listerCommentaires', () => {
   it(
-    'liste les commentaires du scope en antichronologique, en excluant le type CONFIANCE',
+    'liste les commentaires du scope en antichronologique, filtrés par type=DEFAUT',
     integrationTest(async () => {
       const indId = testIndicateurId()
       const indivId = testIndividuId()
@@ -39,14 +39,14 @@ describe.concurrent('listerCommentaires', () => {
       const result = await runAsPrincipal(apiKey.id, () =>
         listerCommentaires(indicateurIndividuConfig, {
           params: { indicateurId: indId, individuId: indivId },
-          query: {},
+          query: { type: 'DEFAUT' },
         }),
       )
 
       expect(result.isOk()).toBe(true)
       const page = result._unsafeUnwrap()
       expect(page.total).toBe(1)
-      expect(page.items.map((c) => c.contenuTexte)).toEqual(['Premier'])
+      expect(page.items.map((c) => c.contenu)).toEqual(['<p>Premier</p>'])
     }),
   )
 

--- a/apps/mb-api/src/commentaire/queries/listerCommentaires.test.ts
+++ b/apps/mb-api/src/commentaire/queries/listerCommentaires.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest'
+
+import { listerCommentaires } from '@/commentaire/queries/listerCommentaires'
+import { indicateurIndividuConfig } from '@/commentaire/sujets'
+import { PermissionAction } from '@/generated/prisma/enums'
+import { fixtures } from '@/test/fixtures'
+import { integrationTest } from '@/test/integrationTest'
+import { testIndicateurId, testIndividuId } from '@/test/randomIds'
+import { runAsPrincipal } from '@/test/runAsPrincipal'
+
+describe.concurrent('listerCommentaires', () => {
+  it(
+    'liste les commentaires du scope en antichronologique, en excluant le type CONFIANCE',
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const indivId = testIndividuId()
+      await fixtures.indicateur({ publicId: indId })
+      await fixtures.individu({ publicId: indivId })
+      const apiKey = await fixtures.apiKey({
+        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.READ }],
+      })
+      await fixtures.commentaire({
+        indicateur: { publicId: indId },
+        individu: { publicId: indivId },
+        createdBy: apiKey.id,
+        contenu: '<p>Premier</p>',
+        contenuTexte: 'Premier',
+        type: 'DEFAUT',
+      })
+      await fixtures.commentaire({
+        indicateur: { publicId: indId },
+        individu: { publicId: indivId },
+        createdBy: apiKey.id,
+        contenu: '<p>Confiance</p>',
+        contenuTexte: 'Confiance',
+        type: 'CONFIANCE',
+      })
+
+      const result = await runAsPrincipal(apiKey.id, () =>
+        listerCommentaires(indicateurIndividuConfig, {
+          params: { indicateurId: indId, individuId: indivId },
+          query: {},
+        }),
+      )
+
+      expect(result.isOk()).toBe(true)
+      const page = result._unsafeUnwrap()
+      expect(page.total).toBe(1)
+      expect(page.items.map((c) => c.contenuTexte)).toEqual(['Premier'])
+    }),
+  )
+
+  it(
+    'filtre explicitement par type=CONFIANCE',
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const indivId = testIndividuId()
+      await fixtures.indicateur({ publicId: indId })
+      await fixtures.individu({ publicId: indivId })
+      const apiKey = await fixtures.apiKey({
+        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.READ }],
+      })
+      await fixtures.commentaire({
+        indicateur: { publicId: indId },
+        individu: { publicId: indivId },
+        createdBy: apiKey.id,
+        type: 'DEFAUT',
+      })
+      await fixtures.commentaire({
+        indicateur: { publicId: indId },
+        individu: { publicId: indivId },
+        createdBy: apiKey.id,
+        contenuTexte: 'Conf',
+        type: 'CONFIANCE',
+      })
+
+      const result = await runAsPrincipal(apiKey.id, () =>
+        listerCommentaires(indicateurIndividuConfig, {
+          params: { indicateurId: indId, individuId: indivId },
+          query: { type: 'CONFIANCE' },
+        }),
+      )
+
+      expect(result._unsafeUnwrap().total).toBe(1)
+      expect(result._unsafeUnwrap().items[0]?.type).toBe('CONFIANCE')
+    }),
+  )
+})

--- a/apps/mb-api/src/commentaire/queries/listerCommentaires.test.ts
+++ b/apps/mb-api/src/commentaire/queries/listerCommentaires.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import { listerCommentaires } from '@/commentaire/queries/listerCommentaires'
-import { indicateurIndividuConfig } from '@/commentaire/sujets'
+import { indicateurIndividuConfig } from '@/indicateur/commands/creerIndicateurIndividuCommentaire'
 import { PermissionAction } from '@/generated/prisma/enums'
 import { fixtures } from '@/test/fixtures'
 import { integrationTest } from '@/test/integrationTest'

--- a/apps/mb-api/src/commentaire/queries/listerCommentaires.ts
+++ b/apps/mb-api/src/commentaire/queries/listerCommentaires.ts
@@ -21,12 +21,8 @@ export const listerCommentaires = <P extends Record<string, string>>(
   { params, query }: ListerCommentairesParams<P>,
 ): ResultAsync<CommentaireListApiModel, never> => {
   const principalId = requireCurrentPrincipalId()
-  // Filtre type : si fourni on le respecte, sinon on exclut les commentaires de confiance.
-  const filtreType: Prisma.CommentaireWhereInput = query.type
-    ? filtreParType(query.type)
-    : { NOT: filtreParType('CONFIANCE') }
   const where: Prisma.CommentaireWhereInput = {
-    AND: [config.whereLecture(params, principalId), filtreType],
+    AND: [config.whereLecture(params, principalId), filtreParType(query.type)],
   }
 
   const fetchPage = db().commentaire.findMany({

--- a/apps/mb-api/src/commentaire/queries/listerCommentaires.ts
+++ b/apps/mb-api/src/commentaire/queries/listerCommentaires.ts
@@ -1,0 +1,52 @@
+import {
+  type CommentaireListApiModel,
+  type ListerCommentairesQuery,
+} from '@pilote/mb-shared/commentaire'
+import { ResultAsync } from 'neverthrow'
+
+import { type SujetCommentaireConfig } from '@/commentaire/sujets'
+import { commentaireInclude, toCommentaireApiModel } from '@/commentaire/utils'
+import { requireCurrentPrincipalId } from '@/framework/auth/userContext'
+import { db } from '@/framework/persistence/dbStore'
+import { buildPaginationArgs, toPaginatedResponse } from '@/framework/persistence/paginate'
+import { type Prisma } from '@/generated/prisma/client'
+
+type ListerCommentairesParams<P extends Record<string, string>> = {
+  params: P
+  query: ListerCommentairesQuery
+}
+
+export const listerCommentaires = <P extends Record<string, string>>(
+  config: SujetCommentaireConfig<P>,
+  { params, query }: ListerCommentairesParams<P>,
+): ResultAsync<CommentaireListApiModel, never> => {
+  const principalId = requireCurrentPrincipalId()
+  // Filtre type : si fourni on le respecte, sinon on exclut les commentaires de confiance.
+  const filtreType: Prisma.CommentaireWhereInput = query.type
+    ? filtreParType(query.type)
+    : { NOT: filtreParType('CONFIANCE') }
+  const where: Prisma.CommentaireWhereInput = {
+    AND: [config.whereLecture(params, principalId), filtreType],
+  }
+
+  const fetchPage = db().commentaire.findMany({
+    where,
+    orderBy: { id: 'desc' }, // uuidv7 → antichronologique
+    include: commentaireInclude,
+    ...buildPaginationArgs(query.cursor, query.pageSize),
+  })
+  const fetchTotal = db().commentaire.count({ where })
+
+  return ResultAsync.fromSafePromise(Promise.all([fetchPage, fetchTotal])).map(([rows, total]) =>
+    toPaginatedResponse(rows, total, toCommentaireApiModel, query.pageSize),
+  )
+}
+
+// Filtre sur le `type` quel que soit le satellite (un seul satellite est renseigné par commentaire).
+const filtreParType = (type: string): Prisma.CommentaireWhereInput => ({
+  OR: [
+    { indicateurIndividu: { type: type as never } },
+    { panierIndividu: { type: type as never } },
+    { panier: { type: type as never } },
+  ],
+})

--- a/apps/mb-api/src/commentaire/resolveCommentairePourEcriture.ts
+++ b/apps/mb-api/src/commentaire/resolveCommentairePourEcriture.ts
@@ -1,0 +1,44 @@
+import { ResultAsync } from 'neverthrow'
+
+import { requireCurrentPrincipalId } from '@/framework/auth/userContext'
+import { ForbiddenError } from '@/framework/errors/AppError'
+import { db } from '@/framework/persistence/dbStore'
+import { ensureIndicateurWritePermission } from '@/indicateur/permissions'
+import { ensurePanierWritePermission } from '@/panier/permissions'
+
+// Charge le commentaire + son satellite, vérifie que le principal courant en est l'auteur
+// ET dispose de WRITE sur le sujet. Throw ForbiddenError / 404 (P2025) sinon.
+export const resolveCommentairePourEcriture = (
+  commentaireId: string,
+): ResultAsync<{ principalId: string }, never> => {
+  const principalId = requireCurrentPrincipalId()
+  return ResultAsync.fromSafePromise(
+    (async () => {
+      const commentaire = await db().commentaire.findUniqueOrThrow({
+        where: { id: commentaireId },
+        select: {
+          createdBy: true,
+          indicateurIndividu: { select: { indicateurId: true } },
+          panierIndividu: { select: { panierId: true } },
+          panier: { select: { panierId: true } },
+        },
+      })
+      if (commentaire.createdBy !== principalId) {
+        throw new ForbiddenError("Seul l'auteur peut modifier ce commentaire")
+      }
+      if (commentaire.indicateurIndividu) {
+        await ensureIndicateurWritePermission({
+          indicateurId: commentaire.indicateurIndividu.indicateurId,
+          principalId,
+        })
+        return { principalId }
+      }
+      const panierId = commentaire.panierIndividu?.panierId ?? commentaire.panier?.panierId
+      if (panierId) {
+        await ensurePanierWritePermission({ panierId, principalId })
+        return { principalId }
+      }
+      throw new ForbiddenError('Commentaire sans sujet rattaché')
+    })(),
+  )
+}

--- a/apps/mb-api/src/commentaire/routes.test.ts
+++ b/apps/mb-api/src/commentaire/routes.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+
+import { app } from '../app'
+
+// Tests de câblage OpenAPI / middleware (sans DB ni auth).
+// Le comportement métier (permissions, brouillon, filtrage type, auteur) est couvert
+// par les tests d'intégration command/query (modèle transactionnel à rollback).
+describe('routes commentaires — câblage OpenAPI', () => {
+  it('déclare les 8 routes commentaires dans le doc OpenAPI', async () => {
+    const res = await app.request('/openapi.json')
+    expect(res.status).toBe(200)
+    const doc = (await res.json()) as { paths: Record<string, Record<string, unknown>> }
+
+    const attendu: Array<[string, string]> = [
+      ['/indicateurs/{indicateurId}/individus/{individuId}/commentaires', 'post'],
+      ['/indicateurs/{indicateurId}/individus/{individuId}/commentaires', 'get'],
+      ['/paniers/{panierId}/individus/{individuId}/commentaires', 'post'],
+      ['/paniers/{panierId}/individus/{individuId}/commentaires', 'get'],
+      ['/paniers/{panierId}/commentaires', 'post'],
+      ['/paniers/{panierId}/commentaires', 'get'],
+      ['/commentaires/{commentaireId}', 'put'],
+      ['/commentaires/{commentaireId}', 'delete'],
+    ]
+
+    for (const [path, method] of attendu) {
+      expect(doc.paths[path], `path ${path} manquant`).toBeDefined()
+      expect(doc.paths[path]?.[method], `${method.toUpperCase()} ${path} manquant`).toBeDefined()
+    }
+  })
+
+  it('renvoie 401 sur une création non authentifiée', async () => {
+    const res = await app.request('/indicateurs/IND-1/individus/REG-1/commentaires', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ type: 'DEFAUT', contenu: '', statut: 'BROUILLON' }),
+    })
+    expect(res.status).toBe(401)
+  })
+})

--- a/apps/mb-api/src/commentaire/routes.ts
+++ b/apps/mb-api/src/commentaire/routes.ts
@@ -1,222 +1,20 @@
 import { createRoute, OpenAPIHono, z } from '@hono/zod-openapi'
-import {
-  commentaireApiModelSchema,
-  commentaireListApiModelSchema,
-  creerIndicateurIndividuCommentaireBodySchema,
-  creerPanierCommentaireBodySchema,
-  creerPanierIndividuCommentaireBodySchema,
-  listerCommentairesQuerySchema,
-  modifierCommentaireBodySchema,
-} from '@pilote/mb-shared/commentaire'
+import { modifierCommentaireBodySchema } from '@pilote/mb-shared/commentaire'
 import { errorApiModelSchema } from '@pilote/mb-shared/error'
-import {
-  indicateurPublicIdSchema,
-  individuPublicIdSchema,
-  panierPublicIdSchema,
-} from '@pilote/mb-shared/publicIds'
 
-import { creerCommentaire } from '@/commentaire/commands/creerCommentaire'
 import { modifierCommentaire } from '@/commentaire/commands/modifierCommentaire'
 import { supprimerCommentaire } from '@/commentaire/commands/supprimerCommentaire'
-import { listerCommentaires } from '@/commentaire/queries/listerCommentaires'
-import { indicateurIndividuConfig, panierConfig, panierIndividuConfig } from '@/commentaire/sujets'
+import { CommentaireApiModelSchema, reponseCommentaire } from '@/commentaire/openapi'
 import { requireAuthentication } from '@/framework/auth/requireAuthentication'
 import { never } from '@/framework/errors/never'
 import { jsonResponseOk } from '@/framework/openapi/jsonResponse'
 import { withTransaction } from '@/framework/persistence/withTransaction'
 
-const CommentaireApiModelSchema = commentaireApiModelSchema.openapi('CommentaireApiModel')
-const CommentaireListApiModelSchema =
-  commentaireListApiModelSchema.openapi('CommentaireListApiModel')
 const ErrorApiModelSchema = errorApiModelSchema.openapi('ErrorApiModel')
 
 export const commentaireRoutes = new OpenAPIHono()
 
-const reponseCommentaire = {
-  200: {
-    content: { 'application/json': { schema: CommentaireApiModelSchema } },
-    description: 'Commentaire',
-  },
-  400: {
-    content: { 'application/json': { schema: ErrorApiModelSchema } },
-    description: 'Requête invalide',
-  },
-  403: {
-    content: { 'application/json': { schema: ErrorApiModelSchema } },
-    description: 'Permission insuffisante',
-  },
-  404: {
-    content: { 'application/json': { schema: ErrorApiModelSchema } },
-    description: 'Sujet introuvable',
-  },
-}
-
-const reponseListe = {
-  200: {
-    content: { 'application/json': { schema: CommentaireListApiModelSchema } },
-    description: 'Liste paginée',
-  },
-  404: {
-    content: { 'application/json': { schema: ErrorApiModelSchema } },
-    description: 'Sujet introuvable',
-  },
-}
-
-// --- indicateur + individu ---------------------------------------------------
-
-const creerIndicateurIndividuRoute = createRoute({
-  method: 'post',
-  path: '/indicateurs/{indicateurId}/individus/{individuId}/commentaires',
-  tags: ['Commentaire'],
-  summary: 'Créer un commentaire sur un indicateur pour un individu',
-  middleware: [requireAuthentication],
-  request: {
-    params: z.object({
-      indicateurId: indicateurPublicIdSchema,
-      individuId: individuPublicIdSchema,
-    }),
-    body: {
-      content: { 'application/json': { schema: creerIndicateurIndividuCommentaireBodySchema } },
-      required: true,
-    },
-  },
-  responses: reponseCommentaire,
-})
-commentaireRoutes.openapi(creerIndicateurIndividuRoute, async (context) => {
-  const params = context.req.valid('param')
-  const body = context.req.valid('json')
-  const result = await withTransaction(async () =>
-    creerCommentaire(indicateurIndividuConfig, { params, body }),
-  )
-  return result.match(
-    (data) => jsonResponseOk({ context, data, schema: CommentaireApiModelSchema, status: 200 }),
-    never,
-  )
-})
-
-const listerIndicateurIndividuRoute = createRoute({
-  method: 'get',
-  path: '/indicateurs/{indicateurId}/individus/{individuId}/commentaires',
-  tags: ['Commentaire'],
-  summary: 'Lister les commentaires d’un indicateur pour un individu',
-  middleware: [requireAuthentication],
-  request: {
-    params: z.object({
-      indicateurId: indicateurPublicIdSchema,
-      individuId: individuPublicIdSchema,
-    }),
-    query: listerCommentairesQuerySchema,
-  },
-  responses: reponseListe,
-})
-commentaireRoutes.openapi(listerIndicateurIndividuRoute, async (context) => {
-  const params = context.req.valid('param')
-  const query = context.req.valid('query')
-  return listerCommentaires(indicateurIndividuConfig, { params, query }).match(
-    (data) => jsonResponseOk({ context, data, schema: CommentaireListApiModelSchema, status: 200 }),
-    never,
-  )
-})
-
-// --- panier + individu -------------------------------------------------------
-
-const creerPanierIndividuRoute = createRoute({
-  method: 'post',
-  path: '/paniers/{panierId}/individus/{individuId}/commentaires',
-  tags: ['Commentaire'],
-  summary: 'Créer un commentaire sur un panier pour un individu',
-  middleware: [requireAuthentication],
-  request: {
-    params: z.object({ panierId: panierPublicIdSchema, individuId: individuPublicIdSchema }),
-    body: {
-      content: { 'application/json': { schema: creerPanierIndividuCommentaireBodySchema } },
-      required: true,
-    },
-  },
-  responses: reponseCommentaire,
-})
-commentaireRoutes.openapi(creerPanierIndividuRoute, async (context) => {
-  const params = context.req.valid('param')
-  const body = context.req.valid('json')
-  const result = await withTransaction(async () =>
-    creerCommentaire(panierIndividuConfig, { params, body }),
-  )
-  return result.match(
-    (data) => jsonResponseOk({ context, data, schema: CommentaireApiModelSchema, status: 200 }),
-    never,
-  )
-})
-
-const listerPanierIndividuRoute = createRoute({
-  method: 'get',
-  path: '/paniers/{panierId}/individus/{individuId}/commentaires',
-  tags: ['Commentaire'],
-  summary: 'Lister les commentaires d’un panier pour un individu',
-  middleware: [requireAuthentication],
-  request: {
-    params: z.object({ panierId: panierPublicIdSchema, individuId: individuPublicIdSchema }),
-    query: listerCommentairesQuerySchema,
-  },
-  responses: reponseListe,
-})
-commentaireRoutes.openapi(listerPanierIndividuRoute, async (context) => {
-  const params = context.req.valid('param')
-  const query = context.req.valid('query')
-  return listerCommentaires(panierIndividuConfig, { params, query }).match(
-    (data) => jsonResponseOk({ context, data, schema: CommentaireListApiModelSchema, status: 200 }),
-    never,
-  )
-})
-
-// --- panier global -----------------------------------------------------------
-
-const creerPanierRoute = createRoute({
-  method: 'post',
-  path: '/paniers/{panierId}/commentaires',
-  tags: ['Commentaire'],
-  summary: 'Créer un commentaire global sur un panier',
-  middleware: [requireAuthentication],
-  request: {
-    params: z.object({ panierId: panierPublicIdSchema }),
-    body: {
-      content: { 'application/json': { schema: creerPanierCommentaireBodySchema } },
-      required: true,
-    },
-  },
-  responses: reponseCommentaire,
-})
-commentaireRoutes.openapi(creerPanierRoute, async (context) => {
-  const params = context.req.valid('param')
-  const body = context.req.valid('json')
-  const result = await withTransaction(async () => creerCommentaire(panierConfig, { params, body }))
-  return result.match(
-    (data) => jsonResponseOk({ context, data, schema: CommentaireApiModelSchema, status: 200 }),
-    never,
-  )
-})
-
-const listerPanierRoute = createRoute({
-  method: 'get',
-  path: '/paniers/{panierId}/commentaires',
-  tags: ['Commentaire'],
-  summary: 'Lister les commentaires globaux d’un panier',
-  middleware: [requireAuthentication],
-  request: {
-    params: z.object({ panierId: panierPublicIdSchema }),
-    query: listerCommentairesQuerySchema,
-  },
-  responses: reponseListe,
-})
-commentaireRoutes.openapi(listerPanierRoute, async (context) => {
-  const params = context.req.valid('param')
-  const query = context.req.valid('query')
-  return listerCommentaires(panierConfig, { params, query }).match(
-    (data) => jsonResponseOk({ context, data, schema: CommentaireListApiModelSchema, status: 200 }),
-    never,
-  )
-})
-
-// --- mutation socle (par id) -------------------------------------------------
+// --- PUT /commentaires/:commentaireId ----------------------------------------
 
 const modifierRoute = createRoute({
   method: 'put',
@@ -233,6 +31,7 @@ const modifierRoute = createRoute({
   },
   responses: reponseCommentaire,
 })
+
 commentaireRoutes.openapi(modifierRoute, async (context) => {
   const { commentaireId } = context.req.valid('param')
   const body = context.req.valid('json')
@@ -242,6 +41,8 @@ commentaireRoutes.openapi(modifierRoute, async (context) => {
     never,
   )
 })
+
+// --- DELETE /commentaires/:commentaireId -------------------------------------
 
 const supprimerRoute = createRoute({
   method: 'delete',
@@ -262,6 +63,7 @@ const supprimerRoute = createRoute({
     },
   },
 })
+
 commentaireRoutes.openapi(supprimerRoute, async (context) => {
   const { commentaireId } = context.req.valid('param')
   const result = await withTransaction(async () => supprimerCommentaire(commentaireId))

--- a/apps/mb-api/src/commentaire/routes.ts
+++ b/apps/mb-api/src/commentaire/routes.ts
@@ -1,0 +1,269 @@
+import { createRoute, OpenAPIHono, z } from '@hono/zod-openapi'
+import {
+  commentaireApiModelSchema,
+  commentaireListApiModelSchema,
+  creerIndicateurIndividuCommentaireBodySchema,
+  creerPanierCommentaireBodySchema,
+  creerPanierIndividuCommentaireBodySchema,
+  listerCommentairesQuerySchema,
+  modifierCommentaireBodySchema,
+} from '@pilote/mb-shared/commentaire'
+import { errorApiModelSchema } from '@pilote/mb-shared/error'
+import {
+  indicateurPublicIdSchema,
+  individuPublicIdSchema,
+  panierPublicIdSchema,
+} from '@pilote/mb-shared/publicIds'
+
+import { creerCommentaire } from '@/commentaire/commands/creerCommentaire'
+import { modifierCommentaire } from '@/commentaire/commands/modifierCommentaire'
+import { supprimerCommentaire } from '@/commentaire/commands/supprimerCommentaire'
+import { listerCommentaires } from '@/commentaire/queries/listerCommentaires'
+import { indicateurIndividuConfig, panierConfig, panierIndividuConfig } from '@/commentaire/sujets'
+import { requireAuthentication } from '@/framework/auth/requireAuthentication'
+import { never } from '@/framework/errors/never'
+import { jsonResponseOk } from '@/framework/openapi/jsonResponse'
+import { withTransaction } from '@/framework/persistence/withTransaction'
+
+const CommentaireApiModelSchema = commentaireApiModelSchema.openapi('CommentaireApiModel')
+const CommentaireListApiModelSchema =
+  commentaireListApiModelSchema.openapi('CommentaireListApiModel')
+const ErrorApiModelSchema = errorApiModelSchema.openapi('ErrorApiModel')
+
+export const commentaireRoutes = new OpenAPIHono()
+
+const reponseCommentaire = {
+  200: {
+    content: { 'application/json': { schema: CommentaireApiModelSchema } },
+    description: 'Commentaire',
+  },
+  400: {
+    content: { 'application/json': { schema: ErrorApiModelSchema } },
+    description: 'Requête invalide',
+  },
+  403: {
+    content: { 'application/json': { schema: ErrorApiModelSchema } },
+    description: 'Permission insuffisante',
+  },
+  404: {
+    content: { 'application/json': { schema: ErrorApiModelSchema } },
+    description: 'Sujet introuvable',
+  },
+}
+
+const reponseListe = {
+  200: {
+    content: { 'application/json': { schema: CommentaireListApiModelSchema } },
+    description: 'Liste paginée',
+  },
+  404: {
+    content: { 'application/json': { schema: ErrorApiModelSchema } },
+    description: 'Sujet introuvable',
+  },
+}
+
+// --- indicateur + individu ---------------------------------------------------
+
+const creerIndicateurIndividuRoute = createRoute({
+  method: 'post',
+  path: '/indicateurs/{indicateurId}/individus/{individuId}/commentaires',
+  tags: ['Commentaire'],
+  summary: 'Créer un commentaire sur un indicateur pour un individu',
+  middleware: [requireAuthentication],
+  request: {
+    params: z.object({
+      indicateurId: indicateurPublicIdSchema,
+      individuId: individuPublicIdSchema,
+    }),
+    body: {
+      content: { 'application/json': { schema: creerIndicateurIndividuCommentaireBodySchema } },
+      required: true,
+    },
+  },
+  responses: reponseCommentaire,
+})
+commentaireRoutes.openapi(creerIndicateurIndividuRoute, async (context) => {
+  const params = context.req.valid('param')
+  const body = context.req.valid('json')
+  const result = await withTransaction(async () =>
+    creerCommentaire(indicateurIndividuConfig, { params, body }),
+  )
+  return result.match(
+    (data) => jsonResponseOk({ context, data, schema: CommentaireApiModelSchema, status: 200 }),
+    never,
+  )
+})
+
+const listerIndicateurIndividuRoute = createRoute({
+  method: 'get',
+  path: '/indicateurs/{indicateurId}/individus/{individuId}/commentaires',
+  tags: ['Commentaire'],
+  summary: 'Lister les commentaires d’un indicateur pour un individu',
+  middleware: [requireAuthentication],
+  request: {
+    params: z.object({
+      indicateurId: indicateurPublicIdSchema,
+      individuId: individuPublicIdSchema,
+    }),
+    query: listerCommentairesQuerySchema,
+  },
+  responses: reponseListe,
+})
+commentaireRoutes.openapi(listerIndicateurIndividuRoute, async (context) => {
+  const params = context.req.valid('param')
+  const query = context.req.valid('query')
+  return listerCommentaires(indicateurIndividuConfig, { params, query }).match(
+    (data) => jsonResponseOk({ context, data, schema: CommentaireListApiModelSchema, status: 200 }),
+    never,
+  )
+})
+
+// --- panier + individu -------------------------------------------------------
+
+const creerPanierIndividuRoute = createRoute({
+  method: 'post',
+  path: '/paniers/{panierId}/individus/{individuId}/commentaires',
+  tags: ['Commentaire'],
+  summary: 'Créer un commentaire sur un panier pour un individu',
+  middleware: [requireAuthentication],
+  request: {
+    params: z.object({ panierId: panierPublicIdSchema, individuId: individuPublicIdSchema }),
+    body: {
+      content: { 'application/json': { schema: creerPanierIndividuCommentaireBodySchema } },
+      required: true,
+    },
+  },
+  responses: reponseCommentaire,
+})
+commentaireRoutes.openapi(creerPanierIndividuRoute, async (context) => {
+  const params = context.req.valid('param')
+  const body = context.req.valid('json')
+  const result = await withTransaction(async () =>
+    creerCommentaire(panierIndividuConfig, { params, body }),
+  )
+  return result.match(
+    (data) => jsonResponseOk({ context, data, schema: CommentaireApiModelSchema, status: 200 }),
+    never,
+  )
+})
+
+const listerPanierIndividuRoute = createRoute({
+  method: 'get',
+  path: '/paniers/{panierId}/individus/{individuId}/commentaires',
+  tags: ['Commentaire'],
+  summary: 'Lister les commentaires d’un panier pour un individu',
+  middleware: [requireAuthentication],
+  request: {
+    params: z.object({ panierId: panierPublicIdSchema, individuId: individuPublicIdSchema }),
+    query: listerCommentairesQuerySchema,
+  },
+  responses: reponseListe,
+})
+commentaireRoutes.openapi(listerPanierIndividuRoute, async (context) => {
+  const params = context.req.valid('param')
+  const query = context.req.valid('query')
+  return listerCommentaires(panierIndividuConfig, { params, query }).match(
+    (data) => jsonResponseOk({ context, data, schema: CommentaireListApiModelSchema, status: 200 }),
+    never,
+  )
+})
+
+// --- panier global -----------------------------------------------------------
+
+const creerPanierRoute = createRoute({
+  method: 'post',
+  path: '/paniers/{panierId}/commentaires',
+  tags: ['Commentaire'],
+  summary: 'Créer un commentaire global sur un panier',
+  middleware: [requireAuthentication],
+  request: {
+    params: z.object({ panierId: panierPublicIdSchema }),
+    body: {
+      content: { 'application/json': { schema: creerPanierCommentaireBodySchema } },
+      required: true,
+    },
+  },
+  responses: reponseCommentaire,
+})
+commentaireRoutes.openapi(creerPanierRoute, async (context) => {
+  const params = context.req.valid('param')
+  const body = context.req.valid('json')
+  const result = await withTransaction(async () => creerCommentaire(panierConfig, { params, body }))
+  return result.match(
+    (data) => jsonResponseOk({ context, data, schema: CommentaireApiModelSchema, status: 200 }),
+    never,
+  )
+})
+
+const listerPanierRoute = createRoute({
+  method: 'get',
+  path: '/paniers/{panierId}/commentaires',
+  tags: ['Commentaire'],
+  summary: 'Lister les commentaires globaux d’un panier',
+  middleware: [requireAuthentication],
+  request: {
+    params: z.object({ panierId: panierPublicIdSchema }),
+    query: listerCommentairesQuerySchema,
+  },
+  responses: reponseListe,
+})
+commentaireRoutes.openapi(listerPanierRoute, async (context) => {
+  const params = context.req.valid('param')
+  const query = context.req.valid('query')
+  return listerCommentaires(panierConfig, { params, query }).match(
+    (data) => jsonResponseOk({ context, data, schema: CommentaireListApiModelSchema, status: 200 }),
+    never,
+  )
+})
+
+// --- mutation socle (par id) -------------------------------------------------
+
+const modifierRoute = createRoute({
+  method: 'put',
+  path: '/commentaires/{commentaireId}',
+  tags: ['Commentaire'],
+  summary: 'Modifier un commentaire (auteur uniquement)',
+  middleware: [requireAuthentication],
+  request: {
+    params: z.object({ commentaireId: z.string().uuid() }),
+    body: {
+      content: { 'application/json': { schema: modifierCommentaireBodySchema } },
+      required: true,
+    },
+  },
+  responses: reponseCommentaire,
+})
+commentaireRoutes.openapi(modifierRoute, async (context) => {
+  const { commentaireId } = context.req.valid('param')
+  const body = context.req.valid('json')
+  const result = await withTransaction(async () => modifierCommentaire(commentaireId, body))
+  return result.match(
+    (data) => jsonResponseOk({ context, data, schema: CommentaireApiModelSchema, status: 200 }),
+    never,
+  )
+})
+
+const supprimerRoute = createRoute({
+  method: 'delete',
+  path: '/commentaires/{commentaireId}',
+  tags: ['Commentaire'],
+  summary: 'Supprimer un commentaire (auteur uniquement)',
+  middleware: [requireAuthentication],
+  request: { params: z.object({ commentaireId: z.string().uuid() }) },
+  responses: {
+    204: { description: 'Commentaire supprimé' },
+    403: {
+      content: { 'application/json': { schema: ErrorApiModelSchema } },
+      description: 'Permission insuffisante',
+    },
+    404: {
+      content: { 'application/json': { schema: ErrorApiModelSchema } },
+      description: 'Commentaire introuvable',
+    },
+  },
+})
+commentaireRoutes.openapi(supprimerRoute, async (context) => {
+  const { commentaireId } = context.req.valid('param')
+  const result = await withTransaction(async () => supprimerCommentaire(commentaireId))
+  return result.match(() => context.body(null, 204), never)
+})

--- a/apps/mb-api/src/commentaire/sujets.ts
+++ b/apps/mb-api/src/commentaire/sujets.ts
@@ -1,13 +1,6 @@
-import { ResultAsync } from 'neverthrow'
+import { type ResultAsync } from 'neverthrow'
 
-import { requireCurrentPrincipalId } from '@/framework/auth/userContext'
-import { db } from '@/framework/persistence/dbStore'
 import { type Prisma } from '@/generated/prisma/client'
-import {
-  ensureIndicateurWritePermission,
-  withIndicateurReadPermission,
-} from '@/indicateur/permissions'
-import { ensurePanierWritePermission, withPanierReadPermission } from '@/panier/permissions'
 
 // Fragment `data` du satellite à greffer sur la création d'un Commentaire.
 type SatelliteCreate = Pick<
@@ -21,109 +14,11 @@ type CibleEcriture = {
   satelliteCreate: (type: string) => SatelliteCreate
 }
 
+// Contrat des configs colocalisées avec les use cases de chaque domaine
+// (cf. indicateur/commands/creer*, panier/commands/creer*).
 export type SujetCommentaireConfig<P extends Record<string, string> = Record<string, string>> = {
   // Résout le path en ids internes + vérifie la permission WRITE ; throw ForbiddenError/404 sinon.
   resoudreCibleEcriture: (params: P) => ResultAsync<CibleEcriture, never>
   // Construit le `where` Prisma sur Commentaire pour le listing (READ permission + scope).
   whereLecture: (params: P, principalId: string) => Prisma.CommentaireWhereInput
-}
-
-// --- indicateur + individu ---------------------------------------------------
-
-export const indicateurIndividuConfig: SujetCommentaireConfig<{
-  indicateurId: string
-  individuId: string
-}> = {
-  resoudreCibleEcriture: ({ indicateurId, individuId }) => {
-    const principalId = requireCurrentPrincipalId()
-    return ResultAsync.fromSafePromise(
-      db().indicateur.findFirstOrThrow({
-        where: withIndicateurReadPermission({ publicId: indicateurId }, principalId),
-        select: { id: true },
-      }),
-    )
-      .andThen((indicateur) =>
-        ResultAsync.fromSafePromise(
-          db().individu.findFirstOrThrow({ where: { publicId: individuId }, select: { id: true } }),
-        ).map((individu) => ({ indId: indicateur.id, indivId: individu.id })),
-      )
-      .andThen(({ indId, indivId }) =>
-        ensureIndicateurWritePermission({ indicateurId: indId, principalId }).map(() => ({
-          principalId,
-          satelliteCreate: (type: string) => ({
-            indicateurIndividu: {
-              create: { indicateurId: indId, individuId: indivId, type: type as never },
-            },
-          }),
-        })),
-      )
-  },
-  whereLecture: ({ indicateurId, individuId }, principalId) => ({
-    indicateurIndividu: {
-      indicateur: withIndicateurReadPermission({ publicId: indicateurId }, principalId),
-      individu: { publicId: individuId },
-    },
-  }),
-}
-
-// --- panier + individu -------------------------------------------------------
-
-export const panierIndividuConfig: SujetCommentaireConfig<{
-  panierId: string
-  individuId: string
-}> = {
-  resoudreCibleEcriture: ({ panierId, individuId }) => {
-    const principalId = requireCurrentPrincipalId()
-    return ResultAsync.fromSafePromise(
-      db().panier.findFirstOrThrow({
-        where: withPanierReadPermission({ publicId: panierId }, principalId),
-        select: { id: true },
-      }),
-    )
-      .andThen((panier) =>
-        ResultAsync.fromSafePromise(
-          db().individu.findFirstOrThrow({ where: { publicId: individuId }, select: { id: true } }),
-        ).map((individu) => ({ panId: panier.id, indivId: individu.id })),
-      )
-      .andThen(({ panId, indivId }) =>
-        ensurePanierWritePermission({ panierId: panId, principalId }).map(() => ({
-          principalId,
-          satelliteCreate: (type: string) => ({
-            panierIndividu: {
-              create: { panierId: panId, individuId: indivId, type: type as never },
-            },
-          }),
-        })),
-      )
-  },
-  whereLecture: ({ panierId, individuId }, principalId) => ({
-    panierIndividu: {
-      panier: withPanierReadPermission({ publicId: panierId }, principalId),
-      individu: { publicId: individuId },
-    },
-  }),
-}
-
-// --- panier global -----------------------------------------------------------
-
-export const panierConfig: SujetCommentaireConfig<{ panierId: string }> = {
-  resoudreCibleEcriture: ({ panierId }) => {
-    const principalId = requireCurrentPrincipalId()
-    return ResultAsync.fromSafePromise(
-      db().panier.findFirstOrThrow({
-        where: withPanierReadPermission({ publicId: panierId }, principalId),
-        select: { id: true },
-      }),
-    ).andThen((panier) =>
-      ensurePanierWritePermission({ panierId: panier.id, principalId }).map(() => ({
-        principalId,
-        satelliteCreate: (type: string) => ({
-          panier: { create: { panierId: panier.id, type: type as never } },
-        }),
-      })),
-    )
-  },
-  whereLecture: ({ panierId }, principalId) => ({
-    panier: { panier: withPanierReadPermission({ publicId: panierId }, principalId) },
-  }),
 }

--- a/apps/mb-api/src/commentaire/sujets.ts
+++ b/apps/mb-api/src/commentaire/sujets.ts
@@ -1,0 +1,124 @@
+import { ResultAsync } from 'neverthrow'
+
+import { requireCurrentPrincipalId } from '@/framework/auth/userContext'
+import { db } from '@/framework/persistence/dbStore'
+import { type Prisma } from '@/generated/prisma/client'
+import { ensureIndicateurWritePermission, withIndicateurReadPermission } from '@/indicateur/permissions'
+import { ensurePanierWritePermission, withPanierReadPermission } from '@/panier/permissions'
+
+// Fragment `data` du satellite à greffer sur la création d'un Commentaire.
+type SatelliteCreate = Pick<
+  Prisma.CommentaireCreateInput,
+  'indicateurIndividu' | 'panierIndividu' | 'panier'
+>
+
+// Données nécessaires pour rattacher un nouveau commentaire à son satellite.
+type CibleEcriture = {
+  principalId: string
+  satelliteCreate: (type: string) => SatelliteCreate
+}
+
+export type SujetCommentaireConfig<P extends Record<string, string> = Record<string, string>> = {
+  // Résout le path en ids internes + vérifie la permission WRITE ; throw ForbiddenError/404 sinon.
+  resoudreCibleEcriture: (params: P) => ResultAsync<CibleEcriture, never>
+  // Construit le `where` Prisma sur Commentaire pour le listing (READ permission + scope).
+  whereLecture: (params: P, principalId: string) => Prisma.CommentaireWhereInput
+}
+
+// --- indicateur + individu ---------------------------------------------------
+
+export const indicateurIndividuConfig: SujetCommentaireConfig<{
+  indicateurId: string
+  individuId: string
+}> = {
+  resoudreCibleEcriture: ({ indicateurId, individuId }) => {
+    const principalId = requireCurrentPrincipalId()
+    return ResultAsync.fromSafePromise(
+      db().indicateur.findFirstOrThrow({
+        where: withIndicateurReadPermission({ publicId: indicateurId }, principalId),
+        select: { id: true },
+      }),
+    )
+      .andThen((indicateur) =>
+        ResultAsync.fromSafePromise(
+          db().individu.findFirstOrThrow({ where: { publicId: individuId }, select: { id: true } }),
+        ).map((individu) => ({ indId: indicateur.id, indivId: individu.id })),
+      )
+      .andThen(({ indId, indivId }) =>
+        ensureIndicateurWritePermission({ indicateurId: indId, principalId }).map(() => ({
+          principalId,
+          satelliteCreate: (type: string) => ({
+            indicateurIndividu: {
+              create: { indicateurId: indId, individuId: indivId, type: type as never },
+            },
+          }),
+        })),
+      )
+  },
+  whereLecture: ({ indicateurId, individuId }, principalId) => ({
+    indicateurIndividu: {
+      indicateur: withIndicateurReadPermission({ publicId: indicateurId }, principalId),
+      individu: { publicId: individuId },
+    },
+  }),
+}
+
+// --- panier + individu -------------------------------------------------------
+
+export const panierIndividuConfig: SujetCommentaireConfig<{
+  panierId: string
+  individuId: string
+}> = {
+  resoudreCibleEcriture: ({ panierId, individuId }) => {
+    const principalId = requireCurrentPrincipalId()
+    return ResultAsync.fromSafePromise(
+      db().panier.findFirstOrThrow({
+        where: withPanierReadPermission({ publicId: panierId }, principalId),
+        select: { id: true },
+      }),
+    )
+      .andThen((panier) =>
+        ResultAsync.fromSafePromise(
+          db().individu.findFirstOrThrow({ where: { publicId: individuId }, select: { id: true } }),
+        ).map((individu) => ({ panId: panier.id, indivId: individu.id })),
+      )
+      .andThen(({ panId, indivId }) =>
+        ensurePanierWritePermission({ panierId: panId, principalId }).map(() => ({
+          principalId,
+          satelliteCreate: (type: string) => ({
+            panierIndividu: { create: { panierId: panId, individuId: indivId, type: type as never } },
+          }),
+        })),
+      )
+  },
+  whereLecture: ({ panierId, individuId }, principalId) => ({
+    panierIndividu: {
+      panier: withPanierReadPermission({ publicId: panierId }, principalId),
+      individu: { publicId: individuId },
+    },
+  }),
+}
+
+// --- panier global -----------------------------------------------------------
+
+export const panierConfig: SujetCommentaireConfig<{ panierId: string }> = {
+  resoudreCibleEcriture: ({ panierId }) => {
+    const principalId = requireCurrentPrincipalId()
+    return ResultAsync.fromSafePromise(
+      db().panier.findFirstOrThrow({
+        where: withPanierReadPermission({ publicId: panierId }, principalId),
+        select: { id: true },
+      }),
+    ).andThen((panier) =>
+      ensurePanierWritePermission({ panierId: panier.id, principalId }).map(() => ({
+        principalId,
+        satelliteCreate: (type: string) => ({
+          panier: { create: { panierId: panier.id, type: type as never } },
+        }),
+      })),
+    )
+  },
+  whereLecture: ({ panierId }, principalId) => ({
+    panier: { panier: withPanierReadPermission({ publicId: panierId }, principalId) },
+  }),
+}

--- a/apps/mb-api/src/commentaire/sujets.ts
+++ b/apps/mb-api/src/commentaire/sujets.ts
@@ -3,7 +3,10 @@ import { ResultAsync } from 'neverthrow'
 import { requireCurrentPrincipalId } from '@/framework/auth/userContext'
 import { db } from '@/framework/persistence/dbStore'
 import { type Prisma } from '@/generated/prisma/client'
-import { ensureIndicateurWritePermission, withIndicateurReadPermission } from '@/indicateur/permissions'
+import {
+  ensureIndicateurWritePermission,
+  withIndicateurReadPermission,
+} from '@/indicateur/permissions'
 import { ensurePanierWritePermission, withPanierReadPermission } from '@/panier/permissions'
 
 // Fragment `data` du satellite à greffer sur la création d'un Commentaire.
@@ -86,7 +89,9 @@ export const panierIndividuConfig: SujetCommentaireConfig<{
         ensurePanierWritePermission({ panierId: panId, principalId }).map(() => ({
           principalId,
           satelliteCreate: (type: string) => ({
-            panierIndividu: { create: { panierId: panId, individuId: indivId, type: type as never } },
+            panierIndividu: {
+              create: { panierId: panId, individuId: indivId, type: type as never },
+            },
           }),
         })),
       )

--- a/apps/mb-api/src/commentaire/utils.test.ts
+++ b/apps/mb-api/src/commentaire/utils.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+
+import { htmlToPlainText } from '@/commentaire/utils'
+
+describe('htmlToPlainText', () => {
+  it('strip les balises et normalise les espaces', () => {
+    expect(htmlToPlainText('<p>Bonjour <strong>monde</strong></p>')).toBe('Bonjour monde')
+  })
+
+  it('remplace les &nbsp; et trim', () => {
+    expect(htmlToPlainText('<p>a&nbsp;&nbsp;b</p>  ')).toBe('a b')
+  })
+
+  it('gère la chaîne vide', () => {
+    expect(htmlToPlainText('')).toBe('')
+  })
+})

--- a/apps/mb-api/src/commentaire/utils.ts
+++ b/apps/mb-api/src/commentaire/utils.ts
@@ -2,6 +2,12 @@ import { type CommentaireApiModel } from '@pilote/mb-shared/commentaire'
 
 import { type Prisma } from '@/generated/prisma/client'
 
+type AuteurRow = {
+  id: string
+  utilisateur: { email: string } | null
+  apiKey: { label: string } | null
+}
+
 // Dérive un texte brut depuis un contenu HTML riche (recherche / LLM).
 // Implémentation minimale (strip de balises + normalisation des espaces) ;
 // à durcir si le richEditor introduit des structures complexes.
@@ -13,9 +19,17 @@ export const htmlToPlainText = (html: string): string =>
     .trim()
 
 // Include réutilisable pour toutes les queries renvoyant un CommentaireApiModel.
+const auteurInclude = {
+  select: {
+    id: true,
+    utilisateur: { select: { email: true } },
+    apiKey: { select: { label: true } },
+  },
+} as const
+
 export const commentaireInclude = {
-  auteurCreation: { select: { id: true, utilisateur: { select: { email: true } } } },
-  auteurModification: { select: { id: true, utilisateur: { select: { email: true } } } },
+  auteurCreation: auteurInclude,
+  auteurModification: auteurInclude,
   indicateurIndividu: { include: { individu: { select: { publicId: true } } } },
   panierIndividu: { include: { individu: { select: { publicId: true } } } },
   panier: true,
@@ -29,21 +43,24 @@ const typeDuCommentaire = (row: CommentaireRow): string =>
 const individuPublicId = (row: CommentaireRow): string | null =>
   row.indicateurIndividu?.individu.publicId ?? row.panierIndividu?.individu.publicId ?? null
 
+const toAuteurApiModel = (row: AuteurRow): CommentaireApiModel['auteurCreation'] => {
+  if (row.utilisateur) {
+    return { type: 'utilisateur', id: row.id, email: row.utilisateur.email }
+  }
+  if (row.apiKey) {
+    return { type: 'apiKey', id: row.id, label: row.apiKey.label }
+  }
+  throw new Error(`Principal ${row.id} sans utilisateur ni clé API associé`)
+}
+
 export const toCommentaireApiModel = (row: CommentaireRow): CommentaireApiModel => ({
   id: row.id,
   type: typeDuCommentaire(row),
   individuId: individuPublicId(row),
   contenu: row.contenu,
-  contenuTexte: row.contenuTexte,
   statut: row.statut,
-  auteurCreation: {
-    id: row.auteurCreation.id,
-    email: row.auteurCreation.utilisateur?.email ?? null,
-  },
-  auteurModification: {
-    id: row.auteurModification.id,
-    email: row.auteurModification.utilisateur?.email ?? null,
-  },
+  auteurCreation: toAuteurApiModel(row.auteurCreation),
+  auteurModification: toAuteurApiModel(row.auteurModification),
   createdAt: row.createdAt.toISOString(),
   updatedAt: row.updatedAt.toISOString(),
 })

--- a/apps/mb-api/src/commentaire/utils.ts
+++ b/apps/mb-api/src/commentaire/utils.ts
@@ -1,0 +1,49 @@
+import { type CommentaireApiModel } from '@pilote/mb-shared/commentaire'
+
+import { type Prisma } from '@/generated/prisma/client'
+
+// Dérive un texte brut depuis un contenu HTML riche (recherche / LLM).
+// Implémentation minimale (strip de balises + normalisation des espaces) ;
+// à durcir si le richEditor introduit des structures complexes.
+export const htmlToPlainText = (html: string): string =>
+  html
+    .replace(/<[^>]*>/g, ' ')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+
+// Include réutilisable pour toutes les queries renvoyant un CommentaireApiModel.
+export const commentaireInclude = {
+  auteurCreation: { select: { id: true, utilisateur: { select: { email: true } } } },
+  auteurModification: { select: { id: true, utilisateur: { select: { email: true } } } },
+  indicateurIndividu: { include: { individu: { select: { publicId: true } } } },
+  panierIndividu: { include: { individu: { select: { publicId: true } } } },
+  panier: true,
+} satisfies Prisma.CommentaireInclude
+
+export type CommentaireRow = Prisma.CommentaireGetPayload<{ include: typeof commentaireInclude }>
+
+const typeDuCommentaire = (row: CommentaireRow): string =>
+  row.indicateurIndividu?.type ?? row.panierIndividu?.type ?? row.panier?.type ?? 'DEFAUT'
+
+const individuPublicId = (row: CommentaireRow): string | null =>
+  row.indicateurIndividu?.individu.publicId ?? row.panierIndividu?.individu.publicId ?? null
+
+export const toCommentaireApiModel = (row: CommentaireRow): CommentaireApiModel => ({
+  id: row.id,
+  type: typeDuCommentaire(row),
+  individuId: individuPublicId(row),
+  contenu: row.contenu,
+  contenuTexte: row.contenuTexte,
+  statut: row.statut,
+  auteurCreation: {
+    id: row.auteurCreation.id,
+    email: row.auteurCreation.utilisateur?.email ?? null,
+  },
+  auteurModification: {
+    id: row.auteurModification.id,
+    email: row.auteurModification.utilisateur?.email ?? null,
+  },
+  createdAt: row.createdAt.toISOString(),
+  updatedAt: row.updatedAt.toISOString(),
+})

--- a/apps/mb-api/src/framework/errors/AppError.ts
+++ b/apps/mb-api/src/framework/errors/AppError.ts
@@ -21,3 +21,8 @@ export class ValidationError extends AppError {
   readonly code = 'VALIDATION_ERROR'
   readonly kind = 'validation' as const
 }
+
+export class ConflictError extends AppError {
+  readonly code = 'CONFLICT'
+  readonly kind = 'conflict' as const
+}

--- a/apps/mb-api/src/indicateur/commands/creerIndicateurIndividuCommentaire.ts
+++ b/apps/mb-api/src/indicateur/commands/creerIndicateurIndividuCommentaire.ts
@@ -1,10 +1,52 @@
 import { type CreerCommentaireBody } from '@pilote/mb-shared/commentaire'
+import { ResultAsync } from 'neverthrow'
 
 import { creerCommentaire } from '@/commentaire/commands/creerCommentaire'
-import { indicateurIndividuConfig } from '@/commentaire/sujets'
+import { type SujetCommentaireConfig } from '@/commentaire/sujets'
+import { requireCurrentPrincipalId } from '@/framework/auth/userContext'
+import { db } from '@/framework/persistence/dbStore'
+import {
+  ensureIndicateurWritePermission,
+  withIndicateurReadPermission,
+} from '@/indicateur/permissions'
+
+type Params = { indicateurId: string; individuId: string }
+
+export const indicateurIndividuConfig: SujetCommentaireConfig<Params> = {
+  resoudreCibleEcriture: ({ indicateurId, individuId }) => {
+    const principalId = requireCurrentPrincipalId()
+    return ResultAsync.fromSafePromise(
+      db().indicateur.findFirstOrThrow({
+        where: withIndicateurReadPermission({ publicId: indicateurId }, principalId),
+        select: { id: true },
+      }),
+    )
+      .andThen((indicateur) =>
+        ResultAsync.fromSafePromise(
+          db().individu.findFirstOrThrow({ where: { publicId: individuId }, select: { id: true } }),
+        ).map((individu) => ({ indId: indicateur.id, indivId: individu.id })),
+      )
+      .andThen(({ indId, indivId }) =>
+        ensureIndicateurWritePermission({ indicateurId: indId, principalId }).map(() => ({
+          principalId,
+          satelliteCreate: (type: string) => ({
+            indicateurIndividu: {
+              create: { indicateurId: indId, individuId: indivId, type: type as never },
+            },
+          }),
+        })),
+      )
+  },
+  whereLecture: ({ indicateurId, individuId }, principalId) => ({
+    indicateurIndividu: {
+      indicateur: withIndicateurReadPermission({ publicId: indicateurId }, principalId),
+      individu: { publicId: individuId },
+    },
+  }),
+}
 
 type Input = {
-  params: { indicateurId: string; individuId: string }
+  params: Params
   body: CreerCommentaireBody
 }
 

--- a/apps/mb-api/src/indicateur/commands/creerIndicateurIndividuCommentaire.ts
+++ b/apps/mb-api/src/indicateur/commands/creerIndicateurIndividuCommentaire.ts
@@ -1,0 +1,12 @@
+import { type CreerCommentaireBody } from '@pilote/mb-shared/commentaire'
+
+import { creerCommentaire } from '@/commentaire/commands/creerCommentaire'
+import { indicateurIndividuConfig } from '@/commentaire/sujets'
+
+type Input = {
+  params: { indicateurId: string; individuId: string }
+  body: CreerCommentaireBody
+}
+
+export const creerIndicateurIndividuCommentaire = (input: Input) =>
+  creerCommentaire(indicateurIndividuConfig, input)

--- a/apps/mb-api/src/indicateur/queries/listerIndicateurIndividuCommentaires.ts
+++ b/apps/mb-api/src/indicateur/queries/listerIndicateurIndividuCommentaires.ts
@@ -1,0 +1,12 @@
+import { type ListerCommentairesQuery } from '@pilote/mb-shared/commentaire'
+
+import { listerCommentaires } from '@/commentaire/queries/listerCommentaires'
+import { indicateurIndividuConfig } from '@/commentaire/sujets'
+
+type Input = {
+  params: { indicateurId: string; individuId: string }
+  query: ListerCommentairesQuery
+}
+
+export const listerIndicateurIndividuCommentaires = (input: Input) =>
+  listerCommentaires(indicateurIndividuConfig, input)

--- a/apps/mb-api/src/indicateur/queries/listerIndicateurIndividuCommentaires.ts
+++ b/apps/mb-api/src/indicateur/queries/listerIndicateurIndividuCommentaires.ts
@@ -1,7 +1,7 @@
 import { type ListerCommentairesQuery } from '@pilote/mb-shared/commentaire'
 
 import { listerCommentaires } from '@/commentaire/queries/listerCommentaires'
-import { indicateurIndividuConfig } from '@/commentaire/sujets'
+import { indicateurIndividuConfig } from '@/indicateur/commands/creerIndicateurIndividuCommentaire'
 
 type Input = {
   params: { indicateurId: string; individuId: string }

--- a/apps/mb-api/src/indicateur/routes.ts
+++ b/apps/mb-api/src/indicateur/routes.ts
@@ -1,7 +1,7 @@
 import { createRoute, OpenAPIHono, z } from '@hono/zod-openapi'
 import {
   creerIndicateurIndividuCommentaireBodySchema,
-  listerCommentairesQuerySchema,
+  listerIndicateurIndividuCommentairesQuerySchema,
 } from '@pilote/mb-shared/commentaire'
 import { errorApiModelSchema } from '@pilote/mb-shared/error'
 import {
@@ -217,7 +217,7 @@ const listerIndicateurIndividuCommentairesRoute = createRoute({
   middleware: [requireAuthentication],
   request: {
     params: indicateurIndividuCommentaireParamsSchema,
-    query: listerCommentairesQuerySchema,
+    query: listerIndicateurIndividuCommentairesQuerySchema,
   },
   responses: reponseListe,
 })

--- a/apps/mb-api/src/indicateur/routes.ts
+++ b/apps/mb-api/src/indicateur/routes.ts
@@ -182,7 +182,7 @@ const indicateurIndividuCommentaireParamsSchema = z.object({
 const creerIndicateurIndividuCommentaireRoute = createRoute({
   method: 'post',
   path: '/indicateurs/{indicateurId}/individus/{individuId}/commentaires',
-  tags: ['Commentaire'],
+  tags: ['Indicateur'],
   summary: 'Créer un commentaire sur un indicateur pour un individu',
   middleware: [requireAuthentication],
   request: {
@@ -212,7 +212,7 @@ indicateurRoutes.openapi(creerIndicateurIndividuCommentaireRoute, async (context
 const listerIndicateurIndividuCommentairesRoute = createRoute({
   method: 'get',
   path: '/indicateurs/{indicateurId}/individus/{individuId}/commentaires',
-  tags: ['Commentaire'],
+  tags: ['Indicateur'],
   summary: 'Lister les commentaires d’un indicateur pour un individu',
   middleware: [requireAuthentication],
   request: {

--- a/apps/mb-api/src/indicateur/routes.ts
+++ b/apps/mb-api/src/indicateur/routes.ts
@@ -1,4 +1,8 @@
 import { createRoute, OpenAPIHono, z } from '@hono/zod-openapi'
+import {
+  creerIndicateurIndividuCommentaireBodySchema,
+  listerCommentairesQuerySchema,
+} from '@pilote/mb-shared/commentaire'
 import { errorApiModelSchema } from '@pilote/mb-shared/error'
 import {
   indicateurApiModelSchema,
@@ -6,15 +10,23 @@ import {
   upsertIndicateurBodySchema,
 } from '@pilote/mb-shared/indicateur'
 import { createPaginatedApiListSchema } from '@pilote/mb-shared/pagination'
-import { indicateurPublicIdSchema } from '@pilote/mb-shared/publicIds'
+import { indicateurPublicIdSchema, individuPublicIdSchema } from '@pilote/mb-shared/publicIds'
 
+import {
+  CommentaireApiModelSchema,
+  CommentaireListApiModelSchema,
+  reponseCommentaire,
+  reponseListe,
+} from '@/commentaire/openapi'
 import { requireAuthentication } from '@/framework/auth/requireAuthentication'
 import { never } from '@/framework/errors/never'
 import { jsonResponseOk } from '@/framework/openapi/jsonResponse'
 import { withTransaction } from '@/framework/persistence/withTransaction'
 import { upsertIndicateur } from '@/indicateur/commands/upsertIndicateur'
+import { creerIndicateurIndividuCommentaire } from '@/indicateur/commands/creerIndicateurIndividuCommentaire'
 import { getIndicateurByPublicId } from '@/indicateur/queries/getIndicateurByPublicId'
 import { listIndicateurs } from '@/indicateur/queries/listIndicateurs'
+import { listerIndicateurIndividuCommentaires } from '@/indicateur/queries/listerIndicateurIndividuCommentaires'
 
 const IndicateurApiModelSchema = indicateurApiModelSchema.openapi('IndicateurApiModel')
 const IndicateurListApiModelSchema =
@@ -156,6 +168,65 @@ indicateurRoutes.openapi(upsertIndicateurRoute, async (context) => {
         schema: IndicateurApiModelSchema,
         status: 200,
       }),
+    never,
+  )
+})
+
+// --- POST /indicateurs/:id/individus/:individuId/commentaires ----------------
+
+const indicateurIndividuCommentaireParamsSchema = z.object({
+  indicateurId: indicateurPublicIdSchema,
+  individuId: individuPublicIdSchema,
+})
+
+const creerIndicateurIndividuCommentaireRoute = createRoute({
+  method: 'post',
+  path: '/indicateurs/{indicateurId}/individus/{individuId}/commentaires',
+  tags: ['Commentaire'],
+  summary: 'Créer un commentaire sur un indicateur pour un individu',
+  middleware: [requireAuthentication],
+  request: {
+    params: indicateurIndividuCommentaireParamsSchema,
+    body: {
+      content: { 'application/json': { schema: creerIndicateurIndividuCommentaireBodySchema } },
+      required: true,
+    },
+  },
+  responses: reponseCommentaire,
+})
+
+indicateurRoutes.openapi(creerIndicateurIndividuCommentaireRoute, async (context) => {
+  const params = context.req.valid('param')
+  const body = context.req.valid('json')
+  const result = await withTransaction(async () =>
+    creerIndicateurIndividuCommentaire({ params, body }),
+  )
+  return result.match(
+    (data) => jsonResponseOk({ context, data, schema: CommentaireApiModelSchema, status: 200 }),
+    never,
+  )
+})
+
+// --- GET /indicateurs/:id/individus/:individuId/commentaires -----------------
+
+const listerIndicateurIndividuCommentairesRoute = createRoute({
+  method: 'get',
+  path: '/indicateurs/{indicateurId}/individus/{individuId}/commentaires',
+  tags: ['Commentaire'],
+  summary: 'Lister les commentaires d’un indicateur pour un individu',
+  middleware: [requireAuthentication],
+  request: {
+    params: indicateurIndividuCommentaireParamsSchema,
+    query: listerCommentairesQuerySchema,
+  },
+  responses: reponseListe,
+})
+
+indicateurRoutes.openapi(listerIndicateurIndividuCommentairesRoute, async (context) => {
+  const params = context.req.valid('param')
+  const query = context.req.valid('query')
+  return listerIndicateurIndividuCommentaires({ params, query }).match(
+    (data) => jsonResponseOk({ context, data, schema: CommentaireListApiModelSchema, status: 200 }),
     never,
   )
 })

--- a/apps/mb-api/src/panier/commands/creerPanierCommentaire.ts
+++ b/apps/mb-api/src/panier/commands/creerPanierCommentaire.ts
@@ -1,10 +1,38 @@
 import { type CreerCommentaireBody } from '@pilote/mb-shared/commentaire'
+import { ResultAsync } from 'neverthrow'
 
 import { creerCommentaire } from '@/commentaire/commands/creerCommentaire'
-import { panierConfig } from '@/commentaire/sujets'
+import { type SujetCommentaireConfig } from '@/commentaire/sujets'
+import { requireCurrentPrincipalId } from '@/framework/auth/userContext'
+import { db } from '@/framework/persistence/dbStore'
+import { ensurePanierWritePermission, withPanierReadPermission } from '@/panier/permissions'
+
+type Params = { panierId: string }
+
+export const panierConfig: SujetCommentaireConfig<Params> = {
+  resoudreCibleEcriture: ({ panierId }) => {
+    const principalId = requireCurrentPrincipalId()
+    return ResultAsync.fromSafePromise(
+      db().panier.findFirstOrThrow({
+        where: withPanierReadPermission({ publicId: panierId }, principalId),
+        select: { id: true },
+      }),
+    ).andThen((panier) =>
+      ensurePanierWritePermission({ panierId: panier.id, principalId }).map(() => ({
+        principalId,
+        satelliteCreate: (type: string) => ({
+          panier: { create: { panierId: panier.id, type: type as never } },
+        }),
+      })),
+    )
+  },
+  whereLecture: ({ panierId }, principalId) => ({
+    panier: { panier: withPanierReadPermission({ publicId: panierId }, principalId) },
+  }),
+}
 
 type Input = {
-  params: { panierId: string }
+  params: Params
   body: CreerCommentaireBody
 }
 

--- a/apps/mb-api/src/panier/commands/creerPanierCommentaire.ts
+++ b/apps/mb-api/src/panier/commands/creerPanierCommentaire.ts
@@ -1,0 +1,11 @@
+import { type CreerCommentaireBody } from '@pilote/mb-shared/commentaire'
+
+import { creerCommentaire } from '@/commentaire/commands/creerCommentaire'
+import { panierConfig } from '@/commentaire/sujets'
+
+type Input = {
+  params: { panierId: string }
+  body: CreerCommentaireBody
+}
+
+export const creerPanierCommentaire = (input: Input) => creerCommentaire(panierConfig, input)

--- a/apps/mb-api/src/panier/commands/creerPanierIndividuCommentaire.ts
+++ b/apps/mb-api/src/panier/commands/creerPanierIndividuCommentaire.ts
@@ -1,0 +1,12 @@
+import { type CreerCommentaireBody } from '@pilote/mb-shared/commentaire'
+
+import { creerCommentaire } from '@/commentaire/commands/creerCommentaire'
+import { panierIndividuConfig } from '@/commentaire/sujets'
+
+type Input = {
+  params: { panierId: string; individuId: string }
+  body: CreerCommentaireBody
+}
+
+export const creerPanierIndividuCommentaire = (input: Input) =>
+  creerCommentaire(panierIndividuConfig, input)

--- a/apps/mb-api/src/panier/commands/creerPanierIndividuCommentaire.ts
+++ b/apps/mb-api/src/panier/commands/creerPanierIndividuCommentaire.ts
@@ -1,10 +1,49 @@
 import { type CreerCommentaireBody } from '@pilote/mb-shared/commentaire'
+import { ResultAsync } from 'neverthrow'
 
 import { creerCommentaire } from '@/commentaire/commands/creerCommentaire'
-import { panierIndividuConfig } from '@/commentaire/sujets'
+import { type SujetCommentaireConfig } from '@/commentaire/sujets'
+import { requireCurrentPrincipalId } from '@/framework/auth/userContext'
+import { db } from '@/framework/persistence/dbStore'
+import { ensurePanierWritePermission, withPanierReadPermission } from '@/panier/permissions'
+
+type Params = { panierId: string; individuId: string }
+
+export const panierIndividuConfig: SujetCommentaireConfig<Params> = {
+  resoudreCibleEcriture: ({ panierId, individuId }) => {
+    const principalId = requireCurrentPrincipalId()
+    return ResultAsync.fromSafePromise(
+      db().panier.findFirstOrThrow({
+        where: withPanierReadPermission({ publicId: panierId }, principalId),
+        select: { id: true },
+      }),
+    )
+      .andThen((panier) =>
+        ResultAsync.fromSafePromise(
+          db().individu.findFirstOrThrow({ where: { publicId: individuId }, select: { id: true } }),
+        ).map((individu) => ({ panId: panier.id, indivId: individu.id })),
+      )
+      .andThen(({ panId, indivId }) =>
+        ensurePanierWritePermission({ panierId: panId, principalId }).map(() => ({
+          principalId,
+          satelliteCreate: (type: string) => ({
+            panierIndividu: {
+              create: { panierId: panId, individuId: indivId, type: type as never },
+            },
+          }),
+        })),
+      )
+  },
+  whereLecture: ({ panierId, individuId }, principalId) => ({
+    panierIndividu: {
+      panier: withPanierReadPermission({ publicId: panierId }, principalId),
+      individu: { publicId: individuId },
+    },
+  }),
+}
 
 type Input = {
-  params: { panierId: string; individuId: string }
+  params: Params
   body: CreerCommentaireBody
 }
 

--- a/apps/mb-api/src/panier/queries/listerPanierCommentaires.ts
+++ b/apps/mb-api/src/panier/queries/listerPanierCommentaires.ts
@@ -1,7 +1,7 @@
 import { type ListerCommentairesQuery } from '@pilote/mb-shared/commentaire'
 
 import { listerCommentaires } from '@/commentaire/queries/listerCommentaires'
-import { panierConfig } from '@/commentaire/sujets'
+import { panierConfig } from '@/panier/commands/creerPanierCommentaire'
 
 type Input = {
   params: { panierId: string }

--- a/apps/mb-api/src/panier/queries/listerPanierCommentaires.ts
+++ b/apps/mb-api/src/panier/queries/listerPanierCommentaires.ts
@@ -1,0 +1,11 @@
+import { type ListerCommentairesQuery } from '@pilote/mb-shared/commentaire'
+
+import { listerCommentaires } from '@/commentaire/queries/listerCommentaires'
+import { panierConfig } from '@/commentaire/sujets'
+
+type Input = {
+  params: { panierId: string }
+  query: ListerCommentairesQuery
+}
+
+export const listerPanierCommentaires = (input: Input) => listerCommentaires(panierConfig, input)

--- a/apps/mb-api/src/panier/queries/listerPanierIndividuCommentaires.ts
+++ b/apps/mb-api/src/panier/queries/listerPanierIndividuCommentaires.ts
@@ -1,7 +1,7 @@
 import { type ListerCommentairesQuery } from '@pilote/mb-shared/commentaire'
 
 import { listerCommentaires } from '@/commentaire/queries/listerCommentaires'
-import { panierIndividuConfig } from '@/commentaire/sujets'
+import { panierIndividuConfig } from '@/panier/commands/creerPanierIndividuCommentaire'
 
 type Input = {
   params: { panierId: string; individuId: string }

--- a/apps/mb-api/src/panier/queries/listerPanierIndividuCommentaires.ts
+++ b/apps/mb-api/src/panier/queries/listerPanierIndividuCommentaires.ts
@@ -1,0 +1,12 @@
+import { type ListerCommentairesQuery } from '@pilote/mb-shared/commentaire'
+
+import { listerCommentaires } from '@/commentaire/queries/listerCommentaires'
+import { panierIndividuConfig } from '@/commentaire/sujets'
+
+type Input = {
+  params: { panierId: string; individuId: string }
+  query: ListerCommentairesQuery
+}
+
+export const listerPanierIndividuCommentaires = (input: Input) =>
+  listerCommentaires(panierIndividuConfig, input)

--- a/apps/mb-api/src/panier/routes.ts
+++ b/apps/mb-api/src/panier/routes.ts
@@ -2,7 +2,8 @@ import { createRoute, OpenAPIHono, z } from '@hono/zod-openapi'
 import {
   creerPanierCommentaireBodySchema,
   creerPanierIndividuCommentaireBodySchema,
-  listerCommentairesQuerySchema,
+  listerPanierCommentairesQuerySchema,
+  listerPanierIndividuCommentairesQuerySchema,
 } from '@pilote/mb-shared/commentaire'
 import { errorApiModelSchema } from '@pilote/mb-shared/error'
 import {
@@ -256,7 +257,7 @@ const listerPanierIndividuCommentairesRoute = createRoute({
   middleware: [requireAuthentication],
   request: {
     params: panierIndividuCommentaireParamsSchema,
-    query: listerCommentairesQuerySchema,
+    query: listerPanierIndividuCommentairesQuerySchema,
   },
   responses: reponseListe,
 })
@@ -310,7 +311,7 @@ const listerPanierCommentairesRoute = createRoute({
   middleware: [requireAuthentication],
   request: {
     params: panierCommentaireParamsSchema,
-    query: listerCommentairesQuerySchema,
+    query: listerPanierCommentairesQuerySchema,
   },
   responses: reponseListe,
 })

--- a/apps/mb-api/src/panier/routes.ts
+++ b/apps/mb-api/src/panier/routes.ts
@@ -223,7 +223,7 @@ const panierIndividuCommentaireParamsSchema = z.object({
 const creerPanierIndividuCommentaireRoute = createRoute({
   method: 'post',
   path: '/paniers/{panierId}/individus/{individuId}/commentaires',
-  tags: ['Commentaire'],
+  tags: ['Panier'],
   summary: 'Créer un commentaire sur un panier pour un individu',
   middleware: [requireAuthentication],
   request: {
@@ -251,7 +251,7 @@ panierRoutes.openapi(creerPanierIndividuCommentaireRoute, async (context) => {
 const listerPanierIndividuCommentairesRoute = createRoute({
   method: 'get',
   path: '/paniers/{panierId}/individus/{individuId}/commentaires',
-  tags: ['Commentaire'],
+  tags: ['Panier'],
   summary: 'Lister les commentaires d’un panier pour un individu',
   middleware: [requireAuthentication],
   request: {
@@ -277,7 +277,7 @@ const panierCommentaireParamsSchema = z.object({ panierId: panierPublicIdSchema 
 const creerPanierCommentaireRoute = createRoute({
   method: 'post',
   path: '/paniers/{panierId}/commentaires',
-  tags: ['Commentaire'],
+  tags: ['Panier'],
   summary: 'Créer un commentaire global sur un panier',
   middleware: [requireAuthentication],
   request: {
@@ -305,7 +305,7 @@ panierRoutes.openapi(creerPanierCommentaireRoute, async (context) => {
 const listerPanierCommentairesRoute = createRoute({
   method: 'get',
   path: '/paniers/{panierId}/commentaires',
-  tags: ['Commentaire'],
+  tags: ['Panier'],
   summary: 'Lister les commentaires globaux d’un panier',
   middleware: [requireAuthentication],
   request: {

--- a/apps/mb-api/src/panier/routes.ts
+++ b/apps/mb-api/src/panier/routes.ts
@@ -1,4 +1,9 @@
 import { createRoute, OpenAPIHono, z } from '@hono/zod-openapi'
+import {
+  creerPanierCommentaireBodySchema,
+  creerPanierIndividuCommentaireBodySchema,
+  listerCommentairesQuerySchema,
+} from '@pilote/mb-shared/commentaire'
 import { errorApiModelSchema } from '@pilote/mb-shared/error'
 import {
   listPaniersQuerySchema,
@@ -10,15 +15,26 @@ import {
   getPanierTauxProgressionQuerySchema,
   panierTauxProgressionApiModelSchema,
 } from '@pilote/mb-shared/panierTauxProgression'
-import { panierPublicIdSchema } from '@pilote/mb-shared/publicIds'
+import { individuPublicIdSchema, panierPublicIdSchema } from '@pilote/mb-shared/publicIds'
 
+import {
+  CommentaireApiModelSchema,
+  CommentaireListApiModelSchema,
+  reponseCommentaire,
+  reponseListe,
+} from '@/commentaire/openapi'
 import { requireAuthentication } from '@/framework/auth/requireAuthentication'
 import { never } from '@/framework/errors/never'
 import { jsonResponseOk } from '@/framework/openapi/jsonResponse'
+import { withTransaction } from '@/framework/persistence/withTransaction'
+import { creerPanierCommentaire } from '@/panier/commands/creerPanierCommentaire'
+import { creerPanierIndividuCommentaire } from '@/panier/commands/creerPanierIndividuCommentaire'
 import { getPanierByPublicId } from '@/panier/queries/getPanierByPublicId'
 import { getPanierResponsables } from '@/panier/queries/getPanierResponsables'
 import { getPanierTauxProgression } from '@/panier/queries/getPanierTauxProgression'
 import { listPaniers } from '@/panier/queries/listPaniers'
+import { listerPanierCommentaires } from '@/panier/queries/listerPanierCommentaires'
+import { listerPanierIndividuCommentaires } from '@/panier/queries/listerPanierIndividuCommentaires'
 
 const PanierApiModelSchema = panierApiModelSchema.openapi('PanierApiModel')
 const PanierListApiModelSchema = panierListApiModelSchema.openapi('PanierListApiModel')
@@ -193,6 +209,117 @@ panierRoutes.openapi(getPanierResponsablesRoute, async (context) => {
         schema: PanierResponsablesApiModelSchema,
         status: 200,
       }),
+    never,
+  )
+})
+
+// --- POST /paniers/:id/individus/:individuId/commentaires --------------------
+
+const panierIndividuCommentaireParamsSchema = z.object({
+  panierId: panierPublicIdSchema,
+  individuId: individuPublicIdSchema,
+})
+
+const creerPanierIndividuCommentaireRoute = createRoute({
+  method: 'post',
+  path: '/paniers/{panierId}/individus/{individuId}/commentaires',
+  tags: ['Commentaire'],
+  summary: 'Créer un commentaire sur un panier pour un individu',
+  middleware: [requireAuthentication],
+  request: {
+    params: panierIndividuCommentaireParamsSchema,
+    body: {
+      content: { 'application/json': { schema: creerPanierIndividuCommentaireBodySchema } },
+      required: true,
+    },
+  },
+  responses: reponseCommentaire,
+})
+
+panierRoutes.openapi(creerPanierIndividuCommentaireRoute, async (context) => {
+  const params = context.req.valid('param')
+  const body = context.req.valid('json')
+  const result = await withTransaction(async () => creerPanierIndividuCommentaire({ params, body }))
+  return result.match(
+    (data) => jsonResponseOk({ context, data, schema: CommentaireApiModelSchema, status: 200 }),
+    never,
+  )
+})
+
+// --- GET /paniers/:id/individus/:individuId/commentaires ---------------------
+
+const listerPanierIndividuCommentairesRoute = createRoute({
+  method: 'get',
+  path: '/paniers/{panierId}/individus/{individuId}/commentaires',
+  tags: ['Commentaire'],
+  summary: 'Lister les commentaires d’un panier pour un individu',
+  middleware: [requireAuthentication],
+  request: {
+    params: panierIndividuCommentaireParamsSchema,
+    query: listerCommentairesQuerySchema,
+  },
+  responses: reponseListe,
+})
+
+panierRoutes.openapi(listerPanierIndividuCommentairesRoute, async (context) => {
+  const params = context.req.valid('param')
+  const query = context.req.valid('query')
+  return listerPanierIndividuCommentaires({ params, query }).match(
+    (data) => jsonResponseOk({ context, data, schema: CommentaireListApiModelSchema, status: 200 }),
+    never,
+  )
+})
+
+// --- POST /paniers/:id/commentaires ------------------------------------------
+
+const panierCommentaireParamsSchema = z.object({ panierId: panierPublicIdSchema })
+
+const creerPanierCommentaireRoute = createRoute({
+  method: 'post',
+  path: '/paniers/{panierId}/commentaires',
+  tags: ['Commentaire'],
+  summary: 'Créer un commentaire global sur un panier',
+  middleware: [requireAuthentication],
+  request: {
+    params: panierCommentaireParamsSchema,
+    body: {
+      content: { 'application/json': { schema: creerPanierCommentaireBodySchema } },
+      required: true,
+    },
+  },
+  responses: reponseCommentaire,
+})
+
+panierRoutes.openapi(creerPanierCommentaireRoute, async (context) => {
+  const params = context.req.valid('param')
+  const body = context.req.valid('json')
+  const result = await withTransaction(async () => creerPanierCommentaire({ params, body }))
+  return result.match(
+    (data) => jsonResponseOk({ context, data, schema: CommentaireApiModelSchema, status: 200 }),
+    never,
+  )
+})
+
+// --- GET /paniers/:id/commentaires -------------------------------------------
+
+const listerPanierCommentairesRoute = createRoute({
+  method: 'get',
+  path: '/paniers/{panierId}/commentaires',
+  tags: ['Commentaire'],
+  summary: 'Lister les commentaires globaux d’un panier',
+  middleware: [requireAuthentication],
+  request: {
+    params: panierCommentaireParamsSchema,
+    query: listerCommentairesQuerySchema,
+  },
+  responses: reponseListe,
+})
+
+panierRoutes.openapi(listerPanierCommentairesRoute, async (context) => {
+  const params = context.req.valid('param')
+  const query = context.req.valid('query')
+  return listerPanierCommentaires({ params, query }).match(
+    (data) => jsonResponseOk({ context, data, schema: CommentaireListApiModelSchema, status: 200 }),
     never,
   )
 })

--- a/apps/mb-api/src/test/fixtures.ts
+++ b/apps/mb-api/src/test/fixtures.ts
@@ -794,8 +794,50 @@ async function panierResponsable(
   return results
 }
 
+// --- Commentaire (indicateur + individu) -------------------------------------
+
+type CommentaireOverrides = {
+  indicateur: IndicateurOverrides
+  individu: IndividuOverrides
+  createdBy: string
+} & Partial<{
+  id: string
+  contenu: string
+  contenuTexte: string
+  statut: 'BROUILLON' | 'PUBLIE'
+  type: 'DEFAUT' | 'CONFIANCE'
+}>
+
+const upsertCommentaire = async (o: CommentaireOverrides) => {
+  const indicateurRow = await upsertIndicateur(o.indicateur)
+  const individuRow = await upsertIndividu(o.individu)
+  return db().commentaire.create({
+    data: {
+      id: o.id ?? uuidv7(),
+      contenu: o.contenu ?? '<p>Commentaire de test</p>',
+      contenuTexte: o.contenuTexte ?? 'Commentaire de test',
+      statut: o.statut ?? 'PUBLIE',
+      createdBy: o.createdBy,
+      updatedBy: o.createdBy,
+      indicateurIndividu: {
+        create: {
+          indicateurId: indicateurRow.id,
+          individuId: individuRow.id,
+          type: o.type ?? 'DEFAUT',
+        },
+      },
+    },
+    include: { indicateurIndividu: true },
+  })
+}
+
+async function commentaire(override: CommentaireOverrides) {
+  return upsertCommentaire(override)
+}
+
 export const fixtures = {
   indicateur,
+  commentaire,
   referentiel,
   individu,
   widget,

--- a/apps/mb-api/tsconfig.json
+++ b/apps/mb-api/tsconfig.json
@@ -15,6 +15,7 @@
     "paths": {
       "@/framework/*": ["./src/framework/*"],
       "@/authentication/*": ["./src/authentication/*"],
+      "@/commentaire/*": ["./src/commentaire/*"],
       "@/healthcheck/*": ["./src/healthcheck/*"],
       "@/indicateur/*": ["./src/indicateur/*"],
       "@/individu/*": ["./src/individu/*"],

--- a/docs/superpowers/specs/2026-06-23-commentaires-niveau-confiance-design.md
+++ b/docs/superpowers/specs/2026-06-23-commentaires-niveau-confiance-design.md
@@ -1,19 +1,19 @@
 # Commentaires & Niveau de confiance — Conception (mb-api)
 
-> Périmètre : tickets **PIL-1581 → PIL-1593** (commentaires + météo/niveau de confiance sur indicateurs et paniers).
+> Périmètre : tickets **PIL-1581 → PIL-1593** (commentaires + niveau de confiance sur indicateurs et paniers).
 > Cible : `apps/mb-api` (Hono + Prisma + Zod, CQRS léger). Aucun de ces concepts n'existe aujourd'hui dans mb-api.
 
 ## 1. Contexte & motivation
 
-Sur le legacy `pilote-ppg`, chaque nature de commentaire avait sa propre table (`commentaire` typé par maille, `synthese_des_resultats` avec une colonne `meteo`), ce qui rendait l'affectation de la météo et l'ajout de nouveaux types douloureux et rigides.
+Sur le legacy `pilote-ppg`, chaque nature de commentaire avait sa propre table (`commentaire` typé par maille, `synthese_des_resultats` avec une colonne `meteo`), ce qui rendait l'affectation de l'indice de confiance et l'ajout de nouveaux types douloureux et rigides.
 
-On repart d'une conception **générique** : un **socle `Commentaire`** unique (contenu, statut, auteur, dates) sur lequel viennent se greffer des **satellites** qui portent le rattachement à un sujet et la catégorie. La météo devient un satellite parmi d'autres — fin de la rigidité « une table par nature ».
+On repart d'une conception **générique** : un **socle `Commentaire`** unique (contenu, statut, auteur, dates) sur lequel viennent se greffer des **satellites** qui portent le rattachement à un sujet et la catégorie. Le niveau de confiance devient un satellite parmi d'autres — fin de la rigidité « une table par nature ».
 
 ## 2. Décisions structurantes
 
 1. **Socle + satellites.** Un seul `Commentaire` porte les champs communs. Chaque sujet commentable a sa propre table satellite (FK → `Commentaire`, FK → sujet) **avec son propre enum `type`** (anti-fourre-tout : pas de table générique mélangeant catégorie + type).
 2. **3 secteurs dans ce lot** : `IndicateurIndividuCommentaire`, `PanierIndividuCommentaire`, `PanierCommentaire` (global, sans individu). Indicateur et panier-par-individu portent une dimension `individuId` ; le panier global non.
-3. **La météo n'est pas une table versionnée.** Un `NiveauConfiance` est accroché à **un commentaire** (1:1). Comme les commentaires sont append-only, l'historique des météos **émerge** de la suite des commentaires porteurs d'un indice. La « courante » = l'indice du dernier commentaire **publié** du scope qui porte un `NiveauConfiance`.
+3. **Le niveau de confiance n'est pas une table dédiée à part.** Un `NiveauConfiance` est accroché à **un commentaire** en **1:n** : un commentaire de type `CONFIANCE` porte un ou plusieurs indices ordonnés par date (historique d'indices, et autres usages à venir). L'indice « courant » d'un commentaire = le dernier (`createdAt` max) ; l'indice de confiance « courant » d'un scope = l'indice courant du dernier commentaire `CONFIANCE` **publié** du scope.
 4. **Statut BROUILLON / PUBLIE** sur le socle, piloté par le `PUT`. Max **1 brouillon par (scope, auteur)**.
 5. **`individuId` dans le path** (et non le body) : routes imbriquées `…/individus/{individuId}/commentaires`. Cohérent avec mb-api où `individus` est déjà une sous-ressource d'un sujet (`/indicateurs/{id}/individus`, `/referentiels/{id}/individus`). Profondeur 3 niveaux assumée (≤3, conforme aux guidelines REST type Zalando/Microsoft).
 6. **Espace d'`id` unifié sur le socle** : `PUT /commentaires/{id}` et `DELETE /commentaires/{id}` opèrent sur le socle, quel que soit le satellite (un resolver retrouve le sujet pour le contrôle de permission).
@@ -59,15 +59,19 @@ PanierCommentaire                       -- global, pas d'individu
   @@index([panierId])
 ```
 
-### Météo (satellite 1:1 sur le commentaire)
+### Niveau de confiance (satellite 1:n sur le commentaire)
 
 ```
 NiveauConfiance
-  commentaireId  uuid (PK, FK → Commentaire, onDelete Cascade)
+  id             uuid (PK, app-generated)
+  commentaireId  uuid (FK → Commentaire, onDelete Cascade)   -- non unique : 1:n
   indice         IndiceConfiance
+  createdAt      timestamptz
+  updatedAt      timestamptz
+  @@index([commentaireId])
 ```
 
-Le scope (sujet + éventuel individu) du `NiveauConfiance` est **hérité** du satellite du commentaire — il n'est pas redupliqué.
+Plusieurs `NiveauConfiance` peuvent pointer le même commentaire (historique d'indices, ordonnés par `createdAt`). Le scope (sujet + éventuel individu) est **hérité** du satellite du commentaire — il n'est pas redupliqué.
 
 ### Enums
 
@@ -77,18 +81,18 @@ CommentaireStatut = BROUILLON | PUBLIE
 IndiceConfiance =
   OBJECTIF_COMPROMIS | APPUIS_NECESSAIRE | OBJECTIF_ATTEIGNABLE | OBJECTIF_SECURISE
 
-IndicateurIndividuCommentaireType = TYPE_COMMENTAIRE_1   -- placeholder
-PanierIndividuCommentaireType     = TYPE_COMMENTAIRE_1   -- placeholder
-PanierCommentaireType             = TYPE_COMMENTAIRE_1   -- placeholder
+IndicateurIndividuCommentaireType = DEFAUT | CONFIANCE
+PanierIndividuCommentaireType     = DEFAUT | CONFIANCE
+PanierCommentaireType             = DEFAUT | CONFIANCE | OBJECTIF
 ```
 
-> **Types = placeholder.** Les vrais types métier ne sont pas figés dans ce périmètre. On seed chaque enum avec `TYPE_COMMENTAIRE_1` ; la migration correspondante sera remplacée quand les vraies valeurs seront connues.
+> **`type` = catégorie du commentaire.** `DEFAUT` = commentaire libre ; `CONFIANCE` = commentaire porteur d'indices de confiance (`NiveauConfiance`) ; `OBJECTIF` (panier) = commentaire d'objectif. Chaque secteur a son propre enum.
 
 ## 4. Règles métier
 
-- **Commentaire libre** = commentaire **sans** `NiveauConfiance`. **Commentaire météo** = commentaire **avec** `NiveauConfiance`. Les deux sections de l'onglet (PIL-1581/1588) se déduisent de la présence/absence du satellite.
-- **Courante** d'un scope = indice du dernier commentaire **PUBLIE** porteur d'un `NiveauConfiance` (pour le picto d'onglet). **Historique météo** = ces commentaires, antichronologique.
-- **Édition météo** : seule la **dernière publiée** du scope est éditable, **par son auteur** (PIL-1583/1590). Modifie indice + contenu.
+- **Commentaire libre** = type `DEFAUT` (sans `NiveauConfiance`). **Commentaire de confiance** = type `CONFIANCE` (porte un ou plusieurs `NiveauConfiance`). Les deux sections de l'onglet (PIL-1581/1588) se déduisent du `type`.
+- **Courant** d'un scope = indice courant (dernier `NiveauConfiance` par `createdAt`) du dernier commentaire `CONFIANCE` **PUBLIE** du scope (pour le picto d'onglet). **Historique des indices** = les indices des commentaires `CONFIANCE`, antichronologique.
+- **Édition d'un niveau de confiance** : seul le **dernier publié** du scope est éditable, **par son auteur** (PIL-1583/1590). Modifie indice + contenu.
 - **Édition commentaire libre** : **tout** commentaire publié reste éditable **par son auteur** (PIL-1586/1593).
 - **Max 1 brouillon par (scope, auteur)** (PIL-1585/1592). Appliqué **en logique applicative dans la transaction** de création (le contrôle porte sur des colonnes réparties socle + satellite, non exprimable en index unique partiel mono-table). À documenter comme invariant testé.
 - **Contenu vide** autorisé à la création ; un check « contenu non vide à la publication » est une **règle à confirmer avec le PO** (non bloquante).
@@ -112,9 +116,9 @@ Pluriel partout, `individuId` dans le path. `{sujet}` = `indicateurs` | `paniers
 | Méthode | Route |
 |---|---|
 | `POST` | `/{sujet}/{id}[/individus/{individuId}]/commentaires` — body `{ type, contenu }` |
-| `GET` | `/{sujet}/{id}[/individus/{individuId}]/commentaires?type=…` — exclut les commentaires-météo, antichrono, paginé |
+| `GET` | `/{sujet}/{id}[/individus/{individuId}]/commentaires?type=…` — exclut les commentaires de confiance (type `CONFIANCE`), antichrono, paginé |
 
-**Météo / niveau de confiance**
+**Niveau de confiance**
 
 | Méthode | Route |
 |---|---|
@@ -155,24 +159,23 @@ packages/mb-shared/src/
 
 **Fondation (PR n°1 — ce qu'on ouvre maintenant)** :
 - Schéma Prisma : socle `Commentaire`, les **3 satellites**, `NiveauConfiance`, tous les enums (+ back-relations sur `Principal` et sur les sujets).
-- Migration correspondante (placeholder de types incluse).
+- Migration correspondante (enums `type` réels : `DEFAUT` / `CONFIANCE` / `OBJECTIF`).
 - Schémas Zod socle dans `mb-shared/src/commentaire.ts`.
 - Mutation transverse socle (`PUT`/`DELETE /commentaires/{id}`) + `resolveCommentaireSujet`.
 - Pré-câblage du montage des 4 routers dans `app.ts` (les routers secteurs sont des modules vides à remplir → `app.ts` n'est plus touché par les secteurs).
 
 **Secteurs (en // après merge de la fondation)** — chaque secteur, sur ses fichiers propres :
 1. `POST` + `GET` commentaires libres.
-2. `POST`/`PUT`/`GET courante`/`GET historique` météo.
+2. `POST`/`PUT`/`GET courant`/`GET historique` niveau de confiance.
 3. Schémas Zod du secteur + commands/queries + permissions (réutilise `with{Indicateur,Panier}WritePermission`).
 
 Points de contact partagés réduits au strict minimum : `app.ts` (pré-câblé en fondation), `schema.prisma` (entièrement en fondation). Les `routes.ts` existants des domaines `indicateur`/`panier` **ne sont pas** modifiés (les commentaires vivent dans le domaine `commentaire/`).
 
 ## 7. Hors périmètre (volontairement non modélisé)
 
-Mentions, pièces jointes, notifications, réponses/threads imbriqués, agrégation automatique de météo (la météo panier est une saisie manuelle, **sans** agrégation des météos d'indicateurs). Pagination « Voir plus » = offset/limit applicatif, pas de structure dédiée.
+Mentions, pièces jointes, notifications, réponses/threads imbriqués, agrégation automatique du niveau de confiance (le niveau de confiance panier est une saisie manuelle, **sans** agrégation des niveaux de confiance des indicateurs). Pagination « Voir plus » = offset/limit applicatif, pas de structure dédiée.
 
 ## 8. Questions ouvertes (PO)
 
 1. Check « contenu non vide à la publication » : oui/non ?
 2. Un « droit de saisie de commentaire » dédié, ou mapping sur la permission `WRITE` du sujet ?
-3. Valeurs réelles des enums `type` (remplacent le placeholder).

--- a/docs/superpowers/specs/2026-06-23-commentaires-niveau-confiance-design.md
+++ b/docs/superpowers/specs/2026-06-23-commentaires-niveau-confiance-design.md
@@ -1,0 +1,178 @@
+# Commentaires & Niveau de confiance — Conception (mb-api)
+
+> Périmètre : tickets **PIL-1581 → PIL-1593** (commentaires + météo/niveau de confiance sur indicateurs et paniers).
+> Cible : `apps/mb-api` (Hono + Prisma + Zod, CQRS léger). Aucun de ces concepts n'existe aujourd'hui dans mb-api.
+
+## 1. Contexte & motivation
+
+Sur le legacy `pilote-ppg`, chaque nature de commentaire avait sa propre table (`commentaire` typé par maille, `synthese_des_resultats` avec une colonne `meteo`), ce qui rendait l'affectation de la météo et l'ajout de nouveaux types douloureux et rigides.
+
+On repart d'une conception **générique** : un **socle `Commentaire`** unique (contenu, statut, auteur, dates) sur lequel viennent se greffer des **satellites** qui portent le rattachement à un sujet et la catégorie. La météo devient un satellite parmi d'autres — fin de la rigidité « une table par nature ».
+
+## 2. Décisions structurantes
+
+1. **Socle + satellites.** Un seul `Commentaire` porte les champs communs. Chaque sujet commentable a sa propre table satellite (FK → `Commentaire`, FK → sujet) **avec son propre enum `type`** (anti-fourre-tout : pas de table générique mélangeant catégorie + type).
+2. **3 secteurs dans ce lot** : `IndicateurIndividuCommentaire`, `PanierIndividuCommentaire`, `PanierCommentaire` (global, sans individu). Indicateur et panier-par-individu portent une dimension `individuId` ; le panier global non.
+3. **La météo n'est pas une table versionnée.** Un `NiveauConfiance` est accroché à **un commentaire** (1:1). Comme les commentaires sont append-only, l'historique des météos **émerge** de la suite des commentaires porteurs d'un indice. La « courante » = l'indice du dernier commentaire **publié** du scope qui porte un `NiveauConfiance`.
+4. **Statut BROUILLON / PUBLIE** sur le socle, piloté par le `PUT`. Max **1 brouillon par (scope, auteur)**.
+5. **`individuId` dans le path** (et non le body) : routes imbriquées `…/individus/{individuId}/commentaires`. Cohérent avec mb-api où `individus` est déjà une sous-ressource d'un sujet (`/indicateurs/{id}/individus`, `/referentiels/{id}/individus`). Profondeur 3 niveaux assumée (≤3, conforme aux guidelines REST type Zalando/Microsoft).
+6. **Espace d'`id` unifié sur le socle** : `PUT /commentaires/{id}` et `DELETE /commentaires/{id}` opèrent sur le socle, quel que soit le satellite (un resolver retrouve le sujet pour le contrôle de permission).
+7. **Contenu** = richtext (HTML) + un champ **`contenuTexte`** dérivé (plain text) pour le futur LLM et la recherche. `contenu` peut être la **chaîne vide `""`** (jamais `null`) à la création.
+
+## 3. Modèle de données
+
+### Socle
+
+```
+Commentaire
+  id            uuid (PK, app-generated)
+  contenu       text          -- richtext/HTML, "" autorisé
+  contenuTexte  text          -- plain text dérivé (LLM/recherche)
+  statut        CommentaireStatut  -- BROUILLON | PUBLIE
+  createdBy     uuid (FK → Principal)
+  updatedBy     uuid (FK → Principal)
+  createdAt     timestamptz
+  updatedAt     timestamptz
+```
+
+### Satellites (FK → Commentaire en PK, cascade ; FK → sujet)
+
+```
+IndicateurIndividuCommentaire
+  commentaireId  uuid (PK, FK → Commentaire, onDelete Cascade)
+  indicateurId   uuid (FK → Indicateur, onDelete Cascade)
+  individuId     uuid (FK → Individu,    onDelete Restrict)
+  type           IndicateurIndividuCommentaireType
+  @@index([indicateurId, individuId])
+
+PanierIndividuCommentaire
+  commentaireId  uuid (PK, FK → Commentaire, onDelete Cascade)
+  panierId       uuid (FK → Panier,   onDelete Cascade)
+  individuId     uuid (FK → Individu, onDelete Restrict)
+  type           PanierIndividuCommentaireType
+  @@index([panierId, individuId])
+
+PanierCommentaire                       -- global, pas d'individu
+  commentaireId  uuid (PK, FK → Commentaire, onDelete Cascade)
+  panierId       uuid (FK → Panier, onDelete Cascade)
+  type           PanierCommentaireType
+  @@index([panierId])
+```
+
+### Météo (satellite 1:1 sur le commentaire)
+
+```
+NiveauConfiance
+  commentaireId  uuid (PK, FK → Commentaire, onDelete Cascade)
+  indice         IndiceConfiance
+```
+
+Le scope (sujet + éventuel individu) du `NiveauConfiance` est **hérité** du satellite du commentaire — il n'est pas redupliqué.
+
+### Enums
+
+```
+CommentaireStatut = BROUILLON | PUBLIE
+
+IndiceConfiance =
+  OBJECTIF_COMPROMIS | APPUIS_NECESSAIRE | OBJECTIF_ATTEIGNABLE | OBJECTIF_SECURISE
+
+IndicateurIndividuCommentaireType = TYPE_COMMENTAIRE_1   -- placeholder
+PanierIndividuCommentaireType     = TYPE_COMMENTAIRE_1   -- placeholder
+PanierCommentaireType             = TYPE_COMMENTAIRE_1   -- placeholder
+```
+
+> **Types = placeholder.** Les vrais types métier ne sont pas figés dans ce périmètre. On seed chaque enum avec `TYPE_COMMENTAIRE_1` ; la migration correspondante sera remplacée quand les vraies valeurs seront connues.
+
+## 4. Règles métier
+
+- **Commentaire libre** = commentaire **sans** `NiveauConfiance`. **Commentaire météo** = commentaire **avec** `NiveauConfiance`. Les deux sections de l'onglet (PIL-1581/1588) se déduisent de la présence/absence du satellite.
+- **Courante** d'un scope = indice du dernier commentaire **PUBLIE** porteur d'un `NiveauConfiance` (pour le picto d'onglet). **Historique météo** = ces commentaires, antichronologique.
+- **Édition météo** : seule la **dernière publiée** du scope est éditable, **par son auteur** (PIL-1583/1590). Modifie indice + contenu.
+- **Édition commentaire libre** : **tout** commentaire publié reste éditable **par son auteur** (PIL-1586/1593).
+- **Max 1 brouillon par (scope, auteur)** (PIL-1585/1592). Appliqué **en logique applicative dans la transaction** de création (le contrôle porte sur des colonnes réparties socle + satellite, non exprimable en index unique partiel mono-table). À documenter comme invariant testé.
+- **Contenu vide** autorisé à la création ; un check « contenu non vide à la publication » est une **règle à confirmer avec le PO** (non bloquante).
+- **Permissions** : lecture = `READ` sur le sujet ; écriture (création/édition) = `WRITE` sur le sujet (mapping du « droit de saisie de commentaire » des tickets, à raffiner si un droit dédié émerge). Édition réservée à l'auteur (`createdBy === principal courant`).
+
+## 5. API
+
+Pluriel partout, `individuId` dans le path. `{sujet}` = `indicateurs` | `paniers`.
+
+### Mutations transverses (socle, secteur « socle »)
+
+| Méthode | Route | Body | Notes |
+|---|---|---|---|
+| `PUT` | `/commentaires/{commentaireId}` | `{ contenu?, statut? }` | Met à jour le socle. Auteur only. Resolver sujet → permission `WRITE`. |
+| `DELETE` | `/commentaires/{commentaireId}` | — | Auteur only. |
+
+### Par secteur (mêmes formes, scope différent)
+
+**Commentaires libres**
+
+| Méthode | Route |
+|---|---|
+| `POST` | `/{sujet}/{id}[/individus/{individuId}]/commentaires` — body `{ type, contenu }` |
+| `GET` | `/{sujet}/{id}[/individus/{individuId}]/commentaires?type=…` — exclut les commentaires-météo, antichrono, paginé |
+
+**Météo / niveau de confiance**
+
+| Méthode | Route |
+|---|---|
+| `POST` | `/{sujet}/{id}[/individus/{individuId}]/niveau-confiance` — body `{ indice, contenu? }` → crée `Commentaire` + `NiveauConfiance` |
+| `PUT` | `/{sujet}/{id}[/individus/{individuId}]/niveau-confiance/{commentaireId}` — body `{ indice?, contenu?, statut? }` (dernière publiée + auteur) |
+| `GET` | `/{sujet}/{id}[/individus/{individuId}]/niveau-confiance` — courante |
+| `GET` | `/{sujet}/{id}[/individus/{individuId}]/niveau-confiance/historique` — antichrono |
+
+Concrètement, les 3 secteurs déclinent :
+- **IndicateurIndividu** : `/indicateurs/{id}/individus/{individuId}/…`
+- **PanierIndividu** : `/paniers/{id}/individus/{individuId}/…`
+- **Panier (global)** : `/paniers/{id}/…`
+
+## 6. Découpage pour parallélisation (3 secteurs + socle)
+
+Objectif : 3 développeurs (3 Claudes) avancent **en parallèle** sur les 3 secteurs, après une **fondation** mergée d'abord. Layout pensé pour des fichiers **disjoints** (zéro conflit de merge).
+
+```
+apps/mb-api/src/commentaire/
+  socle/                         ← FONDATION (PR n°1, ce lot)
+    routes.ts                    PUT/DELETE /commentaires/{id}
+    commands/updateCommentaire.ts, deleteCommentaire.ts
+    resolveCommentaireSujet.ts   commentaire → sujet + contrôle permission
+    utils.ts                     toCommentaireApiModel
+  indicateurIndividu/            ← SECTEUR 1
+    routes.ts | commands/ | queries/
+  panierIndividu/                ← SECTEUR 2
+    routes.ts | commands/ | queries/
+  panier/                        ← SECTEUR 3
+    routes.ts | commands/ | queries/
+
+packages/mb-shared/src/
+  commentaire.ts                 ← FONDATION : socle (commentaireApiModel, statut, indiceConfiance, niveauConfiance)
+  commentaireIndicateurIndividu.ts  ← SECTEUR 1
+  commentairePanierIndividu.ts      ← SECTEUR 2
+  commentairePanier.ts              ← SECTEUR 3
+```
+
+**Fondation (PR n°1 — ce qu'on ouvre maintenant)** :
+- Schéma Prisma : socle `Commentaire`, les **3 satellites**, `NiveauConfiance`, tous les enums (+ back-relations sur `Principal` et sur les sujets).
+- Migration correspondante (placeholder de types incluse).
+- Schémas Zod socle dans `mb-shared/src/commentaire.ts`.
+- Mutation transverse socle (`PUT`/`DELETE /commentaires/{id}`) + `resolveCommentaireSujet`.
+- Pré-câblage du montage des 4 routers dans `app.ts` (les routers secteurs sont des modules vides à remplir → `app.ts` n'est plus touché par les secteurs).
+
+**Secteurs (en // après merge de la fondation)** — chaque secteur, sur ses fichiers propres :
+1. `POST` + `GET` commentaires libres.
+2. `POST`/`PUT`/`GET courante`/`GET historique` météo.
+3. Schémas Zod du secteur + commands/queries + permissions (réutilise `with{Indicateur,Panier}WritePermission`).
+
+Points de contact partagés réduits au strict minimum : `app.ts` (pré-câblé en fondation), `schema.prisma` (entièrement en fondation). Les `routes.ts` existants des domaines `indicateur`/`panier` **ne sont pas** modifiés (les commentaires vivent dans le domaine `commentaire/`).
+
+## 7. Hors périmètre (volontairement non modélisé)
+
+Mentions, pièces jointes, notifications, réponses/threads imbriqués, agrégation automatique de météo (la météo panier est une saisie manuelle, **sans** agrégation des météos d'indicateurs). Pagination « Voir plus » = offset/limit applicatif, pas de structure dédiée.
+
+## 8. Questions ouvertes (PO)
+
+1. Check « contenu non vide à la publication » : oui/non ?
+2. Un « droit de saisie de commentaire » dédié, ou mapping sur la permission `WRITE` du sujet ?
+3. Valeurs réelles des enums `type` (remplacent le placeholder).

--- a/docs/superpowers/specs/2026-06-23-commentaires-niveau-confiance-design.md
+++ b/docs/superpowers/specs/2026-06-23-commentaires-niveau-confiance-design.md
@@ -14,10 +14,10 @@ On repart d'une conception **générique** : un **socle `Commentaire`** unique (
 1. **Socle + satellites.** Un seul `Commentaire` porte les champs communs. Chaque sujet commentable a sa propre table satellite (FK → `Commentaire`, FK → sujet) **avec son propre enum `type`** (anti-fourre-tout : pas de table générique mélangeant catégorie + type).
 2. **3 secteurs dans ce lot** : `IndicateurIndividuCommentaire`, `PanierIndividuCommentaire`, `PanierCommentaire` (global, sans individu). Indicateur et panier-par-individu portent une dimension `individuId` ; le panier global non.
 3. **Le niveau de confiance n'est pas une table dédiée à part.** Un `NiveauConfiance` est accroché à **un commentaire** en **1:n** : un commentaire de type `CONFIANCE` porte un ou plusieurs indices ordonnés par date (historique d'indices, et autres usages à venir). L'indice « courant » d'un commentaire = le dernier (`createdAt` max) ; l'indice de confiance « courant » d'un scope = l'indice courant du dernier commentaire `CONFIANCE` **publié** du scope.
-4. **Statut BROUILLON / PUBLIE** sur le socle, piloté par le `PUT`. Max **1 brouillon par (scope, auteur)**.
+4. **Statut BROUILLON / PUBLIE** sur le socle, choisi à la création (`POST` body) puis piloté par le `PUT`. Max **1 brouillon par (scope, auteur)**.
 5. **`individuId` dans le path** (et non le body) : routes imbriquées `…/individus/{individuId}/commentaires`. Cohérent avec mb-api où `individus` est déjà une sous-ressource d'un sujet (`/indicateurs/{id}/individus`, `/referentiels/{id}/individus`). Profondeur 3 niveaux assumée (≤3, conforme aux guidelines REST type Zalando/Microsoft).
 6. **Espace d'`id` unifié sur le socle** : `PUT /commentaires/{id}` et `DELETE /commentaires/{id}` opèrent sur le socle, quel que soit le satellite (un resolver retrouve le sujet pour le contrôle de permission).
-7. **Contenu** = richtext (HTML) + un champ **`contenuTexte`** dérivé (plain text) pour le futur LLM et la recherche. `contenu` peut être la **chaîne vide `""`** (jamais `null`) à la création.
+7. **Contenu** = richtext (HTML) + un champ **`contenuTexte`** dérivé (plain text) pour le futur LLM et la recherche, **interne (DB uniquement, non exposé dans le modèle API)**. `contenu` peut être la **chaîne vide `""`** (jamais `null`) à la création.
 
 ## 3. Modèle de données
 
@@ -27,7 +27,7 @@ On repart d'une conception **générique** : un **socle `Commentaire`** unique (
 Commentaire
   id            uuid (PK, app-generated)
   contenu       text          -- richtext/HTML, "" autorisé
-  contenuTexte  text          -- plain text dérivé (LLM/recherche)
+  contenuTexte  text          -- plain text dérivé (LLM/recherche), interne (non exposé en API)
   statut        CommentaireStatut  -- BROUILLON | PUBLIE
   createdBy     uuid (FK → Principal)
   updatedBy     uuid (FK → Principal)
@@ -115,8 +115,8 @@ Pluriel partout, `individuId` dans le path. `{sujet}` = `indicateurs` | `paniers
 
 | Méthode | Route |
 |---|---|
-| `POST` | `/{sujet}/{id}[/individus/{individuId}]/commentaires` — body `{ type, contenu }` |
-| `GET` | `/{sujet}/{id}[/individus/{individuId}]/commentaires?type=…` — exclut les commentaires de confiance (type `CONFIANCE`), antichrono, paginé |
+| `POST` | `/{sujet}/{id}[/individus/{individuId}]/commentaires` — body `{ type, contenu, statut }` |
+| `GET` | `/{sujet}/{id}[/individus/{individuId}]/commentaires?type=…` — `type` requis (l'appelant choisit la catégorie), antichrono, paginé |
 
 **Niveau de confiance**
 

--- a/packages/mb-shared/package.json
+++ b/packages/mb-shared/package.json
@@ -12,6 +12,10 @@
       "types": "./src/dates.ts",
       "default": "./src/dates.ts"
     },
+    "./commentaire": {
+      "types": "./src/commentaire.ts",
+      "default": "./src/commentaire.ts"
+    },
     "./error": {
       "types": "./src/error.ts",
       "default": "./src/error.ts"

--- a/packages/mb-shared/src/commentaire.ts
+++ b/packages/mb-shared/src/commentaire.ts
@@ -1,0 +1,84 @@
+import { z } from 'zod'
+
+import { createPaginatedApiListSchema, pageSizeSchema, paginationCursorSchema } from './pagination'
+
+export const commentaireStatutSchema = z
+  .enum(['BROUILLON', 'PUBLIE'])
+  .describe('Statut du commentaire : BROUILLON (en cours de rédaction) ou PUBLIE (visible).')
+export type CommentaireStatut = z.infer<typeof commentaireStatutSchema>
+
+// Enums `type` par sujet (chaque sujet a ses propres valeurs).
+export const indicateurIndividuCommentaireTypeSchema = z.enum(['DEFAUT', 'CONFIANCE'])
+export const panierIndividuCommentaireTypeSchema = z.enum(['DEFAUT', 'CONFIANCE'])
+export const panierCommentaireTypeSchema = z.enum(['DEFAUT', 'CONFIANCE', 'OBJECTIF'])
+
+const auteurApiModelSchema = z
+  .object({
+    id: z.string().uuid().describe('Identifiant du principal (utilisateur ou clé API).'),
+    email: z
+      .string()
+      .email()
+      .nullable()
+      .describe('Email de l’auteur si c’est un utilisateur, sinon null.'),
+  })
+  .describe('Auteur d’un commentaire.')
+
+export const commentaireApiModelSchema = z
+  .object({
+    id: z.string().uuid().describe('Identifiant du commentaire.'),
+    type: z.string().describe('Catégorie du commentaire (enum propre au sujet).'),
+    individuId: z
+      .string()
+      .nullable()
+      .describe(
+        'Identifiant public de l’individu rattaché, ou null pour un commentaire global de panier.',
+      ),
+    contenu: z.string().describe('Contenu HTML riche (peut être vide).'),
+    contenuTexte: z.string().describe('Contenu en texte brut, dérivé du HTML (recherche / LLM).'),
+    statut: commentaireStatutSchema,
+    auteurCreation: auteurApiModelSchema,
+    auteurModification: auteurApiModelSchema,
+    createdAt: z.string().datetime().describe('Date ISO 8601 de création.'),
+    updatedAt: z.string().datetime().describe('Date ISO 8601 de dernière modification.'),
+  })
+  .describe('Commentaire.')
+export type CommentaireApiModel = z.infer<typeof commentaireApiModelSchema>
+
+// Body de création : `type` est contraint par le sujet (cf. factory ci-dessous).
+const creerCommentaireBodySchema = <T extends z.ZodTypeAny>(typeSchema: T) =>
+  z.object({
+    type: typeSchema.describe('Catégorie du commentaire.'),
+    contenu: z.string().describe('Contenu HTML riche (la chaîne vide est autorisée).'),
+    statut: commentaireStatutSchema,
+  })
+
+export const creerIndicateurIndividuCommentaireBodySchema = creerCommentaireBodySchema(
+  indicateurIndividuCommentaireTypeSchema,
+)
+export const creerPanierIndividuCommentaireBodySchema = creerCommentaireBodySchema(
+  panierIndividuCommentaireTypeSchema,
+)
+export const creerPanierCommentaireBodySchema = creerCommentaireBodySchema(
+  panierCommentaireTypeSchema,
+)
+export type CreerCommentaireBody = z.infer<typeof creerIndicateurIndividuCommentaireBodySchema>
+
+// Body de modification (socle, par id) : type non modifiable, individu/sujet figés.
+export const modifierCommentaireBodySchema = z
+  .object({
+    contenu: z.string().optional().describe('Nouveau contenu HTML (optionnel).'),
+    statut: commentaireStatutSchema.optional().describe('Nouveau statut (optionnel).'),
+  })
+  .describe('Modification du contenu et/ou du statut d’un commentaire.')
+export type ModifierCommentaireBody = z.infer<typeof modifierCommentaireBodySchema>
+
+// Query de listing : filtre optionnel par type + pagination cursor.
+export const listerCommentairesQuerySchema = z.object({
+  type: z.string().optional().describe('Filtre optionnel sur la catégorie du commentaire.'),
+  cursor: paginationCursorSchema.optional(),
+  pageSize: pageSizeSchema,
+})
+export type ListerCommentairesQuery = z.infer<typeof listerCommentairesQuerySchema>
+
+export const commentaireListApiModelSchema = createPaginatedApiListSchema(commentaireApiModelSchema)
+export type CommentaireListApiModel = z.infer<typeof commentaireListApiModelSchema>

--- a/packages/mb-shared/src/commentaire.ts
+++ b/packages/mb-shared/src/commentaire.ts
@@ -61,7 +61,13 @@ export const creerPanierIndividuCommentaireBodySchema = creerCommentaireBodySche
 export const creerPanierCommentaireBodySchema = creerCommentaireBodySchema(
   panierCommentaireTypeSchema,
 )
-export type CreerCommentaireBody = z.infer<typeof creerIndicateurIndividuCommentaireBodySchema>
+// Type « élargi » consommé par la couche générique : le `type` est déjà validé
+// par le schéma propre au sujet (route), donc ici on accepte n'importe quelle valeur.
+export type CreerCommentaireBody = {
+  type: string
+  contenu: string
+  statut: CommentaireStatut
+}
 
 // Body de modification (socle, par id) : type non modifiable, individu/sujet figés.
 export const modifierCommentaireBodySchema = z

--- a/packages/mb-shared/src/commentaire.ts
+++ b/packages/mb-shared/src/commentaire.ts
@@ -1,90 +1,131 @@
-import { z } from 'zod'
+import { z } from "zod";
 
-import { createPaginatedApiListSchema, pageSizeSchema, paginationCursorSchema } from './pagination'
+import {
+  createPaginatedApiListSchema,
+  pageSizeSchema,
+  paginationCursorSchema,
+} from "./pagination";
 
 export const commentaireStatutSchema = z
-  .enum(['BROUILLON', 'PUBLIE'])
-  .describe('Statut du commentaire : BROUILLON (en cours de rédaction) ou PUBLIE (visible).')
-export type CommentaireStatut = z.infer<typeof commentaireStatutSchema>
+  .enum(["BROUILLON", "PUBLIE"])
+  .describe(
+    "Statut du commentaire : BROUILLON (en cours de rédaction) ou PUBLIE (visible).",
+  );
+export type CommentaireStatut = z.infer<typeof commentaireStatutSchema>;
 
 // Enums `type` par sujet (chaque sujet a ses propres valeurs).
-export const indicateurIndividuCommentaireTypeSchema = z.enum(['DEFAUT', 'CONFIANCE'])
-export const panierIndividuCommentaireTypeSchema = z.enum(['DEFAUT', 'CONFIANCE'])
-export const panierCommentaireTypeSchema = z.enum(['DEFAUT', 'CONFIANCE', 'OBJECTIF'])
+export const indicateurIndividuCommentaireTypeSchema = z.enum([
+  "DEFAUT",
+  "CONFIANCE",
+]);
+export const panierIndividuCommentaireTypeSchema = z.enum([
+  "DEFAUT",
+  "CONFIANCE",
+]);
+export const panierCommentaireTypeSchema = z.enum([
+  "DEFAUT",
+  "CONFIANCE",
+  "OBJECTIF",
+]);
+
+const auteurUtilisateurApiModelSchema = z.object({
+  type: z.literal("utilisateur"),
+  id: z.string().uuid().describe("Identifiant du principal."),
+  email: z.string().email().describe("Email de l’utilisateur."),
+});
+
+const auteurApiKeyApiModelSchema = z.object({
+  type: z.literal("apiKey"),
+  id: z.string().uuid().describe("Identifiant du principal."),
+  label: z.string().describe("Libellé de la clé API."),
+});
 
 const auteurApiModelSchema = z
-  .object({
-    id: z.string().uuid().describe('Identifiant du principal (utilisateur ou clé API).'),
-    email: z
-      .string()
-      .email()
-      .nullable()
-      .describe('Email de l’auteur si c’est un utilisateur, sinon null.'),
-  })
-  .describe('Auteur d’un commentaire.')
+  .discriminatedUnion("type", [
+    auteurUtilisateurApiModelSchema,
+    auteurApiKeyApiModelSchema,
+  ])
+  .describe("Auteur d’un commentaire (utilisateur ou clé API).");
 
 export const commentaireApiModelSchema = z
   .object({
-    id: z.string().uuid().describe('Identifiant du commentaire.'),
-    type: z.string().describe('Catégorie du commentaire (enum propre au sujet).'),
+    id: z.string().uuid().describe("Identifiant du commentaire."),
+    type: z
+      .string()
+      .describe("Catégorie du commentaire (enum propre au sujet)."),
     individuId: z
       .string()
       .nullable()
       .describe(
-        'Identifiant public de l’individu rattaché, ou null pour un commentaire global de panier.',
+        "Identifiant public de l’individu rattaché, ou null pour un commentaire global de panier.",
       ),
-    contenu: z.string().describe('Contenu HTML riche (peut être vide).'),
-    contenuTexte: z.string().describe('Contenu en texte brut, dérivé du HTML (recherche / LLM).'),
+    contenu: z.string().describe("Contenu HTML riche (peut être vide)."),
     statut: commentaireStatutSchema,
     auteurCreation: auteurApiModelSchema,
     auteurModification: auteurApiModelSchema,
-    createdAt: z.string().datetime().describe('Date ISO 8601 de création.'),
-    updatedAt: z.string().datetime().describe('Date ISO 8601 de dernière modification.'),
+    createdAt: z.string().datetime().describe("Date ISO 8601 de création."),
+    updatedAt: z
+      .string()
+      .datetime()
+      .describe("Date ISO 8601 de dernière modification."),
   })
-  .describe('Commentaire.')
-export type CommentaireApiModel = z.infer<typeof commentaireApiModelSchema>
+  .describe("Commentaire.");
+export type CommentaireApiModel = z.infer<typeof commentaireApiModelSchema>;
 
 // Body de création : `type` est contraint par le sujet (cf. factory ci-dessous).
 const creerCommentaireBodySchema = <T extends z.ZodTypeAny>(typeSchema: T) =>
   z.object({
-    type: typeSchema.describe('Catégorie du commentaire.'),
-    contenu: z.string().describe('Contenu HTML riche (la chaîne vide est autorisée).'),
+    type: typeSchema.describe("Catégorie du commentaire."),
+    contenu: z
+      .string()
+      .describe("Contenu HTML riche (la chaîne vide est autorisée)."),
     statut: commentaireStatutSchema,
-  })
+  });
 
-export const creerIndicateurIndividuCommentaireBodySchema = creerCommentaireBodySchema(
-  indicateurIndividuCommentaireTypeSchema,
-)
-export const creerPanierIndividuCommentaireBodySchema = creerCommentaireBodySchema(
-  panierIndividuCommentaireTypeSchema,
-)
+export const creerIndicateurIndividuCommentaireBodySchema =
+  creerCommentaireBodySchema(indicateurIndividuCommentaireTypeSchema);
+export const creerPanierIndividuCommentaireBodySchema =
+  creerCommentaireBodySchema(panierIndividuCommentaireTypeSchema);
 export const creerPanierCommentaireBodySchema = creerCommentaireBodySchema(
   panierCommentaireTypeSchema,
-)
+);
 // Type « élargi » consommé par la couche générique : le `type` est déjà validé
 // par le schéma propre au sujet (route), donc ici on accepte n'importe quelle valeur.
 export type CreerCommentaireBody = {
-  type: string
-  contenu: string
-  statut: CommentaireStatut
-}
+  type: string;
+  contenu: string;
+  statut: CommentaireStatut;
+};
 
 // Body de modification (socle, par id) : type non modifiable, individu/sujet figés.
 export const modifierCommentaireBodySchema = z
   .object({
-    contenu: z.string().optional().describe('Nouveau contenu HTML (optionnel).'),
-    statut: commentaireStatutSchema.optional().describe('Nouveau statut (optionnel).'),
+    contenu: z
+      .string()
+      .optional()
+      .describe("Nouveau contenu HTML (optionnel)."),
+    statut: commentaireStatutSchema
+      .optional()
+      .describe("Nouveau statut (optionnel)."),
   })
-  .describe('Modification du contenu et/ou du statut d’un commentaire.')
-export type ModifierCommentaireBody = z.infer<typeof modifierCommentaireBodySchema>
+  .describe("Modification du contenu et/ou du statut d’un commentaire.");
+export type ModifierCommentaireBody = z.infer<
+  typeof modifierCommentaireBodySchema
+>;
 
-// Query de listing : filtre optionnel par type + pagination cursor.
+// Query de listing : filtre `type` obligatoire (l'appelant choisit la catégorie) + pagination cursor.
 export const listerCommentairesQuerySchema = z.object({
-  type: z.string().optional().describe('Filtre optionnel sur la catégorie du commentaire.'),
+  type: z.string().describe("Catégorie du commentaire (enum propre au sujet)."),
   cursor: paginationCursorSchema.optional(),
   pageSize: pageSizeSchema,
-})
-export type ListerCommentairesQuery = z.infer<typeof listerCommentairesQuerySchema>
+});
+export type ListerCommentairesQuery = z.infer<
+  typeof listerCommentairesQuerySchema
+>;
 
-export const commentaireListApiModelSchema = createPaginatedApiListSchema(commentaireApiModelSchema)
-export type CommentaireListApiModel = z.infer<typeof commentaireListApiModelSchema>
+export const commentaireListApiModelSchema = createPaginatedApiListSchema(
+  commentaireApiModelSchema,
+);
+export type CommentaireListApiModel = z.infer<
+  typeof commentaireListApiModelSchema
+>;

--- a/packages/mb-shared/src/commentaire.ts
+++ b/packages/mb-shared/src/commentaire.ts
@@ -113,15 +113,28 @@ export type ModifierCommentaireBody = z.infer<
   typeof modifierCommentaireBodySchema
 >;
 
-// Query de listing : filtre `type` obligatoire (l'appelant choisit la catégorie) + pagination cursor.
-export const listerCommentairesQuerySchema = z.object({
-  type: z.string().describe("Catégorie du commentaire (enum propre au sujet)."),
-  cursor: paginationCursorSchema.optional(),
-  pageSize: pageSizeSchema,
-});
-export type ListerCommentairesQuery = z.infer<
-  typeof listerCommentairesQuerySchema
->;
+// Query de listing : `type` obligatoire, contraint par le sujet (cf. factory ci-dessous).
+const listerCommentairesQuerySchema = <T extends z.ZodTypeAny>(typeSchema: T) =>
+  z.object({
+    type: typeSchema.describe("Catégorie du commentaire."),
+    cursor: paginationCursorSchema.optional(),
+    pageSize: pageSizeSchema,
+  });
+
+export const listerIndicateurIndividuCommentairesQuerySchema =
+  listerCommentairesQuerySchema(indicateurIndividuCommentaireTypeSchema);
+export const listerPanierIndividuCommentairesQuerySchema =
+  listerCommentairesQuerySchema(panierIndividuCommentaireTypeSchema);
+export const listerPanierCommentairesQuerySchema = listerCommentairesQuerySchema(
+  panierCommentaireTypeSchema,
+);
+// Type « élargi » consommé par la couche générique : le `type` est déjà validé
+// par le schéma propre au sujet (route).
+export type ListerCommentairesQuery = {
+  type: string;
+  cursor?: string | undefined;
+  pageSize?: number | undefined;
+};
 
 export const commentaireListApiModelSchema = createPaginatedApiListSchema(
   commentaireApiModelSchema,


### PR DESCRIPTION
## Contexte

Système de **commentaires** + **niveau de confiance** pour `mb-api`, en remplacement de l'approche rigide de `pilote-ppg` (une table par nature de commentaire). Couvre les tickets **PIL-1581 → PIL-1593**.

Cette PR contient le **schéma de données** ET l'**implémentation des commentaires libres** (3 sujets). Le niveau de confiance (type `CONFIANCE` + endpoints dédiés) fera l'objet d'une PR de suivi (plan 2).

## Modèle de données (socle + satellites)

- **`Commentaire`** (socle) : `contenu` (richtext, `""` autorisé) + `contenuTexte` (texte dérivé) + `statut` (BROUILLON/PUBLIE) + auteur/dates.
- **3 satellites** (FK → `Commentaire`, FK → sujet, enum `type` propre) : `IndicateurIndividuCommentaire`, `PanierIndividuCommentaire`, `PanierCommentaire` (global).
- **`NiveauConfiance`** : satellite **1:n** sur un commentaire (`indice` ∈ OBJECTIF_COMPROMIS / APPUIS_NECESSAIRE / OBJECTIF_ATTEIGNABLE / OBJECTIF_SECURISE) — historique d'indices. *(Endpoints au plan 2.)*
- Enums `type` : `DEFAUT` / `CONFIANCE` (+ `OBJECTIF` côté panier).

## Implémentation (commentaires libres)

Domaine `src/commentaire/` avec un **cœur générique** (zéro triplication) piloté par un descripteur de sujet :
- `POST` / `GET` scopés sujet, `individuId` **dans le path** (`…/individus/{individuId}/commentaires`).
- `PUT` / `DELETE /commentaires/{id}` : mutation socle (espace d'id unifié, **auteur uniquement**).
- Règle **1 brouillon max par (scope, auteur)** (PIL-1585/1592).
- Listing antichronologique (uuidv7 → `id desc`), pagination cursor, exclusion du type `CONFIANCE`.

## Tests & qualité

- **361 tests** mb-api PASS (dont commentaires : commands/queries d'intégration + câblage OpenAPI).
- `pnpm lint` (eslint + tsc + prettier) **vert**.
- Migration appliquée sans drift.
- 8 routes commentaires exposées dans `/openapi.json` (vérifié par test).

## À suivre (plan 2)
Endpoints niveau de confiance (`POST`/`PUT`/`GET courant`/`GET historique`), sémantique 1:n.

🤖 Generated with [Claude Code](https://claude.com/claude-code)