### PR TITLE
feat: contacts utiles sur les paniers

### DIFF
--- a/apps/mb-api/prisma/migrations/20260622100000_contacts_utiles/migration.sql
+++ b/apps/mb-api/prisma/migrations/20260622100000_contacts_utiles/migration.sql
@@ -1,0 +1,28 @@
+CREATE TABLE "organisme" (
+  "id" UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  "nom" TEXT NOT NULL,
+  "created_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+  "updated_at" TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE "contact_utile" (
+  "id" UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  "organisme_id" UUID NOT NULL REFERENCES "organisme"("id") ON DELETE RESTRICT,
+  "nom" TEXT NOT NULL,
+  "description" TEXT,
+  "telephone" TEXT,
+  "email" TEXT,
+  "url" TEXT,
+  "adresse" TEXT,
+  "created_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+  "updated_at" TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE "panier_contact_utile" (
+  "panier_id" UUID NOT NULL REFERENCES "panier"("id") ON DELETE CASCADE,
+  "contact_utile_id" UUID NOT NULL REFERENCES "contact_utile"("id") ON DELETE CASCADE,
+  "created_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY ("panier_id", "contact_utile_id")
+);
+
+CREATE INDEX "panier_contact_utile_panier_id_idx" ON "panier_contact_utile"("panier_id");

--- a/apps/mb-api/prisma/schema.prisma
+++ b/apps/mb-api/prisma/schema.prisma
@@ -14,14 +14,14 @@ model Principal {
   id        String   @id @db.Uuid
   createdAt DateTime @default(now()) @map("created_at")
 
-  utilisateur           Utilisateur?
-  apiKey                ApiKey?
-  indicateurPermissions IndicateurPermission[]
-  panierPermissions     PanierPermission[]
-  commentairesCrees       Commentaire[]     @relation("commentaireCreatedBy")
-  commentairesModifies    Commentaire[]     @relation("commentaireUpdatedBy")
-  niveauxConfianceCrees   NiveauConfiance[] @relation("niveauConfianceCreatedBy")
-  niveauxConfianceModifies NiveauConfiance[] @relation("niveauConfianceUpdatedBy")
+  utilisateur              Utilisateur?
+  apiKey                   ApiKey?
+  indicateurPermissions    IndicateurPermission[]
+  panierPermissions        PanierPermission[]
+  commentairesCrees        Commentaire[]          @relation("commentaireCreatedBy")
+  commentairesModifies     Commentaire[]          @relation("commentaireUpdatedBy")
+  niveauxConfianceCrees    NiveauConfiance[]      @relation("niveauConfianceCreatedBy")
+  niveauxConfianceModifies NiveauConfiance[]      @relation("niveauConfianceUpdatedBy")
 
   @@map("principal")
 }
@@ -309,6 +309,7 @@ model Panier {
   responsables         PanierResponsable[]
   individuCommentaires PanierIndividuCommentaire[]
   panierCommentaires   PanierCommentaire[]
+  contactsUtiles       PanierContactUtile[]
 
   @@map("panier")
 }
@@ -342,16 +343,58 @@ model PanierIndicateur {
 }
 
 model PanierResponsable {
-  panierId      String   @map("panier_id")      @db.Uuid
+  panierId      String   @map("panier_id") @db.Uuid
   utilisateurId String   @map("utilisateur_id") @db.Uuid
-  createdAt     DateTime @default(now())         @map("created_at")
+  createdAt     DateTime @default(now()) @map("created_at")
 
-  panier      Panier      @relation(fields: [panierId],      references: [id], onDelete: Cascade)
+  panier      Panier      @relation(fields: [panierId], references: [id], onDelete: Cascade)
   utilisateur Utilisateur @relation(fields: [utilisateurId], references: [id], onDelete: Cascade)
 
   @@id([panierId, utilisateurId])
   @@index([panierId, createdAt])
   @@map("panier_responsable")
+}
+
+model Organisme {
+  id        String   @id @default(uuid()) @db.Uuid
+  nom       String
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
+
+  contacts ContactUtile[]
+
+  @@map("organisme")
+}
+
+model ContactUtile {
+  id          String   @id @default(uuid()) @db.Uuid
+  organismeId String   @map("organisme_id") @db.Uuid
+  nom         String
+  description String?
+  telephone   String?
+  email       String?
+  url         String?
+  adresse     String?
+  createdAt   DateTime @default(now()) @map("created_at")
+  updatedAt   DateTime @updatedAt @map("updated_at")
+
+  organisme Organisme            @relation(fields: [organismeId], references: [id])
+  paniers   PanierContactUtile[]
+
+  @@map("contact_utile")
+}
+
+model PanierContactUtile {
+  panierId       String   @map("panier_id") @db.Uuid
+  contactUtileId String   @map("contact_utile_id") @db.Uuid
+  createdAt      DateTime @default(now()) @map("created_at")
+
+  panier       Panier       @relation(fields: [panierId], references: [id], onDelete: Cascade)
+  contactUtile ContactUtile @relation(fields: [contactUtileId], references: [id], onDelete: Cascade)
+
+  @@id([panierId, contactUtileId])
+  @@index([panierId])
+  @@map("panier_contact_utile")
 }
 
 enum ApplicationLogLevel {

--- a/apps/mb-api/prisma/seed.ts
+++ b/apps/mb-api/prisma/seed.ts
@@ -816,14 +816,12 @@ const main = async () => {
     where: { email: 'claire.dupont@example.com' },
     select: { id: true },
   })
-  if (pan005) {
-    for (const utilisateurId of [ditpAdmin.id, claireDupont.id]) {
-      await prisma.panierResponsable.upsert({
-        where: { panierId_utilisateurId: { panierId: pan005.id, utilisateurId } },
-        update: {},
-        create: { panierId: pan005.id, utilisateurId },
-      })
-    }
+  for (const utilisateurId of [ditpAdmin.id, claireDupont.id]) {
+    await prisma.panierResponsable.upsert({
+      where: { panierId_utilisateurId: { panierId: pan005.id, utilisateurId } },
+      update: {},
+      create: { panierId: pan005.id, utilisateurId },
+    })
   }
   const panierResponsablesCount = 2
 

--- a/apps/mb-api/prisma/seed.ts
+++ b/apps/mb-api/prisma/seed.ts
@@ -832,19 +832,19 @@ const main = async () => {
   const prismaAny = prisma as any
 
   const ditp = await prismaAny.organisme.upsert({
-    where:  { id: 'a1b2c3d4-0000-0000-0000-000000000001' },
+    where: { id: 'a1b2c3d4-0000-0000-0000-000000000001' },
     update: {},
     create: {
-      id:  'a1b2c3d4-0000-0000-0000-000000000001',
+      id: 'a1b2c3d4-0000-0000-0000-000000000001',
       nom: 'Direction interministérielle de la transformation publique (DITP)',
     },
   })
 
   const dinum = await prismaAny.organisme.upsert({
-    where:  { id: 'a1b2c3d4-0000-0000-0000-000000000002' },
+    where: { id: 'a1b2c3d4-0000-0000-0000-000000000002' },
     update: {},
     create: {
-      id:  'a1b2c3d4-0000-0000-0000-000000000002',
+      id: 'a1b2c3d4-0000-0000-0000-000000000002',
       nom: 'Direction interministérielle du numérique (DINUM)',
     },
   })
@@ -852,55 +852,56 @@ const main = async () => {
   // ── Contacts utiles ────────────────────────────────────────────────────────────
 
   const supportMethodo = await prismaAny.contactUtile.upsert({
-    where:  { id: 'b0000000-0000-0000-0000-000000000001' },
+    where: { id: 'b0000000-0000-0000-0000-000000000001' },
     update: {},
     create: {
-      id:          'b0000000-0000-0000-0000-000000000001',
+      id: 'b0000000-0000-0000-0000-000000000001',
       organismeId: ditp.id,
-      nom:         'Support méthodologique et accompagnement',
-      description: 'Accompagnement des équipes projet dans la démarche de pilotage par les résultats',
-      telephone:   '01 23 45 67 89',
-      email:       'support.methodologie@ditp.gouv.fr',
-      url:         'https://www.modernisation.gouv.fr',
-      adresse:     '20 avenue de Ségur, 75007 Paris',
+      nom: 'Support méthodologique et accompagnement',
+      description:
+        'Accompagnement des équipes projet dans la démarche de pilotage par les résultats',
+      telephone: '01 23 45 67 89',
+      email: 'support.methodologie@ditp.gouv.fr',
+      url: 'https://www.modernisation.gouv.fr',
+      adresse: '20 avenue de Ségur, 75007 Paris',
     },
   })
 
   const celluleFormation = await prismaAny.contactUtile.upsert({
-    where:  { id: 'b0000000-0000-0000-0000-000000000002' },
+    where: { id: 'b0000000-0000-0000-0000-000000000002' },
     update: {},
     create: {
-      id:          'b0000000-0000-0000-0000-000000000002',
+      id: 'b0000000-0000-0000-0000-000000000002',
       organismeId: ditp.id,
-      nom:         'Cellule formation et montée en compétences',
+      nom: 'Cellule formation et montée en compétences',
       description: 'Formations au pilotage par les résultats, ateliers et webinaires',
-      telephone:   '01 23 45 67 90',
-      email:       'formation@ditp.gouv.fr',
+      telephone: '01 23 45 67 90',
+      email: 'formation@ditp.gouv.fr',
     },
   })
 
   const supportTechnique = await prismaAny.contactUtile.upsert({
-    where:  { id: 'b0000000-0000-0000-0000-000000000003' },
+    where: { id: 'b0000000-0000-0000-0000-000000000003' },
     update: {},
     create: {
-      id:          'b0000000-0000-0000-0000-000000000003',
+      id: 'b0000000-0000-0000-0000-000000000003',
       organismeId: dinum.id,
-      nom:         'Support technique Pilote',
-      email:       'support@pilote.gouv.fr',
-      url:         'https://pilote.numerique.gouv.fr',
+      nom: 'Support technique Pilote',
+      email: 'support@pilote.gouv.fr',
+      url: 'https://pilote.numerique.gouv.fr',
     },
   })
 
   const ouvertureDonnees = await prismaAny.contactUtile.upsert({
-    where:  { id: 'b0000000-0000-0000-0000-000000000004' },
+    where: { id: 'b0000000-0000-0000-0000-000000000004' },
     update: {},
     create: {
-      id:          'b0000000-0000-0000-0000-000000000004',
+      id: 'b0000000-0000-0000-0000-000000000004',
       organismeId: dinum.id,
-      nom:         'Département ouverture des données',
+      nom: 'Département ouverture des données',
       description: "Accompagnement à l'ouverture et au partage des données publiques",
-      email:       'data@numerique.gouv.fr',
-      url:         'https://data.gouv.fr',
+      email: 'data@numerique.gouv.fr',
+      url: 'https://data.gouv.fr',
     },
   })
 
@@ -909,7 +910,7 @@ const main = async () => {
   if (pan005) {
     for (const contact of [supportMethodo, celluleFormation, supportTechnique, ouvertureDonnees]) {
       await prismaAny.panierContactUtile.upsert({
-        where:  { panierId_contactUtileId: { panierId: pan005.id, contactUtileId: contact.id } },
+        where: { panierId_contactUtileId: { panierId: pan005.id, contactUtileId: contact.id } },
         update: {},
         create: { panierId: pan005.id, contactUtileId: contact.id },
       })
@@ -918,7 +919,9 @@ const main = async () => {
 
   if (pan004) {
     await prismaAny.panierContactUtile.upsert({
-      where:  { panierId_contactUtileId: { panierId: pan004.id, contactUtileId: ouvertureDonnees.id } },
+      where: {
+        panierId_contactUtileId: { panierId: pan004.id, contactUtileId: ouvertureDonnees.id },
+      },
       update: {},
       create: { panierId: pan004.id, contactUtileId: ouvertureDonnees.id },
     })

--- a/apps/mb-api/prisma/seed.ts
+++ b/apps/mb-api/prisma/seed.ts
@@ -832,19 +832,19 @@ const main = async () => {
   const prismaAny = prisma as any
 
   const ditp = await prismaAny.organisme.upsert({
-    where: { id: 'a1b2c3d4-0000-0000-0000-000000000001' },
+    where: { id: 'a1b2c3d4-e5f6-4a7b-8c9d-e0f1a2b3c401' },
     update: {},
     create: {
-      id: 'a1b2c3d4-0000-0000-0000-000000000001',
+      id: 'a1b2c3d4-e5f6-4a7b-8c9d-e0f1a2b3c401',
       nom: 'Direction interministérielle de la transformation publique (DITP)',
     },
   })
 
   const dinum = await prismaAny.organisme.upsert({
-    where: { id: 'a1b2c3d4-0000-0000-0000-000000000002' },
+    where: { id: 'a1b2c3d4-e5f6-4a7b-8c9d-e0f1a2b3c402' },
     update: {},
     create: {
-      id: 'a1b2c3d4-0000-0000-0000-000000000002',
+      id: 'a1b2c3d4-e5f6-4a7b-8c9d-e0f1a2b3c402',
       nom: 'Direction interministérielle du numérique (DINUM)',
     },
   })
@@ -852,10 +852,10 @@ const main = async () => {
   // ── Contacts utiles ────────────────────────────────────────────────────────────
 
   const supportMethodo = await prismaAny.contactUtile.upsert({
-    where: { id: 'b0000000-0000-0000-0000-000000000001' },
+    where: { id: 'b1c2d3e4-f5a6-4b7c-8d9e-f0a1b2c3d401' },
     update: {},
     create: {
-      id: 'b0000000-0000-0000-0000-000000000001',
+      id: 'b1c2d3e4-f5a6-4b7c-8d9e-f0a1b2c3d401',
       organismeId: ditp.id,
       nom: 'Support méthodologique et accompagnement',
       description:
@@ -868,10 +868,10 @@ const main = async () => {
   })
 
   const celluleFormation = await prismaAny.contactUtile.upsert({
-    where: { id: 'b0000000-0000-0000-0000-000000000002' },
+    where: { id: 'b1c2d3e4-f5a6-4b7c-8d9e-f0a1b2c3d402' },
     update: {},
     create: {
-      id: 'b0000000-0000-0000-0000-000000000002',
+      id: 'b1c2d3e4-f5a6-4b7c-8d9e-f0a1b2c3d402',
       organismeId: ditp.id,
       nom: 'Cellule formation et montée en compétences',
       description: 'Formations au pilotage par les résultats, ateliers et webinaires',
@@ -881,10 +881,10 @@ const main = async () => {
   })
 
   const supportTechnique = await prismaAny.contactUtile.upsert({
-    where: { id: 'b0000000-0000-0000-0000-000000000003' },
+    where: { id: 'b1c2d3e4-f5a6-4b7c-8d9e-f0a1b2c3d403' },
     update: {},
     create: {
-      id: 'b0000000-0000-0000-0000-000000000003',
+      id: 'b1c2d3e4-f5a6-4b7c-8d9e-f0a1b2c3d403',
       organismeId: dinum.id,
       nom: 'Support technique Pilote',
       email: 'support@pilote.gouv.fr',
@@ -893,10 +893,10 @@ const main = async () => {
   })
 
   const ouvertureDonnees = await prismaAny.contactUtile.upsert({
-    where: { id: 'b0000000-0000-0000-0000-000000000004' },
+    where: { id: 'b1c2d3e4-f5a6-4b7c-8d9e-f0a1b2c3d404' },
     update: {},
     create: {
-      id: 'b0000000-0000-0000-0000-000000000004',
+      id: 'b1c2d3e4-f5a6-4b7c-8d9e-f0a1b2c3d404',
       organismeId: dinum.id,
       nom: 'Département ouverture des données',
       description: "Accompagnement à l'ouverture et au partage des données publiques",

--- a/apps/mb-api/prisma/seed.ts
+++ b/apps/mb-api/prisma/seed.ts
@@ -810,8 +810,8 @@ const main = async () => {
   const panierPermissionsCount = 2
 
   // Responsables panier : ditp.admin et claire.dupont sont responsables de PAN-005.
-  const pan005 = paniersByPublicId.get('PAN-005')
-  const pan004 = paniersByPublicId.get('PAN-004')
+  const pan005 = paniersByPublicId.get('PAN-005')!
+  const pan004 = paniersByPublicId.get('PAN-004')!
   const claireDupont = await prisma.utilisateur.findUniqueOrThrow({
     where: { email: 'claire.dupont@example.com' },
     select: { id: true },
@@ -828,10 +828,8 @@ const main = async () => {
   const panierResponsablesCount = 2
 
   // ── Organismes ────────────────────────────────────────────────────────────────
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const prismaAny = prisma as any
 
-  const ditp = await prismaAny.organisme.upsert({
+  const ditp = await prisma.organisme.upsert({
     where: { id: 'a1b2c3d4-e5f6-4a7b-8c9d-e0f1a2b3c401' },
     update: {},
     create: {
@@ -840,7 +838,7 @@ const main = async () => {
     },
   })
 
-  const dinum = await prismaAny.organisme.upsert({
+  const dinum = await prisma.organisme.upsert({
     where: { id: 'a1b2c3d4-e5f6-4a7b-8c9d-e0f1a2b3c402' },
     update: {},
     create: {
@@ -851,7 +849,7 @@ const main = async () => {
 
   // ── Contacts utiles ────────────────────────────────────────────────────────────
 
-  const supportMethodo = await prismaAny.contactUtile.upsert({
+  const supportMethodo = await prisma.contactUtile.upsert({
     where: { id: 'b1c2d3e4-f5a6-4b7c-8d9e-f0a1b2c3d401' },
     update: {},
     create: {
@@ -867,7 +865,7 @@ const main = async () => {
     },
   })
 
-  const celluleFormation = await prismaAny.contactUtile.upsert({
+  const celluleFormation = await prisma.contactUtile.upsert({
     where: { id: 'b1c2d3e4-f5a6-4b7c-8d9e-f0a1b2c3d402' },
     update: {},
     create: {
@@ -880,7 +878,7 @@ const main = async () => {
     },
   })
 
-  const supportTechnique = await prismaAny.contactUtile.upsert({
+  const supportTechnique = await prisma.contactUtile.upsert({
     where: { id: 'b1c2d3e4-f5a6-4b7c-8d9e-f0a1b2c3d403' },
     update: {},
     create: {
@@ -892,7 +890,7 @@ const main = async () => {
     },
   })
 
-  const ouvertureDonnees = await prismaAny.contactUtile.upsert({
+  const ouvertureDonnees = await prisma.contactUtile.upsert({
     where: { id: 'b1c2d3e4-f5a6-4b7c-8d9e-f0a1b2c3d404' },
     update: {},
     create: {
@@ -907,25 +905,21 @@ const main = async () => {
 
   // ── Rattachements ──────────────────────────────────────────────────────────────
 
-  if (pan005) {
-    for (const contact of [supportMethodo, celluleFormation, supportTechnique, ouvertureDonnees]) {
-      await prismaAny.panierContactUtile.upsert({
-        where: { panierId_contactUtileId: { panierId: pan005.id, contactUtileId: contact.id } },
-        update: {},
-        create: { panierId: pan005.id, contactUtileId: contact.id },
-      })
-    }
-  }
-
-  if (pan004) {
-    await prismaAny.panierContactUtile.upsert({
-      where: {
-        panierId_contactUtileId: { panierId: pan004.id, contactUtileId: ouvertureDonnees.id },
-      },
+  for (const contact of [supportMethodo, celluleFormation, supportTechnique, ouvertureDonnees]) {
+    await prisma.panierContactUtile.upsert({
+      where: { panierId_contactUtileId: { panierId: pan005.id, contactUtileId: contact.id } },
       update: {},
-      create: { panierId: pan004.id, contactUtileId: ouvertureDonnees.id },
+      create: { panierId: pan005.id, contactUtileId: contact.id },
     })
   }
+
+  await prisma.panierContactUtile.upsert({
+    where: {
+      panierId_contactUtileId: { panierId: pan004.id, contactUtileId: ouvertureDonnees.id },
+    },
+    update: {},
+    create: { panierId: pan004.id, contactUtileId: ouvertureDonnees.id },
+  })
 
   const contactsUtilesCount = 4
 

--- a/apps/mb-api/prisma/seed.ts
+++ b/apps/mb-api/prisma/seed.ts
@@ -811,6 +811,7 @@ const main = async () => {
 
   // Responsables panier : ditp.admin et claire.dupont sont responsables de PAN-005.
   const pan005 = paniersByPublicId.get('PAN-005')
+  const pan004 = paniersByPublicId.get('PAN-004')
   const claireDupont = await prisma.utilisateur.findUniqueOrThrow({
     where: { email: 'claire.dupont@example.com' },
     select: { id: true },
@@ -826,10 +827,109 @@ const main = async () => {
   }
   const panierResponsablesCount = 2
 
+  // ── Organismes ────────────────────────────────────────────────────────────────
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const prismaAny = prisma as any
+
+  const ditp = await prismaAny.organisme.upsert({
+    where:  { id: 'a1b2c3d4-0000-0000-0000-000000000001' },
+    update: {},
+    create: {
+      id:  'a1b2c3d4-0000-0000-0000-000000000001',
+      nom: 'Direction interministérielle de la transformation publique (DITP)',
+    },
+  })
+
+  const dinum = await prismaAny.organisme.upsert({
+    where:  { id: 'a1b2c3d4-0000-0000-0000-000000000002' },
+    update: {},
+    create: {
+      id:  'a1b2c3d4-0000-0000-0000-000000000002',
+      nom: 'Direction interministérielle du numérique (DINUM)',
+    },
+  })
+
+  // ── Contacts utiles ────────────────────────────────────────────────────────────
+
+  const supportMethodo = await prismaAny.contactUtile.upsert({
+    where:  { id: 'b0000000-0000-0000-0000-000000000001' },
+    update: {},
+    create: {
+      id:          'b0000000-0000-0000-0000-000000000001',
+      organismeId: ditp.id,
+      nom:         'Support méthodologique et accompagnement',
+      description: 'Accompagnement des équipes projet dans la démarche de pilotage par les résultats',
+      telephone:   '01 23 45 67 89',
+      email:       'support.methodologie@ditp.gouv.fr',
+      url:         'https://www.modernisation.gouv.fr',
+      adresse:     '20 avenue de Ségur, 75007 Paris',
+    },
+  })
+
+  const celluleFormation = await prismaAny.contactUtile.upsert({
+    where:  { id: 'b0000000-0000-0000-0000-000000000002' },
+    update: {},
+    create: {
+      id:          'b0000000-0000-0000-0000-000000000002',
+      organismeId: ditp.id,
+      nom:         'Cellule formation et montée en compétences',
+      description: 'Formations au pilotage par les résultats, ateliers et webinaires',
+      telephone:   '01 23 45 67 90',
+      email:       'formation@ditp.gouv.fr',
+    },
+  })
+
+  const supportTechnique = await prismaAny.contactUtile.upsert({
+    where:  { id: 'b0000000-0000-0000-0000-000000000003' },
+    update: {},
+    create: {
+      id:          'b0000000-0000-0000-0000-000000000003',
+      organismeId: dinum.id,
+      nom:         'Support technique Pilote',
+      email:       'support@pilote.gouv.fr',
+      url:         'https://pilote.numerique.gouv.fr',
+    },
+  })
+
+  const ouvertureDonnees = await prismaAny.contactUtile.upsert({
+    where:  { id: 'b0000000-0000-0000-0000-000000000004' },
+    update: {},
+    create: {
+      id:          'b0000000-0000-0000-0000-000000000004',
+      organismeId: dinum.id,
+      nom:         'Département ouverture des données',
+      description: "Accompagnement à l'ouverture et au partage des données publiques",
+      email:       'data@numerique.gouv.fr',
+      url:         'https://data.gouv.fr',
+    },
+  })
+
+  // ── Rattachements ──────────────────────────────────────────────────────────────
+
+  if (pan005) {
+    for (const contact of [supportMethodo, celluleFormation, supportTechnique, ouvertureDonnees]) {
+      await prismaAny.panierContactUtile.upsert({
+        where:  { panierId_contactUtileId: { panierId: pan005.id, contactUtileId: contact.id } },
+        update: {},
+        create: { panierId: pan005.id, contactUtileId: contact.id },
+      })
+    }
+  }
+
+  if (pan004) {
+    await prismaAny.panierContactUtile.upsert({
+      where:  { panierId_contactUtileId: { panierId: pan004.id, contactUtileId: ouvertureDonnees.id } },
+      update: {},
+      create: { panierId: pan004.id, contactUtileId: ouvertureDonnees.id },
+    })
+  }
+
+  const contactsUtilesCount = 4
+
   const permissionsCount = 8 * 2
   const widgetLiaisonsCount = widgetsSeed.reduce((acc, w) => acc + w.referentielPublicIds.length, 0)
   console.log(
-    `Seed terminé : ${indicateursSeed.length} indicateurs, ${utilisateursSeed.length} utilisateurs, ${permissionsCount} permissions indicateur, ${referentielsSeed.length} référentiels, ${individusSeed.length} individus, ${liaisonsCount} liaisons indicateur-référentiel, ${relationsSeed.length} relations, ${valeursCount} valeurs insérées, ${objectifsCount} objectifs insérés (les doublons ont été ignorés), ${widgetsSeed.length} widgets, ${widgetLiaisonsCount} liaisons référentiel-widget, ${paniersSeed.length} paniers (${panierLiaisonsCount} liaisons panier-indicateur, ${panierPermissionsCount} permissions panier, ${panierResponsablesCount} responsable panier).`,
+    `Seed terminé : ${indicateursSeed.length} indicateurs, ${utilisateursSeed.length} utilisateurs, ${permissionsCount} permissions indicateur, ${referentielsSeed.length} référentiels, ${individusSeed.length} individus, ${liaisonsCount} liaisons indicateur-référentiel, ${relationsSeed.length} relations, ${valeursCount} valeurs insérées, ${objectifsCount} objectifs insérés (les doublons ont été ignorés), ${widgetsSeed.length} widgets, ${widgetLiaisonsCount} liaisons référentiel-widget, ${paniersSeed.length} paniers (${panierLiaisonsCount} liaisons panier-indicateur, ${panierPermissionsCount} permissions panier, ${panierResponsablesCount} responsable panier, ${contactsUtilesCount} contacts utiles).`,
   )
 }
 

--- a/apps/mb-api/src/panier/queries/getPanierContactsUtiles.test.ts
+++ b/apps/mb-api/src/panier/queries/getPanierContactsUtiles.test.ts
@@ -8,7 +8,7 @@ import { runAsPrincipal } from '@/test/runAsPrincipal'
 
 describe.concurrent('getPanierContactsUtiles', () => {
   it(
-    'retourne une liste vide quand le panier na aucun contact',
+    "retourne une liste vide quand le panier n'a aucun contact",
     integrationTest(async () => {
       const panVide = testPanierId()
       await fixtures.panier({ publicId: panVide, visibilite: 'PUBLIC' })
@@ -22,7 +22,7 @@ describe.concurrent('getPanierContactsUtiles', () => {
   )
 
   it(
-    'retourne tous les champs dun contact quand ils sont tous renseignés',
+    "retourne tous les champs d'un contact quand ils sont tous renseignés",
     integrationTest(async () => {
       const panComplet = testPanierId()
       await fixtures.panierContactUtile({
@@ -56,7 +56,7 @@ describe.concurrent('getPanierContactsUtiles', () => {
   )
 
   it(
-    'retourne null pour les champs absents dun contact minimal',
+    "retourne null pour les champs absents d'un contact minimal",
     integrationTest(async () => {
       const panMinimal = testPanierId()
       await fixtures.panierContactUtile({
@@ -143,7 +143,7 @@ describe.concurrent('getPanierContactsUtiles', () => {
   )
 
   it(
-    'trie les contacts dun organisme alphabétiquement par nom',
+    "trie les contacts d'un organisme alphabétiquement par nom",
     integrationTest(async () => {
       const panContactsTri = testPanierId()
       await fixtures.panier({ publicId: panContactsTri, visibilite: 'PUBLIC' })
@@ -206,7 +206,7 @@ describe.concurrent('getPanierContactsUtiles', () => {
   )
 
   it(
-    'lève une erreur si le panier nexiste pas',
+    "lève une erreur si le panier n'existe pas",
     integrationTest(async () => {
       const panInexistant = testPanierId()
       const apiKey = await fixtures.apiKey()

--- a/apps/mb-api/src/panier/queries/getPanierContactsUtiles.test.ts
+++ b/apps/mb-api/src/panier/queries/getPanierContactsUtiles.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, it } from 'vitest'
+
+import { getPanierContactsUtiles } from '@/panier/queries/getPanierContactsUtiles'
+import { fixtures } from '@/test/fixtures'
+import { integrationTest } from '@/test/integrationTest'
+import { testPanierId } from '@/test/randomIds'
+import { runAsPrincipal } from '@/test/runAsPrincipal'
+
+describe.concurrent('getPanierContactsUtiles', () => {
+  it(
+    'retourne une liste vide quand le panier na aucun contact',
+    integrationTest(async () => {
+      const panVide = testPanierId()
+      await fixtures.panier({ publicId: panVide, visibilite: 'PUBLIC' })
+      const apiKey = await fixtures.apiKey()
+
+      const result = await runAsPrincipal(apiKey.id, () => getPanierContactsUtiles(panVide))
+
+      expect(result.isOk()).toBe(true)
+      expect(result._unsafeUnwrap()).toEqual({ items: [] })
+    }),
+  )
+
+  it(
+    'retourne tous les champs dun contact quand ils sont tous renseignés',
+    integrationTest(async () => {
+      const panComplet = testPanierId()
+      await fixtures.panierContactUtile({
+        panier: { publicId: panComplet, visibilite: 'PUBLIC' },
+        contactUtile: {
+          nom: 'Contact complet',
+          description: 'Une description',
+          telephone: '01 23 45 67 89',
+          email: 'contact@example.com',
+          url: 'https://example.com',
+          adresse: '1 rue de la Paix, 75001 Paris',
+          organisme: { nom: 'Organisme A' },
+        },
+      })
+      const apiKey = await fixtures.apiKey()
+
+      const result = await runAsPrincipal(apiKey.id, () => getPanierContactsUtiles(panComplet))
+      const item = result._unsafeUnwrap().items[0]
+
+      expect(item).toBeDefined()
+      expect(item!.organisme.nom).toBe('Organisme A')
+      expect(item!.contacts[0]).toMatchObject({
+        nom:         'Contact complet',
+        description: 'Une description',
+        telephone:   '01 23 45 67 89',
+        email:       'contact@example.com',
+        url:         'https://example.com',
+        adresse:     '1 rue de la Paix, 75001 Paris',
+      })
+    }),
+  )
+
+  it(
+    'retourne null pour les champs absents dun contact minimal',
+    integrationTest(async () => {
+      const panMinimal = testPanierId()
+      await fixtures.panierContactUtile({
+        panier: { publicId: panMinimal, visibilite: 'PUBLIC' },
+        contactUtile: { nom: 'Contact minimal' },
+      })
+      const apiKey = await fixtures.apiKey()
+
+      const result = await runAsPrincipal(apiKey.id, () => getPanierContactsUtiles(panMinimal))
+      const contact = result._unsafeUnwrap().items[0]!.contacts[0]!
+
+      expect(contact.nom).toBe('Contact minimal')
+      expect(contact.description).toBeNull()
+      expect(contact.telephone).toBeNull()
+      expect(contact.email).toBeNull()
+      expect(contact.url).toBeNull()
+      expect(contact.adresse).toBeNull()
+    }),
+  )
+
+  it(
+    'regroupe plusieurs contacts du même organisme dans un seul item',
+    integrationTest(async () => {
+      const panGroupé = testPanierId()
+      const panierRow = await fixtures.panier({ publicId: panGroupé, visibilite: 'PUBLIC' })
+      const org = await fixtures.organisme({ nom: 'Organisme Unique' })
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const prismaDb = (await import('@/framework/persistence/dbStore')).db() as any
+      const c1 = await prismaDb.contactUtile.create({
+        data: { organismeId: org.id, nom: 'Alpha' },
+      })
+      const c2 = await prismaDb.contactUtile.create({
+        data: { organismeId: org.id, nom: 'Beta' },
+      })
+      await prismaDb.panierContactUtile.createMany({
+        data: [
+          { panierId: panierRow.id, contactUtileId: c1.id },
+          { panierId: panierRow.id, contactUtileId: c2.id },
+        ],
+      })
+      const apiKey = await fixtures.apiKey()
+
+      const result = await runAsPrincipal(apiKey.id, () => getPanierContactsUtiles(panGroupé))
+      const items = result._unsafeUnwrap().items
+
+      expect(items).toHaveLength(1)
+      expect(items[0]!.organisme.nom).toBe('Organisme Unique')
+      expect(items[0]!.contacts).toHaveLength(2)
+    }),
+  )
+
+  it(
+    'retourne plusieurs organismes triés alphabétiquement',
+    integrationTest(async () => {
+      const panTri = testPanierId()
+      const panierRow = await fixtures.panier({ publicId: panTri, visibilite: 'PUBLIC' })
+      const orgZ = await fixtures.organisme({ nom: 'Zzz Organisation' })
+      const orgA = await fixtures.organisme({ nom: 'Aaa Organisation' })
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const prismaDb = (await import('@/framework/persistence/dbStore')).db() as any
+      const cZ = await prismaDb.contactUtile.create({ data: { organismeId: orgZ.id, nom: 'Contact Z' } })
+      const cA = await prismaDb.contactUtile.create({ data: { organismeId: orgA.id, nom: 'Contact A' } })
+      await prismaDb.panierContactUtile.createMany({
+        data: [
+          { panierId: panierRow.id, contactUtileId: cZ.id },
+          { panierId: panierRow.id, contactUtileId: cA.id },
+        ],
+      })
+      const apiKey = await fixtures.apiKey()
+
+      const result = await runAsPrincipal(apiKey.id, () => getPanierContactsUtiles(panTri))
+      const noms = result._unsafeUnwrap().items.map((i) => i.organisme.nom)
+
+      expect(noms).toEqual(['Aaa Organisation', 'Zzz Organisation'])
+    }),
+  )
+
+  it(
+    'trie les contacts dun organisme alphabétiquement par nom',
+    integrationTest(async () => {
+      const panContactsTri = testPanierId()
+      const panierRow = await fixtures.panier({ publicId: panContactsTri, visibilite: 'PUBLIC' })
+      const org = await fixtures.organisme({ nom: 'Organisme Tri' })
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const prismaDb = (await import('@/framework/persistence/dbStore')).db() as any
+      const cZ = await prismaDb.contactUtile.create({ data: { organismeId: org.id, nom: 'Zebra' } })
+      const cA = await prismaDb.contactUtile.create({ data: { organismeId: org.id, nom: 'Alpha' } })
+      await prismaDb.panierContactUtile.createMany({
+        data: [
+          { panierId: panierRow.id, contactUtileId: cZ.id },
+          { panierId: panierRow.id, contactUtileId: cA.id },
+        ],
+      })
+      const apiKey = await fixtures.apiKey()
+
+      const result = await runAsPrincipal(apiKey.id, () => getPanierContactsUtiles(panContactsTri))
+      const nomsContacts = result._unsafeUnwrap().items[0]!.contacts.map((c) => c.nom)
+
+      expect(nomsContacts).toEqual(['Alpha', 'Zebra'])
+    }),
+  )
+
+  it(
+    'est accessible sur un panier PRIVE avec permission READ',
+    integrationTest(async () => {
+      const panPrive = testPanierId()
+      await fixtures.panierContactUtile({
+        panier: { publicId: panPrive, visibilite: 'PRIVE' },
+        contactUtile: { nom: 'Contact privé' },
+      })
+      const apiKey = await fixtures.apiKey({
+        panierPermissions: [{ panier: { publicId: panPrive }, action: 'READ' }],
+      })
+
+      const result = await runAsPrincipal(apiKey.id, () => getPanierContactsUtiles(panPrive))
+
+      expect(result.isOk()).toBe(true)
+      expect(result._unsafeUnwrap().items[0]!.contacts).toHaveLength(1)
+    }),
+  )
+
+  it(
+    'lève une erreur sur un panier PRIVE sans permission',
+    integrationTest(async () => {
+      const panPriveSans = testPanierId()
+      await fixtures.panier({ publicId: panPriveSans, visibilite: 'PRIVE' })
+      const apiKey = await fixtures.apiKey()
+
+      await expect(
+        runAsPrincipal(apiKey.id, () => getPanierContactsUtiles(panPriveSans)),
+      ).rejects.toThrow()
+    }),
+  )
+
+  it(
+    'lève une erreur si le panier nexiste pas',
+    integrationTest(async () => {
+      const panInexistant = testPanierId()
+      const apiKey = await fixtures.apiKey()
+
+      await expect(
+        runAsPrincipal(apiKey.id, () => getPanierContactsUtiles(panInexistant)),
+      ).rejects.toThrow()
+    }),
+  )
+
+  it(
+    'un contact rattaché à deux paniers est visible dans chacun indépendamment',
+    integrationTest(async () => {
+      const pan1 = testPanierId()
+      const pan2 = testPanierId()
+      const panierRow1 = await fixtures.panier({ publicId: pan1, visibilite: 'PUBLIC' })
+      const panierRow2 = await fixtures.panier({ publicId: pan2, visibilite: 'PUBLIC' })
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const prismaDb = (await import('@/framework/persistence/dbStore')).db() as any
+      const org = await fixtures.organisme({ nom: 'Organisme Partagé' })
+      const contact = await prismaDb.contactUtile.create({
+        data: { organismeId: org.id, nom: 'Contact Partagé' },
+      })
+      await prismaDb.panierContactUtile.createMany({
+        data: [
+          { panierId: panierRow1.id, contactUtileId: contact.id },
+          { panierId: panierRow2.id, contactUtileId: contact.id },
+        ],
+      })
+      const apiKey = await fixtures.apiKey()
+
+      const result1 = await runAsPrincipal(apiKey.id, () => getPanierContactsUtiles(pan1))
+      const result2 = await runAsPrincipal(apiKey.id, () => getPanierContactsUtiles(pan2))
+
+      expect(result1._unsafeUnwrap().items[0]!.contacts[0]!.nom).toBe('Contact Partagé')
+      expect(result2._unsafeUnwrap().items[0]!.contacts[0]!.nom).toBe('Contact Partagé')
+    }),
+  )
+})

--- a/apps/mb-api/src/panier/queries/getPanierContactsUtiles.test.ts
+++ b/apps/mb-api/src/panier/queries/getPanierContactsUtiles.test.ts
@@ -81,21 +81,23 @@ describe.concurrent('getPanierContactsUtiles', () => {
     'regroupe plusieurs contacts du même organisme dans un seul item',
     integrationTest(async () => {
       const panGroupé = testPanierId()
-      const panierRow = await fixtures.panier({ publicId: panGroupé, visibilite: 'PUBLIC' })
+      await fixtures.panier({ publicId: panGroupé, visibilite: 'PUBLIC' })
       const org = await fixtures.organisme({ nom: 'Organisme Unique' })
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const prismaDb = (await import('@/framework/persistence/dbStore')).db() as any
-      const c1 = await prismaDb.contactUtile.create({
-        data: { organismeId: org.id, nom: 'Alpha' },
+      const c1 = await fixtures.contactUtile({
+        nom: 'Alpha',
+        organisme: { id: org.id, nom: org.nom },
       })
-      const c2 = await prismaDb.contactUtile.create({
-        data: { organismeId: org.id, nom: 'Beta' },
+      const c2 = await fixtures.contactUtile({
+        nom: 'Beta',
+        organisme: { id: org.id, nom: org.nom },
       })
-      await prismaDb.panierContactUtile.createMany({
-        data: [
-          { panierId: panierRow.id, contactUtileId: c1.id },
-          { panierId: panierRow.id, contactUtileId: c2.id },
-        ],
+      await fixtures.panierContactUtile({
+        panier: { publicId: panGroupé },
+        contactUtile: { id: c1.id },
+      })
+      await fixtures.panierContactUtile({
+        panier: { publicId: panGroupé },
+        contactUtile: { id: c2.id },
       })
       const apiKey = await fixtures.apiKey()
 
@@ -112,22 +114,24 @@ describe.concurrent('getPanierContactsUtiles', () => {
     'retourne plusieurs organismes triés alphabétiquement',
     integrationTest(async () => {
       const panTri = testPanierId()
-      const panierRow = await fixtures.panier({ publicId: panTri, visibilite: 'PUBLIC' })
+      await fixtures.panier({ publicId: panTri, visibilite: 'PUBLIC' })
       const orgZ = await fixtures.organisme({ nom: 'Zzz Organisation' })
       const orgA = await fixtures.organisme({ nom: 'Aaa Organisation' })
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const prismaDb = (await import('@/framework/persistence/dbStore')).db() as any
-      const cZ = await prismaDb.contactUtile.create({
-        data: { organismeId: orgZ.id, nom: 'Contact Z' },
+      const cZ = await fixtures.contactUtile({
+        nom: 'Contact Z',
+        organisme: { id: orgZ.id, nom: orgZ.nom },
       })
-      const cA = await prismaDb.contactUtile.create({
-        data: { organismeId: orgA.id, nom: 'Contact A' },
+      const cA = await fixtures.contactUtile({
+        nom: 'Contact A',
+        organisme: { id: orgA.id, nom: orgA.nom },
       })
-      await prismaDb.panierContactUtile.createMany({
-        data: [
-          { panierId: panierRow.id, contactUtileId: cZ.id },
-          { panierId: panierRow.id, contactUtileId: cA.id },
-        ],
+      await fixtures.panierContactUtile({
+        panier: { publicId: panTri },
+        contactUtile: { id: cZ.id },
+      })
+      await fixtures.panierContactUtile({
+        panier: { publicId: panTri },
+        contactUtile: { id: cA.id },
       })
       const apiKey = await fixtures.apiKey()
 
@@ -142,17 +146,23 @@ describe.concurrent('getPanierContactsUtiles', () => {
     'trie les contacts dun organisme alphabétiquement par nom',
     integrationTest(async () => {
       const panContactsTri = testPanierId()
-      const panierRow = await fixtures.panier({ publicId: panContactsTri, visibilite: 'PUBLIC' })
+      await fixtures.panier({ publicId: panContactsTri, visibilite: 'PUBLIC' })
       const org = await fixtures.organisme({ nom: 'Organisme Tri' })
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const prismaDb = (await import('@/framework/persistence/dbStore')).db() as any
-      const cZ = await prismaDb.contactUtile.create({ data: { organismeId: org.id, nom: 'Zebra' } })
-      const cA = await prismaDb.contactUtile.create({ data: { organismeId: org.id, nom: 'Alpha' } })
-      await prismaDb.panierContactUtile.createMany({
-        data: [
-          { panierId: panierRow.id, contactUtileId: cZ.id },
-          { panierId: panierRow.id, contactUtileId: cA.id },
-        ],
+      const cZ = await fixtures.contactUtile({
+        nom: 'Zebra',
+        organisme: { id: org.id, nom: org.nom },
+      })
+      const cA = await fixtures.contactUtile({
+        nom: 'Alpha',
+        organisme: { id: org.id, nom: org.nom },
+      })
+      await fixtures.panierContactUtile({
+        panier: { publicId: panContactsTri },
+        contactUtile: { id: cZ.id },
+      })
+      await fixtures.panierContactUtile({
+        panier: { publicId: panContactsTri },
+        contactUtile: { id: cA.id },
       })
       const apiKey = await fixtures.apiKey()
 
@@ -212,19 +222,20 @@ describe.concurrent('getPanierContactsUtiles', () => {
     integrationTest(async () => {
       const pan1 = testPanierId()
       const pan2 = testPanierId()
-      const panierRow1 = await fixtures.panier({ publicId: pan1, visibilite: 'PUBLIC' })
-      const panierRow2 = await fixtures.panier({ publicId: pan2, visibilite: 'PUBLIC' })
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const prismaDb = (await import('@/framework/persistence/dbStore')).db() as any
+      await fixtures.panier({ publicId: pan1, visibilite: 'PUBLIC' })
+      await fixtures.panier({ publicId: pan2, visibilite: 'PUBLIC' })
       const org = await fixtures.organisme({ nom: 'Organisme Partagé' })
-      const contact = await prismaDb.contactUtile.create({
-        data: { organismeId: org.id, nom: 'Contact Partagé' },
+      const contact = await fixtures.contactUtile({
+        nom: 'Contact Partagé',
+        organisme: { id: org.id, nom: org.nom },
       })
-      await prismaDb.panierContactUtile.createMany({
-        data: [
-          { panierId: panierRow1.id, contactUtileId: contact.id },
-          { panierId: panierRow2.id, contactUtileId: contact.id },
-        ],
+      await fixtures.panierContactUtile({
+        panier: { publicId: pan1 },
+        contactUtile: { id: contact.id },
+      })
+      await fixtures.panierContactUtile({
+        panier: { publicId: pan2 },
+        contactUtile: { id: contact.id },
       })
       const apiKey = await fixtures.apiKey()
 

--- a/apps/mb-api/src/panier/queries/getPanierContactsUtiles.test.ts
+++ b/apps/mb-api/src/panier/queries/getPanierContactsUtiles.test.ts
@@ -45,12 +45,12 @@ describe.concurrent('getPanierContactsUtiles', () => {
       expect(item).toBeDefined()
       expect(item!.organisme.nom).toBe('Organisme A')
       expect(item!.contacts[0]).toMatchObject({
-        nom:         'Contact complet',
+        nom: 'Contact complet',
         description: 'Une description',
-        telephone:   '01 23 45 67 89',
-        email:       'contact@example.com',
-        url:         'https://example.com',
-        adresse:     '1 rue de la Paix, 75001 Paris',
+        telephone: '01 23 45 67 89',
+        email: 'contact@example.com',
+        url: 'https://example.com',
+        adresse: '1 rue de la Paix, 75001 Paris',
       })
     }),
   )
@@ -117,8 +117,12 @@ describe.concurrent('getPanierContactsUtiles', () => {
       const orgA = await fixtures.organisme({ nom: 'Aaa Organisation' })
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const prismaDb = (await import('@/framework/persistence/dbStore')).db() as any
-      const cZ = await prismaDb.contactUtile.create({ data: { organismeId: orgZ.id, nom: 'Contact Z' } })
-      const cA = await prismaDb.contactUtile.create({ data: { organismeId: orgA.id, nom: 'Contact A' } })
+      const cZ = await prismaDb.contactUtile.create({
+        data: { organismeId: orgZ.id, nom: 'Contact Z' },
+      })
+      const cA = await prismaDb.contactUtile.create({
+        data: { organismeId: orgA.id, nom: 'Contact A' },
+      })
       await prismaDb.panierContactUtile.createMany({
         data: [
           { panierId: panierRow.id, contactUtileId: cZ.id },

--- a/apps/mb-api/src/panier/queries/getPanierContactsUtiles.ts
+++ b/apps/mb-api/src/panier/queries/getPanierContactsUtiles.ts
@@ -26,15 +26,6 @@ export const getPanierContactsUtiles = (
           contacts: {
             where: { paniers: { some: { panierId } } },
             orderBy: { nom: 'asc' },
-            select: {
-              id: true,
-              nom: true,
-              description: true,
-              telephone: true,
-              email: true,
-              url: true,
-              adresse: true,
-            },
           },
         },
       }),

--- a/apps/mb-api/src/panier/queries/getPanierContactsUtiles.ts
+++ b/apps/mb-api/src/panier/queries/getPanierContactsUtiles.ts
@@ -9,56 +9,40 @@ export const getPanierContactsUtiles = (
   panierPublicId: string,
 ): ResultAsync<PanierContactsUtilesApiModel, never> => {
   const principalId = requireCurrentPrincipalId()
+
   return ResultAsync.fromSafePromise(
     db().panier.findFirstOrThrow({
       where: withPanierReadPermission({ publicId: panierPublicId }, principalId),
-      include: {
-        contactsUtiles: {
-          include: {
-            contactUtile: {
-              include: {
-                organisme: true,
-              },
+      select: { id: true },
+    }),
+  ).andThen(({ id: panierId }) =>
+    ResultAsync.fromSafePromise(
+      db().organisme.findMany({
+        where: { contacts: { some: { paniers: { some: { panierId } } } } },
+        orderBy: { nom: 'asc' },
+        select: {
+          id: true,
+          nom: true,
+          contacts: {
+            where: { paniers: { some: { panierId } } },
+            orderBy: { nom: 'asc' },
+            select: {
+              id: true,
+              nom: true,
+              description: true,
+              telephone: true,
+              email: true,
+              url: true,
+              adresse: true,
             },
           },
-          orderBy: [
-            { contactUtile: { organisme: { nom: 'asc' } } },
-            { contactUtile: { nom: 'asc' } },
-          ],
         },
-      },
-    }),
-  ).map((panier) => {
-    const grouped = new Map<
-      string,
-      {
-        organisme: { id: string; nom: string }
-        contacts: (typeof panier.contactsUtiles)[0]['contactUtile'][]
-      }
-    >()
-
-    for (const joinRow of panier.contactsUtiles) {
-      const c = joinRow.contactUtile
-      const o = c.organisme
-      if (!grouped.has(o.id)) {
-        grouped.set(o.id, { organisme: { id: o.id, nom: o.nom }, contacts: [] })
-      }
-      grouped.get(o.id)!.contacts.push(c)
-    }
-
-    return {
-      items: Array.from(grouped.values()).map(({ organisme, contacts }) => ({
-        organisme,
-        contacts: contacts.map((c) => ({
-          id: c.id,
-          nom: c.nom,
-          description: c.description,
-          telephone: c.telephone,
-          email: c.email,
-          url: c.url,
-          adresse: c.adresse,
-        })),
+      }),
+    ).map((organismes) => ({
+      items: organismes.map(({ id, nom, contacts }) => ({
+        organisme: { id, nom },
+        contacts,
       })),
-    }
-  })
+    })),
+  )
 }

--- a/apps/mb-api/src/panier/queries/getPanierContactsUtiles.ts
+++ b/apps/mb-api/src/panier/queries/getPanierContactsUtiles.ts
@@ -31,7 +31,13 @@ export const getPanierContactsUtiles = (
       },
     }),
   ).map((panier) => {
-    const grouped = new Map<string, { organisme: { id: string; nom: string }; contacts: typeof panier.contactsUtiles[0]['contactUtile'][] }>()
+    const grouped = new Map<
+      string,
+      {
+        organisme: { id: string; nom: string }
+        contacts: (typeof panier.contactsUtiles)[0]['contactUtile'][]
+      }
+    >()
 
     for (const joinRow of panier.contactsUtiles) {
       const c = joinRow.contactUtile
@@ -46,13 +52,13 @@ export const getPanierContactsUtiles = (
       items: Array.from(grouped.values()).map(({ organisme, contacts }) => ({
         organisme,
         contacts: contacts.map((c) => ({
-          id:          c.id,
-          nom:         c.nom,
+          id: c.id,
+          nom: c.nom,
           description: c.description,
-          telephone:   c.telephone,
-          email:       c.email,
-          url:         c.url,
-          adresse:     c.adresse,
+          telephone: c.telephone,
+          email: c.email,
+          url: c.url,
+          adresse: c.adresse,
         })),
       })),
     }

--- a/apps/mb-api/src/panier/queries/getPanierContactsUtiles.ts
+++ b/apps/mb-api/src/panier/queries/getPanierContactsUtiles.ts
@@ -9,10 +9,8 @@ export const getPanierContactsUtiles = (
   panierPublicId: string,
 ): ResultAsync<PanierContactsUtilesApiModel, never> => {
   const principalId = requireCurrentPrincipalId()
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const prismaDb = db() as any
   return ResultAsync.fromSafePromise(
-    prismaDb.panier.findFirstOrThrow({
+    db().panier.findFirstOrThrow({
       where: withPanierReadPermission({ publicId: panierPublicId }, principalId),
       include: {
         contactsUtiles: {

--- a/apps/mb-api/src/panier/queries/getPanierContactsUtiles.ts
+++ b/apps/mb-api/src/panier/queries/getPanierContactsUtiles.ts
@@ -1,0 +1,60 @@
+import { type PanierContactsUtilesApiModel } from '@pilote/mb-shared/panierContactUtile'
+import { ResultAsync } from 'neverthrow'
+
+import { requireCurrentPrincipalId } from '@/framework/auth/userContext'
+import { db } from '@/framework/persistence/dbStore'
+import { withPanierReadPermission } from '@/panier/permissions'
+
+export const getPanierContactsUtiles = (
+  panierPublicId: string,
+): ResultAsync<PanierContactsUtilesApiModel, never> => {
+  const principalId = requireCurrentPrincipalId()
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const prismaDb = db() as any
+  return ResultAsync.fromSafePromise(
+    prismaDb.panier.findFirstOrThrow({
+      where: withPanierReadPermission({ publicId: panierPublicId }, principalId),
+      include: {
+        contactsUtiles: {
+          include: {
+            contactUtile: {
+              include: {
+                organisme: true,
+              },
+            },
+          },
+          orderBy: [
+            { contactUtile: { organisme: { nom: 'asc' } } },
+            { contactUtile: { nom: 'asc' } },
+          ],
+        },
+      },
+    }),
+  ).map((panier) => {
+    const grouped = new Map<string, { organisme: { id: string; nom: string }; contacts: typeof panier.contactsUtiles[0]['contactUtile'][] }>()
+
+    for (const joinRow of panier.contactsUtiles) {
+      const c = joinRow.contactUtile
+      const o = c.organisme
+      if (!grouped.has(o.id)) {
+        grouped.set(o.id, { organisme: { id: o.id, nom: o.nom }, contacts: [] })
+      }
+      grouped.get(o.id)!.contacts.push(c)
+    }
+
+    return {
+      items: Array.from(grouped.values()).map(({ organisme, contacts }) => ({
+        organisme,
+        contacts: contacts.map((c) => ({
+          id:          c.id,
+          nom:         c.nom,
+          description: c.description,
+          telephone:   c.telephone,
+          email:       c.email,
+          url:         c.url,
+          adresse:     c.adresse,
+        })),
+      })),
+    }
+  })
+}

--- a/apps/mb-api/src/panier/routes.ts
+++ b/apps/mb-api/src/panier/routes.ts
@@ -11,6 +11,7 @@ import {
   panierApiModelSchema,
   panierListApiModelSchema,
 } from '@pilote/mb-shared/panier'
+import { panierContactsUtilesApiModelSchema } from '@pilote/mb-shared/panierContactUtile'
 import { panierResponsablesApiModelSchema } from '@pilote/mb-shared/panierResponsable'
 import {
   getPanierTauxProgressionQuerySchema,
@@ -43,6 +44,7 @@ import {
   panierIndividuConfig,
 } from '@/panier/commands/creerPanierIndividuCommentaire'
 import { getPanierByPublicId } from '@/panier/queries/getPanierByPublicId'
+import { getPanierContactsUtiles } from '@/panier/queries/getPanierContactsUtiles'
 import { getPanierResponsables } from '@/panier/queries/getPanierResponsables'
 import { getPanierTauxProgression } from '@/panier/queries/getPanierTauxProgression'
 import { listPaniers } from '@/panier/queries/listPaniers'
@@ -57,6 +59,10 @@ const PanierTauxProgressionApiModelSchema = panierTauxProgressionApiModelSchema.
 const PanierResponsablesApiModelSchema = panierResponsablesApiModelSchema.openapi(
   'PanierResponsablesApiModel',
 )
+const PanierContactsUtilesApiModelSchema = panierContactsUtilesApiModelSchema.openapi(
+  'PanierContactsUtilesApiModel',
+)
+const ErrorApiModelSchema = errorApiModelSchema.openapi('ErrorApiModel')
 
 // --- GET /paniers ------------------------------------------------------------
 
@@ -150,6 +156,32 @@ const getPanierResponsablesRoute = createRoute({
     200: {
       content: { 'application/json': { schema: PanierResponsablesApiModelSchema } },
       description: 'Liste des responsables du panier',
+    },
+  },
+})
+
+// --- GET /paniers/:id/contacts-utiles ----------------------------------------
+
+const getPanierContactsUtilesRoute = createRoute({
+  method: 'get',
+  path: '/paniers/{id}/contacts-utiles',
+  tags: ['Panier'],
+  summary: "Lister les contacts utiles d'un panier",
+  description:
+    'Retourne les contacts utiles du panier, regroupés par organisme et triés alphabétiquement. ' +
+    'Accessible à tout principal pouvant lire le panier ' +
+    '(visibilite PUBLIC ou permission READ/WRITE explicite). ' +
+    'Renvoie 404 (`ENTITY_NOT_FOUND`) si le panier est introuvable ou inaccessible.',
+  middleware: [requireAuthentication],
+  request: { params: detailParamsSchema },
+  responses: {
+    200: {
+      content: { 'application/json': { schema: PanierContactsUtilesApiModelSchema } },
+      description: 'Contacts utiles du panier groupés par organisme',
+    },
+    404: {
+      content: { 'application/json': { schema: ErrorApiModelSchema } },
+      description: 'Panier introuvable',
     },
   },
 })
@@ -424,6 +456,21 @@ panierRoutes.openapi(listerHistoriqueNiveauConfiancePanierRoute, async (context)
         context,
         data,
         schema: NiveauConfianceListApiModelSchema,
+        status: 200,
+      }),
+    never,
+  )
+})
+
+panierRoutes.openapi(getPanierContactsUtilesRoute, async (context) => {
+  const { id } = context.req.valid('param')
+
+  return getPanierContactsUtiles(id).match(
+    (data) =>
+      jsonResponseOk({
+        context,
+        data,
+        schema: PanierContactsUtilesApiModelSchema,
         status: 200,
       }),
     never,

--- a/apps/mb-api/src/panier/routes.ts
+++ b/apps/mb-api/src/panier/routes.ts
@@ -62,7 +62,6 @@ const PanierResponsablesApiModelSchema = panierResponsablesApiModelSchema.openap
 const PanierContactsUtilesApiModelSchema = panierContactsUtilesApiModelSchema.openapi(
   'PanierContactsUtilesApiModel',
 )
-const ErrorApiModelSchema = errorApiModelSchema.openapi('ErrorApiModel')
 
 // --- GET /paniers ------------------------------------------------------------
 
@@ -170,18 +169,13 @@ const getPanierContactsUtilesRoute = createRoute({
   description:
     'Retourne les contacts utiles du panier, regroupés par organisme et triés alphabétiquement. ' +
     'Accessible à tout principal pouvant lire le panier ' +
-    '(visibilite PUBLIC ou permission READ/WRITE explicite). ' +
-    'Renvoie 404 (`ENTITY_NOT_FOUND`) si le panier est introuvable ou inaccessible.',
+    '(visibilite PUBLIC ou permission READ/WRITE explicite).',
   middleware: [requireAuthentication],
   request: { params: detailParamsSchema },
   responses: {
     200: {
       content: { 'application/json': { schema: PanierContactsUtilesApiModelSchema } },
       description: 'Contacts utiles du panier groupés par organisme',
-    },
-    404: {
-      content: { 'application/json': { schema: ErrorApiModelSchema } },
-      description: 'Panier introuvable',
     },
   },
 })

--- a/apps/mb-api/src/test/fixtures.ts
+++ b/apps/mb-api/src/test/fixtures.ts
@@ -30,6 +30,21 @@ import {
   type ValeurAvancementModel,
   type WidgetModel,
 } from '@/generated/prisma/models'
+
+type OrganismeModel = { id: string; nom: string; createdAt: Date; updatedAt: Date }
+type ContactUtileModel = {
+  id: string
+  organismeId: string
+  nom: string
+  description: string | null
+  telephone: string | null
+  email: string | null
+  url: string | null
+  adresse: string | null
+  createdAt: Date
+  updatedAt: Date
+}
+type PanierContactUtileModel = { panierId: string; contactUtileId: string; createdAt: Date }
 import {
   ApiKeyRole,
   PermissionAction,
@@ -835,6 +850,106 @@ async function commentaire(override: CommentaireOverrides) {
   return upsertCommentaire(override)
 }
 
+// --- Organisme ---------------------------------------------------------------
+
+type OrganismeOverrides = Partial<{
+  id: string
+  nom: string
+}>
+
+const upsertOrganisme = async (o: OrganismeOverrides = {}): Promise<OrganismeModel> => {
+  const id = o.id ?? uuidv7()
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const prismaDb = db() as any
+  return prismaDb.organisme.upsert({
+    where: { id },
+    update: { nom: o.nom ?? 'Organisme Test' },
+    create: {
+      id,
+      nom: o.nom ?? 'Organisme Test',
+    },
+  })
+}
+
+function organisme(): Promise<OrganismeModel>
+function organisme(override: OrganismeOverrides): Promise<OrganismeModel>
+async function organisme(override?: OrganismeOverrides): Promise<OrganismeModel> {
+  return upsertOrganisme(override)
+}
+
+// --- ContactUtile ------------------------------------------------------------
+
+type ContactUtileOverrides = Partial<{
+  id: string
+  nom: string
+  description: string | null
+  telephone: string | null
+  email: string | null
+  url: string | null
+  adresse: string | null
+  organisme: OrganismeOverrides
+}>
+
+const upsertContactUtile = async (o: ContactUtileOverrides = {}): Promise<ContactUtileModel> => {
+  const organismeRow = await upsertOrganisme(o.organisme)
+  const id = o.id ?? uuidv7()
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const prismaDb = db() as any
+  return prismaDb.contactUtile.upsert({
+    where: { id },
+    update: {},
+    create: {
+      id,
+      organismeId: organismeRow.id,
+      nom: o.nom ?? 'Contact Test',
+      description: o.description ?? null,
+      telephone: o.telephone ?? null,
+      email: o.email ?? null,
+      url: o.url ?? null,
+      adresse: o.adresse ?? null,
+    },
+  })
+}
+
+function contactUtile(): Promise<ContactUtileModel>
+function contactUtile(override: ContactUtileOverrides): Promise<ContactUtileModel>
+async function contactUtile(override?: ContactUtileOverrides): Promise<ContactUtileModel> {
+  return upsertContactUtile(override)
+}
+
+// --- PanierContactUtile ------------------------------------------------------
+
+type PanierContactUtileOverrides = {
+  panier?: PanierOverrides
+  contactUtile?: ContactUtileOverrides
+}
+
+const upsertPanierContactUtile = async (
+  o: PanierContactUtileOverrides,
+): Promise<PanierContactUtileModel> => {
+  const panierRow = await upsertPanier(o.panier)
+  const contactUtileRow = await upsertContactUtile(o.contactUtile)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const prismaDb = db() as any
+  return prismaDb.panierContactUtile.upsert({
+    where: {
+      panierId_contactUtileId: {
+        panierId: panierRow.id,
+        contactUtileId: contactUtileRow.id,
+      },
+    },
+    update: {},
+    create: { panierId: panierRow.id, contactUtileId: contactUtileRow.id },
+  })
+}
+
+function panierContactUtile(override: PanierContactUtileOverrides): Promise<PanierContactUtileModel>
+async function panierContactUtile(
+  override: PanierContactUtileOverrides,
+): Promise<PanierContactUtileModel> {
+  return upsertPanierContactUtile(override)
+}
+
 export const fixtures = {
   indicateur,
   commentaire,
@@ -852,4 +967,7 @@ export const fixtures = {
   indicateurPermission,
   panierPermission,
   panierResponsable,
+  organisme,
+  contactUtile,
+  panierContactUtile,
 }

--- a/apps/mb-api/src/test/fixtures.ts
+++ b/apps/mb-api/src/test/fixtures.ts
@@ -15,11 +15,14 @@ import {
 } from '@/test/randomIds'
 import {
   type ApiKeyModel,
+  type ContactUtileModel,
   type IndicateurModel,
   type IndicateurPermissionModel,
   type IndicateurReferentielModel,
   type IndividuModel,
   type ObjectifIndicateurIndividuModel,
+  type OrganismeModel,
+  type PanierContactUtileModel,
   type PanierModel,
   type PanierPermissionModel,
   type PanierResponsableModel,
@@ -30,21 +33,6 @@ import {
   type ValeurAvancementModel,
   type WidgetModel,
 } from '@/generated/prisma/models'
-
-type OrganismeModel = { id: string; nom: string; createdAt: Date; updatedAt: Date }
-type ContactUtileModel = {
-  id: string
-  organismeId: string
-  nom: string
-  description: string | null
-  telephone: string | null
-  email: string | null
-  url: string | null
-  adresse: string | null
-  createdAt: Date
-  updatedAt: Date
-}
-type PanierContactUtileModel = { panierId: string; contactUtileId: string; createdAt: Date }
 import {
   ApiKeyRole,
   PermissionAction,
@@ -859,9 +847,7 @@ type OrganismeOverrides = Partial<{
 
 const upsertOrganisme = async (o: OrganismeOverrides = {}): Promise<OrganismeModel> => {
   const id = o.id ?? uuidv7()
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const prismaDb = db() as any
-  return prismaDb.organisme.upsert({
+  return db().organisme.upsert({
     where: { id },
     update: { nom: o.nom ?? 'Organisme Test' },
     create: {
@@ -893,9 +879,7 @@ type ContactUtileOverrides = Partial<{
 const upsertContactUtile = async (o: ContactUtileOverrides = {}): Promise<ContactUtileModel> => {
   const organismeRow = await upsertOrganisme(o.organisme)
   const id = o.id ?? uuidv7()
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const prismaDb = db() as any
-  return prismaDb.contactUtile.upsert({
+  return db().contactUtile.upsert({
     where: { id },
     update: {},
     create: {
@@ -929,9 +913,7 @@ const upsertPanierContactUtile = async (
 ): Promise<PanierContactUtileModel> => {
   const panierRow = await upsertPanier(o.panier)
   const contactUtileRow = await upsertContactUtile(o.contactUtile)
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const prismaDb = db() as any
-  return prismaDb.panierContactUtile.upsert({
+  return db().panierContactUtile.upsert({
     where: {
       panierId_contactUtileId: {
         panierId: panierRow.id,

--- a/apps/mb-webapp/src/api/paniers.ts
+++ b/apps/mb-webapp/src/api/paniers.ts
@@ -6,6 +6,10 @@ import {
   panierListApiModelSchema,
 } from '@pilote/mb-shared/panier'
 import {
+  type PanierContactsUtilesApiModel,
+  panierContactsUtilesApiModelSchema,
+} from '@pilote/mb-shared/panierContactUtile'
+import {
   type PanierResponsablesApiModel,
   panierResponsablesApiModelSchema,
 } from '@pilote/mb-shared/panierResponsable'
@@ -44,4 +48,11 @@ export const fetchPanierResponsables = async (
 ): Promise<PanierResponsablesApiModel> => {
   const json = await apiClient.get(`paniers/${panierId}/responsables`).json()
   return panierResponsablesApiModelSchema.parse(json)
+}
+
+export const fetchPanierContactsUtiles = async (
+  panierId: string,
+): Promise<PanierContactsUtilesApiModel> => {
+  const json = await apiClient.get(`paniers/${panierId}/contacts-utiles`).json()
+  return panierContactsUtilesApiModelSchema.parse(json)
 }

--- a/apps/mb-webapp/src/components/paniers/PanierContactsUtiles.tsx
+++ b/apps/mb-webapp/src/components/paniers/PanierContactsUtiles.tsx
@@ -27,7 +27,10 @@ export function PanierContactsUtiles({ panierId }: { panierId: string }) {
 
           <ul className="space-y-2">
             {contacts.map((contact) => (
-              <li key={contact.id} className="rounded-lg border border-gray-200 bg-white p-4 space-y-2">
+              <li
+                key={contact.id}
+                className="rounded-lg border border-gray-200 bg-white p-4 space-y-2"
+              >
                 <p className="text-sm font-semibold text-gray-900">{contact.nom}</p>
                 {contact.description && (
                   <p className="text-sm text-gray-500 italic">{contact.description}</p>
@@ -41,13 +44,20 @@ export function PanierContactsUtiles({ panierId }: { panierId: string }) {
                 {contact.email && (
                   <div className="flex items-center gap-2 text-sm text-gray-600">
                     <Mail size={14} className="shrink-0 text-gray-400" />
-                    <a href={`mailto:${contact.email}`} className="hover:underline">{contact.email}</a>
+                    <a href={`mailto:${contact.email}`} className="hover:underline">
+                      {contact.email}
+                    </a>
                   </div>
                 )}
                 {contact.url && (
                   <div className="flex items-center gap-2 text-sm text-gray-600">
                     <Globe size={14} className="shrink-0 text-gray-400" />
-                    <a href={contact.url} target="_blank" rel="noopener noreferrer" className="hover:underline truncate max-w-xs">
+                    <a
+                      href={contact.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="hover:underline truncate max-w-xs"
+                    >
                       {contact.url.length > 50 ? contact.url.slice(0, 50) + '…' : contact.url}
                     </a>
                   </div>

--- a/apps/mb-webapp/src/components/paniers/PanierContactsUtiles.tsx
+++ b/apps/mb-webapp/src/components/paniers/PanierContactsUtiles.tsx
@@ -19,39 +19,39 @@ export function PanierContactsUtiles({ panierId }: { panierId: string }) {
       {data.items.map(({ organisme, contacts }) => (
         <div key={organisme.id} className="space-y-3">
           <div className="flex items-center gap-3">
-            <span className="text-xs font-semibold uppercase tracking-widest text-gray-400 whitespace-nowrap">
+            <span className="text-xs font-semibold uppercase tracking-widest text-text-subtle whitespace-nowrap">
               {organisme.nom}
             </span>
-            <hr className="flex-1 border-gray-200" />
+            <hr className="flex-1 border-border" />
           </div>
 
           <ul className="space-y-2">
             {contacts.map((contact) => (
               <li
                 key={contact.id}
-                className="rounded-lg border border-gray-200 bg-white p-4 space-y-2"
+                className="rounded-lg border border-border bg-surface p-4 space-y-2"
               >
-                <p className="text-sm font-semibold text-gray-900">{contact.nom}</p>
+                <p className="text-sm font-semibold text-text">{contact.nom}</p>
                 {contact.description && (
-                  <p className="text-sm text-gray-500 italic">{contact.description}</p>
+                  <p className="text-sm text-text-muted italic">{contact.description}</p>
                 )}
                 {contact.telephone && (
-                  <div className="flex items-center gap-2 text-sm text-gray-600">
-                    <Phone size={14} className="shrink-0 text-gray-400" />
+                  <div className="flex items-center gap-2 text-sm text-text-muted">
+                    <Phone size={14} className="shrink-0 text-text-subtle" />
                     <span>{contact.telephone}</span>
                   </div>
                 )}
                 {contact.email && (
-                  <div className="flex items-center gap-2 text-sm text-gray-600">
-                    <Mail size={14} className="shrink-0 text-gray-400" />
+                  <div className="flex items-center gap-2 text-sm text-text-muted">
+                    <Mail size={14} className="shrink-0 text-text-subtle" />
                     <a href={`mailto:${contact.email}`} className="hover:underline">
                       {contact.email}
                     </a>
                   </div>
                 )}
                 {contact.url && (
-                  <div className="flex items-center gap-2 text-sm text-gray-600">
-                    <Globe size={14} className="shrink-0 text-gray-400" />
+                  <div className="flex items-center gap-2 text-sm text-text-muted">
+                    <Globe size={14} className="shrink-0 text-text-subtle" />
                     <a
                       href={contact.url}
                       target="_blank"
@@ -63,8 +63,8 @@ export function PanierContactsUtiles({ panierId }: { panierId: string }) {
                   </div>
                 )}
                 {contact.adresse && (
-                  <div className="flex items-center gap-2 text-sm text-gray-600">
-                    <MapPin size={14} className="shrink-0 text-gray-400" />
+                  <div className="flex items-center gap-2 text-sm text-text-muted">
+                    <MapPin size={14} className="shrink-0 text-text-subtle" />
                     <span>{contact.adresse}</span>
                   </div>
                 )}

--- a/apps/mb-webapp/src/components/paniers/PanierContactsUtiles.tsx
+++ b/apps/mb-webapp/src/components/paniers/PanierContactsUtiles.tsx
@@ -44,7 +44,11 @@ export function PanierContactsUtiles({ panierId }: { panierId: string }) {
                 {contact.email && (
                   <div className="flex items-center gap-2 text-sm text-text-muted">
                     <Mail size={14} className="shrink-0 text-text-subtle" />
-                    <a href={`mailto:${contact.email}`} className="hover:underline">
+                    <a
+                      href={`mailto:${contact.email}`}
+                      aria-label={`Envoyer un email à ${contact.email}`}
+                      className="hover:underline"
+                    >
                       {contact.email}
                     </a>
                   </div>
@@ -58,7 +62,7 @@ export function PanierContactsUtiles({ panierId }: { panierId: string }) {
                       rel="noopener noreferrer"
                       className="hover:underline truncate max-w-xs"
                     >
-                      {contact.url.length > 50 ? contact.url.slice(0, 50) + '…' : contact.url}
+                      {contact.url}
                     </a>
                   </div>
                 )}

--- a/apps/mb-webapp/src/components/paniers/PanierContactsUtiles.tsx
+++ b/apps/mb-webapp/src/components/paniers/PanierContactsUtiles.tsx
@@ -1,0 +1,68 @@
+import { Globe, Mail, MapPin, Phone } from 'lucide-react'
+import { useSuspenseQuery } from '@tanstack/react-query'
+
+import { EmptyState } from '@/components/ui/EmptyState'
+import { Heading } from '@/components/ui/Typography'
+import { panierContactsUtilesQueryOptions } from '@/queries/paniers'
+
+export function PanierContactsUtiles({ panierId }: { panierId: string }) {
+  const { data } = useSuspenseQuery(panierContactsUtilesQueryOptions(panierId))
+
+  if (data.items.length === 0) {
+    return <EmptyState title="Aucun contact utile pour ce panier." />
+  }
+
+  return (
+    <div className="space-y-6">
+      <Heading size="sm">Contacts utiles</Heading>
+
+      {data.items.map(({ organisme, contacts }) => (
+        <div key={organisme.id} className="space-y-3">
+          <div className="flex items-center gap-3">
+            <span className="text-xs font-semibold uppercase tracking-widest text-gray-400 whitespace-nowrap">
+              {organisme.nom}
+            </span>
+            <hr className="flex-1 border-gray-200" />
+          </div>
+
+          <ul className="space-y-2">
+            {contacts.map((contact) => (
+              <li key={contact.id} className="rounded-lg border border-gray-200 bg-white p-4 space-y-2">
+                <p className="text-sm font-semibold text-gray-900">{contact.nom}</p>
+                {contact.description && (
+                  <p className="text-sm text-gray-500 italic">{contact.description}</p>
+                )}
+                {contact.telephone && (
+                  <div className="flex items-center gap-2 text-sm text-gray-600">
+                    <Phone size={14} className="shrink-0 text-gray-400" />
+                    <span>{contact.telephone}</span>
+                  </div>
+                )}
+                {contact.email && (
+                  <div className="flex items-center gap-2 text-sm text-gray-600">
+                    <Mail size={14} className="shrink-0 text-gray-400" />
+                    <a href={`mailto:${contact.email}`} className="hover:underline">{contact.email}</a>
+                  </div>
+                )}
+                {contact.url && (
+                  <div className="flex items-center gap-2 text-sm text-gray-600">
+                    <Globe size={14} className="shrink-0 text-gray-400" />
+                    <a href={contact.url} target="_blank" rel="noopener noreferrer" className="hover:underline truncate max-w-xs">
+                      {contact.url.length > 50 ? contact.url.slice(0, 50) + '…' : contact.url}
+                    </a>
+                  </div>
+                )}
+                {contact.adresse && (
+                  <div className="flex items-center gap-2 text-sm text-gray-600">
+                    <MapPin size={14} className="shrink-0 text-gray-400" />
+                    <span>{contact.adresse}</span>
+                  </div>
+                )}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/apps/mb-webapp/src/components/paniers/PanierGouvernanceTab.tsx
+++ b/apps/mb-webapp/src/components/paniers/PanierGouvernanceTab.tsx
@@ -1,6 +1,5 @@
 import { Mail } from 'lucide-react'
 import { useSuspenseQuery } from '@tanstack/react-query'
-import { Suspense } from 'react'
 
 import { PanierContactsUtiles } from '@/components/paniers/PanierContactsUtiles'
 import { EmptyState } from '@/components/ui/EmptyState'
@@ -60,9 +59,7 @@ export function PanierGouvernanceTab({ panierId }: { panierId: string }) {
         )}
       </div>
 
-      <Suspense>
-        <PanierContactsUtiles panierId={panierId} />
-      </Suspense>
+      <PanierContactsUtiles panierId={panierId} />
     </div>
   )
 }

--- a/apps/mb-webapp/src/components/paniers/PanierGouvernanceTab.tsx
+++ b/apps/mb-webapp/src/components/paniers/PanierGouvernanceTab.tsx
@@ -1,6 +1,8 @@
 import { Mail } from 'lucide-react'
 import { useSuspenseQuery } from '@tanstack/react-query'
+import { Suspense } from 'react'
 
+import { PanierContactsUtiles } from '@/components/paniers/PanierContactsUtiles'
 import { EmptyState } from '@/components/ui/EmptyState'
 import { Heading, Text } from '@/components/ui/Typography'
 import { panierResponsablesQueryOptions } from '@/queries/paniers'
@@ -22,39 +24,44 @@ export function PanierGouvernanceTab({ panierId }: { panierId: string }) {
   const { data } = useSuspenseQuery(panierResponsablesQueryOptions(panierId))
 
   return (
-    <div className="flex flex-col gap-4">
-      <Heading size="sm">Responsables</Heading>
-      {data.items.length === 0 ? (
-        <EmptyState title="Aucun responsable désigné pour ce panier." />
-      ) : (
-        <ul className="divide-y divide-border rounded-xl border border-border">
-          {data.items.map((r) => {
-            const nomComplet = [r.prenom, r.nom].filter(Boolean).join(' ')
-            const meta = [r.fonction, r.service].filter(Boolean).join(' · ')
-            return (
-              <li key={r.email} className="flex items-center gap-4 px-5 py-4">
-                <Initiales nom={r.nom} prenom={r.prenom} />
-                <div className="flex min-w-0 flex-1 flex-col">
-                  <Text weight="medium">{nomComplet || r.email}</Text>
-                  {meta && (
-                    <Text variant="caption" tone="muted">
-                      {meta}
-                    </Text>
-                  )}
-                </div>
-                <a
-                  href={`mailto:${r.email}`}
-                  aria-label={`Envoyer un email à ${r.email}`}
-                  className="flex shrink-0 items-center gap-1.5 text-sm text-text-muted hover:text-text transition-colors"
-                >
-                  <Mail className="size-4" aria-hidden />
-                  <span className="hidden sm:inline">{r.email}</span>
-                </a>
-              </li>
-            )
-          })}
-        </ul>
-      )}
+    <div className="flex flex-col gap-8">
+      <div className="flex flex-col gap-4">
+        <Heading size="sm">Responsables</Heading>
+        {data.items.length === 0 ? (
+          <EmptyState title="Aucun responsable désigné pour ce panier." />
+        ) : (
+          <ul className="divide-y divide-border rounded-xl border border-border">
+            {data.items.map((r) => {
+              const nomComplet = [r.prenom, r.nom].filter(Boolean).join(' ')
+              const meta = [r.fonction, r.service].filter(Boolean).join(' · ')
+              return (
+                <li key={r.email} className="flex items-center gap-4 px-5 py-4">
+                  <Initiales nom={r.nom} prenom={r.prenom} />
+                  <div className="flex min-w-0 flex-1 flex-col">
+                    <Text weight="medium">{nomComplet || r.email}</Text>
+                    {meta && (
+                      <Text variant="caption" tone="muted">
+                        {meta}
+                      </Text>
+                    )}
+                  </div>
+                  <a
+                    href={`mailto:${r.email}`}
+                    className="flex shrink-0 items-center gap-1.5 text-sm text-text-muted hover:text-text transition-colors"
+                  >
+                    <Mail className="size-4" aria-hidden />
+                    <span className="hidden sm:inline">{r.email}</span>
+                  </a>
+                </li>
+              )
+            })}
+          </ul>
+        )}
+      </div>
+
+      <Suspense>
+        <PanierContactsUtiles panierId={panierId} />
+      </Suspense>
     </div>
   )
 }

--- a/apps/mb-webapp/src/components/paniers/PanierGouvernanceTab.tsx
+++ b/apps/mb-webapp/src/components/paniers/PanierGouvernanceTab.tsx
@@ -47,6 +47,7 @@ export function PanierGouvernanceTab({ panierId }: { panierId: string }) {
                   </div>
                   <a
                     href={`mailto:${r.email}`}
+                    aria-label={r.email}
                     className="flex shrink-0 items-center gap-1.5 text-sm text-text-muted hover:text-text transition-colors"
                   >
                     <Mail className="size-4" aria-hidden />

--- a/apps/mb-webapp/src/components/paniers/PanierGouvernanceTab.tsx
+++ b/apps/mb-webapp/src/components/paniers/PanierGouvernanceTab.tsx
@@ -46,7 +46,7 @@ export function PanierGouvernanceTab({ panierId }: { panierId: string }) {
                   </div>
                   <a
                     href={`mailto:${r.email}`}
-                    aria-label={r.email}
+                    aria-label={`Envoyer un email à ${r.email}`}
                     className="flex shrink-0 items-center gap-1.5 text-sm text-text-muted hover:text-text transition-colors"
                   >
                     <Mail className="size-4" aria-hidden />

--- a/apps/mb-webapp/src/queries/paniers.ts
+++ b/apps/mb-webapp/src/queries/paniers.ts
@@ -3,6 +3,7 @@ import { type QueryClient, queryOptions } from '@tanstack/react-query'
 
 import {
   fetchPanierById,
+  fetchPanierContactsUtiles,
   fetchPanierResponsables,
   fetchPaniers,
   fetchPanierTauxProgression,
@@ -57,5 +58,12 @@ export const panierResponsablesQueryOptions = (panierId: string) =>
   queryOptions({
     queryKey: ['panier', panierId, 'responsables'],
     queryFn: () => fetchPanierResponsables(panierId),
+    staleTime: DEFAULT_STALE_TIME,
+  })
+
+export const panierContactsUtilesQueryOptions = (panierId: string) =>
+  queryOptions({
+    queryKey: ['panier', panierId, 'contacts-utiles'],
+    queryFn: () => fetchPanierContactsUtiles(panierId),
     staleTime: DEFAULT_STALE_TIME,
   })

--- a/apps/mb-webapp/src/routes/_authenticated/paniers/$id.tsx
+++ b/apps/mb-webapp/src/routes/_authenticated/paniers/$id.tsx
@@ -68,14 +68,15 @@ export const Route = createFileRoute('/_authenticated/paniers/$id')({
       },
     })
 
-    if (deps.individu) {
-      void queryClient.prefetchQuery(
-        panierTauxProgressionQueryOptions({ panierId: params.id, individu: deps.individu }),
-      )
-    }
-
-    void queryClient.prefetchQuery(panierResponsablesQueryOptions(params.id))
-    void queryClient.prefetchQuery(panierContactsUtilesQueryOptions(params.id))
+    await Promise.all([
+      deps.individu
+        ? queryClient.prefetchQuery(
+            panierTauxProgressionQueryOptions({ panierId: params.id, individu: deps.individu }),
+          )
+        : Promise.resolve(),
+      queryClient.prefetchQuery(panierResponsablesQueryOptions(params.id)),
+      queryClient.prefetchQuery(panierContactsUtilesQueryOptions(params.id)),
+    ])
 
     return { panier }
   },

--- a/apps/mb-webapp/src/routes/_authenticated/paniers/$id.tsx
+++ b/apps/mb-webapp/src/routes/_authenticated/paniers/$id.tsx
@@ -23,6 +23,7 @@ import { ensureIndividuReferentielPair } from '@/lib/individus/pair'
 import { indicateursQueryOptions } from '@/queries/indicateurs'
 import {
   loadPanier,
+  panierContactsUtilesQueryOptions,
   panierQueryOptions,
   panierResponsablesQueryOptions,
   panierTauxProgressionQueryOptions,
@@ -67,14 +68,14 @@ export const Route = createFileRoute('/_authenticated/paniers/$id')({
       },
     })
 
-    await Promise.all([
-      deps.individu
-        ? queryClient.prefetchQuery(
-            panierTauxProgressionQueryOptions({ panierId: params.id, individu: deps.individu }),
-          )
-        : Promise.resolve(),
-      queryClient.prefetchQuery(panierResponsablesQueryOptions(params.id)),
-    ])
+    if (deps.individu) {
+      void queryClient.prefetchQuery(
+        panierTauxProgressionQueryOptions({ panierId: params.id, individu: deps.individu }),
+      )
+    }
+
+    void queryClient.prefetchQuery(panierResponsablesQueryOptions(params.id))
+    void queryClient.prefetchQuery(panierContactsUtilesQueryOptions(params.id))
 
     return { panier }
   },

--- a/packages/mb-shared/package.json
+++ b/packages/mb-shared/package.json
@@ -79,6 +79,10 @@
     "./panierResponsable": {
       "types": "./src/panierResponsable.ts",
       "default": "./src/panierResponsable.ts"
+    },
+    "./panierContactUtile": {
+      "types": "./src/panierContactUtile.ts",
+      "default": "./src/panierContactUtile.ts"
     }
   },
   "files": [

--- a/packages/mb-shared/src/panierContactUtile.ts
+++ b/packages/mb-shared/src/panierContactUtile.ts
@@ -1,0 +1,26 @@
+import { z } from 'zod'
+
+export const contactUtileApiModelSchema = z.object({
+  id: z.string(),
+  nom: z.string(),
+  description: z.string().nullable(),
+  telephone: z.string().nullable(),
+  email: z.string().nullable(),
+  url: z.string().nullable(),
+  adresse: z.string().nullable(),
+})
+export type ContactUtileApiModel = z.infer<typeof contactUtileApiModelSchema>
+
+export const panierContactsUtilesGroupSchema = z.object({
+  organisme: z.object({
+    id: z.string(),
+    nom: z.string(),
+  }),
+  contacts: z.array(contactUtileApiModelSchema),
+})
+export type PanierContactsUtilesGroup = z.infer<typeof panierContactsUtilesGroupSchema>
+
+export const panierContactsUtilesApiModelSchema = z.object({
+  items: z.array(panierContactsUtilesGroupSchema),
+})
+export type PanierContactsUtilesApiModel = z.infer<typeof panierContactsUtilesApiModelSchema>

--- a/packages/mb-shared/src/panierContactUtile.ts
+++ b/packages/mb-shared/src/panierContactUtile.ts
@@ -5,7 +5,7 @@ export const contactUtileApiModelSchema = z.object({
   nom: z.string(),
   description: z.string().nullable(),
   telephone: z.string().nullable(),
-  email: z.string().nullable(),
+  email: z.string().email().nullable(),
   url: z.string().nullable(),
   adresse: z.string().nullable(),
 })


### PR DESCRIPTION
## Summary

- Ajout des modèles `Organisme`, `ContactUtile` et `PanierContactUtile` en base (migration Prisma + seed)
- Nouvelle route API `GET /paniers/{id}/contacts-utiles` avec query et tests d'intégration
- Composant webapp `PanierContactsUtiles` intégré dans l'onglet Gouvernance
- Query simplifiée : deux requêtes Prisma séparées (permission check + grouping natif par organisme)

## Test plan

- [ ] Vérifier que la migration s'applique correctement
- [ ] Tester l'endpoint `GET /paniers/{id}/contacts-utiles`
- [ ] Vérifier l'affichage du bloc Contacts utiles dans l'onglet Gouvernance d'un panier (PAN-005)
- [ ] Vérifier qu'un panier sans contacts affiche l'état vide
- [ ] Vérifier l'accessibilité du lien mailto sur mobile (aria-label)

## Changements post-review

- Tokens Tailwind custom (`text-text-muted`, `border-border`, `bg-surface`) à la place des `gray-*` bruts
- `aria-label` ajouté sur les liens `mailto:` pour l'accessibilité mobile
- Apostrophes corrigées dans les libellés de tests
- `prisma as any` supprimé dans le seed — utilisation des types Prisma générés
- Guards `if (pan005)` / `if (pan004)` supprimés dans le seed (toujours présents)
- `<Suspense>` interne redondant supprimé dans `PanierGouvernanceTab`
- Refactoring de `getPanierContactsUtiles` : `Map`+`for` remplacé par `organisme.findMany` avec `select` imbriqué

🤖 Generated with [Claude Code](https://claude.com/claude-code)