### PR TITLE
refactor(PIL-1629): nouveau texte du bandeau des chantiers archivés

### DIFF
--- a/apps/pilote-ppg/src/client/components/PageChantier/BandeauChantierEstArchive.tsx
+++ b/apps/pilote-ppg/src/client/components/PageChantier/BandeauChantierEstArchive.tsx
@@ -3,9 +3,9 @@ export const BandeauChantierEstArchive = () => {
     <div className="fr-notice fr-notice--info fr-notice--warning !bg-dsfr-grey-925 !text-dsfr-grey-200 w-full">
       <div className="fr-notice__body flex fr-mx-3w">
         <p className="fr-notice__desc fr-ml-1v">
-          Ce chantier n'est désormais plus suivi via PILOTE. Les données de ce
-          chantier restent consultables mais il n'est plus possible de le mettre
-          à jour.
+          Ce chantier n'est désormais plus suivi via PILOTE. Toutefois, les
+          données de ce chantier restent consultables et les indicateurs peuvent
+          être mis à jour
         </p>
       </div>
     </div>

--- a/apps/pilote-ppg/src/client/constants/statut.ts
+++ b/apps/pilote-ppg/src/client/constants/statut.ts
@@ -20,7 +20,7 @@ export const statutArchive = {
   id: "ARCHIVE",
   nom: "Chantiers précédemment suivis",
   texteInfobulle:
-    "Ces chantiers ne sont désormais plus suivis via PILOTE. Leurs données restent consultables mais il n'est plus possible de les mettre à jour.",
+    "Ces chantiers ne sont désormais plus suivis via PILOTE. Toutefois, leurs données restent consultables et les indicateurs peuvent être mis à jour.",
 };
 
 export const listeStatuts = [


### PR DESCRIPTION
## Contexte

Demande directe du métier : ajuster le texte du bandeau affiché sur la page d'un chantier archivé pour préciser que les indicateurs peuvent toujours être mis à jour. On en profite pour aligner l'infobulle du filtre de statut correspondant.

🎫 Ticket : [PIL-1629](https://data-ditp.atlassian.net/browse/PIL-1629)

## Changements

### 1. Bandeau page chantier archivé (`BandeauChantierEstArchive.tsx`)

**Avant :**
> Ce chantier n'est désormais plus suivi via PILOTE. Les données de ce chantier restent consultables mais il n'est plus possible de le mettre à jour.

**Après :**
> Ce chantier n'est désormais plus suivi via PILOTE. Toutefois, les données de ce chantier restent consultables et les indicateurs peuvent être mis à jour

### 2. Infobulle du filtre de statut « Chantiers précédemment suivis » (`constants/statut.ts`)

Aligné pour rester cohérent avec le bandeau.

**Avant :**
> Ces chantiers ne sont désormais plus suivis via PILOTE. Leurs données restent consultables mais il n'est plus possible de les mettre à jour.

**Après :**
> Ces chantiers ne sont désormais plus suivis via PILOTE. Toutefois, leurs données restent consultables et les indicateurs peuvent être mis à jour.

## Critères d'acceptation

- [x] Le bandeau d'un chantier archivé affiche le nouveau texte
- [x] L'infobulle du filtre de statut archivé est cohérente avec le bandeau

[PIL-1629]: https://data-ditp.atlassian.net/browse/PIL-1629?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ