### PR TITLE
refactor(commentaires): niveau de confiance en libellés colorés (sans météo)

### DIFF
--- a/apps/mb-webapp/src/components/indicateurs/commentaires/EditeurCommentaire.tsx
+++ b/apps/mb-webapp/src/components/indicateurs/commentaires/EditeurCommentaire.tsx
@@ -132,7 +132,7 @@ function EditeurInterne({
         {avecNiveauConfiance && (
           <div className="mb-5">
             <Text variant="caption" weight="semibold" tone="muted" className="mb-2 block">
-              Météo
+              Niveau de confiance
             </Text>
             <Controller
               control={form.control}
@@ -163,7 +163,7 @@ function EditeurInterne({
               <>
                 {publicationBloquee && (
                   <Text variant="caption" tone="muted">
-                    Une météo est requise pour publier.
+                    Un niveau de confiance est requis pour publier.
                   </Text>
                 )}
                 <Button variant="secondary" size="sm" type="submit" disabled={enCours}>

--- a/apps/mb-webapp/src/components/indicateurs/commentaires/IndicateurCommentairesTab.tsx
+++ b/apps/mb-webapp/src/components/indicateurs/commentaires/IndicateurCommentairesTab.tsx
@@ -26,7 +26,7 @@ export function IndicateurCommentairesTab({
           value={type}
           onValueChange={onTypeChange}
           options={[
-            { value: 'CONFIANCE', label: 'Météo & synthèse des résultats', icon: <CloudSun /> },
+            { value: 'CONFIANCE', label: 'Synthèse des résultats', icon: <CloudSun /> },
             { value: 'DEFAUT', label: 'Autres commentaires', icon: <MessageSquare /> },
           ]}
         />

--- a/apps/mb-webapp/src/components/indicateurs/commentaires/LigneHistorique.tsx
+++ b/apps/mb-webapp/src/components/indicateurs/commentaires/LigneHistorique.tsx
@@ -3,8 +3,9 @@ import { useSuspenseQuery } from '@tanstack/react-query'
 
 import { ContenuRepliable } from '@/components/indicateurs/commentaires/ContenuRepliable'
 import { libelleAuteur } from '@/components/indicateurs/commentaires/libelleAuteur'
-import { meteoFromIndice } from '@/components/indicateurs/commentaires/meteo'
+import { couleurIndice, meteoFromIndice } from '@/components/indicateurs/commentaires/meteo'
 import { Text } from '@/components/ui/Typography'
+import { clsxm } from '@/lib/clsxm'
 import { formatDateHeureFr } from '@/lib/format'
 import { niveauPourCommentaireQueryOptions } from '@/queries/niveauConfiance'
 
@@ -52,10 +53,14 @@ function MeteoInline({
     niveauPourCommentaireQueryOptions(indicateurId, individuId, commentaireId),
   )
   if (!niveau) return null
-  const { label, Icon } = meteoFromIndice(niveau.indice)
+  const { label } = meteoFromIndice(niveau.indice)
   return (
-    <span className="inline-flex items-center gap-1.5 text-sm font-medium leading-none text-primary">
-      <Icon className="size-4 shrink-0" />
+    <span
+      className={clsxm(
+        'inline-flex items-center text-sm font-semibold leading-none',
+        couleurIndice(niveau.indice).texte,
+      )}
+    >
       {label}
     </span>
   )

--- a/apps/mb-webapp/src/components/indicateurs/commentaires/MeteoTag.tsx
+++ b/apps/mb-webapp/src/components/indicateurs/commentaires/MeteoTag.tsx
@@ -1,12 +1,17 @@
 import { type IndiceConfiance } from '@pilote/mb-shared/niveauConfiance'
 
-import { meteoFromIndice } from '@/components/indicateurs/commentaires/meteo'
+import { couleurIndice, meteoFromIndice } from '@/components/indicateurs/commentaires/meteo'
+import { clsxm } from '@/lib/clsxm'
 
 export function MeteoTag({ indice }: { indice: IndiceConfiance }) {
-  const { label, Icon } = meteoFromIndice(indice)
+  const { label } = meteoFromIndice(indice)
   return (
-    <span className="inline-flex items-center gap-2 rounded-xl bg-primary-tinted px-4 py-2 text-sm font-semibold leading-none text-primary">
-      <Icon className="size-5 shrink-0" />
+    <span
+      className={clsxm(
+        'inline-flex items-center rounded-xl px-4 py-2 text-sm font-semibold leading-none',
+        couleurIndice(indice).badge,
+      )}
+    >
       {label}
     </span>
   )

--- a/apps/mb-webapp/src/components/indicateurs/commentaires/SelecteurMeteo.tsx
+++ b/apps/mb-webapp/src/components/indicateurs/commentaires/SelecteurMeteo.tsx
@@ -1,6 +1,6 @@
 import { type IndiceConfiance } from '@pilote/mb-shared/niveauConfiance'
 
-import { METEOS } from '@/components/indicateurs/commentaires/meteo'
+import { METEOS, couleurIndice } from '@/components/indicateurs/commentaires/meteo'
 import { clsxm } from '@/lib/clsxm'
 
 export function SelecteurMeteo({
@@ -14,8 +14,9 @@ export function SelecteurMeteo({
 }) {
   return (
     <div className="flex flex-wrap gap-2.5">
-      {METEOS.map(({ indice, label, Icon }) => {
+      {METEOS.map(({ indice, label }) => {
         const actif = value === indice
+        const couleur = couleurIndice(indice)
         return (
           <button
             key={indice}
@@ -26,12 +27,9 @@ export function SelecteurMeteo({
             className={clsxm(
               'inline-flex items-center gap-2 rounded-xl border px-4 py-2.5 text-sm font-semibold leading-none transition-colors',
               'disabled:cursor-not-allowed disabled:opacity-60',
-              actif
-                ? 'border-primary-tinted bg-primary-tinted text-primary'
-                : 'border-border bg-surface text-text-muted hover:border-border-strong',
+              actif ? couleur.actif : couleur.inactif,
             )}
           >
-            <Icon className="size-5 shrink-0" />
             {label}
           </button>
         )

--- a/apps/mb-webapp/src/components/indicateurs/commentaires/meteo.ts
+++ b/apps/mb-webapp/src/components/indicateurs/commentaires/meteo.ts
@@ -1,14 +1,57 @@
 import { type IndiceConfiance } from '@pilote/mb-shared/niveauConfiance'
-import { Cloud, CloudLightning, CloudSun, Sun, type LucideIcon } from 'lucide-react'
 
-export type Meteo = { indice: IndiceConfiance; label: string; Icon: LucideIcon }
+export type Meteo = { indice: IndiceConfiance; label: string }
 
-// Record exhaustif : ajouter un IndiceConfiance fait échouer la compilation.
-const METEO_PAR_INDICE: Record<IndiceConfiance, Omit<Meteo, 'indice'>> = {
-  OBJECTIF_COMPROMIS: { label: 'Orage', Icon: CloudLightning },
-  APPUIS_NECESSAIRE: { label: 'Couvert', Icon: Cloud },
-  OBJECTIF_ATTEIGNABLE: { label: 'Nuage', Icon: CloudSun },
-  OBJECTIF_SECURISE: { label: 'Soleil', Icon: Sun },
+// Classes Tailwind par indice. Écrites en entier (pas de concaténation) pour
+// rester détectables par le scanner de contenu de Tailwind.
+//  - actif   : état sélectionné (fond foncé, texte blanc)
+//  - inactif : état non sélectionné (fond clair, texte coloré)
+//  - badge   : pastille de lecture seule (fond clair, texte coloré)
+//  - texte   : couleur de texte seule (affichage inline)
+export type CouleurIndice = {
+  actif: string
+  inactif: string
+  badge: string
+  texte: string
+}
+
+const COULEUR_PAR_INDICE: Record<IndiceConfiance, CouleurIndice> = {
+  OBJECTIF_COMPROMIS: {
+    actif: 'border-confiance-rouge bg-confiance-rouge text-white',
+    inactif:
+      'border-confiance-rouge-light bg-confiance-rouge-light text-confiance-rouge hover:border-confiance-rouge',
+    badge: 'bg-confiance-rouge-light text-confiance-rouge',
+    texte: 'text-confiance-rouge',
+  },
+  APPUIS_NECESSAIRE: {
+    actif: 'border-confiance-orange bg-confiance-orange text-white',
+    inactif:
+      'border-confiance-orange-light bg-confiance-orange-light text-confiance-orange hover:border-confiance-orange',
+    badge: 'bg-confiance-orange-light text-confiance-orange',
+    texte: 'text-confiance-orange',
+  },
+  OBJECTIF_ATTEIGNABLE: {
+    actif: 'border-confiance-jaune bg-confiance-jaune text-white',
+    inactif:
+      'border-confiance-jaune-light bg-confiance-jaune-light text-confiance-jaune hover:border-confiance-jaune',
+    badge: 'bg-confiance-jaune-light text-confiance-jaune',
+    texte: 'text-confiance-jaune',
+  },
+  OBJECTIF_SECURISE: {
+    actif: 'border-confiance-vert bg-confiance-vert text-white',
+    inactif:
+      'border-confiance-vert-light bg-confiance-vert-light text-confiance-vert hover:border-confiance-vert',
+    badge: 'bg-confiance-vert-light text-confiance-vert',
+    texte: 'text-confiance-vert',
+  },
+}
+
+// Libellés métier (alignés sur pilote-ppg), du plus dégradé au plus serein.
+const LABEL_PAR_INDICE: Record<IndiceConfiance, string> = {
+  OBJECTIF_COMPROMIS: 'Objectifs compromis',
+  APPUIS_NECESSAIRE: 'Appuis nécessaires',
+  OBJECTIF_ATTEIGNABLE: 'Objectifs atteignables',
+  OBJECTIF_SECURISE: 'Objectifs sécurisés',
 }
 
 // Ordre d'affichage du sélecteur, du plus dégradé au plus serein.
@@ -19,12 +62,14 @@ const ORDRE_SELECTEUR: readonly IndiceConfiance[] = [
   'OBJECTIF_SECURISE',
 ]
 
+export const couleurIndice = (indice: IndiceConfiance): CouleurIndice => COULEUR_PAR_INDICE[indice]
+
 export const METEOS: readonly Meteo[] = ORDRE_SELECTEUR.map((indice) => ({
   indice,
-  ...METEO_PAR_INDICE[indice],
+  label: LABEL_PAR_INDICE[indice],
 }))
 
 export const meteoFromIndice = (indice: IndiceConfiance): Meteo => ({
   indice,
-  ...METEO_PAR_INDICE[indice],
+  label: LABEL_PAR_INDICE[indice],
 })

--- a/apps/mb-webapp/src/index.css
+++ b/apps/mb-webapp/src/index.css
@@ -52,6 +52,16 @@
   --color-warning: #b34000;
   --color-warning-tinted: #fff4e6;
 
+  /* Niveau de confiance — une couleur par indice (clair = non sélectionné, foncé = sélectionné) */
+  --color-confiance-rouge: #ce0500;
+  --color-confiance-rouge-light: #fff4f3;
+  --color-confiance-orange: #c44d00;
+  --color-confiance-orange-light: #fff6f0;
+  --color-confiance-jaune: #946700;
+  --color-confiance-jaune-light: #fdf9ea;
+  --color-confiance-vert: #18753c;
+  --color-confiance-vert-light: #f1fcf4;
+
   /* Animations Collapsible (radix expose --radix-collapsible-content-height). */
   --animate-collapsible-down: collapsible-down 220ms ease-out;
   --animate-collapsible-up: collapsible-up 220ms ease-out;

--- a/apps/mb-webapp/src/mutations/niveauConfiance.ts
+++ b/apps/mb-webapp/src/mutations/niveauConfiance.ts
@@ -22,7 +22,7 @@ export function useEnregistrerNiveauConfiance(indicateurId: string, individuId: 
   const creer = useMutation({
     mutationFn: (body: CreerNiveauConfianceBody) => createNiveauConfiance(body),
     onSuccess: () => void invalider(),
-    onError: () => toast({ title: 'Météo non enregistrée.', variant: 'error' }),
+    onError: () => toast({ title: 'Niveau de confiance non enregistré.', variant: 'error' }),
   })
 
   const modifier = useMutation({
@@ -34,7 +34,7 @@ export function useEnregistrerNiveauConfiance(indicateurId: string, individuId: 
       body: ModifierNiveauConfianceBody
     }) => updateNiveauConfiance(niveauConfianceId, body),
     onSuccess: () => void invalider(),
-    onError: () => toast({ title: 'Météo non mise à jour.', variant: 'error' }),
+    onError: () => toast({ title: 'Niveau de confiance non mis à jour.', variant: 'error' }),
   })
 
   return { creer, modifier }


### PR DESCRIPTION
## Contexte

L'affichage du niveau de confiance sur les commentaires d'indicateur reposait sur une métaphore météo (icônes Soleil / Nuage / Couvert / Orage). On la remplace par les **libellés métier** alignés sur pilote-ppg, avec une palette de couleurs dédiée par indice.

## Changements

- **Libellés métier** à la place des termes météo :
  - `OBJECTIF_SECURISE` → « Objectifs sécurisés »
  - `OBJECTIF_ATTEIGNABLE` → « Objectifs atteignables »
  - `APPUIS_NECESSAIRE` → « Appuis nécessaires »
  - `OBJECTIF_COMPROMIS` → « Objectifs compromis »
- **Suppression des icônes** Lucide (plus de dépendance météo dans le sélecteur, le tag et l'inline historique).
- **Palette de couleurs par indice** : nouvelles variables CSS `--color-confiance-*` (rouge/orange/jaune/vert + déclinaisons light), exposées via `couleurIndice()` en états `actif` / `inactif` / `badge` / `texte`. Classes Tailwind écrites en entier pour rester détectables par le scanner de contenu.
- **Libellés & messages** mis à jour : onglet (« Synthèse des résultats »), éditeur (« Niveau de confiance », « Un niveau de confiance est requis pour publier. »), toasts d'erreur.

## Fichiers

8 fichiers — `meteo.ts` (cœur du mapping), `SelecteurMeteo`, `MeteoTag`, `LigneHistorique`, `EditeurCommentaire`, `IndicateurCommentairesTab`, `index.css`, `mutations/niveauConfiance.ts`.

## Vérifications

- `pnpm lint` (tsr + eslint + tsc + prettier) ✅