### PR TITLE
refactor(commentaires): fix toggle « Voir plus / Voir moins » des cartes commentaire

### DIFF
--- a/apps/mb-webapp/src/components/indicateurs/commentaires/ContenuRepliable.tsx
+++ b/apps/mb-webapp/src/components/indicateurs/commentaires/ContenuRepliable.tsx
@@ -12,33 +12,46 @@ const PEEK_PX = 72
 export function ContenuRepliable({ html }: { html: string }) {
   const contenuRef = useRef<HTMLDivElement>(null)
   const [ouvert, setOuvert] = useState(false)
-  // On part de l'hypothèse « dépasse » pour replier dès le premier rendu (pas
-  // de flash) ; la mesure ajuste ensuite si le contenu est court.
-  const [depasse, setDepasse] = useState(true)
+  // Hauteur réelle du contenu, mesurée sur le `div` interne non contraint.
+  // `null` tant qu'on n'a pas mesuré.
+  const [hauteur, setHauteur] = useState<number | null>(null)
 
   useEffect(() => {
     const el = contenuRef.current
     if (!el) return
-    const observer = new ResizeObserver(() => setDepasse(el.offsetHeight > PEEK_PX + 1))
+    const observer = new ResizeObserver(() => setHauteur(el.offsetHeight))
     observer.observe(el)
     return () => observer.disconnect()
   }, [])
 
+  // Avant la première mesure on suppose que le contenu dépasse (aperçu replié,
+  // pas de flash) ; la mesure ajuste ensuite si le contenu est court.
+  const depasse = hauteur === null ? true : hauteur > PEEK_PX + 1
   // Pas de bouton si le contenu tient dans l'aperçu : on force « ouvert ».
   const effectivementOuvert = ouvert || !depasse
 
   return (
     <Collapsible open={effectivementOuvert} onOpenChange={setOuvert}>
-      {/* `forceMount` garde le contenu monté → Radix calcule
-          --radix-collapsible-content-height, qu'on anime via height. */}
-      <CollapsiblePrimitive.Content
-        forceMount
-        className="h-[var(--radix-collapsible-content-height)] overflow-hidden transition-[height] duration-200 ease-out data-[state=closed]:h-[4.5rem]"
+      {/* On anime la hauteur de CE wrapper externe (aperçu ↔ hauteur réelle
+          mesurée), que Radix ne mesure pas : son layout effect appelle
+          getBoundingClientRect() sur le `Content` en remettant la transition à
+          0s, ce qui « snapperait » toute animation portée par le `Content`
+          lui-même. On pilote la hauteur via notre propre mesure plutôt que
+          --radix-collapsible-content-height (bloquée à l'aperçu, car Radix
+          mesure l'élément contraint). */}
+      <div
+        className="overflow-hidden transition-[height] duration-200 ease-out"
+        style={{ height: effectivementOuvert ? (hauteur ?? PEEK_PX) : PEEK_PX }}
       >
-        <div ref={contenuRef}>
-          <RenduContenuHtml html={html} className="text-sm leading-relaxed text-text" />
-        </div>
-      </CollapsiblePrimitive.Content>
+        {/* `forceMount` : Radix ne rend ses enfants qu'à l'ouverture ; on les
+            garde montés pour afficher l'aperçu. Le `Content` reste à sa hauteur
+            naturelle et sert au câblage a11y (aria-controls du Trigger). */}
+        <CollapsiblePrimitive.Content forceMount>
+          <div ref={contenuRef}>
+            <RenduContenuHtml html={html} className="text-sm leading-relaxed text-text" />
+          </div>
+        </CollapsiblePrimitive.Content>
+      </div>
       {depasse && (
         <CollapsibleTrigger className="mt-2 inline-flex items-center gap-1 text-sm font-semibold text-primary">
           <ChevronDown className={clsxm('size-4 transition-transform', ouvert && 'rotate-180')} />


### PR DESCRIPTION
## Contexte

Sur les cartes commentaire d'un indicateur, le toggle **« Voir plus / Voir moins »** était cassé : cliquer sur « Voir plus » n'affichait pas le texte supplémentaire, et l'animation de hauteur ne fonctionnait pas.

## Cause racine

`ContenuRepliable` s'appuyait sur `CollapsiblePrimitive.Content` (Radix) pour la hauteur :

1. La hauteur ouverte était pilotée par `--radix-collapsible-content-height`. Or Radix calcule cette variable en mesurant `getBoundingClientRect()` de l'élément **tel quel**, sans forcer `height: auto`. Comme l'élément était contraint (`data-[state=closed]:h-[4.5rem]`), Radix mesurait toujours 72px → la variable restait bloquée à 72px → **aucune expansion au clic**.
2. Le `useLayoutEffect` interne de `Content` re-mesure sur le changement de `open` en désactivant la transition (`transitionDuration = "0s"` + reflow forcé avant paint) → **l'animation « snappait »** au lieu de glisser.

## Correctif

- Suppression de `CollapsiblePrimitive.Content` (et de la dépendance Radix dans ce composant).
- La hauteur du conteneur est pilotée nous-mêmes via le `ResizeObserver` déjà présent, qui mesure la **vraie** hauteur sur le `div` interne non contraint : aperçu (72px) ↔ hauteur mesurée, animé par `transition-[height] duration-200`.
- Garde anti-flash conservé (avant la première mesure, on suppose que le contenu dépasse).
- Accessibilité préservée : `<button>` avec `aria-expanded` + `aria-controls`.

## Vérification

- ✅ `pnpm --filter mb-webapp lint` (eslint + tsc + prettier)
- ✅ Vérifié manuellement : le clic déplie/replie le contenu et l'animation est fluide.