### PR TITLE
feat(commentaires): déplier le contenu à l'impression (PIL-1636)

### DIFF
--- a/apps/pilote-ppg/src/client/components/PageChantier/PublicationV2/Affichage/AffichagePublication.tsx
+++ b/apps/pilote-ppg/src/client/components/PageChantier/PublicationV2/Affichage/AffichagePublication.tsx
@@ -86,7 +86,10 @@ export const AffichagePublication = ({
       ) : null}
       <div
         ref={contenuRef}
-        className={clsxm("fr-text--sm mb-1", !afficherContenuComplet && "line-clamp-3")}
+        className={clsxm(
+          "fr-text--sm mb-1 print:line-clamp-none",
+          !afficherContenuComplet && "line-clamp-3",
+        )}
       >
         <RenduContenuHtml
           className="[&_p]:text-sm [&_p]:mb-1"
@@ -94,11 +97,13 @@ export const AffichagePublication = ({
         />
       </div>
       {contenuTronque || afficherContenuComplet ? (
-        <BoutonsAffichage
-          deplie={afficherContenuComplet}
-          deplierLeContenu={() => setAfficherContenuComplet(true)}
-          replierLeContenu={() => setAfficherContenuComplet(false)}
-        />
+        <div className="print:hidden">
+          <BoutonsAffichage
+            deplie={afficherContenuComplet}
+            deplierLeContenu={() => setAfficherContenuComplet(true)}
+            replierLeContenu={() => setAfficherContenuComplet(false)}
+          />
+        </div>
       ) : null}
     </>
   );

--- a/apps/pilote-ppg/src/client/components/PageChantier/PublicationV2/Affichage/AffichagePublication.tsx
+++ b/apps/pilote-ppg/src/client/components/PageChantier/PublicationV2/Affichage/AffichagePublication.tsx
@@ -9,6 +9,7 @@ import { Publication } from "@/components/PageChantier/PublicationV2/Publication
 import { BoutonsAffichage } from "@/components/_commons/BoutonsAffichage/BoutonsAffichage";
 import { RenduContenuHtml } from "@/components/_commons/EditeurRiche/RenduContenuHtml";
 import { NomUtilisateurAvecTooltip } from "@/components/_commons/NomUtilisateurAvecTooltip/NomUtilisateurAvecTooltip";
+import { clsxm } from "@/utils/clsxm";
 
 export const AffichagePublication = ({
   commentaire,
@@ -85,7 +86,7 @@ export const AffichagePublication = ({
       ) : null}
       <div
         ref={contenuRef}
-        className={`fr-text--sm mb-1 ${!afficherContenuComplet ? "line-clamp-3" : ""}`}
+        className={clsxm("fr-text--sm mb-1", !afficherContenuComplet && "line-clamp-3")}
       >
         <RenduContenuHtml
           className="[&_p]:text-sm [&_p]:mb-1"

--- a/apps/pilote-ppg/src/client/components/PageChantier/SynthèseDesRésultatsChantier/Affichage/Affichage.tsx
+++ b/apps/pilote-ppg/src/client/components/PageChantier/SynthèseDesRésultatsChantier/Affichage/Affichage.tsx
@@ -90,7 +90,10 @@ const SynthèseDesRésultatsAffichage = ({
       ) : null}
       <div
         ref={contenuRef}
-        className={clsxm("fr-text--sm mb-1", !afficherContenuComplet && "line-clamp-3")}
+        className={clsxm(
+          "fr-text--sm mb-1 print:line-clamp-none",
+          !afficherContenuComplet && "line-clamp-3",
+        )}
       >
         <RenduContenuHtml
           className="[&_p]:text-sm [&_p]:mb-1"
@@ -98,11 +101,13 @@ const SynthèseDesRésultatsAffichage = ({
         />
       </div>
       {contenuTronque || afficherContenuComplet ? (
-        <BoutonsAffichage
-          deplie={afficherContenuComplet}
-          deplierLeContenu={() => setAfficherContenuComplet(true)}
-          replierLeContenu={() => setAfficherContenuComplet(false)}
-        />
+        <div className="print:hidden">
+          <BoutonsAffichage
+            deplie={afficherContenuComplet}
+            deplierLeContenu={() => setAfficherContenuComplet(true)}
+            replierLeContenu={() => setAfficherContenuComplet(false)}
+          />
+        </div>
       ) : null}
     </>
   );

--- a/apps/pilote-ppg/src/client/components/PageChantier/SynthèseDesRésultatsChantier/Affichage/Affichage.tsx
+++ b/apps/pilote-ppg/src/client/components/PageChantier/SynthèseDesRésultatsChantier/Affichage/Affichage.tsx
@@ -8,6 +8,7 @@ import { SyntheseDesResultatsHistoriqueItem } from "@/server/syntheses-des-resul
 import { PiloteDateFormatter } from "@/utils/PiloteDateFormatter";
 import { RenduContenuHtml } from "@/components/_commons/EditeurRiche/RenduContenuHtml";
 import { NomUtilisateurAvecTooltip } from "@/components/_commons/NomUtilisateurAvecTooltip/NomUtilisateurAvecTooltip";
+import { clsxm } from "@/utils/clsxm";
 
 const SynthèseDesRésultatsAffichage = ({
   itemHistoriqueSyntheseDesResultats: synthèseDesRésultats,
@@ -89,7 +90,7 @@ const SynthèseDesRésultatsAffichage = ({
       ) : null}
       <div
         ref={contenuRef}
-        className={`fr-text--sm mb-1 ${!afficherContenuComplet ? "line-clamp-3" : ""}`}
+        className={clsxm("fr-text--sm mb-1", !afficherContenuComplet && "line-clamp-3")}
       >
         <RenduContenuHtml
           className="[&_p]:text-sm [&_p]:mb-1"


### PR DESCRIPTION
## Summary
- Ajoute les variants `print:line-clamp-none` et `print:hidden` sur les cartes commentaire et synthèse des résultats de la page chantier, pour que le texte complet soit visible à l'impression sans avoir à cliquer sur « Voir plus » au préalable.
- Refactor mineur : passage à `clsxm` pour les classes conditionnelles des deux composants concernés.

Fixes PIL-1636

## Test plan
- [ ] Ouvrir `/chantier/CH-105/DEPT-24?maille=departementale&jalon=2026` sur un chantier avec un commentaire et une synthèse des résultats plus longs que 3 lignes
- [ ] Vérifier à l'écran que le comportement « Voir plus / Voir moins » est inchangé
- [ ] Lancer l'aperçu avant impression (Cmd+P) : le contenu doit être entièrement déplié et les boutons « Voir plus / Voir moins » doivent être masqués

🤖 Generated with [Claude Code](https://claude.com/claude-code)