### PR TITLE
fix(auth): traitement propre de l'expiration ProConnect (PIL-1637)

### DIFF
--- a/apps/mb-webapp/src/api/client.test.ts
+++ b/apps/mb-webapp/src/api/client.test.ts
@@ -89,7 +89,7 @@ describe.sequential('apiClient retry on 401', () => {
     expect(authHeadersSeen).toEqual(['Bearer stale', 'Bearer fresh'])
   })
 
-  it('redirects to /auth/login with the current path when refresh fails', async () => {
+  it("redirige vers /auth/login avec le chemin courant en cas d'échec du refresh", async () => {
     tokenStore.set('stale')
     const assignSpy = vi.fn()
     vi.stubGlobal('window', {

--- a/apps/mb-webapp/src/api/client.test.ts
+++ b/apps/mb-webapp/src/api/client.test.ts
@@ -1,5 +1,5 @@
 import { http, HttpResponse } from 'msw'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { apiClient, isApiOrigin } from '@/api/client'
 import { tokenStore } from '@/auth/tokenStore'
@@ -87,5 +87,26 @@ describe.sequential('apiClient retry on 401', () => {
     expect(data).toEqual(buildMe())
     expect(meCallCount).toBe(2)
     expect(authHeadersSeen).toEqual(['Bearer stale', 'Bearer fresh'])
+  })
+
+  it('redirects to /auth/login with the current path when refresh fails', async () => {
+    tokenStore.set('stale')
+    const assignSpy = vi.fn()
+    vi.stubGlobal('window', {
+      ...window,
+      location: { assign: assignSpy, pathname: '/indicateurs', search: '?statut=actif' },
+    })
+    server.use(
+      http.post(bffUrl('/auth/refresh'), () => new HttpResponse(null, { status: 401 })),
+      http.get(apiUrl('/me'), () => new HttpResponse(null, { status: 401 })),
+    )
+
+    await apiClient.get('me').catch(() => {})
+
+    expect(assignSpy).toHaveBeenCalledWith(
+      `/auth/login?redirect=${encodeURIComponent('/indicateurs?statut=actif')}`,
+    )
+
+    vi.unstubAllGlobals()
   })
 })

--- a/apps/mb-webapp/src/api/client.ts
+++ b/apps/mb-webapp/src/api/client.ts
@@ -35,7 +35,8 @@ export const apiClient = ky.create({
       async ({ request }) => {
         const token = await refreshAccessToken()
         if (!token) {
-          window.location.assign('/auth/login')
+          const currentPath = `${window.location.pathname}${window.location.search}`
+          window.location.assign(`/auth/login?redirect=${encodeURIComponent(currentPath)}`)
           return ky.stop
         }
         request.headers.set('Authorization', `Bearer ${token}`)

--- a/apps/mb-webapp/src/routes/login-error.tsx
+++ b/apps/mb-webapp/src/routes/login-error.tsx
@@ -32,6 +32,12 @@ type ErrorContent = {
   action: 'logout' | 'retry'
 }
 
+const GENERIC_ERROR: ErrorContent = {
+  title: 'Une erreur est survenue',
+  description: "L'authentification a échoué. Merci de réessayer.",
+  action: 'retry',
+}
+
 const CONTENT_BY_REASON: Record<Reason | 'default', ErrorContent> = {
   user_not_found: {
     title: 'Accès refusé',
@@ -45,34 +51,11 @@ const CONTENT_BY_REASON: Record<Reason | 'default', ErrorContent> = {
       'Votre session a expiré ou votre navigateur a bloqué nos cookies. Merci de vous reconnecter.',
     action: 'retry',
   },
-  callback_failed: {
-    title: 'Connexion interrompue',
-    description: "L'échange avec votre fournisseur d'identité a échoué. Merci de réessayer.",
-    action: 'retry',
-  },
-  missing_tokens: {
-    title: 'Réponse incomplète',
-    description:
-      "Votre fournisseur d'identité n'a pas renvoyé toutes les informations nécessaires. Merci de réessayer.",
-    action: 'retry',
-  },
-  missing_access_token: {
-    title: 'Réponse incomplète',
-    description:
-      "Votre fournisseur d'identité n'a pas renvoyé de jeton d'accès. Merci de réessayer.",
-    action: 'retry',
-  },
-  me_failed: {
-    title: 'Service indisponible',
-    description:
-      'Impossible de vérifier votre compte pour le moment. Merci de réessayer dans quelques instants.',
-    action: 'retry',
-  },
-  default: {
-    title: 'Authentification impossible',
-    description: 'Une erreur inattendue est survenue. Merci de réessayer.',
-    action: 'retry',
-  },
+  callback_failed: GENERIC_ERROR,
+  missing_tokens: GENERIC_ERROR,
+  missing_access_token: GENERIC_ERROR,
+  me_failed: GENERIC_ERROR,
+  default: GENERIC_ERROR,
 }
 
 function LoginErrorPage() {

--- a/apps/mb-webapp/src/routes/login-error.tsx
+++ b/apps/mb-webapp/src/routes/login-error.tsx
@@ -1,31 +1,101 @@
-import { createFileRoute } from '@tanstack/react-router'
+import { createFileRoute, useNavigate } from '@tanstack/react-router'
+import { z } from 'zod'
 
 import { Button } from '@/components/ui/Button'
 import { EmptyState } from '@/components/ui/EmptyState'
 import { Section } from '@/components/ui/Section'
 import { auth } from '@/auth'
 
+const reasonSchema = z.enum([
+  'user_not_found',
+  'invalid_state',
+  'callback_failed',
+  'missing_tokens',
+  'missing_access_token',
+  'me_failed',
+])
+type Reason = z.infer<typeof reasonSchema>
+
+const loginErrorSearchSchema = z.object({
+  reason: reasonSchema.optional(),
+  redirect: z.string().optional(),
+})
+
 export const Route = createFileRoute('/login-error')({
+  validateSearch: loginErrorSearchSchema,
   component: LoginErrorPage,
 })
 
+type ErrorContent = {
+  title: string
+  description: string
+  action: 'logout' | 'retry'
+}
+
+const CONTENT_BY_REASON: Record<Reason | 'default', ErrorContent> = {
+  user_not_found: {
+    title: 'Accès refusé',
+    description:
+      "Votre compte n'est pas autorisé à accéder à cette application. Contactez votre administrateur si vous pensez qu'il s'agit d'une erreur.",
+    action: 'logout',
+  },
+  invalid_state: {
+    title: 'Session expirée',
+    description:
+      'Votre session a expiré ou votre navigateur a bloqué nos cookies. Merci de vous reconnecter.',
+    action: 'retry',
+  },
+  callback_failed: {
+    title: 'Connexion interrompue',
+    description: "L'échange avec votre fournisseur d'identité a échoué. Merci de réessayer.",
+    action: 'retry',
+  },
+  missing_tokens: {
+    title: 'Réponse incomplète',
+    description:
+      "Votre fournisseur d'identité n'a pas renvoyé toutes les informations nécessaires. Merci de réessayer.",
+    action: 'retry',
+  },
+  missing_access_token: {
+    title: 'Réponse incomplète',
+    description:
+      "Votre fournisseur d'identité n'a pas renvoyé de jeton d'accès. Merci de réessayer.",
+    action: 'retry',
+  },
+  me_failed: {
+    title: 'Service indisponible',
+    description:
+      'Impossible de vérifier votre compte pour le moment. Merci de réessayer dans quelques instants.',
+    action: 'retry',
+  },
+  default: {
+    title: 'Authentification impossible',
+    description: 'Une erreur inattendue est survenue. Merci de réessayer.',
+    action: 'retry',
+  },
+}
+
 function LoginErrorPage() {
+  const { reason, redirect } = Route.useSearch()
+  const navigate = useNavigate()
+  const content = CONTENT_BY_REASON[reason ?? 'default']
+
+  const handleClick = () => {
+    if (content.action === 'logout') {
+      void auth.logout()
+      return
+    }
+    void navigate({ to: '/login', search: redirect ? { redirect } : {} })
+  }
+
   return (
     <main className="mx-auto flex min-h-screen max-w-xl flex-col justify-center px-4">
       <Section>
         <div className="space-y-6 text-center">
-          <EmptyState
-            title="Accès refusé"
-            description="Votre compte n'est pas autorisé à accéder à cette application. Contactez votre administrateur si vous pensez qu'il s'agit d'une erreur."
-          />
+          <EmptyState title={content.title} description={content.description} />
           <div className="flex justify-center">
-            <Button
-              type="button"
-              onClick={() => {
-                void auth.logout()
-              }}
-            >
-              Se déconnecter
+            <Button type="button" onClick={handleClick}>
+              {content.action === 'logout' ? 'Se déconnecter' : 'Se reconnecter'}
             </Button>
           </div>
         </div>

--- a/apps/mb-webapp/src/server/auth/router.ts
+++ b/apps/mb-webapp/src/server/auth/router.ts
@@ -10,8 +10,10 @@ import { type Provider, getOidcConfig, providerSchema } from '@/server/auth/oidc
 import {
   clearPkce,
   clearSession,
+  readLastProvider,
   readPkce,
   readSession,
+  writeLastProvider,
   writePkce,
   writeSession,
 } from '@/server/auth/session'
@@ -22,13 +24,27 @@ const SCOPES: Record<Provider, string> = {
   proconnect: 'openid given_name usual_name email uid',
   keycloak: 'openid profile email offline_access',
 }
-const DEFAULT_SESSION_TTL_SECONDS = 60 * 60 * 24 * 30
+
+// ProConnect plafonne le refresh_token à 2h dur depuis la génération du token, sans rotation
+// et sans champ `refresh_expires_in` dans la réponse token endpoint.
+// Sources :
+// - https://partenaires.proconnect.gouv.fr/docs/fournisseur-service/refresh-token
+// - https://github.com/proconnect-gouv/proconnect-documentation
+// Vérifié empiriquement (cf. commentaire PIL-1637) : refresh_expires_in reçu = null,
+// et le fingerprint du refresh_token ne change pas entre plusieurs appels successifs.
+// Keycloak (dev) demande `offline_access` et supporte un refresh long, on garde 30 jours.
+const SESSION_TTL_DEFAULTS_SECONDS: Record<Provider, number> = {
+  proconnect: 60 * 60 * 2,
+  keycloak: 60 * 60 * 24 * 30,
+}
 const ALLOWED_CALLBACK_PARAMS = ['code', 'state', 'iss', 'error', 'error_description'] as const
 const PUBLIC_ORIGIN = new URL(serverEnv.PUBLIC_BASE_URL).origin
 
-const sessionTtlSeconds = (refreshExpiresIn: unknown): number => {
+const sessionTtlSeconds = (provider: Provider, refreshExpiresIn: unknown): number => {
+  const default_ = SESSION_TTL_DEFAULTS_SECONDS[provider]
   const value = Number(refreshExpiresIn)
-  return Number.isFinite(value) && value > 0 ? value : DEFAULT_SESSION_TTL_SECONDS
+  const idpValue = Number.isFinite(value) && value > 0 ? value : default_
+  return Math.min(idpValue, default_)
 }
 
 const SAFE_INTERNAL_PATH = /^\/(?:[^/\\].*)?$/
@@ -100,14 +116,29 @@ const checkUserProvisioned = (accessToken: string) =>
 
 export const authRouter = new Hono()
 
+const resolveLoginProvider = (context: Context): Provider | null => {
+  const queryProvider = context.req.query('provider')
+  if (queryProvider !== undefined) {
+    const parsed = providerSchema.safeParse(queryProvider)
+    return parsed.success ? parsed.data : null
+  }
+  return readLastProvider(context)
+}
+
 authRouter.get('/login', loginLimiter, async (context) => {
-  const provider = providerSchema.parse(context.req.query('provider'))
+  const redirectPath = safeRedirectPath(context.req.query('redirect'))
+  const provider = resolveLoginProvider(context)
+
+  if (!provider) {
+    const target = redirectPath ? `/login?redirect=${encodeURIComponent(redirectPath)}` : '/login'
+    return context.redirect(target)
+  }
+
   const config = await getOidcConfig(provider)
   const codeVerifier = client.randomPKCECodeVerifier()
   const codeChallenge = await client.calculatePKCECodeChallenge(codeVerifier)
   const state = client.randomState()
   const nonce = client.randomNonce()
-  const redirectPath = safeRedirectPath(context.req.query('redirect'))
 
   await writePkce(context, {
     codeVerifier,
@@ -134,7 +165,7 @@ authRouter.get('/callback', async (context) => {
   const pkce = await readPkce(context)
   if (!pkce) {
     logger.error({ event: 'auth.callback.no_pkce' }, 'Callback received without PKCE state')
-    return context.text('Invalid auth state', 400)
+    return context.redirect('/login-error?reason=invalid_state')
   }
   clearPkce(context)
 
@@ -153,7 +184,7 @@ authRouter.get('/callback', async (context) => {
       { event: 'auth.callback.failed', reason: error instanceof Error ? error.message : 'unknown' },
       'OIDC code exchange failed',
     )
-    return context.text('Authentication failed', 401)
+    return context.redirect('/login-error?reason=callback_failed')
   }
 
   const claims = tokens.claims()
@@ -162,7 +193,7 @@ authRouter.get('/callback', async (context) => {
       { event: 'auth.callback.missing_tokens' },
       'Missing claims, refresh token or id token',
     )
-    return context.text('Authentication failed', 401)
+    return context.redirect('/login-error?reason=missing_tokens')
   }
 
   if (!tokens.access_token) {
@@ -170,7 +201,7 @@ authRouter.get('/callback', async (context) => {
       { event: 'auth.callback.missing_access_token' },
       'Missing access token in OIDC response',
     )
-    return context.text('Authentication failed', 401)
+    return context.redirect('/login-error?reason=missing_access_token')
   }
 
   const sub = claims.sub
@@ -182,14 +213,15 @@ authRouter.get('/callback', async (context) => {
     async (provisioned) => {
       if (!provisioned) {
         logger.warn({ event: 'auth.login.user_not_found', sub }, 'PMB user not found')
-        return context.redirect('/login-error')
+        return context.redirect('/login-error?reason=user_not_found')
       }
 
       await writeSession(
         context,
         { refreshToken, sub, idToken, provider: pkce.provider },
-        sessionTtlSeconds(tokens.refresh_expires_in),
+        sessionTtlSeconds(pkce.provider, tokens.refresh_expires_in),
       )
+      writeLastProvider(context, pkce.provider)
 
       logger.debug({ event: 'auth.login.success', provider: pkce.provider }, 'PMB login completed')
 
@@ -203,7 +235,7 @@ authRouter.get('/callback', async (context) => {
         { event: 'auth.callback.me_failed', err: error },
         'Failed to verify user provisioning',
       )
-      return context.text('Authentication failed', 502)
+      return context.redirect('/login-error?reason=me_failed')
     },
   )
 })
@@ -245,7 +277,7 @@ authRouter.post('/refresh', refreshLimiter, async (context) => {
       idToken: tokens.id_token ?? session.idToken,
       provider: session.provider,
     },
-    sessionTtlSeconds(tokens.refresh_expires_in),
+    sessionTtlSeconds(session.provider, tokens.refresh_expires_in),
   )
 
   logger.debug({ event: 'auth.refresh.success' }, 'Refresh succeeded')

--- a/apps/mb-webapp/src/server/auth/session.ts
+++ b/apps/mb-webapp/src/server/auth/session.ts
@@ -2,12 +2,14 @@ import type { Context } from 'hono'
 import { deleteCookie, getCookie, setCookie } from 'hono/cookie'
 import { sealData, unsealData } from 'iron-session'
 
-import type { Provider } from '@/server/auth/oidc'
+import { providerSchema, type Provider } from '@/server/auth/oidc'
 import { serverEnv } from '@/server/env'
 
 const SESSION_COOKIE = 'mb_session'
 const PKCE_COOKIE = 'mb_pkce'
+const LAST_PROVIDER_COOKIE = 'mb_last_provider'
 const COOKIE_PATH = '/auth'
+const LAST_PROVIDER_MAX_AGE_SECONDS = 60 * 60 * 24 * 180
 
 export type SessionPayload = {
   refreshToken: string
@@ -78,4 +80,21 @@ export const readPkce = async (context: Context): Promise<PkcePayload | null> =>
 
 export const clearPkce = (context: Context) => {
   deleteCookie(context, PKCE_COOKIE, { path: COOKIE_PATH })
+}
+
+export const writeLastProvider = (context: Context, provider: Provider) => {
+  setCookie(context, LAST_PROVIDER_COOKIE, provider, {
+    httpOnly: true,
+    secure: true,
+    sameSite: 'Lax',
+    path: COOKIE_PATH,
+    maxAge: LAST_PROVIDER_MAX_AGE_SECONDS,
+  })
+}
+
+export const readLastProvider = (context: Context): Provider | null => {
+  const raw = getCookie(context, LAST_PROVIDER_COOKIE)
+  if (!raw) return null
+  const parsed = providerSchema.safeParse(raw)
+  return parsed.success ? parsed.data : null
 }


### PR DESCRIPTION
## Contexte

Fix [PIL-1637](https://data-ditp.atlassian.net/browse/PIL-1637). À l'expiration de la session ProConnect côté BFF, on observait une cascade d'erreurs :

- Le refresh_token grant échouait avec `unexpected HTTP response status code`
- Le SPA redirigeait vers `/auth/login` **sans query param `provider`**, ce qui déclenchait un `providerSchema.parse(undefined)` → ZodError 500 non-catché
- Côté API, les tokens expirés provoquaient un 500 du userinfo AgentConnect, wrappé indistinctement en `auth.jwt.invalid` (traité à part, hors scope de cette PR)

## Enquête préalable

Instrumentation temporaire ajoutée puis retirée (cf. commentaire PIL-1637). Résultats vérifiés empiriquement en env dev :

- ProConnect ne rotate **pas** le refresh_token : le même token est renvoyé sur chaque appel au `token_endpoint`
- ProConnect ne renvoie **pas** `refresh_expires_in` dans la réponse
- Le refresh_token expire **2h après le login initial**, quoi qu'il arrive — aucun heartbeat ni refresh proactif ne peut prolonger cette deadline
- Le fallback `DEFAULT_SESSION_TTL_SECONDS = 30 jours` du BFF était donc systématiquement activé, créant un cookie session incohérent avec la réalité IdP

Sources ProConnect (doc partenaires + GitHub officiel) :
- [Refresh token](https://partenaires.proconnect.gouv.fr/docs/fournisseur-service/refresh-token) : « le refresh_token a expiré (temps écoulé depuis la génération du token >= 2 heures) »
- [Implémentation technique](https://partenaires.proconnect.gouv.fr/docs/fournisseur-service/implementation_technique)
- [proconnect-documentation](https://github.com/proconnect-gouv/proconnect-documentation)

## Ce qui change dans cette PR

### Couche 1 — Page `/login-error` enrichie avec `?reason=X`
Toutes les erreurs de `/callback` redirigent désormais vers `/login-error?reason=X` au lieu d'un `context.text('Authentication failed', 401)` brut. Reasons supportées : `user_not_found` (comportement existant), `invalid_state`, `callback_failed`, `missing_tokens`, `missing_access_token`, `me_failed`. Message et CTA adaptés au reason (« Se déconnecter » vs « Se reconnecter »).

### Couche 2 — TTL cookie session par provider
`DEFAULT_SESSION_TTL_SECONDS` (30j) remplacé par un `SESSION_TTL_DEFAULTS_SECONDS: Record<Provider, number>` documenté :
- `proconnect: 7200` (2h dur, deadline IdP absolue, sources doc dans le commentaire)
- `keycloak: 60 * 60 * 24 * 30` (30j — Keycloak délivre `offline_access`)

`sessionTtlSeconds` prend maintenant le provider en param et plafonne par `Math.min(idp_value, default)` en défense en profondeur.

### Couche 3 — Cookie `mb_last_provider` + redirect propre
- Cookie httpOnly, secure, SameSite=Lax, path=/auth, TTL 180j écrit au succès du callback
- `/auth/login` sans query `provider` lit le cookie pour rediriger direct vers l'IdP (SSO ProConnect transparent tant que la session IdP est vivante)
- Fallback : sans query ni cookie, redirection vers `/login` SPA qui présente les deux options
- `client.ts:beforeRetry` passe le path courant en `redirect` param pour préserver la navigation

## Test plan

- [x] Typecheck (`tsc --noEmit`) passe
- [x] Lint (`pnpm lint`) passe
- [x] Tests unitaires (`vitest run`) : 36 tests passent, dont un nouveau test qui vérifie que sur échec de refresh, `client.ts` redirige avec `?redirect=<pathname+search>` encodé
- [ ] Test manuel en browser du flow complet à faire :
  - Login normal ProConnect → cookie `mb_last_provider` écrit
  - Suppression manuelle du cookie session → refresh du navigateur → doit rediriger transparent via SSO ProConnect sans re-saisie
  - Force ZodError sur `/auth/login?provider=xxx` → doit rediriger vers `/login` SPA (fallback)
  - Force erreur callback (paramètre `code` invalide) → doit afficher `/login-error?reason=callback_failed` avec CTA « Se reconnecter »

Note : la déconnexion au bout de 2h reste imposée par ProConnect. Le fix ne vise pas à supprimer cette déconnexion (impossible sans changement côté IdP), mais à la **rendre transparente** grâce au SSO IdP + cookie `mb_last_provider`.

## Reste à traiter dans une PR séparée

- Robustesse `mb-api` : distinguer 401 (token expiré, normal) vs 5xx (panne provider) dans `verifyProconnectToken` — actuellement tout est wrappé en `auth.jwt.invalid`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PIL-1637]: https://data-ditp.atlassian.net/browse/PIL-1637?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ