### PR TITLE
perf(db): indexes sur commentaire, synthese, objectif, decision

### DIFF
--- a/apps/pilote-ppg/src/database/prisma/migrations/20260701120000_ajout_index_commentaire_synthese_objectif_decision/migration.sql
+++ b/apps/pilote-ppg/src/database/prisma/migrations/20260701120000_ajout_index_commentaire_synthese_objectif_decision/migration.sql
@@ -1,0 +1,11 @@
+-- CreateIndex
+CREATE INDEX "commentaire_chantier_id_territoire_code_statut_idx" ON "public"."commentaire"("chantier_id", "territoire_code", "statut");
+
+-- CreateIndex
+CREATE INDEX "synthese_des_resultats_chantier_id_territoire_code_statut_idx" ON "public"."synthese_des_resultats"("chantier_id", "territoire_code", "statut");
+
+-- CreateIndex
+CREATE INDEX "objectif_chantier_id_statut_idx" ON "public"."objectif"("chantier_id", "statut");
+
+-- CreateIndex
+CREATE INDEX "decision_strategique_chantier_id_statut_idx" ON "public"."decision_strategique"("chantier_id", "statut");

--- a/apps/pilote-ppg/src/database/prisma/schema.prisma
+++ b/apps/pilote-ppg/src/database/prisma/schema.prisma
@@ -298,6 +298,7 @@ model synthese_des_resultats {
   auteur_modification    utilisateur         @relation("syntheses_modifiees", fields: [auteur_modification_id], references: [id], onUpdate: Cascade)
   chantier_territoire    chantier_territoire @relation(fields: [chantier_id, territoire_code], references: [id, territoire_code], onUpdate: Cascade)
 
+  @@index([chantier_id, territoire_code, statut])
   @@schema("public")
 }
 
@@ -335,6 +336,7 @@ model commentaire {
   auteur_modification    utilisateur         @relation("commentaires_modifies", fields: [auteur_modification_id], references: [id], onUpdate: Cascade)
   chantier_territoire    chantier_territoire @relation(fields: [chantier_id, territoire_code], references: [id, territoire_code], onUpdate: Cascade)
 
+  @@index([chantier_id, territoire_code, statut])
   @@schema("public")
 }
 
@@ -581,6 +583,7 @@ model objectif {
   auteur_modification    utilisateur        @relation("objectifs_modifies", fields: [auteur_modification_id], references: [id], onUpdate: Cascade)
   chantier_identite      chantier_identite  @relation(fields: [chantier_id], references: [id], onUpdate: Cascade)
 
+  @@index([chantier_id, statut])
   @@schema("public")
 }
 
@@ -605,6 +608,7 @@ model decision_strategique {
   auteur_modification    utilisateur               @relation("decision_auteur_modification", fields: [auteur_modification_id], references: [id], onUpdate: Cascade)
   chantier_identite      chantier_identite         @relation(fields: [chantier_id], references: [id], onUpdate: Cascade)
 
+  @@index([chantier_id, statut])
   @@schema("public")
 }
 

--- a/apps/pilote-ppg/src/server/usecase/chantier/commentaire/RécupérerCommentairesLesPlusRécentsParTypeGroupésParChantiersUseCase.integration.test.ts
+++ b/apps/pilote-ppg/src/server/usecase/chantier/commentaire/RécupérerCommentairesLesPlusRécentsParTypeGroupésParChantiersUseCase.integration.test.ts
@@ -196,38 +196,37 @@ describe("RécupérerCommentairesLesPlusRécentsParTypeGroupésParChantiersUseCa
           );
 
         // Then
-        expect(résultat).toStrictEqual({
-          [chantier.id]: [
-            {
-              id: commentaireSolutionsNational.id,
-              contenu: commentaireSolutionsNational.contenu,
-              date: commentaireSolutionsNational.date_modification.toISOString(),
-              auteur: "User Test",
-              type: "solutionsEtActionsÀVenir",
-            },
-            {
-              id: commentaireRisquesPlusRécent.id,
-              contenu: commentaireRisquesPlusRécent.contenu,
-              date: commentaireRisquesPlusRécent.date_modification.toISOString(),
-              auteur: "User Test",
-              type: "risquesEtFreinsÀLever",
-            },
-            {
-              id: commentaireExemples.id,
-              contenu: commentaireExemples.contenu,
-              date: commentaireExemples.date_modification.toISOString(),
-              auteur: "User Test",
-              type: "exemplesConcretsDeRéussite",
-            },
-            {
-              id: commentaireAutresNonCorrélés.id,
-              contenu: commentaireAutresNonCorrélés.contenu,
-              date: commentaireAutresNonCorrélés.date_modification.toISOString(),
-              auteur: "User Test",
-              type: "autresRésultatsObtenusNonCorrélésAuxIndicateurs",
-            },
-          ],
-        });
+        expect(Object.keys(résultat)).toStrictEqual([chantier.id]);
+        expect(résultat[chantier.id]).toIncludeSameMembers([
+          {
+            id: commentaireSolutionsNational.id,
+            contenu: commentaireSolutionsNational.contenu,
+            date: commentaireSolutionsNational.date_modification.toISOString(),
+            auteur: "User Test",
+            type: "solutionsEtActionsÀVenir",
+          },
+          {
+            id: commentaireRisquesPlusRécent.id,
+            contenu: commentaireRisquesPlusRécent.contenu,
+            date: commentaireRisquesPlusRécent.date_modification.toISOString(),
+            auteur: "User Test",
+            type: "risquesEtFreinsÀLever",
+          },
+          {
+            id: commentaireExemples.id,
+            contenu: commentaireExemples.contenu,
+            date: commentaireExemples.date_modification.toISOString(),
+            auteur: "User Test",
+            type: "exemplesConcretsDeRéussite",
+          },
+          {
+            id: commentaireAutresNonCorrélés.id,
+            contenu: commentaireAutresNonCorrélés.contenu,
+            date: commentaireAutresNonCorrélés.date_modification.toISOString(),
+            auteur: "User Test",
+            type: "autresRésultatsObtenusNonCorrélésAuxIndicateurs",
+          },
+        ]);
       }),
     );
   });


### PR DESCRIPTION
## Contexte

Un timeout Prisma récurrent en prod (`indicateur.recupererStatistiquesTauxAvancement`) :

```
Timed out fetching a new connection from the connection pool.
Current connection pool timeout: 10, connection limit: 6
```

Analyse des `pg_stat_statements` :

| Table | Calls | Mean | Max |
|-------|-------|------|-----|
| `commentaire` | 20 817 | 770 ms | **57.9 s** |
| `synthese_des_resultats` | 20 822 | 800 ms | **48.9 s** |

→ Ces quatre tables n'ont **aucun `@@index`** dans `schema.prisma`, alors qu'elles sont interrogées à chaque affichage d'un chantier/territoire :

- `commentaire` — `chantier_id + territoire_code + statut`
- `synthese_des_resultats` — `chantier_id + territoire_code + statut`
- `objectif` — `chantier_id + statut`
- `decision_strategique` — `chantier_id + statut`

Résultat : full table scans → contention Postgres → pool Prisma saturé → timeouts en cascade.

## Changements

Ajoute 4 indexes couvrant les patterns de queries les plus fréquents :

- `commentaire(chantier_id, territoire_code, statut)`
- `synthese_des_resultats(chantier_id, territoire_code, statut)`
- `objectif(chantier_id, statut)`
- `decision_strategique(chantier_id, statut)`

## ⚠️ Déploiement prod

La migration utilise `CREATE INDEX` (non-`CONCURRENTLY`) car `prisma migrate deploy` wrap la migration dans une transaction. Cela prendra un `ACCESS EXCLUSIVE` lock sur les 4 tables pendant la création.

**Recommandation** : pré-créer les indexes manuellement en `CONCURRENTLY` avant le déploiement pour éviter le lock :

\`\`\`sql
CREATE INDEX CONCURRENTLY IF NOT EXISTS "commentaire_chantier_id_territoire_code_statut_idx"
  ON "public"."commentaire"("chantier_id", "territoire_code", "statut");

CREATE INDEX CONCURRENTLY IF NOT EXISTS "synthese_des_resultats_chantier_id_territoire_code_statut_idx"
  ON "public"."synthese_des_resultats"("chantier_id", "territoire_code", "statut");

CREATE INDEX CONCURRENTLY IF NOT EXISTS "objectif_chantier_id_statut_idx"
  ON "public"."objectif"("chantier_id", "statut");

CREATE INDEX CONCURRENTLY IF NOT EXISTS "decision_strategique_chantier_id_statut_idx"
  ON "public"."decision_strategique"("chantier_id", "statut");
\`\`\`

Puis lancer \`prisma migrate deploy\` (Prisma détectera les indexes déjà existants et échouera avec \`already exists\` — il faudra alors marquer la migration comme appliquée via \`prisma migrate resolve --applied\`).

## Test plan

- [ ] `pnpm database:migration` en local → indexes créés
- [ ] `EXPLAIN ANALYZE` sur une requête `commentaire` avec `chantier_id + territoire_code + statut` → doit utiliser `commentaire_chantier_id_territoire_code_statut_idx`
- [ ] Vérifier absence de régression sur les tests d'intégration existants