### PR TITLE
feat(mb): génération serveur du publicId indicateur (IND-<n>)

### DIFF
--- a/apps/mb-admin/src/api/indicateurs.ts
+++ b/apps/mb-admin/src/api/indicateurs.ts
@@ -27,7 +27,12 @@ export const fetchIndicateurById = async (id: string): Promise<IndicateurApiMode
   return indicateurApiModelSchema.parse(json)
 }
 
-export const upsertIndicateur = async (
+export const createIndicateur = async (body: UpsertIndicateurBody): Promise<IndicateurApiModel> => {
+  const json = await bffClient.post('indicateurs', { json: body }).json()
+  return indicateurApiModelSchema.parse(json)
+}
+
+export const updateIndicateur = async (
   id: string,
   body: UpsertIndicateurBody,
 ): Promise<IndicateurApiModel> => {

--- a/apps/mb-admin/src/components/IndicateurForm.tsx
+++ b/apps/mb-admin/src/components/IndicateurForm.tsx
@@ -3,7 +3,7 @@ import { Plus, Trash2 } from 'lucide-react'
 import { useState } from 'react'
 
 import type { IndicateurApiModel } from '@pilote/mb-shared/indicateur'
-import { indicateurPublicIdSchema, referentielPublicIdSchema } from '@pilote/mb-shared/publicIds'
+import { referentielPublicIdSchema } from '@pilote/mb-shared/publicIds'
 
 import { fetchAllReferentiels } from '@/api/referentiels'
 import { Button } from '@/components/ui/Button'
@@ -76,28 +76,24 @@ export function IndicateurForm({
 
   const canSubmit =
     values.nom.trim().length > 0 &&
-    (mode === 'edit' || indicateurPublicIdSchema.safeParse(values.id).success) &&
     values.referentiels.every((ref) => referentielPublicIdSchema.safeParse(ref.id).success)
 
   return (
     <div className="mx-auto max-w-2xl">
       <div className="rounded-xl border border-border bg-surface p-6">
-        <div className="mb-5">
-          <label className="mb-1.5 block text-xs font-semibold">Identifiant</label>
-          {mode === 'edit' ? (
+        {mode === 'edit' ? (
+          <div className="mb-5">
+            <label className="mb-1.5 block text-xs font-semibold">Identifiant</label>
             <span className="inline-flex items-center gap-2 rounded-md border border-primary/20 bg-surface-tinted px-3 py-2 font-mono text-sm text-primary">
               {values.id}{' '}
               <span className="font-sans text-xs text-text-subtle">🔒 non modifiable</span>
             </span>
-          ) : (
-            <input
-              value={values.id}
-              onChange={(event) => update({ id: event.target.value.toUpperCase() })}
-              placeholder="IND-001"
-              className="w-48 rounded-md border border-border px-3 py-2 font-mono text-sm focus:border-primary focus:outline-none"
-            />
-          )}
-        </div>
+          </div>
+        ) : (
+          <p className="mb-5 text-xs text-text-subtle">
+            L'identifiant (<code>IND-…</code>) est généré automatiquement à la création.
+          </p>
+        )}
 
         <div className="mb-5">
           <label className="mb-1.5 block text-xs font-semibold">

--- a/apps/mb-admin/src/components/IndicateurForm.tsx
+++ b/apps/mb-admin/src/components/IndicateurForm.tsx
@@ -3,6 +3,7 @@ import { Plus, Trash2 } from 'lucide-react'
 import { useState } from 'react'
 
 import type { IndicateurApiModel } from '@pilote/mb-shared/indicateur'
+import { indicateurPublicIdSchema, referentielPublicIdSchema } from '@pilote/mb-shared/publicIds'
 
 import { fetchAllReferentiels } from '@/api/referentiels'
 import { Button } from '@/components/ui/Button'
@@ -75,8 +76,8 @@ export function IndicateurForm({
 
   const canSubmit =
     values.nom.trim().length > 0 &&
-    (mode === 'edit' || /^IND-\d+$/.test(values.id)) &&
-    values.referentiels.every((ref) => /^REF-[A-Z0-9-]{1,16}$/.test(ref.id))
+    (mode === 'edit' || indicateurPublicIdSchema.safeParse(values.id).success) &&
+    values.referentiels.every((ref) => referentielPublicIdSchema.safeParse(ref.id).success)
 
   return (
     <div className="mx-auto max-w-2xl">

--- a/apps/mb-admin/src/components/ReferentielForm.tsx
+++ b/apps/mb-admin/src/components/ReferentielForm.tsx
@@ -1,6 +1,8 @@
 import { Plus, Trash2 } from 'lucide-react'
 import { useState } from 'react'
 
+import { individuPublicIdSchema, referentielPublicIdSchema } from '@pilote/mb-shared/publicIds'
+
 import { Button } from '@/components/ui/Button'
 import { clsxm } from '@/lib/clsxm'
 
@@ -45,9 +47,10 @@ export function ReferentielForm({
 
   const canSubmit =
     values.nom.trim().length > 0 &&
-    (mode === 'edit' || /^REF-[A-Z0-9-]{1,16}$/.test(values.id)) &&
+    (mode === 'edit' || referentielPublicIdSchema.safeParse(values.id).success) &&
     values.individus.every(
-      (item) => /^[A-Z][A-Z0-9-]{0,19}$/.test(item.publicId) && item.nom.trim().length > 0,
+      (item) =>
+        individuPublicIdSchema.safeParse(item.publicId).success && item.nom.trim().length > 0,
     )
 
   return (

--- a/apps/mb-admin/src/routes/_authed/indicateurs/$id.tsx
+++ b/apps/mb-admin/src/routes/_authed/indicateurs/$id.tsx
@@ -2,7 +2,7 @@ import { useMutation, useQueryClient, useSuspenseQuery } from '@tanstack/react-q
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router'
 import { useState } from 'react'
 
-import { upsertIndicateur } from '@/api/indicateurs'
+import { updateIndicateur } from '@/api/indicateurs'
 import { Breadcrumb } from '@/components/Breadcrumb'
 import {
   buildInitialValues,
@@ -30,7 +30,7 @@ function EditIndicateurComponent() {
 
   const mutation = useMutation({
     mutationFn: (values: IndicateurFormValues) =>
-      upsertIndicateur(id, {
+      updateIndicateur(id, {
         nom: values.nom,
         visibilite: values.visibilite,
         unite: values.unite,

--- a/apps/mb-admin/src/routes/_authed/indicateurs/nouveau.tsx
+++ b/apps/mb-admin/src/routes/_authed/indicateurs/nouveau.tsx
@@ -2,7 +2,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router'
 import { useState } from 'react'
 
-import { upsertIndicateur } from '@/api/indicateurs'
+import { createIndicateur } from '@/api/indicateurs'
 import { Breadcrumb } from '@/components/Breadcrumb'
 import {
   buildInitialValues,
@@ -25,7 +25,7 @@ function NewIndicateurComponent() {
 
   const mutation = useMutation({
     mutationFn: (values: IndicateurFormValues) =>
-      upsertIndicateur(values.id, {
+      createIndicateur({
         nom: values.nom,
         visibilite: values.visibilite,
         unite: values.unite,

--- a/apps/mb-api/src/indicateur/commands/generateIndicateurPublicId.test.ts
+++ b/apps/mb-api/src/indicateur/commands/generateIndicateurPublicId.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+
+import { generateIndicateurPublicId } from '@/indicateur/commands/generateIndicateurPublicId'
+import { fixtures } from '@/test/fixtures'
+import { integrationTest } from '@/test/integrationTest'
+
+describe('generateIndicateurPublicId', () => {
+  it(
+    'retourne IND-<max+1> à partir du plus grand numéro existant',
+    integrationTest(async () => {
+      await fixtures.indicateur({ publicId: 'IND-900001' })
+
+      const publicId = await generateIndicateurPublicId()
+
+      expect(publicId).toBe('IND-900002')
+    }),
+  )
+
+  it(
+    'ignore les publicId non numériques pour le calcul du max',
+    integrationTest(async () => {
+      await fixtures.indicateur({ publicId: 'IND-900001' })
+      await fixtures.indicateur({ publicId: 'IND-ZZZ' })
+
+      const publicId = await generateIndicateurPublicId()
+
+      expect(publicId).toBe('IND-900002')
+    }),
+  )
+
+  it(
+    'deux appels successifs (après persistance) donnent des numéros consécutifs',
+    integrationTest(async () => {
+      await fixtures.indicateur({ publicId: 'IND-900001' })
+
+      const premier = await generateIndicateurPublicId()
+      await fixtures.indicateur({ publicId: premier })
+      const second = await generateIndicateurPublicId()
+
+      expect(premier).toBe('IND-900002')
+      expect(second).toBe('IND-900003')
+    }),
+  )
+})

--- a/apps/mb-api/src/indicateur/commands/generateIndicateurPublicId.ts
+++ b/apps/mb-api/src/indicateur/commands/generateIndicateurPublicId.ts
@@ -1,0 +1,17 @@
+import { db } from '@/framework/persistence/dbStore'
+
+// Clé arbitraire, dédiée à la numérotation des indicateurs, pour
+// pg_advisory_xact_lock (sérialise les créations concurrentes). Le verrou est
+// relâché automatiquement au commit/rollback de la transaction courante.
+const INDICATEUR_NUMBERING_LOCK = 4815162342n
+
+export const generateIndicateurPublicId = async (): Promise<string> => {
+  await db().$executeRaw`SELECT pg_advisory_xact_lock(${INDICATEUR_NUMBERING_LOCK})`
+  const rows = await db().$queryRaw<{ max: number }[]>`
+    SELECT COALESCE(MAX(CAST(SUBSTRING(public_id FROM 5) AS INTEGER)), 0) AS max
+    FROM indicateur
+    WHERE public_id ~ '^IND-[0-9]+$'
+  `
+  const max = Number(rows[0]?.max ?? 0)
+  return `IND-${max + 1}`
+}

--- a/apps/mb-api/src/indicateur/commands/writeIndicateur.test.ts
+++ b/apps/mb-api/src/indicateur/commands/writeIndicateur.test.ts
@@ -62,6 +62,12 @@ describe.concurrent('createIndicateur', () => {
         { id: refCreateB, fonctionAgregation: 'NONE' as const },
       ].sort((a, b) => a.id.localeCompare(b.id))
       expect(await getConfigurationsReferentiels(publicId)).toEqual(configurationsTriees)
+
+      const created = await db().indicateur.findUniqueOrThrow({ where: { publicId } })
+      const perms = await db().indicateurPermission.findMany({
+        where: { principalId: apiKey.id, indicateurId: created.id },
+      })
+      expect(perms.map((p) => p.action).sort()).toEqual(['READ', 'WRITE'])
     }),
   )
 

--- a/apps/mb-api/src/indicateur/commands/writeIndicateur.test.ts
+++ b/apps/mb-api/src/indicateur/commands/writeIndicateur.test.ts
@@ -2,10 +2,10 @@ import { describe, expect, it } from 'vitest'
 
 import { ForbiddenError, ValidationError } from '@/framework/errors/AppError'
 import { db } from '@/framework/persistence/dbStore'
-import { upsertIndicateur } from '@/indicateur/commands/upsertIndicateur'
+import { createIndicateur, updateIndicateur } from '@/indicateur/commands/writeIndicateur'
 import { fixtures } from '@/test/fixtures'
 import { integrationTest } from '@/test/integrationTest'
-import { testIndicateurId, testReferentielId } from '@/test/randomIds'
+import { testReferentielId } from '@/test/randomIds'
 import { runAsAdmin, runAsContributor, runAsUser } from '@/test/runAsPrincipal'
 
 const METADONNEES_VIDES = {
@@ -30,11 +30,10 @@ const getConfigurationsReferentiels = async (publicId: string) => {
     .sort((a, b) => a.id.localeCompare(b.id))
 }
 
-describe.concurrent('upsertIndicateur', () => {
+describe.concurrent('createIndicateur', () => {
   it(
     'crée un indicateur avec ses référentiels configurés et auto-grant READ+WRITE au créateur',
     integrationTest(async () => {
-      const indId = testIndicateurId()
       const refCreateA = testReferentielId()
       const refCreateB = testReferentielId()
       const apiKey = await fixtures.apiKey()
@@ -42,7 +41,7 @@ describe.concurrent('upsertIndicateur', () => {
       const refB = await fixtures.referentiel({ publicId: refCreateB })
 
       const result = await runAsAdmin(apiKey.id, () =>
-        upsertIndicateur(indId, {
+        createIndicateur({
           nom: 'Nouvel indicateur',
           visibilite: 'PRIVE',
           unite: null,
@@ -55,27 +54,44 @@ describe.concurrent('upsertIndicateur', () => {
       )
 
       expect(result.isOk()).toBe(true)
+      const publicId = result._unsafeUnwrap()
+      expect(publicId).toMatch(/^IND-\d+$/)
+
       const configurationsTriees = [
         { id: refCreateA, fonctionAgregation: 'SUM' as const },
         { id: refCreateB, fonctionAgregation: 'NONE' as const },
       ].sort((a, b) => a.id.localeCompare(b.id))
-      expect(await getConfigurationsReferentiels(indId)).toEqual(configurationsTriees)
-      const grants = await db().indicateurPermission.findMany({
-        where: { principalId: apiKey.id, indicateur: { publicId: indId } },
-        orderBy: { action: 'asc' },
-      })
-      expect(grants.map((g) => g.action)).toEqual(['READ', 'WRITE'])
+      expect(await getConfigurationsReferentiels(publicId)).toEqual(configurationsTriees)
+    }),
+  )
+
+  it(
+    'génère un publicId IND-<max+1>',
+    integrationTest(async () => {
+      await fixtures.indicateur({ publicId: 'IND-900001' })
+      const apiKey = await fixtures.apiKey()
+
+      const result = await runAsAdmin(apiKey.id, () =>
+        createIndicateur({
+          nom: 'Indicateur numéroté',
+          visibilite: 'PRIVE',
+          unite: null,
+          ...METADONNEES_VIDES,
+          referentiels: [],
+        }),
+      )
+
+      expect(result._unsafeUnwrap()).toBe('IND-900002')
     }),
   )
 
   it(
     'persiste la visibilité fournie à la création',
     integrationTest(async () => {
-      const indId = testIndicateurId()
       const apiKey = await fixtures.apiKey()
 
-      await runAsAdmin(apiKey.id, () =>
-        upsertIndicateur(indId, {
+      const result = await runAsAdmin(apiKey.id, () =>
+        createIndicateur({
           nom: 'I',
           visibilite: 'PUBLIC',
           unite: null,
@@ -84,7 +100,8 @@ describe.concurrent('upsertIndicateur', () => {
         }),
       )
 
-      const row = await db().indicateur.findUniqueOrThrow({ where: { publicId: indId } })
+      const publicId = result._unsafeUnwrap()
+      const row = await db().indicateur.findUniqueOrThrow({ where: { publicId } })
       expect(row.visibilite).toBe('PUBLIC')
     }),
   )
@@ -92,11 +109,10 @@ describe.concurrent('upsertIndicateur', () => {
   it(
     "persiste l'unité fournie à la création et la met à jour via PUT",
     integrationTest(async () => {
-      const indId = testIndicateurId()
       const apiKey = await fixtures.apiKey()
 
-      await runAsAdmin(apiKey.id, () =>
-        upsertIndicateur(indId, {
+      const createResult = await runAsAdmin(apiKey.id, () =>
+        createIndicateur({
           nom: 'I',
           visibilite: 'PRIVE',
           unite: 'POURCENTAGE',
@@ -104,11 +120,12 @@ describe.concurrent('upsertIndicateur', () => {
           referentiels: [],
         }),
       )
-      const apresCreation = await db().indicateur.findUniqueOrThrow({ where: { publicId: indId } })
+      const publicId = createResult._unsafeUnwrap()
+      const apresCreation = await db().indicateur.findUniqueOrThrow({ where: { publicId } })
       expect(apresCreation.unite).toBe('POURCENTAGE')
 
       await runAsAdmin(apiKey.id, () =>
-        upsertIndicateur(indId, {
+        updateIndicateur(publicId, {
           nom: 'I',
           visibilite: 'PRIVE',
           unite: 'ANNEES',
@@ -116,11 +133,11 @@ describe.concurrent('upsertIndicateur', () => {
           referentiels: [],
         }),
       )
-      const apresMaj = await db().indicateur.findUniqueOrThrow({ where: { publicId: indId } })
+      const apresMaj = await db().indicateur.findUniqueOrThrow({ where: { publicId } })
       expect(apresMaj.unite).toBe('ANNEES')
 
       await runAsAdmin(apiKey.id, () =>
-        upsertIndicateur(indId, {
+        updateIndicateur(publicId, {
           nom: 'I',
           visibilite: 'PRIVE',
           unite: null,
@@ -128,7 +145,7 @@ describe.concurrent('upsertIndicateur', () => {
           referentiels: [],
         }),
       )
-      const apresRemise = await db().indicateur.findUniqueOrThrow({ where: { publicId: indId } })
+      const apresRemise = await db().indicateur.findUniqueOrThrow({ where: { publicId } })
       expect(apresRemise.unite).toBeNull()
     }),
   )
@@ -136,11 +153,10 @@ describe.concurrent('upsertIndicateur', () => {
   it(
     'persiste les métadonnées (description, méthode, sources, période/jour) à la création et au PUT',
     integrationTest(async () => {
-      const indId = testIndicateurId()
       const apiKey = await fixtures.apiKey()
 
-      await runAsAdmin(apiKey.id, () =>
-        upsertIndicateur(indId, {
+      const createResult = await runAsAdmin(apiKey.id, () =>
+        createIndicateur({
           nom: 'I',
           visibilite: 'PRIVE',
           unite: null,
@@ -153,8 +169,9 @@ describe.concurrent('upsertIndicateur', () => {
           referentiels: [],
         }),
       )
+      const publicId = createResult._unsafeUnwrap()
 
-      const apresCreation = await db().indicateur.findUniqueOrThrow({ where: { publicId: indId } })
+      const apresCreation = await db().indicateur.findUniqueOrThrow({ where: { publicId } })
       expect(apresCreation.description).toBe('Description initiale')
       expect(apresCreation.methodeCalcul).toBe('Moyenne')
       expect(apresCreation.sourceDonnees).toBe('INSEE')
@@ -163,7 +180,7 @@ describe.concurrent('upsertIndicateur', () => {
       expect(apresCreation.jourMiseAJour).toBe(5)
 
       await runAsAdmin(apiKey.id, () =>
-        upsertIndicateur(indId, {
+        updateIndicateur(publicId, {
           nom: 'I',
           visibilite: 'PRIVE',
           unite: null,
@@ -177,7 +194,7 @@ describe.concurrent('upsertIndicateur', () => {
         }),
       )
 
-      const apresMaj = await db().indicateur.findUniqueOrThrow({ where: { publicId: indId } })
+      const apresMaj = await db().indicateur.findUniqueOrThrow({ where: { publicId } })
       expect(apresMaj.description).toBeNull()
       expect(apresMaj.methodeCalcul).toBeNull()
       expect(apresMaj.sourceDonnees).toBeNull()
@@ -188,33 +205,8 @@ describe.concurrent('upsertIndicateur', () => {
   )
 
   it(
-    "permet à un principal disposant de WRITE de modifier la visibilité d'un indicateur existant",
-    integrationTest(async () => {
-      const indId = testIndicateurId()
-      await fixtures.indicateur({ publicId: indId, visibilite: 'PRIVE' })
-      const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: 'WRITE' }],
-      })
-
-      await runAsAdmin(apiKey.id, () =>
-        upsertIndicateur(indId, {
-          nom: 'I',
-          visibilite: 'PUBLIC',
-          unite: null,
-          ...METADONNEES_VIDES,
-          referentiels: [],
-        }),
-      )
-
-      const row = await db().indicateur.findUniqueOrThrow({ where: { publicId: indId } })
-      expect(row.visibilite).toBe('PUBLIC')
-    }),
-  )
-
-  it(
     "remplace l'ensemble des configurations à chaque PUT (ajout + suppression)",
     integrationTest(async () => {
-      const indId = testIndicateurId()
       const refReplaceA = testReferentielId()
       const refReplaceB = testReferentielId()
       const refReplaceC = testReferentielId()
@@ -224,8 +216,8 @@ describe.concurrent('upsertIndicateur', () => {
         { publicId: refReplaceC },
       )
       const apiKey = await fixtures.apiKey()
-      await runAsAdmin(apiKey.id, () =>
-        upsertIndicateur(indId, {
+      const createResult = await runAsAdmin(apiKey.id, () =>
+        createIndicateur({
           nom: 'I',
           visibilite: 'PRIVE',
           unite: null,
@@ -236,9 +228,10 @@ describe.concurrent('upsertIndicateur', () => {
           ],
         }),
       )
+      const publicId = createResult._unsafeUnwrap()
 
       await runAsAdmin(apiKey.id, () =>
-        upsertIndicateur(indId, {
+        updateIndicateur(publicId, {
           nom: 'I',
           visibilite: 'PRIVE',
           unite: null,
@@ -254,19 +247,18 @@ describe.concurrent('upsertIndicateur', () => {
         { id: refReplaceB, fonctionAgregation: 'SUM' as const },
         { id: refReplaceC, fonctionAgregation: 'SUM' as const },
       ].sort((a, b) => a.id.localeCompare(b.id))
-      expect(await getConfigurationsReferentiels(indId)).toEqual(configurationsTriees)
+      expect(await getConfigurationsReferentiels(publicId)).toEqual(configurationsTriees)
     }),
   )
 
   it(
     'accepte un tableau vide (supprime toutes les configurations)',
     integrationTest(async () => {
-      const indId = testIndicateurId()
       const refEmptyA = testReferentielId()
       await fixtures.referentiel({ publicId: refEmptyA })
       const apiKey = await fixtures.apiKey()
-      await runAsAdmin(apiKey.id, () =>
-        upsertIndicateur(indId, {
+      const createResult = await runAsAdmin(apiKey.id, () =>
+        createIndicateur({
           nom: 'I',
           visibilite: 'PRIVE',
           unite: null,
@@ -274,9 +266,10 @@ describe.concurrent('upsertIndicateur', () => {
           referentiels: [{ id: refEmptyA, fonctionAgregation: 'SUM' }],
         }),
       )
+      const publicId = createResult._unsafeUnwrap()
 
       await runAsAdmin(apiKey.id, () =>
-        upsertIndicateur(indId, {
+        updateIndicateur(publicId, {
           nom: 'I',
           visibilite: 'PRIVE',
           unite: null,
@@ -285,20 +278,19 @@ describe.concurrent('upsertIndicateur', () => {
         }),
       )
 
-      expect(await getConfigurationsReferentiels(indId)).toEqual([])
+      expect(await getConfigurationsReferentiels(publicId)).toEqual([])
     }),
   )
 
   it(
     'dédoublonne silencieusement les id en double',
     integrationTest(async () => {
-      const indId = testIndicateurId()
       const refDedupA = testReferentielId()
       await fixtures.referentiel({ publicId: refDedupA })
       const apiKey = await fixtures.apiKey()
 
       const result = await runAsAdmin(apiKey.id, () =>
-        upsertIndicateur(indId, {
+        createIndicateur({
           nom: 'I',
           visibilite: 'PRIVE',
           unite: null,
@@ -311,7 +303,8 @@ describe.concurrent('upsertIndicateur', () => {
       )
 
       expect(result.isOk()).toBe(true)
-      expect(await getConfigurationsReferentiels(indId)).toEqual([
+      const publicId = result._unsafeUnwrap()
+      expect(await getConfigurationsReferentiels(publicId)).toEqual([
         { id: refDedupA, fonctionAgregation: 'SUM' },
       ])
     }),
@@ -320,7 +313,6 @@ describe.concurrent('upsertIndicateur', () => {
   it(
     'rejette quand un id est inconnu, avec la liste des IDs manquants',
     integrationTest(async () => {
-      const indId = testIndicateurId()
       const refKnownA = testReferentielId()
       const refUnknownX = testReferentielId()
       const refUnknownY = testReferentielId()
@@ -329,7 +321,7 @@ describe.concurrent('upsertIndicateur', () => {
 
       await expect(
         runAsAdmin(apiKey.id, () =>
-          upsertIndicateur(indId, {
+          createIndicateur({
             nom: 'I',
             visibilite: 'PRIVE',
             unite: null,
@@ -345,45 +337,18 @@ describe.concurrent('upsertIndicateur', () => {
         constructor: ValidationError,
         details: { unknownReferentielIds: [refUnknownX, refUnknownY].sort() },
       })
-
-      const created = await db().indicateur.findUnique({ where: { publicId: indId } })
-      expect(created).toBeNull()
-    }),
-  )
-
-  it(
-    "rejette la mise à jour quand le principal n'a pas la permission WRITE",
-    integrationTest(async () => {
-      const indId = testIndicateurId()
-      await fixtures.indicateur({ publicId: indId, nom: 'Ancien' })
-      const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: 'READ' }],
-      })
-
-      await expect(
-        runAsAdmin(apiKey.id, () =>
-          upsertIndicateur(indId, {
-            nom: 'X',
-            visibilite: 'PRIVE',
-            unite: null,
-            ...METADONNEES_VIDES,
-            referentiels: [],
-          }),
-        ),
-      ).rejects.toThrow(/permission/i)
     }),
   )
 
   it(
     'met à jour la fonctionAgregation pour une configuration existante',
     integrationTest(async () => {
-      const indId = testIndicateurId()
       const refUpdateA = testReferentielId()
       await fixtures.referentiel({ publicId: refUpdateA })
       const apiKey = await fixtures.apiKey()
 
-      await runAsAdmin(apiKey.id, () =>
-        upsertIndicateur(indId, {
+      const createResult = await runAsAdmin(apiKey.id, () =>
+        createIndicateur({
           nom: 'I',
           visibilite: 'PRIVE',
           unite: null,
@@ -391,9 +356,10 @@ describe.concurrent('upsertIndicateur', () => {
           referentiels: [{ id: refUpdateA, fonctionAgregation: 'SUM' }],
         }),
       )
+      const publicId = createResult._unsafeUnwrap()
 
       await runAsAdmin(apiKey.id, () =>
-        upsertIndicateur(indId, {
+        updateIndicateur(publicId, {
           nom: 'I',
           visibilite: 'PRIVE',
           unite: null,
@@ -402,7 +368,7 @@ describe.concurrent('upsertIndicateur', () => {
         }),
       )
 
-      expect(await getConfigurationsReferentiels(indId)).toEqual([
+      expect(await getConfigurationsReferentiels(publicId)).toEqual([
         { id: refUpdateA, fonctionAgregation: 'NONE' },
       ])
     }),
@@ -411,13 +377,12 @@ describe.concurrent('upsertIndicateur', () => {
   it(
     "dédoublonne sur id : en cas de fonctions différentes, la dernière l'emporte",
     integrationTest(async () => {
-      const indId = testIndicateurId()
       const refDedupFn = testReferentielId()
       await fixtures.referentiel({ publicId: refDedupFn })
       const apiKey = await fixtures.apiKey()
 
       const result = await runAsAdmin(apiKey.id, () =>
-        upsertIndicateur(indId, {
+        createIndicateur({
           nom: 'I',
           visibilite: 'PRIVE',
           unite: null,
@@ -430,14 +395,110 @@ describe.concurrent('upsertIndicateur', () => {
       )
 
       expect(result.isOk()).toBe(true)
-      expect(await getConfigurationsReferentiels(indId)).toEqual([
+      const publicId = result._unsafeUnwrap()
+      expect(await getConfigurationsReferentiels(publicId)).toEqual([
         { id: refDedupFn, fonctionAgregation: 'NONE' },
       ])
     }),
   )
 })
 
-describe.concurrent('upsertIndicateur — garde ADMIN', () => {
+describe.concurrent('updateIndicateur', () => {
+  it(
+    'met à jour un indicateur existant',
+    integrationTest(async () => {
+      const apiKey = await fixtures.apiKey()
+      const principalId = apiKey.id
+      const existant = await fixtures.indicateur({ publicId: 'IND-900500', nom: 'Ancien nom' })
+      await db().indicateurPermission.createMany({
+        data: [
+          { principalId, indicateurId: existant.id, action: 'WRITE' },
+          { principalId, indicateurId: existant.id, action: 'READ' },
+        ],
+      })
+
+      const result = await runAsAdmin(apiKey.id, () =>
+        updateIndicateur('IND-900500', {
+          nom: 'Nouveau nom',
+          visibilite: 'PUBLIC',
+          unite: null,
+          ...METADONNEES_VIDES,
+          referentiels: [],
+        }),
+      )
+
+      expect(result.isOk()).toBe(true)
+      const maj = await db().indicateur.findUniqueOrThrow({ where: { publicId: 'IND-900500' } })
+      expect(maj.nom).toBe('Nouveau nom')
+    }),
+  )
+
+  it(
+    "échoue en 404 (P2025) si l'indicateur à mettre à jour n'existe pas",
+    integrationTest(async () => {
+      const apiKey = await fixtures.apiKey()
+
+      await expect(
+        runAsAdmin(apiKey.id, () =>
+          updateIndicateur('IND-909090', {
+            nom: 'Peu importe',
+            visibilite: 'PRIVE',
+            unite: null,
+            ...METADONNEES_VIDES,
+            referentiels: [],
+          }),
+        ),
+      ).rejects.toMatchObject({ code: 'P2025' })
+    }),
+  )
+
+  it(
+    "permet à un principal disposant de WRITE de modifier la visibilité d'un indicateur existant",
+    integrationTest(async () => {
+      await fixtures.indicateur({ publicId: 'IND-900501', visibilite: 'PRIVE' })
+      const apiKey = await fixtures.apiKey({
+        permissions: [{ indicateur: { publicId: 'IND-900501' }, action: 'WRITE' }],
+      })
+
+      await runAsAdmin(apiKey.id, () =>
+        updateIndicateur('IND-900501', {
+          nom: 'I',
+          visibilite: 'PUBLIC',
+          unite: null,
+          ...METADONNEES_VIDES,
+          referentiels: [],
+        }),
+      )
+
+      const row = await db().indicateur.findUniqueOrThrow({ where: { publicId: 'IND-900501' } })
+      expect(row.visibilite).toBe('PUBLIC')
+    }),
+  )
+
+  it(
+    "rejette la mise à jour quand le principal n'a pas la permission WRITE",
+    integrationTest(async () => {
+      await fixtures.indicateur({ publicId: 'IND-900502', nom: 'Ancien' })
+      const apiKey = await fixtures.apiKey({
+        permissions: [{ indicateur: { publicId: 'IND-900502' }, action: 'READ' }],
+      })
+
+      await expect(
+        runAsAdmin(apiKey.id, () =>
+          updateIndicateur('IND-900502', {
+            nom: 'X',
+            visibilite: 'PRIVE',
+            unite: null,
+            ...METADONNEES_VIDES,
+            referentiels: [],
+          }),
+        ),
+      ).rejects.toThrow(/permission/i)
+    }),
+  )
+})
+
+describe.concurrent('writeIndicateur — garde ADMIN', () => {
   const body = {
     nom: 'Nouveau nom',
     visibilite: 'PRIVE' as const,
@@ -449,13 +510,10 @@ describe.concurrent('upsertIndicateur — garde ADMIN', () => {
   it(
     'refuse une clé CONTRIBUTOR (403)',
     integrationTest(async () => {
-      const indId = testIndicateurId()
-      const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: 'WRITE' }],
-      })
+      const apiKey = await fixtures.apiKey()
 
       await expect(
-        runAsContributor(apiKey.id, () => upsertIndicateur(indId, body)),
+        runAsContributor(apiKey.id, () => createIndicateur(body)),
       ).rejects.toBeInstanceOf(ForbiddenError)
     }),
   )
@@ -463,13 +521,13 @@ describe.concurrent('upsertIndicateur — garde ADMIN', () => {
   it(
     'autorise une clé ADMIN à créer un indicateur',
     integrationTest(async () => {
-      const indId = testIndicateurId()
       const apiKey = await fixtures.apiKey()
 
-      const result = await runAsAdmin(apiKey.id, () => upsertIndicateur(indId, body))
+      const result = await runAsAdmin(apiKey.id, () => createIndicateur(body))
 
       expect(result.isOk()).toBe(true)
-      const row = await db().indicateur.findUnique({ where: { publicId: indId } })
+      const publicId = result._unsafeUnwrap()
+      const row = await db().indicateur.findUnique({ where: { publicId } })
       expect(row?.nom).toBe('Nouveau nom')
     }),
   )
@@ -477,10 +535,9 @@ describe.concurrent('upsertIndicateur — garde ADMIN', () => {
   it(
     'autorise un utilisateur OIDC à créer un indicateur',
     integrationTest(async () => {
-      const indId = testIndicateurId()
       const utilisateur = await fixtures.utilisateur()
 
-      const result = await runAsUser(utilisateur.id, () => upsertIndicateur(indId, body))
+      const result = await runAsUser(utilisateur.id, () => createIndicateur(body))
 
       expect(result.isOk()).toBe(true)
     }),

--- a/apps/mb-api/src/indicateur/commands/writeIndicateur.ts
+++ b/apps/mb-api/src/indicateur/commands/writeIndicateur.ts
@@ -10,6 +10,7 @@ import { requireCurrentPrincipalId } from '@/framework/auth/userContext'
 import { ForbiddenError, ValidationError } from '@/framework/errors/AppError'
 import { db } from '@/framework/persistence/dbStore'
 import { type FonctionAgregation, PermissionAction } from '@/generated/prisma/enums'
+import { generateIndicateurPublicId } from '@/indicateur/commands/generateIndicateurPublicId'
 
 type ConfigurationResolue = {
   referentielId: string
@@ -122,26 +123,6 @@ const metadonneesData = (body: UpsertIndicateurBody) => ({
   ...(body.jourMiseAJour !== undefined && { jourMiseAJour: body.jourMiseAJour }),
 })
 
-const updateIndicateurExistant = async (
-  publicId: string,
-  indicateurId: string,
-  body: UpsertIndicateurBody,
-  principalId: string,
-): Promise<void> => {
-  await assertWritePermission(indicateurId, principalId)
-  const configurations = await resoudreConfigurationsReferentiels(body.referentiels)
-  await db().indicateur.update({
-    where: { publicId },
-    data: {
-      nom: body.nom,
-      visibilite: body.visibilite,
-      unite: body.unite,
-      ...metadonneesData(body),
-    },
-  })
-  await remplacerConfigurationsReferentiels(indicateurId, configurations)
-}
-
 const grantOwnerPermissions = async (principalId: string, indicateurId: string): Promise<void> => {
   await db().indicateurPermission.createMany({
     data: [
@@ -152,11 +133,11 @@ const grantOwnerPermissions = async (principalId: string, indicateurId: string):
 }
 
 const createIndicateurAvecGrants = async (
-  publicId: string,
   body: UpsertIndicateurBody,
   principalId: string,
-): Promise<void> => {
+): Promise<string> => {
   const configurations = await resoudreConfigurationsReferentiels(body.referentiels)
+  const publicId = await generateIndicateurPublicId()
   const indicateurId = uuidv7()
   await db().indicateur.create({
     data: {
@@ -178,20 +159,45 @@ const createIndicateurAvecGrants = async (
       })),
     })
   }
+  return publicId
 }
 
-const performUpsert = async (publicId: string, body: UpsertIndicateurBody): Promise<void> => {
-  ensureApiKeyAdmin()
-  const principalId = requireCurrentPrincipalId()
-  const existant = await db().indicateur.findUnique({ where: { publicId } })
-  if (existant) {
-    await updateIndicateurExistant(publicId, existant.id, body, principalId)
-    return
-  }
-  await createIndicateurAvecGrants(publicId, body, principalId)
-}
-
-export const upsertIndicateur = (
+const updateIndicateurExistant = async (
   publicId: string,
   body: UpsertIndicateurBody,
-): ResultAsync<void, never> => ResultAsync.fromSafePromise(performUpsert(publicId, body))
+  principalId: string,
+): Promise<void> => {
+  const existant = await db().indicateur.findUniqueOrThrow({ where: { publicId } })
+  await assertWritePermission(existant.id, principalId)
+  const configurations = await resoudreConfigurationsReferentiels(body.referentiels)
+  await db().indicateur.update({
+    where: { publicId },
+    data: {
+      nom: body.nom,
+      visibilite: body.visibilite,
+      unite: body.unite,
+      ...metadonneesData(body),
+    },
+  })
+  await remplacerConfigurationsReferentiels(existant.id, configurations)
+}
+
+const performCreate = async (body: UpsertIndicateurBody): Promise<string> => {
+  ensureApiKeyAdmin()
+  const principalId = requireCurrentPrincipalId()
+  return createIndicateurAvecGrants(body, principalId)
+}
+
+const performUpdate = async (publicId: string, body: UpsertIndicateurBody): Promise<void> => {
+  ensureApiKeyAdmin()
+  const principalId = requireCurrentPrincipalId()
+  await updateIndicateurExistant(publicId, body, principalId)
+}
+
+export const createIndicateur = (body: UpsertIndicateurBody): ResultAsync<string, never> =>
+  ResultAsync.fromSafePromise(performCreate(body))
+
+export const updateIndicateur = (
+  publicId: string,
+  body: UpsertIndicateurBody,
+): ResultAsync<void, never> => ResultAsync.fromSafePromise(performUpdate(publicId, body))

--- a/apps/mb-api/src/indicateur/routes.ts
+++ b/apps/mb-api/src/indicateur/routes.ts
@@ -26,8 +26,9 @@ import { requireAuthentication } from '@/framework/auth/requireAuthentication'
 import { never } from '@/framework/errors/never'
 import { jsonResponseOk } from '@/framework/openapi/jsonResponse'
 import { erreur400, erreur403, erreur404 } from '@/framework/openapi/responses'
+import { db } from '@/framework/persistence/dbStore'
 import { withTransaction } from '@/framework/persistence/withTransaction'
-import { upsertIndicateur } from '@/indicateur/commands/upsertIndicateur'
+import { createIndicateur, updateIndicateur } from '@/indicateur/commands/writeIndicateur'
 import {
   creerIndicateurIndividuCommentaire,
   indicateurIndividuConfig,
@@ -156,8 +157,14 @@ indicateurRoutes.openapi(upsertIndicateurRoute, async (context) => {
   const body = context.req.valid('json')
 
   const result = await withTransaction(async () => {
-    await upsertIndicateur(id, body)
-    return getIndicateurByPublicId(id)
+    // Temporary adapter — Task 4 will split create/update into dedicated routes
+    const existing = await db().indicateur.findUnique({ where: { publicId: id } })
+    if (existing) {
+      await updateIndicateur(id, body)
+      return getIndicateurByPublicId(id)
+    }
+    const generatedId = (await createIndicateur(body))._unsafeUnwrap()
+    return getIndicateurByPublicId(generatedId)
   })
 
   return result.match(

--- a/apps/mb-api/src/indicateur/routes.ts
+++ b/apps/mb-api/src/indicateur/routes.ts
@@ -118,7 +118,7 @@ const createIndicateurRoute = createRoute({
 
 // --- PUT /indicateurs/:id ----------------------------------------------------
 
-const upsertIndicateurRoute = createRoute({
+const updateIndicateurRoute = createRoute({
   method: 'put',
   path: '/indicateurs/{id}',
   tags: ['Indicateur', 'Admin'],
@@ -192,7 +192,7 @@ indicateurRoutes.openapi(createIndicateurRoute, async (context) => {
   )
 })
 
-indicateurRoutes.openapi(upsertIndicateurRoute, async (context) => {
+indicateurRoutes.openapi(updateIndicateurRoute, async (context) => {
   const { id } = context.req.valid('param')
   const body = context.req.valid('json')
 

--- a/apps/mb-api/src/indicateur/routes.ts
+++ b/apps/mb-api/src/indicateur/routes.ts
@@ -26,7 +26,6 @@ import { requireAuthentication } from '@/framework/auth/requireAuthentication'
 import { never } from '@/framework/errors/never'
 import { jsonResponseOk } from '@/framework/openapi/jsonResponse'
 import { erreur400, erreur403, erreur404 } from '@/framework/openapi/responses'
-import { db } from '@/framework/persistence/dbStore'
 import { withTransaction } from '@/framework/persistence/withTransaction'
 import { createIndicateur, updateIndicateur } from '@/indicateur/commands/writeIndicateur'
 import {
@@ -91,15 +90,41 @@ const getIndicateurByIdRoute = createRoute({
   },
 })
 
+// --- POST /indicateurs -------------------------------------------------------
+
+const createIndicateurRoute = createRoute({
+  method: 'post',
+  path: '/indicateurs',
+  tags: ['Indicateur', 'Admin'],
+  summary: 'Créer un indicateur (identifiant public généré par le serveur)',
+  description:
+    "Réservé aux clés API de rôle `ADMIN` (les utilisateurs OIDC authentifiés restent autorisés). Crée un indicateur ; l'identifiant public (`IND-<n>`) est généré côté serveur (dernier numéro + 1). Le champ `referentiels` applique la sémantique replace-all. Si un `referentielId` n'existe pas, 400 `VALIDATION_ERROR` + `details.unknownReferentielIds`. L'opération est atomique.",
+  middleware: [requireAuthentication],
+  request: {
+    body: {
+      content: { 'application/json': { schema: UpsertIndicateurBodySchema } },
+      required: true,
+    },
+  },
+  responses: {
+    200: {
+      content: { 'application/json': { schema: IndicateurApiModelSchema } },
+      description: 'Indicateur créé',
+    },
+    400: erreur400,
+    403: erreur403,
+  },
+})
+
 // --- PUT /indicateurs/:id ----------------------------------------------------
 
 const upsertIndicateurRoute = createRoute({
   method: 'put',
   path: '/indicateurs/{id}',
   tags: ['Indicateur', 'Admin'],
-  summary: 'Créer ou remplacer un indicateur (nom + référentiels liés)',
+  summary: 'Mettre à jour un indicateur (nom + référentiels liés)',
   description:
-    "Réservé aux clés API de rôle `ADMIN` (les utilisateurs OIDC authentifiés restent autorisés). Crée l'indicateur s'il n'existe pas, ou met à jour son `nom` si déjà présent. Le champ `referentielIds` est obligatoire et applique une sémantique replace-all : l'ensemble des liens devient strictement celui décrit dans le body (tableau vide pour aucun lien). Les doublons sont silencieusement dédupliqués. Si un `referentielId` n'existe pas, l'appel échoue avec 400 `VALIDATION_ERROR` et `details.unknownReferentielIds`. L'opération est atomique (transaction unique).",
+    "Réservé aux clés API de rôle `ADMIN` (les utilisateurs OIDC authentifiés restent autorisés). Met à jour le `nom`, la visibilité, l'unité, les métadonnées et les référentiels liés (replace-all). Renvoie 404 (`ENTITY_NOT_FOUND`) si l'indicateur n'existe pas. L'opération est atomique.",
   middleware: [requireAuthentication],
   request: {
     params: detailParamsSchema,
@@ -111,10 +136,11 @@ const upsertIndicateurRoute = createRoute({
   responses: {
     200: {
       content: { 'application/json': { schema: IndicateurApiModelSchema } },
-      description: 'Indicateur créé ou mis à jour',
+      description: 'Indicateur mis à jour',
     },
     400: erreur400,
     403: erreur403,
+    404: erreur404,
   },
 })
 
@@ -152,29 +178,31 @@ indicateurRoutes.openapi(getIndicateurByIdRoute, async (context) => {
   )
 })
 
+indicateurRoutes.openapi(createIndicateurRoute, async (context) => {
+  const body = context.req.valid('json')
+
+  const result = await withTransaction(async () => {
+    const publicId = (await createIndicateur(body))._unsafeUnwrap()
+    return getIndicateurByPublicId(publicId)
+  })
+
+  return result.match(
+    (data) => jsonResponseOk({ context, data, schema: IndicateurApiModelSchema, status: 200 }),
+    never,
+  )
+})
+
 indicateurRoutes.openapi(upsertIndicateurRoute, async (context) => {
   const { id } = context.req.valid('param')
   const body = context.req.valid('json')
 
   const result = await withTransaction(async () => {
-    // Temporary adapter — Task 4 will split create/update into dedicated routes
-    const existing = await db().indicateur.findUnique({ where: { publicId: id } })
-    if (existing) {
-      await updateIndicateur(id, body)
-      return getIndicateurByPublicId(id)
-    }
-    const generatedId = (await createIndicateur(body))._unsafeUnwrap()
-    return getIndicateurByPublicId(generatedId)
+    ;(await updateIndicateur(id, body))._unsafeUnwrap()
+    return getIndicateurByPublicId(id)
   })
 
   return result.match(
-    (data) =>
-      jsonResponseOk({
-        context,
-        data,
-        schema: IndicateurApiModelSchema,
-        status: 200,
-      }),
+    (data) => jsonResponseOk({ context, data, schema: IndicateurApiModelSchema, status: 200 }),
     never,
   )
 })

--- a/packages/mb-shared/src/publicIds.ts
+++ b/packages/mb-shared/src/publicIds.ts
@@ -2,13 +2,8 @@ import { z } from 'zod'
 
 export const indicateurPublicIdSchema = z
   .string()
-  .regex(
-    /^(?!PAN-|REF-|WID-)[A-Z][A-Z0-9-]{0,19}$/,
-    "Identifiant public d'indicateur attendu (lettre majuscule puis lettres/chiffres/tirets, max 20 caractères ; préfixes PAN-, REF-, WID- réservés)",
-  )
-  .describe(
-    "Identifiant public de l'indicateur (ex. IND-001, IND-TAUX-CHOMAGE). Lettre majuscule puis lettres/chiffres/tirets, max 20 caractères. Préfixes PAN-, REF-, WID- réservés.",
-  )
+  .regex(/^IND-\d+$/, 'Identifiant public attendu au format IND-XXX')
+  .describe("Identifiant public de l'indicateur (format IND-XXX).")
 
 export const panierPublicIdSchema = z
   .string()

--- a/packages/mb-shared/src/publicIds.ts
+++ b/packages/mb-shared/src/publicIds.ts
@@ -2,8 +2,13 @@ import { z } from 'zod'
 
 export const indicateurPublicIdSchema = z
   .string()
-  .regex(/^IND-\d+$/, 'Identifiant public attendu au format IND-XXX')
-  .describe("Identifiant public de l'indicateur (format IND-XXX).")
+  .regex(
+    /^(?!PAN-|REF-|WID-)[A-Z][A-Z0-9-]{0,19}$/,
+    "Identifiant public d'indicateur attendu (lettre majuscule puis lettres/chiffres/tirets, max 20 caractères ; préfixes PAN-, REF-, WID- réservés)",
+  )
+  .describe(
+    "Identifiant public de l'indicateur (ex. IND-001, IND-TAUX-CHOMAGE). Lettre majuscule puis lettres/chiffres/tirets, max 20 caractères. Préfixes PAN-, REF-, WID- réservés.",
+  )
 
 export const panierPublicIdSchema = z
   .string()


### PR DESCRIPTION
## Contexte

Avant : le `publicId` d'un indicateur (`IND-XXX`) était **choisi par le client** via `PUT /indicateurs/{id}` (upsert). Désormais il est **généré par le serveur** (dernier numéro + 1), et la création est distincte de la mise à jour.

## Changements

### API (mb-api)
- **`POST /indicateurs`** (nouveau) : crée un indicateur, l'identifiant public `IND-<n>` est **généré côté serveur**. Le client ne fournit plus d'id.
- **`PUT /indicateurs/{id}`** : devient **update-only** — renvoie **404** (`ENTITY_NOT_FOUND`) si l'indicateur n'existe pas (fini l'upsert-création).
- Génération : `MAX(numéro des IND-<n> existants) + 1`, sérialisée par un **verrou consultatif Postgres** (`pg_advisory_xact_lock`) pris dans la transaction → pas de collision concurrente, sans retry. Entier brut (`IND-51`, pas de zéro-padding).
- Command `upsertIndicateur` scindée en `createIndicateur` (génère l'id + grants owner READ/WRITE) et `updateIndicateur` (404 si absent).

### Schéma partagé (mb-shared)
- `indicateurPublicIdSchema` restauré au format strict `/^IND-\d+$/`. `panierPublicIdSchema` / `referentielPublicIdSchema` inchangés.
- (Depuis la 1re itération de cette PR) suppression des regex de format d'id **dupliquées en dur** dans les formulaires mb-admin, au profit des schémas partagés `@pilote/mb-shared/publicIds`.

### Front (mb-admin)
- `api/indicateurs.ts` : `createIndicateur` (POST) / `updateIndicateur` (PUT).
- Formulaire de création : le **champ Identifiant est retiré** (l'id est généré) ; le mode édition affiche l'id en lecture seule.

## Compatibilité / hors périmètre

- Les indicateurs existants (`IND-001`…`IND-050`, seeds) restent valides.
- **pilote-ppg (cron `sync-mb-valeurs`)** pousse ses indicateurs vers mb-api via `PUT` avec ses propres ids. On considère que ces indicateurs **existent déjà** dans mb-api (le PUT update-only les met à jour). Le cas « création sous id imposé par ppg » (route admin dédiée + mapping) sera traité **ultérieurement** lors de l'approfondissement de la synchro.

## Tests

- mb-api : suite complète verte (415 tests). Nouveaux tests : génération `IND-<max+1>`, ignore les ids non numériques, numéros consécutifs, update, 404 sur update d'un id absent, grant owner READ/WRITE à la création.
- mb-admin : lint (eslint + tsc + prettier) vert.