### PR TITLE
feat(utilisateurs): CRU utilisateurs OIDC pré-provisionnés (mb-api) + IHM d'administration (mb-admin)

### DIFF
--- a/apps/mb-admin/src/api/utilisateurs.ts
+++ b/apps/mb-admin/src/api/utilisateurs.ts
@@ -16,16 +16,6 @@ export const fetchUtilisateurs = async (): Promise<UtilisateurListApiModel> => {
   return utilisateurListApiModelSchema.parse(json)
 }
 
-// La liste étant petite (v0), on l'utilise comme source de vérité pour la page
-// détail via le cache React Query. Ce helper couvre le cas du deep link direct.
-// Une route GET /utilisateurs/:id pourra le remplacer si le besoin l'exige.
-export const fetchUtilisateur = async (id: string): Promise<UtilisateurApiModel> => {
-  const items = await fetchUtilisateurs()
-  const found = items.find((u) => u.id === id)
-  if (!found) throw new Error('Utilisateur introuvable')
-  return found
-}
-
 export const createUtilisateur = async (
   body: CreateUtilisateurBody,
 ): Promise<UtilisateurApiModel> => {

--- a/apps/mb-admin/src/api/utilisateurs.ts
+++ b/apps/mb-admin/src/api/utilisateurs.ts
@@ -1,0 +1,42 @@
+import type {
+  CreateUtilisateurBody,
+  UpdateUtilisateurBody,
+  UtilisateurApiModel,
+  UtilisateurListApiModel,
+} from '@pilote/mb-shared/utilisateur'
+import {
+  utilisateurApiModelSchema,
+  utilisateurListApiModelSchema,
+} from '@pilote/mb-shared/utilisateur'
+
+import { bffClient } from '@/api/client'
+
+export const fetchUtilisateurs = async (): Promise<UtilisateurListApiModel> => {
+  const json = await bffClient.get('utilisateurs').json()
+  return utilisateurListApiModelSchema.parse(json)
+}
+
+// La liste étant petite (v0), on l'utilise comme source de vérité pour la page
+// détail via le cache React Query. Ce helper couvre le cas du deep link direct.
+// Une route GET /utilisateurs/:id pourra le remplacer si le besoin l'exige.
+export const fetchUtilisateur = async (id: string): Promise<UtilisateurApiModel> => {
+  const items = await fetchUtilisateurs()
+  const found = items.find((u) => u.id === id)
+  if (!found) throw new Error('Utilisateur introuvable')
+  return found
+}
+
+export const createUtilisateur = async (
+  body: CreateUtilisateurBody,
+): Promise<UtilisateurApiModel> => {
+  const json = await bffClient.post('utilisateurs', { json: body }).json()
+  return utilisateurApiModelSchema.parse(json)
+}
+
+export const updateUtilisateur = async (
+  id: string,
+  body: UpdateUtilisateurBody,
+): Promise<UtilisateurApiModel> => {
+  const json = await bffClient.patch(`utilisateurs/${id}`, { json: body }).json()
+  return utilisateurApiModelSchema.parse(json)
+}

--- a/apps/mb-admin/src/api/utilisateurs.ts
+++ b/apps/mb-admin/src/api/utilisateurs.ts
@@ -11,9 +11,19 @@ import {
 
 import { bffClient } from '@/api/client'
 
-export const fetchUtilisateurs = async (): Promise<UtilisateurListApiModel> => {
-  const json = await bffClient.get('utilisateurs').json()
+export const fetchUtilisateurs = async (
+  params: { recherche?: string | undefined; cursor?: string | undefined } = {},
+): Promise<UtilisateurListApiModel> => {
+  const searchParams: Record<string, string> = {}
+  if (params.recherche) searchParams.recherche = params.recherche
+  if (params.cursor) searchParams.cursor = params.cursor
+  const json = await bffClient.get('utilisateurs', { searchParams }).json()
   return utilisateurListApiModelSchema.parse(json)
+}
+
+export const fetchUtilisateurById = async (id: string): Promise<UtilisateurApiModel> => {
+  const json = await bffClient.get(`utilisateurs/${id}`).json()
+  return utilisateurApiModelSchema.parse(json)
 }
 
 export const createUtilisateur = async (

--- a/apps/mb-admin/src/components/ApiKeyForm.tsx
+++ b/apps/mb-admin/src/components/ApiKeyForm.tsx
@@ -3,6 +3,7 @@ import { useForm } from 'react-hook-form'
 import { z } from 'zod'
 
 import { Button } from '@/components/ui/Button'
+import { Input } from '@/components/ui/Input'
 import { useAppConfig } from '@/context/AppConfigContext'
 import { clsxm } from '@/lib/clsxm'
 
@@ -40,15 +41,13 @@ export function ApiKeyForm({
     <form onSubmit={(event) => void handleSubmit(onSubmit)(event)} className="mx-auto max-w-2xl">
       <div className="rounded-xl border border-border bg-surface p-6">
         <div className="mb-5">
-          <label className="mb-1.5 block text-xs font-semibold">
-            Label <span className="text-accent">*</span>
-          </label>
-          <input
-            {...register('label')}
+          <Input
+            label="Label"
+            required
             placeholder="Intégration SI-X"
-            className="w-full rounded-md border border-border px-3 py-2.5 text-sm focus:border-primary focus:outline-none"
+            error={errors.label?.message}
+            {...register('label')}
           />
-          {errors.label ? <p className="mt-1 text-xs text-accent">{errors.label.message}</p> : null}
         </div>
 
         <div className="mb-5">
@@ -63,11 +62,11 @@ export function ApiKeyForm({
         </div>
 
         <div className="mb-2">
-          <label className="mb-1.5 block text-xs font-semibold">Expiration (optionnelle)</label>
-          <input
+          <Input
+            label="Expiration (optionnelle)"
             type="date"
+            className="w-56"
             {...register('expiresAt')}
-            className="w-56 rounded-md border border-border px-3 py-2 text-sm focus:border-primary focus:outline-none"
           />
         </div>
       </div>

--- a/apps/mb-admin/src/components/UtilisateurForm.tsx
+++ b/apps/mb-admin/src/components/UtilisateurForm.tsx
@@ -3,6 +3,7 @@ import { useForm } from 'react-hook-form'
 import { z } from 'zod'
 
 import { Button } from '@/components/ui/Button'
+import { Input } from '@/components/ui/Input'
 import { useAppConfig } from '@/context/AppConfigContext'
 import { clsxm } from '@/lib/clsxm'
 
@@ -16,15 +17,6 @@ const utilisateurFormSchema = z.object({
 
 export type UtilisateurFormValues = z.infer<typeof utilisateurFormSchema>
 
-export type UtilisateurFormProps = {
-  mode: 'create' | 'update'
-  initialValues?: Partial<UtilisateurFormValues>
-  pending: boolean
-  errorMessage: string | null
-  onSubmit: (values: UtilisateurFormValues) => void
-  onCancel: () => void
-}
-
 export function UtilisateurForm({
   mode,
   initialValues,
@@ -32,7 +24,14 @@ export function UtilisateurForm({
   errorMessage,
   onSubmit,
   onCancel,
-}: UtilisateurFormProps) {
+}: {
+  mode: 'create' | 'update'
+  initialValues?: Partial<UtilisateurFormValues>
+  pending: boolean
+  errorMessage: string | null
+  onSubmit: (values: UtilisateurFormValues) => void
+  onCancel: () => void
+}) {
   const { isProd } = useAppConfig()
   const {
     register,
@@ -68,78 +67,53 @@ export function UtilisateurForm({
     <form onSubmit={(event) => void handleSubmit(onSubmit)(event)} className="mx-auto max-w-2xl">
       <div className="rounded-xl border border-border bg-surface p-6">
         <div className="mb-5">
-          <label className="mb-1.5 block text-xs font-semibold">
-            Email <span className="text-accent">*</span>
-            {emailReadOnly ? (
-              <span className="ml-2 text-xs font-normal text-text-muted">(non modifiable)</span>
-            ) : null}
-          </label>
-          <input
+          <Input
+            label="Email"
+            required
             type="email"
-            {...register('email')}
-            readOnly={emailReadOnly}
             placeholder="prenom.nom@example.gouv.fr"
-            className={clsxm(
-              'w-full rounded-md border border-border px-3 py-2.5 text-sm focus:border-primary focus:outline-none',
-              emailReadOnly && 'bg-surface-muted text-text-muted',
-            )}
+            readOnly={emailReadOnly}
+            hint={emailReadOnly ? '(non modifiable)' : undefined}
+            error={errors.email?.message}
+            {...register('email')}
           />
-          {errors.email ? <p className="mt-1 text-xs text-accent">{errors.email.message}</p> : null}
         </div>
 
         <div className="mb-5 grid grid-cols-2 gap-4">
-          <div>
-            <label className="mb-1.5 block text-xs font-semibold">
-              Prénom <span className="text-accent">*</span>
-            </label>
-            <input
-              {...register('prenom')}
-              placeholder="Jane"
-              className="w-full rounded-md border border-border px-3 py-2.5 text-sm focus:border-primary focus:outline-none"
-            />
-            {errors.prenom ? (
-              <p className="mt-1 text-xs text-accent">{errors.prenom.message}</p>
-            ) : null}
-          </div>
-          <div>
-            <label className="mb-1.5 block text-xs font-semibold">
-              Nom <span className="text-accent">*</span>
-            </label>
-            <input
-              {...register('nom')}
-              placeholder="Doe"
-              className="w-full rounded-md border border-border px-3 py-2.5 text-sm focus:border-primary focus:outline-none"
-            />
-            {errors.nom ? <p className="mt-1 text-xs text-accent">{errors.nom.message}</p> : null}
-          </div>
+          <Input
+            label="Prénom"
+            required
+            placeholder="Jane"
+            error={errors.prenom?.message}
+            {...register('prenom')}
+          />
+          <Input
+            label="Nom"
+            required
+            placeholder="Doe"
+            error={errors.nom?.message}
+            {...register('nom')}
+          />
         </div>
 
         <div className="mb-5">
-          <label className="mb-1.5 block text-xs font-semibold">
-            Service <span className="text-accent">*</span>
-          </label>
-          <input
-            {...register('service')}
+          <Input
+            label="Service"
+            required
             placeholder="DITP / SI / …"
-            className="w-full rounded-md border border-border px-3 py-2.5 text-sm focus:border-primary focus:outline-none"
+            error={errors.service?.message}
+            {...register('service')}
           />
-          {errors.service ? (
-            <p className="mt-1 text-xs text-accent">{errors.service.message}</p>
-          ) : null}
         </div>
 
         <div className="mb-2">
-          <label className="mb-1.5 block text-xs font-semibold">
-            Fonction <span className="text-accent">*</span>
-          </label>
-          <input
-            {...register('fonction')}
+          <Input
+            label="Fonction"
+            required
             placeholder="Chargée de mission"
-            className="w-full rounded-md border border-border px-3 py-2.5 text-sm focus:border-primary focus:outline-none"
+            error={errors.fonction?.message}
+            {...register('fonction')}
           />
-          {errors.fonction ? (
-            <p className="mt-1 text-xs text-accent">{errors.fonction.message}</p>
-          ) : null}
         </div>
       </div>
 

--- a/apps/mb-admin/src/components/UtilisateurForm.tsx
+++ b/apps/mb-admin/src/components/UtilisateurForm.tsx
@@ -1,0 +1,164 @@
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useForm } from 'react-hook-form'
+import { z } from 'zod'
+
+import { Button } from '@/components/ui/Button'
+import { useAppConfig } from '@/context/AppConfigContext'
+import { clsxm } from '@/lib/clsxm'
+
+const utilisateurFormSchema = z.object({
+  email: z.string().email('Email invalide'),
+  nom: z.string().trim().min(1, 'Le nom est requis'),
+  prenom: z.string().trim().min(1, 'Le prénom est requis'),
+  service: z.string().trim().min(1, 'Le service est requis'),
+  fonction: z.string().trim().min(1, 'La fonction est requise'),
+})
+
+export type UtilisateurFormValues = z.infer<typeof utilisateurFormSchema>
+
+export type UtilisateurFormProps = {
+  mode: 'create' | 'update'
+  initialValues?: Partial<UtilisateurFormValues>
+  pending: boolean
+  errorMessage: string | null
+  onSubmit: (values: UtilisateurFormValues) => void
+  onCancel: () => void
+}
+
+export function UtilisateurForm({
+  mode,
+  initialValues,
+  pending,
+  errorMessage,
+  onSubmit,
+  onCancel,
+}: UtilisateurFormProps) {
+  const { isProd } = useAppConfig()
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isValid },
+  } = useForm<UtilisateurFormValues>({
+    resolver: zodResolver(utilisateurFormSchema),
+    mode: 'onChange',
+    defaultValues: {
+      email: initialValues?.email ?? '',
+      nom: initialValues?.nom ?? '',
+      prenom: initialValues?.prenom ?? '',
+      service: initialValues?.service ?? '',
+      fonction: initialValues?.fonction ?? '',
+    },
+  })
+
+  const emailReadOnly = mode === 'update'
+
+  const submitLabel = pending
+    ? mode === 'create'
+      ? 'Création…'
+      : 'Enregistrement…'
+    : isProd
+      ? mode === 'create'
+        ? '🚨 Créer en Prod'
+        : '🚨 Enregistrer en Prod'
+      : mode === 'create'
+        ? "Créer l'utilisateur"
+        : 'Enregistrer'
+
+  return (
+    <form onSubmit={(event) => void handleSubmit(onSubmit)(event)} className="mx-auto max-w-2xl">
+      <div className="rounded-xl border border-border bg-surface p-6">
+        <div className="mb-5">
+          <label className="mb-1.5 block text-xs font-semibold">
+            Email <span className="text-accent">*</span>
+            {emailReadOnly ? (
+              <span className="ml-2 text-xs font-normal text-text-muted">(non modifiable)</span>
+            ) : null}
+          </label>
+          <input
+            type="email"
+            {...register('email')}
+            readOnly={emailReadOnly}
+            placeholder="prenom.nom@example.gouv.fr"
+            className={clsxm(
+              'w-full rounded-md border border-border px-3 py-2.5 text-sm focus:border-primary focus:outline-none',
+              emailReadOnly && 'bg-surface-muted text-text-muted',
+            )}
+          />
+          {errors.email ? <p className="mt-1 text-xs text-accent">{errors.email.message}</p> : null}
+        </div>
+
+        <div className="mb-5 grid grid-cols-2 gap-4">
+          <div>
+            <label className="mb-1.5 block text-xs font-semibold">
+              Prénom <span className="text-accent">*</span>
+            </label>
+            <input
+              {...register('prenom')}
+              placeholder="Jane"
+              className="w-full rounded-md border border-border px-3 py-2.5 text-sm focus:border-primary focus:outline-none"
+            />
+            {errors.prenom ? (
+              <p className="mt-1 text-xs text-accent">{errors.prenom.message}</p>
+            ) : null}
+          </div>
+          <div>
+            <label className="mb-1.5 block text-xs font-semibold">
+              Nom <span className="text-accent">*</span>
+            </label>
+            <input
+              {...register('nom')}
+              placeholder="Doe"
+              className="w-full rounded-md border border-border px-3 py-2.5 text-sm focus:border-primary focus:outline-none"
+            />
+            {errors.nom ? <p className="mt-1 text-xs text-accent">{errors.nom.message}</p> : null}
+          </div>
+        </div>
+
+        <div className="mb-5">
+          <label className="mb-1.5 block text-xs font-semibold">
+            Service <span className="text-accent">*</span>
+          </label>
+          <input
+            {...register('service')}
+            placeholder="DITP / SI / …"
+            className="w-full rounded-md border border-border px-3 py-2.5 text-sm focus:border-primary focus:outline-none"
+          />
+          {errors.service ? (
+            <p className="mt-1 text-xs text-accent">{errors.service.message}</p>
+          ) : null}
+        </div>
+
+        <div className="mb-2">
+          <label className="mb-1.5 block text-xs font-semibold">
+            Fonction <span className="text-accent">*</span>
+          </label>
+          <input
+            {...register('fonction')}
+            placeholder="Chargée de mission"
+            className="w-full rounded-md border border-border px-3 py-2.5 text-sm focus:border-primary focus:outline-none"
+          />
+          {errors.fonction ? (
+            <p className="mt-1 text-xs text-accent">{errors.fonction.message}</p>
+          ) : null}
+        </div>
+      </div>
+
+      {errorMessage ? (
+        <p className="mt-3 text-right text-sm font-medium text-accent">{errorMessage}</p>
+      ) : null}
+
+      <div className="mt-5 flex justify-end gap-3">
+        <Button variant="secondary" type="button" onClick={onCancel}>
+          Annuler
+        </Button>
+        <Button
+          type="submit"
+          disabled={!isValid || pending}
+          className={clsxm(isProd && 'bg-accent hover:bg-accent')}
+        >
+          {submitLabel}
+        </Button>
+      </div>
+    </form>
+  )
+}

--- a/apps/mb-admin/src/components/ui/Input.tsx
+++ b/apps/mb-admin/src/components/ui/Input.tsx
@@ -1,0 +1,43 @@
+import type { InputHTMLAttributes, Ref } from 'react'
+
+import { clsxm } from '@/lib/clsxm'
+
+export type InputProps = InputHTMLAttributes<HTMLInputElement> & {
+  label: string
+  required?: boolean
+  hint?: string | undefined
+  error?: string | undefined
+  ref?: Ref<HTMLInputElement>
+}
+
+export function Input({
+  label,
+  required,
+  hint,
+  error,
+  className,
+  readOnly,
+  ref,
+  ...props
+}: InputProps) {
+  return (
+    <div>
+      <label className="mb-1.5 block text-xs font-semibold">
+        {label}
+        {required ? <span className="text-accent"> *</span> : null}
+        {hint ? <span className="ml-2 text-xs font-normal text-text-muted">{hint}</span> : null}
+      </label>
+      <input
+        ref={ref}
+        readOnly={readOnly}
+        className={clsxm(
+          'w-full rounded-md border border-border px-3 py-2.5 text-sm focus:border-primary focus:outline-none',
+          readOnly && 'bg-surface-muted text-text-muted',
+          className,
+        )}
+        {...props}
+      />
+      {error ? <p className="mt-1 text-xs text-accent">{error}</p> : null}
+    </div>
+  )
+}

--- a/apps/mb-admin/src/queries/utilisateurs.ts
+++ b/apps/mb-admin/src/queries/utilisateurs.ts
@@ -1,6 +1,16 @@
-import { queryOptions } from '@tanstack/react-query'
+import { infiniteQueryOptions, queryOptions } from '@tanstack/react-query'
 
-import { fetchUtilisateurs } from '@/api/utilisateurs'
+import { fetchUtilisateurById, fetchUtilisateurs } from '@/api/utilisateurs'
 
-export const utilisateursQueryOptions = () =>
-  queryOptions({ queryKey: ['utilisateurs'], queryFn: fetchUtilisateurs })
+export const utilisateursInfiniteQueryOptions = (recherche: string) =>
+  infiniteQueryOptions({
+    queryKey: ['utilisateurs', { recherche }],
+    queryFn: ({ pageParam }) =>
+      fetchUtilisateurs({ recherche: recherche || undefined, cursor: pageParam ?? undefined }),
+    initialPageParam: undefined as string | undefined,
+    getNextPageParam: (lastPage) =>
+      lastPage.pagination.hasMore ? (lastPage.pagination.cursor ?? undefined) : undefined,
+  })
+
+export const utilisateurQueryOptions = (id: string) =>
+  queryOptions({ queryKey: ['utilisateur', id], queryFn: () => fetchUtilisateurById(id) })

--- a/apps/mb-admin/src/queries/utilisateurs.ts
+++ b/apps/mb-admin/src/queries/utilisateurs.ts
@@ -1,0 +1,9 @@
+import { queryOptions } from '@tanstack/react-query'
+
+import { fetchUtilisateur, fetchUtilisateurs } from '@/api/utilisateurs'
+
+export const utilisateursQueryOptions = () =>
+  queryOptions({ queryKey: ['utilisateurs'], queryFn: fetchUtilisateurs })
+
+export const utilisateurQueryOptions = (id: string) =>
+  queryOptions({ queryKey: ['utilisateurs', id], queryFn: () => fetchUtilisateur(id) })

--- a/apps/mb-admin/src/queries/utilisateurs.ts
+++ b/apps/mb-admin/src/queries/utilisateurs.ts
@@ -1,9 +1,6 @@
 import { queryOptions } from '@tanstack/react-query'
 
-import { fetchUtilisateur, fetchUtilisateurs } from '@/api/utilisateurs'
+import { fetchUtilisateurs } from '@/api/utilisateurs'
 
 export const utilisateursQueryOptions = () =>
   queryOptions({ queryKey: ['utilisateurs'], queryFn: fetchUtilisateurs })
-
-export const utilisateurQueryOptions = (id: string) =>
-  queryOptions({ queryKey: ['utilisateurs', id], queryFn: () => fetchUtilisateur(id) })

--- a/apps/mb-admin/src/routes/_authed/fonctionnalites.tsx
+++ b/apps/mb-admin/src/routes/_authed/fonctionnalites.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
-import { BarChart3, FolderTree, KeyRound } from 'lucide-react'
+import { BarChart3, FolderTree, KeyRound, Users } from 'lucide-react'
 
 import { BarCard } from '@/components/ui/BarCard'
 import { FadeIn } from '@/components/ui/FadeIn'
@@ -36,6 +36,14 @@ function FeaturesComponent() {
             title="Gérer les clés API"
             description="Créer, lister et révoquer les clés API (réservé aux clés ADMIN)."
             onClick={() => void navigate({ to: '/api-keys' })}
+          />
+        </FadeIn>
+        <FadeIn delayMs={240}>
+          <BarCard
+            icon={Users}
+            title="Gérer les utilisateurs"
+            description="Créer, lister et modifier les utilisateurs OIDC pré-provisionnés (réservé aux clés ADMIN)."
+            onClick={() => void navigate({ to: '/utilisateurs' })}
           />
         </FadeIn>
       </div>

--- a/apps/mb-admin/src/routes/_authed/utilisateurs/$id.tsx
+++ b/apps/mb-admin/src/routes/_authed/utilisateurs/$id.tsx
@@ -7,11 +7,11 @@ import { Breadcrumb } from '@/components/Breadcrumb'
 import { PageHeading } from '@/components/PageHeading'
 import { UtilisateurForm, type UtilisateurFormValues } from '@/components/UtilisateurForm'
 import { extractApiError } from '@/lib/apiError'
-import { utilisateursQueryOptions } from '@/queries/utilisateurs'
+import { utilisateurQueryOptions } from '@/queries/utilisateurs'
 
 export const Route = createFileRoute('/_authed/utilisateurs/$id')({
-  loader: async ({ context }) => {
-    await context.queryClient.ensureQueryData(utilisateursQueryOptions())
+  loader: async ({ context, params }) => {
+    await context.queryClient.ensureQueryData(utilisateurQueryOptions(params.id))
   },
   component: EditUtilisateurComponent,
 })
@@ -22,10 +22,7 @@ function EditUtilisateurComponent() {
   const queryClient = useQueryClient()
   const [error, setError] = useState<string | null>(null)
 
-  const { data: utilisateur } = useSuspenseQuery({
-    ...utilisateursQueryOptions(),
-    select: (items) => items.find((u) => u.id === id),
-  })
+  const { data: utilisateur } = useSuspenseQuery(utilisateurQueryOptions(id))
 
   const mutation = useMutation({
     mutationFn: (values: UtilisateurFormValues) =>

--- a/apps/mb-admin/src/routes/_authed/utilisateurs/$id.tsx
+++ b/apps/mb-admin/src/routes/_authed/utilisateurs/$id.tsx
@@ -1,0 +1,77 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { createFileRoute, Link, useNavigate } from '@tanstack/react-router'
+import { useState } from 'react'
+
+import { updateUtilisateur } from '@/api/utilisateurs'
+import { Breadcrumb } from '@/components/Breadcrumb'
+import { PageHeading } from '@/components/PageHeading'
+import { UtilisateurForm, type UtilisateurFormValues } from '@/components/UtilisateurForm'
+import { extractApiError } from '@/lib/apiError'
+import { utilisateurQueryOptions } from '@/queries/utilisateurs'
+
+export const Route = createFileRoute('/_authed/utilisateurs/$id')({
+  component: EditUtilisateurComponent,
+})
+
+function EditUtilisateurComponent() {
+  const { id } = Route.useParams()
+  const navigate = useNavigate()
+  const queryClient = useQueryClient()
+  const [error, setError] = useState<string | null>(null)
+
+  const query = useQuery(utilisateurQueryOptions(id))
+
+  const mutation = useMutation({
+    mutationFn: (values: UtilisateurFormValues) =>
+      updateUtilisateur(id, {
+        nom: values.nom,
+        prenom: values.prenom,
+        service: values.service,
+        fonction: values.fonction,
+      }),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ['utilisateurs'] })
+      await queryClient.invalidateQueries({ queryKey: ['utilisateurs', id] })
+      await navigate({ to: '/utilisateurs' })
+    },
+    onError: (err: unknown) => {
+      void extractApiError(err).then(setError)
+    },
+  })
+
+  return (
+    <div>
+      <Breadcrumb>
+        <Link to="/fonctionnalites" className="hover:text-primary">
+          Fonctionnalités
+        </Link>
+        <Link to="/utilisateurs" className="hover:text-primary">
+          Utilisateurs
+        </Link>
+        <span className="font-medium text-text">Modifier</span>
+      </Breadcrumb>
+      <PageHeading title="Modifier l'utilisateur" />
+
+      {query.isLoading ? (
+        <p className="text-sm text-text-muted">Chargement…</p>
+      ) : query.isError || !query.data ? (
+        <p className="text-sm font-medium text-accent">Utilisateur introuvable.</p>
+      ) : (
+        <UtilisateurForm
+          mode="update"
+          initialValues={{
+            email: query.data.email,
+            nom: query.data.nom,
+            prenom: query.data.prenom,
+            service: query.data.service,
+            fonction: query.data.fonction,
+          }}
+          pending={mutation.isPending}
+          errorMessage={error}
+          onCancel={() => void navigate({ to: '/utilisateurs' })}
+          onSubmit={(values) => mutation.mutate(values)}
+        />
+      )}
+    </div>
+  )
+}

--- a/apps/mb-admin/src/routes/_authed/utilisateurs/$id.tsx
+++ b/apps/mb-admin/src/routes/_authed/utilisateurs/$id.tsx
@@ -1,4 +1,4 @@
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient, useSuspenseQuery } from '@tanstack/react-query'
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router'
 import { useState } from 'react'
 
@@ -7,9 +7,12 @@ import { Breadcrumb } from '@/components/Breadcrumb'
 import { PageHeading } from '@/components/PageHeading'
 import { UtilisateurForm, type UtilisateurFormValues } from '@/components/UtilisateurForm'
 import { extractApiError } from '@/lib/apiError'
-import { utilisateurQueryOptions } from '@/queries/utilisateurs'
+import { utilisateursQueryOptions } from '@/queries/utilisateurs'
 
 export const Route = createFileRoute('/_authed/utilisateurs/$id')({
+  loader: async ({ context }) => {
+    await context.queryClient.ensureQueryData(utilisateursQueryOptions())
+  },
   component: EditUtilisateurComponent,
 })
 
@@ -19,7 +22,10 @@ function EditUtilisateurComponent() {
   const queryClient = useQueryClient()
   const [error, setError] = useState<string | null>(null)
 
-  const query = useQuery(utilisateurQueryOptions(id))
+  const { data: utilisateur } = useSuspenseQuery({
+    ...utilisateursQueryOptions(),
+    select: (items) => items.find((u) => u.id === id),
+  })
 
   const mutation = useMutation({
     mutationFn: (values: UtilisateurFormValues) =>
@@ -31,7 +37,6 @@ function EditUtilisateurComponent() {
       }),
     onSuccess: async () => {
       await queryClient.invalidateQueries({ queryKey: ['utilisateurs'] })
-      await queryClient.invalidateQueries({ queryKey: ['utilisateurs', id] })
       await navigate({ to: '/utilisateurs' })
     },
     onError: (err: unknown) => {
@@ -52,25 +57,23 @@ function EditUtilisateurComponent() {
       </Breadcrumb>
       <PageHeading title="Modifier l'utilisateur" />
 
-      {query.isLoading ? (
-        <p className="text-sm text-text-muted">Chargement…</p>
-      ) : query.isError || !query.data ? (
-        <p className="text-sm font-medium text-accent">Utilisateur introuvable.</p>
-      ) : (
+      {utilisateur ? (
         <UtilisateurForm
           mode="update"
           initialValues={{
-            email: query.data.email,
-            nom: query.data.nom,
-            prenom: query.data.prenom,
-            service: query.data.service,
-            fonction: query.data.fonction,
+            email: utilisateur.email,
+            nom: utilisateur.nom,
+            prenom: utilisateur.prenom,
+            service: utilisateur.service,
+            fonction: utilisateur.fonction,
           }}
           pending={mutation.isPending}
           errorMessage={error}
           onCancel={() => void navigate({ to: '/utilisateurs' })}
           onSubmit={(values) => mutation.mutate(values)}
         />
+      ) : (
+        <p className="text-sm font-medium text-accent">Utilisateur introuvable.</p>
       )}
     </div>
   )

--- a/apps/mb-admin/src/routes/_authed/utilisateurs/index.tsx
+++ b/apps/mb-admin/src/routes/_authed/utilisateurs/index.tsx
@@ -1,25 +1,26 @@
 import type { UtilisateurApiModel } from '@pilote/mb-shared/utilisateur'
-import { useSuspenseQuery } from '@tanstack/react-query'
+import { useInfiniteQuery } from '@tanstack/react-query'
 import { createFileRoute, Link } from '@tanstack/react-router'
-import { Plus } from 'lucide-react'
+import { Plus, Search } from 'lucide-react'
+import { useState } from 'react'
 
 import { Breadcrumb } from '@/components/Breadcrumb'
 import { PageHeading } from '@/components/PageHeading'
 import { Button } from '@/components/ui/Button'
 import { EmptyState } from '@/components/ui/EmptyState'
 import { Table } from '@/components/ui/Table'
-import { utilisateursQueryOptions } from '@/queries/utilisateurs'
+import { utilisateursInfiniteQueryOptions } from '@/queries/utilisateurs'
 import { session } from '@/session'
 
 export const Route = createFileRoute('/_authed/utilisateurs/')({
   loader: async ({ context }) => {
-    await context.queryClient.ensureQueryData(utilisateursQueryOptions())
+    await context.queryClient.ensureInfiniteQueryData(utilisateursInfiniteQueryOptions(''))
   },
   component: UtilisateursListComponent,
 })
 
 const STATUS_LABEL: Record<UtilisateurApiModel['status'], string> = {
-  en_attente: 'En attente',
+  en_attente: 'Jamais connecté',
   actif: 'Actif',
 }
 
@@ -35,7 +36,10 @@ const PROVIDER_LABEL: Record<UtilisateurApiModel['providers'][number], string> =
 
 function UtilisateursListComponent() {
   const isProd = session.current?.environment === 'prod'
-  const { data: items } = useSuspenseQuery(utilisateursQueryOptions())
+  const [recherche, setRecherche] = useState('')
+  const query = useInfiniteQuery(utilisateursInfiniteQueryOptions(recherche))
+  const items = query.data?.pages.flatMap((page) => page.items) ?? []
+  const total = query.data?.pages[0]?.total ?? 0
 
   return (
     <div>
@@ -49,7 +53,7 @@ function UtilisateursListComponent() {
         title="Utilisateurs"
         subtitle={
           <>
-            {items.length} utilisateur{items.length > 1 ? 's' : ''} · environnement{' '}
+            {total} utilisateur{total > 1 ? 's' : ''} · environnement{' '}
             <b className={isProd ? 'text-accent' : undefined}>{session.current?.environment}</b>
           </>
         }
@@ -62,7 +66,17 @@ function UtilisateursListComponent() {
         }
       />
 
-      {items.length === 0 ? (
+      <div className="mb-4 flex max-w-sm items-center gap-2 rounded-md border border-border px-3 py-2 text-sm">
+        <Search className="size-4 text-text-subtle" />
+        <input
+          value={recherche}
+          onChange={(event) => setRecherche(event.target.value)}
+          placeholder="Rechercher un utilisateur…"
+          className="w-full bg-transparent focus:outline-none"
+        />
+      </div>
+
+      {items.length === 0 && !query.isLoading ? (
         <EmptyState
           title="Aucun utilisateur"
           description="Créez votre premier utilisateur pré-provisionné."
@@ -130,6 +144,19 @@ function UtilisateursListComponent() {
           </Table.Body>
         </Table>
       )}
+
+      {query.hasNextPage ? (
+        <div className="mt-4 flex justify-center">
+          <Button
+            variant="secondary"
+            type="button"
+            disabled={query.isFetchingNextPage}
+            onClick={() => void query.fetchNextPage()}
+          >
+            {query.isFetchingNextPage ? 'Chargement…' : 'Charger plus'}
+          </Button>
+        </div>
+      ) : null}
     </div>
   )
 }

--- a/apps/mb-admin/src/routes/_authed/utilisateurs/index.tsx
+++ b/apps/mb-admin/src/routes/_authed/utilisateurs/index.tsx
@@ -1,0 +1,139 @@
+import type { UtilisateurApiModel } from '@pilote/mb-shared/utilisateur'
+import { useQuery } from '@tanstack/react-query'
+import { createFileRoute, Link } from '@tanstack/react-router'
+import { Plus } from 'lucide-react'
+
+import { Breadcrumb } from '@/components/Breadcrumb'
+import { PageHeading } from '@/components/PageHeading'
+import { Button } from '@/components/ui/Button'
+import { EmptyState } from '@/components/ui/EmptyState'
+import { Table } from '@/components/ui/Table'
+import { utilisateursQueryOptions } from '@/queries/utilisateurs'
+import { session } from '@/session'
+
+export const Route = createFileRoute('/_authed/utilisateurs/')({
+  component: UtilisateursListComponent,
+})
+
+const STATUS_LABEL: Record<UtilisateurApiModel['status'], string> = {
+  en_attente: 'En attente',
+  actif: 'Actif',
+}
+
+const STATUS_CLASS: Record<UtilisateurApiModel['status'], string> = {
+  en_attente: 'text-text-muted',
+  actif: 'font-semibold text-primary',
+}
+
+const PROVIDER_LABEL: Record<UtilisateurApiModel['providers'][number], string> = {
+  proconnect: 'ProConnect',
+  keycloak: 'Keycloak',
+}
+
+function UtilisateursListComponent() {
+  const isProd = session.current?.environment === 'prod'
+  const query = useQuery(utilisateursQueryOptions())
+  const items = query.data ?? []
+
+  return (
+    <div>
+      <Breadcrumb>
+        <Link to="/fonctionnalites" className="hover:text-primary">
+          Fonctionnalités
+        </Link>
+        <span className="font-medium text-text">Utilisateurs</span>
+      </Breadcrumb>
+      <PageHeading
+        title="Utilisateurs"
+        subtitle={
+          <>
+            {items.length} utilisateur{items.length > 1 ? 's' : ''} · environnement{' '}
+            <b className={isProd ? 'text-accent' : undefined}>{session.current?.environment}</b>
+          </>
+        }
+        action={
+          <Button asChild>
+            <Link to="/utilisateurs/nouveau">
+              <Plus className="size-4" /> Créer un utilisateur
+            </Link>
+          </Button>
+        }
+      />
+
+      {query.isError ? (
+        <p className="mb-4 text-sm font-medium text-accent">
+          Impossible de charger les utilisateurs. Une clé de session de rôle ADMIN est requise.
+        </p>
+      ) : null}
+
+      {items.length === 0 && !query.isLoading && !query.isError ? (
+        <EmptyState
+          title="Aucun utilisateur"
+          description="Créez votre premier utilisateur pré-provisionné."
+        />
+      ) : (
+        <Table>
+          <Table.Head>
+            <Table.Row>
+              <Table.HeaderCell>Email</Table.HeaderCell>
+              <Table.HeaderCell>Prénom / Nom</Table.HeaderCell>
+              <Table.HeaderCell>Service</Table.HeaderCell>
+              <Table.HeaderCell>Fonction</Table.HeaderCell>
+              <Table.HeaderCell>Statut</Table.HeaderCell>
+              <Table.HeaderCell>Providers</Table.HeaderCell>
+              <Table.HeaderCell>Créé le</Table.HeaderCell>
+              <Table.HeaderCell align="right" />
+            </Table.Row>
+          </Table.Head>
+          <Table.Body>
+            {items.map((u) => (
+              <Table.Row key={u.id}>
+                <Table.Cell>
+                  <span className="font-mono text-sm">{u.email}</span>
+                </Table.Cell>
+                <Table.Cell>
+                  <span className="font-semibold">
+                    {u.prenom} {u.nom}
+                  </span>
+                </Table.Cell>
+                <Table.Cell>{u.service}</Table.Cell>
+                <Table.Cell>{u.fonction}</Table.Cell>
+                <Table.Cell>
+                  <span className={STATUS_CLASS[u.status]}>{STATUS_LABEL[u.status]}</span>
+                </Table.Cell>
+                <Table.Cell>
+                  {u.providers.length === 0 ? (
+                    <span className="text-text-subtle">—</span>
+                  ) : (
+                    <span className="inline-flex gap-1">
+                      {u.providers.map((p) => (
+                        <span
+                          key={p}
+                          className="rounded-full border border-border px-2 py-0.5 text-xs"
+                        >
+                          {PROVIDER_LABEL[p]}
+                        </span>
+                      ))}
+                    </span>
+                  )}
+                </Table.Cell>
+                <Table.Cell>
+                  <span className="text-text-muted">
+                    {new Date(u.createdAt).toLocaleDateString('fr-FR')}
+                  </span>
+                </Table.Cell>
+                <Table.Cell align="right">
+                  <Button variant="tertiary" size="sm" type="button" asChild>
+                    <Link to="/utilisateurs/$id" params={{ id: u.id }}>
+                      Modifier
+                    </Link>
+                  </Button>
+                </Table.Cell>
+              </Table.Row>
+            ))}
+          </Table.Body>
+        </Table>
+      )}
+    </div>
+  )
+}

--- a/apps/mb-admin/src/routes/_authed/utilisateurs/index.tsx
+++ b/apps/mb-admin/src/routes/_authed/utilisateurs/index.tsx
@@ -1,5 +1,5 @@
 import type { UtilisateurApiModel } from '@pilote/mb-shared/utilisateur'
-import { useQuery } from '@tanstack/react-query'
+import { useSuspenseQuery } from '@tanstack/react-query'
 import { createFileRoute, Link } from '@tanstack/react-router'
 import { Plus } from 'lucide-react'
 
@@ -12,6 +12,9 @@ import { utilisateursQueryOptions } from '@/queries/utilisateurs'
 import { session } from '@/session'
 
 export const Route = createFileRoute('/_authed/utilisateurs/')({
+  loader: async ({ context }) => {
+    await context.queryClient.ensureQueryData(utilisateursQueryOptions())
+  },
   component: UtilisateursListComponent,
 })
 
@@ -32,8 +35,7 @@ const PROVIDER_LABEL: Record<UtilisateurApiModel['providers'][number], string> =
 
 function UtilisateursListComponent() {
   const isProd = session.current?.environment === 'prod'
-  const query = useQuery(utilisateursQueryOptions())
-  const items = query.data ?? []
+  const { data: items } = useSuspenseQuery(utilisateursQueryOptions())
 
   return (
     <div>
@@ -60,13 +62,7 @@ function UtilisateursListComponent() {
         }
       />
 
-      {query.isError ? (
-        <p className="mb-4 text-sm font-medium text-accent">
-          Impossible de charger les utilisateurs. Une clé de session de rôle ADMIN est requise.
-        </p>
-      ) : null}
-
-      {items.length === 0 && !query.isLoading && !query.isError ? (
+      {items.length === 0 ? (
         <EmptyState
           title="Aucun utilisateur"
           description="Créez votre premier utilisateur pré-provisionné."

--- a/apps/mb-admin/src/routes/_authed/utilisateurs/nouveau.tsx
+++ b/apps/mb-admin/src/routes/_authed/utilisateurs/nouveau.tsx
@@ -1,0 +1,52 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { createFileRoute, Link, useNavigate } from '@tanstack/react-router'
+import { useState } from 'react'
+
+import { createUtilisateur } from '@/api/utilisateurs'
+import { Breadcrumb } from '@/components/Breadcrumb'
+import { PageHeading } from '@/components/PageHeading'
+import { UtilisateurForm, type UtilisateurFormValues } from '@/components/UtilisateurForm'
+import { extractApiError } from '@/lib/apiError'
+
+export const Route = createFileRoute('/_authed/utilisateurs/nouveau')({
+  component: NewUtilisateurComponent,
+})
+
+function NewUtilisateurComponent() {
+  const navigate = useNavigate()
+  const queryClient = useQueryClient()
+  const [error, setError] = useState<string | null>(null)
+
+  const mutation = useMutation({
+    mutationFn: (values: UtilisateurFormValues) => createUtilisateur(values),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ['utilisateurs'] })
+      await navigate({ to: '/utilisateurs' })
+    },
+    onError: (err: unknown) => {
+      void extractApiError(err).then(setError)
+    },
+  })
+
+  return (
+    <div>
+      <Breadcrumb>
+        <Link to="/fonctionnalites" className="hover:text-primary">
+          Fonctionnalités
+        </Link>
+        <Link to="/utilisateurs" className="hover:text-primary">
+          Utilisateurs
+        </Link>
+        <span className="font-medium text-text">Nouvel utilisateur</span>
+      </Breadcrumb>
+      <PageHeading title="Nouvel utilisateur" />
+      <UtilisateurForm
+        mode="create"
+        pending={mutation.isPending}
+        errorMessage={error}
+        onCancel={() => void navigate({ to: '/utilisateurs' })}
+        onSubmit={(values) => mutation.mutate(values)}
+      />
+    </div>
+  )
+}

--- a/apps/mb-admin/src/server/api/router.ts
+++ b/apps/mb-admin/src/server/api/router.ts
@@ -6,7 +6,7 @@ import { readSession } from '@/server/session'
 // Ressources relayables (lecture + upsert indicateurs/référentiels/individus).
 // Segments sûrs uniquement : une ressource autorisée, puis des segments composés
 // de caractères de public id (alphanum, `_`, `-`). Tout le reste est rejeté.
-const SAFE_PATH = /^(indicateurs|referentiels|individus|api-keys)(\/[A-Za-z0-9_-]+)*$/
+const SAFE_PATH = /^(indicateurs|referentiels|individus|api-keys|utilisateurs)(\/[A-Za-z0-9_-]+)*$/
 
 // Rejette toute tentative de traversal / d'injection d'URL absolue AVANT de
 // matcher l'allowlist (sinon la normalisation d'URL des `..` permettrait

--- a/apps/mb-api/src/app.ts
+++ b/apps/mb-api/src/app.ts
@@ -16,6 +16,7 @@ import { meRoutes } from '@/me/routes'
 import { panierRoutes } from '@/panier/routes'
 import { referentielRoutes } from '@/referentiel/routes'
 import { objectifIndicateurIndividuRoutes } from '@/objectifIndicateurIndividu/routes'
+import { utilisateurRoutes } from '@/utilisateur/routes'
 import { valeurAvancementRoutes } from '@/valeurAvancement/routes'
 import { whoamiRoutes } from '@/whoami/routes'
 
@@ -45,6 +46,7 @@ app.route('/', niveauConfianceRoutes)
 app.route('/', meRoutes)
 app.route('/', whoamiRoutes)
 app.route('/', apiKeyRoutes)
+app.route('/', utilisateurRoutes)
 
 app.doc('/openapi.json', {
   openapi: '3.0.0',

--- a/apps/mb-api/src/framework/errors/errorHandler.ts
+++ b/apps/mb-api/src/framework/errors/errorHandler.ts
@@ -77,6 +77,17 @@ export const registerErrorHandler = (app: OpenAPIHono): void => {
       )
     }
 
+    if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002') {
+      logger.warn({ method, url, prismaCode: error.code }, error.message)
+      return context.json(
+        {
+          code: 'UNIQUE_CONSTRAINT_VIOLATION',
+          message: 'Une ressource avec ces valeurs existe déjà',
+        },
+        409,
+      )
+    }
+
     logger.error({ method, url, err: error }, 'Unhandled error')
     return context.json(
       {

--- a/apps/mb-api/src/utilisateur/commands/createUtilisateur.test.ts
+++ b/apps/mb-api/src/utilisateur/commands/createUtilisateur.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from 'vitest'
 
-import { ConflictError, ForbiddenError } from '@/framework/errors/AppError'
+import { ForbiddenError } from '@/framework/errors/AppError'
 import { db } from '@/framework/persistence/dbStore'
+import { Prisma } from '@/generated/prisma/client'
 import { fixtures } from '@/test/fixtures'
 import { integrationTest } from '@/test/integrationTest'
 import { runAsAdmin, runAsContributor, runAsUser } from '@/test/runAsPrincipal'
@@ -69,7 +70,7 @@ describe.concurrent('createUtilisateur', () => {
   )
 
   it(
-    'rejette un email déjà utilisé (ConflictError)',
+    "throw PrismaClientKnownRequestError P2002 quand l'email est déjà utilisé",
     integrationTest(async () => {
       await fixtures.utilisateur({ email: 'existant@example.gouv.fr' })
       await expect(
@@ -82,7 +83,10 @@ describe.concurrent('createUtilisateur', () => {
             fonction: 'Agent',
           }),
         ),
-      ).rejects.toBeInstanceOf(ConflictError)
+      ).rejects.toMatchObject({
+        constructor: Prisma.PrismaClientKnownRequestError,
+        code: 'P2002',
+      })
     }),
   )
 })

--- a/apps/mb-api/src/utilisateur/commands/createUtilisateur.test.ts
+++ b/apps/mb-api/src/utilisateur/commands/createUtilisateur.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest'
+
+import { ConflictError, ForbiddenError } from '@/framework/errors/AppError'
+import { db } from '@/framework/persistence/dbStore'
+import { fixtures } from '@/test/fixtures'
+import { integrationTest } from '@/test/integrationTest'
+import { runAsAdmin, runAsContributor, runAsUser } from '@/test/runAsPrincipal'
+import { createUtilisateur } from '@/utilisateur/commands/createUtilisateur'
+
+const ADMIN_ID = '00000000-0000-0000-0000-000000000101'
+
+describe.concurrent('createUtilisateur', () => {
+  it(
+    'crée un utilisateur en attente (status=en_attente, providers=[])',
+    integrationTest(async () => {
+      const result = await runAsAdmin(ADMIN_ID, () =>
+        createUtilisateur({
+          email: 'agent.a@example.gouv.fr',
+          nom: 'Aaa',
+          prenom: 'Aline',
+          service: 'DITP',
+          fonction: 'Chargée de mission',
+        }),
+      )
+      const created = result._unsafeUnwrap()
+      expect(created.status).toBe('en_attente')
+      expect(created.providers).toEqual([])
+      expect(created.email).toBe('agent.a@example.gouv.fr')
+
+      const row = await db().utilisateur.findUniqueOrThrow({ where: { id: created.id } })
+      expect(row.nom).toBe('Aaa')
+      const principal = await db().principal.findUniqueOrThrow({ where: { id: created.id } })
+      expect(principal.id).toBe(created.id)
+    }),
+  )
+
+  it(
+    'rejette une clé CONTRIBUTOR (ForbiddenError)',
+    integrationTest(async () => {
+      await expect(
+        runAsContributor(ADMIN_ID, () =>
+          createUtilisateur({
+            email: 'agent.b@example.gouv.fr',
+            nom: 'Bbb',
+            prenom: 'Ben',
+            service: 'DITP',
+            fonction: 'Chef',
+          }),
+        ),
+      ).rejects.toBeInstanceOf(ForbiddenError)
+    }),
+  )
+
+  it(
+    'rejette un utilisateur OIDC (ForbiddenError)',
+    integrationTest(async () => {
+      await expect(
+        runAsUser('00000000-0000-0000-0000-000000000102', () =>
+          createUtilisateur({
+            email: 'agent.c@example.gouv.fr',
+            nom: 'Ccc',
+            prenom: 'Cléa',
+            service: 'DITP',
+            fonction: 'Agent',
+          }),
+        ),
+      ).rejects.toBeInstanceOf(ForbiddenError)
+    }),
+  )
+
+  it(
+    'rejette un email déjà utilisé (ConflictError)',
+    integrationTest(async () => {
+      await fixtures.utilisateur({ email: 'existant@example.gouv.fr' })
+      await expect(
+        runAsAdmin(ADMIN_ID, () =>
+          createUtilisateur({
+            email: 'existant@example.gouv.fr',
+            nom: 'Ddd',
+            prenom: 'Dora',
+            service: 'DITP',
+            fonction: 'Agent',
+          }),
+        ),
+      ).rejects.toBeInstanceOf(ConflictError)
+    }),
+  )
+})

--- a/apps/mb-api/src/utilisateur/commands/createUtilisateur.ts
+++ b/apps/mb-api/src/utilisateur/commands/createUtilisateur.ts
@@ -1,0 +1,36 @@
+import { type CreateUtilisateurBody, type UtilisateurApiModel } from '@pilote/mb-shared/utilisateur'
+import { ResultAsync } from 'neverthrow'
+import { uuidv7 } from 'uuidv7'
+
+import { ensurePrincipal, isApiKeyAdmin } from '@/framework/auth/principalPredicates'
+import { ConflictError } from '@/framework/errors/AppError'
+import { db } from '@/framework/persistence/dbStore'
+import { toUtilisateurApiModel } from '@/utilisateur/utils'
+
+const performCreate = async (body: CreateUtilisateurBody): Promise<UtilisateurApiModel> => {
+  ensurePrincipal(isApiKeyAdmin, 'Cette opération requiert une clé API de rôle ADMIN')
+
+  // Anti-collision : `email` est unique en base — on préempte le 409 avec un
+  // message lisible plutôt que laisser remonter une PrismaClientKnownRequestError.
+  const conflict = await db().utilisateur.findUnique({ where: { email: body.email } })
+  if (conflict) throw new ConflictError('Un utilisateur avec cet email existe déjà')
+
+  const id = uuidv7()
+  await db().principal.create({ data: { id } })
+  const created = await db().utilisateur.create({
+    data: {
+      id,
+      email: body.email,
+      nom: body.nom,
+      prenom: body.prenom,
+      service: body.service,
+      fonction: body.fonction,
+    },
+    include: { identites: true },
+  })
+  return toUtilisateurApiModel(created)
+}
+
+export const createUtilisateur = (
+  body: CreateUtilisateurBody,
+): ResultAsync<UtilisateurApiModel, never> => ResultAsync.fromSafePromise(performCreate(body))

--- a/apps/mb-api/src/utilisateur/commands/createUtilisateur.ts
+++ b/apps/mb-api/src/utilisateur/commands/createUtilisateur.ts
@@ -3,17 +3,11 @@ import { ResultAsync } from 'neverthrow'
 import { uuidv7 } from 'uuidv7'
 
 import { ensurePrincipal, isApiKeyAdmin } from '@/framework/auth/principalPredicates'
-import { ConflictError } from '@/framework/errors/AppError'
 import { db } from '@/framework/persistence/dbStore'
 import { toUtilisateurApiModel } from '@/utilisateur/utils'
 
 const performCreate = async (body: CreateUtilisateurBody): Promise<UtilisateurApiModel> => {
   ensurePrincipal(isApiKeyAdmin, 'Cette opération requiert une clé API de rôle ADMIN')
-
-  // Anti-collision : `email` est unique en base — on préempte le 409 avec un
-  // message lisible plutôt que laisser remonter une PrismaClientKnownRequestError.
-  const conflict = await db().utilisateur.findUnique({ where: { email: body.email } })
-  if (conflict) throw new ConflictError('Un utilisateur avec cet email existe déjà')
 
   const id = uuidv7()
   await db().principal.create({ data: { id } })

--- a/apps/mb-api/src/utilisateur/commands/updateUtilisateur.test.ts
+++ b/apps/mb-api/src/utilisateur/commands/updateUtilisateur.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest'
+
+import { ForbiddenError } from '@/framework/errors/AppError'
+import { db } from '@/framework/persistence/dbStore'
+import { ProviderType } from '@/generated/prisma/enums'
+import { fixtures } from '@/test/fixtures'
+import { integrationTest } from '@/test/integrationTest'
+import { runAsAdmin, runAsContributor } from '@/test/runAsPrincipal'
+import { updateUtilisateur } from '@/utilisateur/commands/updateUtilisateur'
+
+const ADMIN_ID = '00000000-0000-0000-0000-000000000301'
+
+describe.concurrent('updateUtilisateur', () => {
+  it(
+    "met à jour les 4 champs éditables (nom, prénom, service, fonction) sans casser l'email",
+    integrationTest(async () => {
+      const u = await fixtures.utilisateur({
+        email: 'edit-me@example.gouv.fr',
+        nom: 'AvantNom',
+        prenom: 'AvantPrenom',
+        service: 'AvantService',
+        fonction: 'AvantFonction',
+      })
+      const result = await runAsAdmin(ADMIN_ID, () =>
+        updateUtilisateur(u.id, {
+          nom: 'ApresNom',
+          prenom: 'ApresPrenom',
+          service: 'ApresService',
+          fonction: 'ApresFonction',
+        }),
+      )
+      const updated = result._unsafeUnwrap()
+      expect(updated.nom).toBe('ApresNom')
+      expect(updated.prenom).toBe('ApresPrenom')
+      expect(updated.service).toBe('ApresService')
+      expect(updated.fonction).toBe('ApresFonction')
+      expect(updated.email).toBe('edit-me@example.gouv.fr')
+
+      const row = await db().utilisateur.findUniqueOrThrow({ where: { id: u.id } })
+      expect(row.email).toBe('edit-me@example.gouv.fr')
+    }),
+  )
+
+  it(
+    "préserve les identités externes lors d'un update",
+    integrationTest(async () => {
+      const u = await fixtures.utilisateur({
+        email: 'linked@example.gouv.fr',
+        identite: { provider: ProviderType.keycloak, providerSub: 'sub-linked-kc' },
+      })
+      const result = await runAsAdmin(ADMIN_ID, () =>
+        updateUtilisateur(u.id, {
+          nom: 'Nouveau',
+          prenom: 'Prenom',
+          service: 'Service',
+          fonction: 'Fonction',
+        }),
+      )
+      const updated = result._unsafeUnwrap()
+      expect(updated.status).toBe('actif')
+      expect(updated.providers).toEqual(['keycloak'])
+    }),
+  )
+
+  it(
+    'rejette une clé CONTRIBUTOR (ForbiddenError)',
+    integrationTest(async () => {
+      const u = await fixtures.utilisateur({ email: 'forbidden-edit@example.gouv.fr' })
+      await expect(
+        runAsContributor(ADMIN_ID, () =>
+          updateUtilisateur(u.id, {
+            nom: 'N',
+            prenom: 'P',
+            service: 'S',
+            fonction: 'F',
+          }),
+        ),
+      ).rejects.toBeInstanceOf(ForbiddenError)
+    }),
+  )
+
+  it(
+    'rejette un id inconnu',
+    integrationTest(async () => {
+      await expect(
+        runAsAdmin(ADMIN_ID, () =>
+          updateUtilisateur('00000000-0000-0000-0000-0000000003ff', {
+            nom: 'N',
+            prenom: 'P',
+            service: 'S',
+            fonction: 'F',
+          }),
+        ),
+      ).rejects.toThrow()
+    }),
+  )
+})

--- a/apps/mb-api/src/utilisateur/commands/updateUtilisateur.ts
+++ b/apps/mb-api/src/utilisateur/commands/updateUtilisateur.ts
@@ -1,0 +1,33 @@
+import { type UpdateUtilisateurBody, type UtilisateurApiModel } from '@pilote/mb-shared/utilisateur'
+import { ResultAsync } from 'neverthrow'
+
+import { ensurePrincipal, isApiKeyAdmin } from '@/framework/auth/principalPredicates'
+import { db } from '@/framework/persistence/dbStore'
+import { toUtilisateurApiModel } from '@/utilisateur/utils'
+
+const performUpdate = async (
+  id: string,
+  body: UpdateUtilisateurBody,
+): Promise<UtilisateurApiModel> => {
+  ensurePrincipal(isApiKeyAdmin, 'Cette opération requiert une clé API de rôle ADMIN')
+
+  // 404 : `findUniqueOrThrow` lève P2025 mappé en 404 par le ErrorHandler global.
+  await db().utilisateur.findUniqueOrThrow({ where: { id } })
+
+  const updated = await db().utilisateur.update({
+    where: { id },
+    data: {
+      nom: body.nom,
+      prenom: body.prenom,
+      service: body.service,
+      fonction: body.fonction,
+    },
+    include: { identites: true },
+  })
+  return toUtilisateurApiModel(updated)
+}
+
+export const updateUtilisateur = (
+  id: string,
+  body: UpdateUtilisateurBody,
+): ResultAsync<UtilisateurApiModel, never> => ResultAsync.fromSafePromise(performUpdate(id, body))

--- a/apps/mb-api/src/utilisateur/queries/getUtilisateurById.test.ts
+++ b/apps/mb-api/src/utilisateur/queries/getUtilisateurById.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+
+import { ForbiddenError } from '@/framework/errors/AppError'
+import { ProviderType } from '@/generated/prisma/enums'
+import { fixtures } from '@/test/fixtures'
+import { integrationTest } from '@/test/integrationTest'
+import { runAsAdmin, runAsContributor } from '@/test/runAsPrincipal'
+import { getUtilisateurById } from '@/utilisateur/queries/getUtilisateurById'
+
+const ADMIN_ID = '00000000-0000-0000-0000-000000000201'
+
+describe.concurrent('getUtilisateurById', () => {
+  it(
+    'retourne un utilisateur avec statut et providers dérivés',
+    integrationTest(async () => {
+      const u = await fixtures.utilisateur({
+        email: 'detail@example.gouv.fr',
+        identite: { provider: ProviderType.proconnect, providerSub: 'sub-detail-pc' },
+      })
+
+      const result = await runAsAdmin(ADMIN_ID, () => getUtilisateurById(u.id))
+
+      expect(result._unsafeUnwrap()).toMatchObject({
+        id: u.id,
+        email: 'detail@example.gouv.fr',
+        status: 'actif',
+        providers: ['proconnect'],
+      })
+    }),
+  )
+
+  it(
+    'rejette quand l’utilisateur est introuvable',
+    integrationTest(async () => {
+      await expect(
+        runAsAdmin(ADMIN_ID, () => getUtilisateurById('00000000-0000-0000-0000-0000000009ff')),
+      ).rejects.toThrow()
+    }),
+  )
+
+  it(
+    'rejette une clé CONTRIBUTOR (ForbiddenError)',
+    integrationTest(async () => {
+      const u = await fixtures.utilisateur({ email: 'detail2@example.gouv.fr' })
+      await expect(
+        runAsContributor(ADMIN_ID, () => getUtilisateurById(u.id)),
+      ).rejects.toBeInstanceOf(ForbiddenError)
+    }),
+  )
+})

--- a/apps/mb-api/src/utilisateur/queries/getUtilisateurById.ts
+++ b/apps/mb-api/src/utilisateur/queries/getUtilisateurById.ts
@@ -1,0 +1,18 @@
+import { type UtilisateurApiModel } from '@pilote/mb-shared/utilisateur'
+import { ResultAsync } from 'neverthrow'
+
+import { ensurePrincipal, isApiKeyAdmin } from '@/framework/auth/principalPredicates'
+import { db } from '@/framework/persistence/dbStore'
+import { toUtilisateurApiModel } from '@/utilisateur/utils'
+
+const performGet = async (id: string): Promise<UtilisateurApiModel> => {
+  ensurePrincipal(isApiKeyAdmin, 'Cette opération requiert une clé API de rôle ADMIN')
+  const row = await db().utilisateur.findUniqueOrThrow({
+    where: { id },
+    include: { identites: true },
+  })
+  return toUtilisateurApiModel(row)
+}
+
+export const getUtilisateurById = (id: string): ResultAsync<UtilisateurApiModel, never> =>
+  ResultAsync.fromSafePromise(performGet(id))

--- a/apps/mb-api/src/utilisateur/queries/listUtilisateurs.test.ts
+++ b/apps/mb-api/src/utilisateur/queries/listUtilisateurs.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import { ForbiddenError } from '@/framework/errors/AppError'
+import { encodeCursor } from '@/framework/persistence/paginate'
 import { ProviderType } from '@/generated/prisma/enums'
 import { fixtures } from '@/test/fixtures'
 import { integrationTest } from '@/test/integrationTest'
@@ -19,8 +20,8 @@ describe.concurrent('listUtilisateurs', () => {
         identite: { provider: ProviderType.proconnect, providerSub: 'sub-u2-pc' },
       })
 
-      const result = await runAsAdmin(ADMIN_ID, () => listUtilisateurs())
-      const items = result._unsafeUnwrap()
+      const result = await runAsAdmin(ADMIN_ID, () => listUtilisateurs({}))
+      const { items } = result._unsafeUnwrap()
       const byId = new Map(items.map((u) => [u.id, u]))
 
       expect(byId.get(u1.id)?.status).toBe('en_attente')
@@ -31,9 +32,52 @@ describe.concurrent('listUtilisateurs', () => {
   )
 
   it(
+    'filtre par recherche (email, nom ou prénom) case-insensitive',
+    integrationTest(async () => {
+      const cible = await fixtures.utilisateur({
+        email: 'martin.durand@example.gouv.fr',
+        nom: 'Durand',
+        prenom: 'Martin',
+      })
+      await fixtures.utilisateur({ email: 'autre@example.gouv.fr', nom: 'Petit', prenom: 'Claire' })
+
+      const result = await runAsAdmin(ADMIN_ID, () => listUtilisateurs({ recherche: 'DURAND' }))
+
+      const { items, total } = result._unsafeUnwrap()
+      expect(total).toBe(1)
+      expect(items.map((u) => u.id)).toEqual([cible.id])
+    }),
+  )
+
+  it(
+    'pagine au-delà de la taille de page (tri par id croissant)',
+    integrationTest(async () => {
+      const created = await fixtures.utilisateur(
+        { email: 'p1@example.gouv.fr' },
+        { email: 'p2@example.gouv.fr' },
+        { email: 'p3@example.gouv.fr' },
+        { email: 'p4@example.gouv.fr' },
+      )
+
+      const first = await runAsAdmin(ADMIN_ID, () => listUtilisateurs({ pageSize: 3 }))
+      const firstPage = first._unsafeUnwrap()
+      expect(firstPage.items.map((u) => u.id)).toEqual(created.slice(0, 3).map((u) => u.id))
+      expect(firstPage.pagination).toEqual({ cursor: encodeCursor(created[2]!.id), hasMore: true })
+      expect(firstPage.total).toBe(4)
+
+      const second = await runAsAdmin(ADMIN_ID, () =>
+        listUtilisateurs({ pageSize: 3, cursor: firstPage.pagination.cursor ?? undefined }),
+      )
+      const secondPage = second._unsafeUnwrap()
+      expect(secondPage.items.map((u) => u.id)).toEqual([created[3]!.id])
+      expect(secondPage.pagination).toEqual({ cursor: null, hasMore: false })
+    }),
+  )
+
+  it(
     'rejette une clé CONTRIBUTOR (ForbiddenError)',
     integrationTest(async () => {
-      await expect(runAsContributor(ADMIN_ID, () => listUtilisateurs())).rejects.toBeInstanceOf(
+      await expect(runAsContributor(ADMIN_ID, () => listUtilisateurs({}))).rejects.toBeInstanceOf(
         ForbiddenError,
       )
     }),

--- a/apps/mb-api/src/utilisateur/queries/listUtilisateurs.test.ts
+++ b/apps/mb-api/src/utilisateur/queries/listUtilisateurs.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+
+import { ForbiddenError } from '@/framework/errors/AppError'
+import { ProviderType } from '@/generated/prisma/enums'
+import { fixtures } from '@/test/fixtures'
+import { integrationTest } from '@/test/integrationTest'
+import { runAsAdmin, runAsContributor } from '@/test/runAsPrincipal'
+import { listUtilisateurs } from '@/utilisateur/queries/listUtilisateurs'
+
+const ADMIN_ID = '00000000-0000-0000-0000-000000000201'
+
+describe.concurrent('listUtilisateurs', () => {
+  it(
+    'liste avec statut et providers dérivés',
+    integrationTest(async () => {
+      const u1 = await fixtures.utilisateur({ email: 'u1@example.gouv.fr' })
+      const u2 = await fixtures.utilisateur({
+        email: 'u2@example.gouv.fr',
+        identite: { provider: ProviderType.proconnect, providerSub: 'sub-u2-pc' },
+      })
+
+      const result = await runAsAdmin(ADMIN_ID, () => listUtilisateurs())
+      const items = result._unsafeUnwrap()
+      const byId = new Map(items.map((u) => [u.id, u]))
+
+      expect(byId.get(u1.id)?.status).toBe('en_attente')
+      expect(byId.get(u1.id)?.providers).toEqual([])
+      expect(byId.get(u2.id)?.status).toBe('actif')
+      expect(byId.get(u2.id)?.providers).toEqual(['proconnect'])
+    }),
+  )
+
+  it(
+    'rejette une clé CONTRIBUTOR (ForbiddenError)',
+    integrationTest(async () => {
+      await expect(runAsContributor(ADMIN_ID, () => listUtilisateurs())).rejects.toBeInstanceOf(
+        ForbiddenError,
+      )
+    }),
+  )
+})

--- a/apps/mb-api/src/utilisateur/queries/listUtilisateurs.ts
+++ b/apps/mb-api/src/utilisateur/queries/listUtilisateurs.ts
@@ -1,0 +1,18 @@
+import { type UtilisateurListApiModel } from '@pilote/mb-shared/utilisateur'
+import { ResultAsync } from 'neverthrow'
+
+import { ensurePrincipal, isApiKeyAdmin } from '@/framework/auth/principalPredicates'
+import { db } from '@/framework/persistence/dbStore'
+import { toUtilisateurApiModel } from '@/utilisateur/utils'
+
+const performList = async (): Promise<UtilisateurListApiModel> => {
+  ensurePrincipal(isApiKeyAdmin, 'Cette opération requiert une clé API de rôle ADMIN')
+  const rows = await db().utilisateur.findMany({
+    include: { identites: true },
+    orderBy: { createdAt: 'desc' },
+  })
+  return rows.map((row) => toUtilisateurApiModel(row))
+}
+
+export const listUtilisateurs = (): ResultAsync<UtilisateurListApiModel, never> =>
+  ResultAsync.fromSafePromise(performList())

--- a/apps/mb-api/src/utilisateur/queries/listUtilisateurs.ts
+++ b/apps/mb-api/src/utilisateur/queries/listUtilisateurs.ts
@@ -1,18 +1,38 @@
-import { type UtilisateurListApiModel } from '@pilote/mb-shared/utilisateur'
+import {
+  type ListUtilisateursQuery,
+  type UtilisateurListApiModel,
+} from '@pilote/mb-shared/utilisateur'
 import { ResultAsync } from 'neverthrow'
 
 import { ensurePrincipal, isApiKeyAdmin } from '@/framework/auth/principalPredicates'
 import { db } from '@/framework/persistence/dbStore'
+import { buildPaginationArgs, toPaginatedResponse } from '@/framework/persistence/paginate'
+import { type Prisma } from '@/generated/prisma/client'
 import { toUtilisateurApiModel } from '@/utilisateur/utils'
 
-const performList = async (): Promise<UtilisateurListApiModel> => {
-  ensurePrincipal(isApiKeyAdmin, 'Cette opération requiert une clé API de rôle ADMIN')
-  const rows = await db().utilisateur.findMany({
-    include: { identites: true },
-    orderBy: { createdAt: 'desc' },
-  })
-  return rows.map((row) => toUtilisateurApiModel(row))
+const buildWhere = (recherche: string | undefined): Prisma.UtilisateurWhereInput => {
+  if (!recherche) return {}
+  const contains = { contains: recherche, mode: 'insensitive' as const }
+  return { OR: [{ email: contains }, { nom: contains }, { prenom: contains }] }
 }
 
-export const listUtilisateurs = (): ResultAsync<UtilisateurListApiModel, never> =>
-  ResultAsync.fromSafePromise(performList())
+const performList = async (params: ListUtilisateursQuery): Promise<UtilisateurListApiModel> => {
+  ensurePrincipal(isApiKeyAdmin, 'Cette opération requiert une clé API de rôle ADMIN')
+
+  const where = buildWhere(params.recherche)
+  const [rows, total] = await Promise.all([
+    db().utilisateur.findMany({
+      where,
+      orderBy: { id: 'asc' },
+      include: { identites: true },
+      ...buildPaginationArgs(params.cursor, params.pageSize),
+    }),
+    db().utilisateur.count({ where }),
+  ])
+
+  return toPaginatedResponse(rows, total, toUtilisateurApiModel, params.pageSize)
+}
+
+export const listUtilisateurs = (
+  params: ListUtilisateursQuery,
+): ResultAsync<UtilisateurListApiModel, never> => ResultAsync.fromSafePromise(performList(params))

--- a/apps/mb-api/src/utilisateur/routes.test.ts
+++ b/apps/mb-api/src/utilisateur/routes.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+
+import { app } from '../app'
+
+describe('routes utilisateurs — câblage OpenAPI', () => {
+  it('déclare les routes utilisateurs dans le doc OpenAPI', async () => {
+    const res = await app.request('/openapi.json')
+    expect(res.status).toBe(200)
+    const doc = (await res.json()) as { paths: Record<string, Record<string, unknown>> }
+
+    const attendu: Array<[string, string]> = [
+      ['/utilisateurs', 'post'],
+      ['/utilisateurs', 'get'],
+      ['/utilisateurs/{id}', 'patch'],
+    ]
+
+    for (const [path, method] of attendu) {
+      expect(doc.paths[path], `path ${path} manquant`).toBeDefined()
+      expect(doc.paths[path]?.[method], `${method.toUpperCase()} ${path} manquant`).toBeDefined()
+    }
+  })
+
+  it('renvoie 401 sur une création non authentifiée', async () => {
+    const res = await app.request('/utilisateurs', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        email: 'x@example.gouv.fr',
+        nom: 'X',
+        prenom: 'X',
+        service: 'X',
+        fonction: 'X',
+      }),
+    })
+    expect(res.status).toBe(401)
+  })
+
+  it('renvoie 401 sur une mise à jour non authentifiée', async () => {
+    const res = await app.request('/utilisateurs/00000000-0000-0000-0000-0000000000ff', {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ nom: 'N', prenom: 'P', service: 'S', fonction: 'F' }),
+    })
+    expect(res.status).toBe(401)
+  })
+
+  it('renvoie 401 sur une lecture non authentifiée', async () => {
+    const res = await app.request('/utilisateurs')
+    expect(res.status).toBe(401)
+  })
+})

--- a/apps/mb-api/src/utilisateur/routes.ts
+++ b/apps/mb-api/src/utilisateur/routes.ts
@@ -1,6 +1,8 @@
 import { createRoute, OpenAPIHono, z } from '@hono/zod-openapi'
+import { createPaginatedApiListSchema } from '@pilote/mb-shared/pagination'
 import {
   createUtilisateurBodySchema,
+  listUtilisateursQuerySchema,
   updateUtilisateurBodySchema,
   utilisateurApiModelSchema,
 } from '@pilote/mb-shared/utilisateur'
@@ -8,21 +10,21 @@ import {
 import { requireAuthentication } from '@/framework/auth/requireAuthentication'
 import { never } from '@/framework/errors/never'
 import { jsonResponseOk } from '@/framework/openapi/jsonResponse'
-import { erreur403, erreur404, erreur409 } from '@/framework/openapi/responses'
+import { erreur400, erreur403, erreur404, erreur409 } from '@/framework/openapi/responses'
 import { withTransaction } from '@/framework/persistence/withTransaction'
 import { createUtilisateur } from '@/utilisateur/commands/createUtilisateur'
 import { updateUtilisateur } from '@/utilisateur/commands/updateUtilisateur'
+import { getUtilisateurById } from '@/utilisateur/queries/getUtilisateurById'
 import { listUtilisateurs } from '@/utilisateur/queries/listUtilisateurs'
 
 const UtilisateurApiModelSchema = utilisateurApiModelSchema.openapi('UtilisateurApiModel')
-const UtilisateurListApiModelSchema = z
-  .array(UtilisateurApiModelSchema)
-  .openapi('UtilisateurListApiModel')
+const UtilisateurListApiModelSchema =
+  createPaginatedApiListSchema(utilisateurApiModelSchema).openapi('UtilisateurListApiModel')
 const CreateUtilisateurBodySchema = createUtilisateurBodySchema.openapi('CreateUtilisateurBody')
 const UpdateUtilisateurBodySchema = updateUtilisateurBodySchema.openapi('UpdateUtilisateurBody')
 
-const updateParamsSchema = z.object({
-  id: z.string().uuid().openapi({ description: "Identifiant (UUID) de l'utilisateur à modifier." }),
+const detailParamsSchema = z.object({
+  id: z.string().uuid().openapi({ description: "Identifiant (UUID) de l'utilisateur." }),
 })
 
 // --- POST /utilisateurs ------------------------------------------------------
@@ -59,14 +61,37 @@ const listUtilisateursRoute = createRoute({
   tags: ['Utilisateur', 'Admin'],
   summary: 'Lister les utilisateurs',
   description:
-    'Réservé aux clés API de rôle `ADMIN`. Retourne les utilisateurs triés par date de création décroissante, avec leur statut (`en_attente` / `actif`) et la liste des providers OIDC rattachés.',
+    'Réservé aux clés API de rôle `ADMIN`. Retourne la liste paginée des utilisateurs (tri par identifiant croissant), avec leur statut (`en_attente` / `actif`) et la liste des providers OIDC rattachés. Filtre optionnel `recherche` (email, nom, prénom). Pagination cursor-based : passez `cursor` (renvoyé dans la réponse précédente) pour obtenir la page suivante.',
   middleware: [requireAuthentication],
+  request: { query: listUtilisateursQuerySchema },
   responses: {
     200: {
       content: { 'application/json': { schema: UtilisateurListApiModelSchema } },
-      description: 'Liste des utilisateurs',
+      description: 'Liste paginée des utilisateurs',
+    },
+    400: erreur400,
+    403: erreur403,
+  },
+})
+
+// --- GET /utilisateurs/{id} --------------------------------------------------
+
+const getUtilisateurByIdRoute = createRoute({
+  method: 'get',
+  path: '/utilisateurs/{id}',
+  tags: ['Utilisateur', 'Admin'],
+  summary: 'Récupérer un utilisateur',
+  description:
+    'Réservé aux clés API de rôle `ADMIN`. Retourne un utilisateur identifié par son identifiant (UUID).',
+  middleware: [requireAuthentication],
+  request: { params: detailParamsSchema },
+  responses: {
+    200: {
+      content: { 'application/json': { schema: UtilisateurApiModelSchema } },
+      description: 'Utilisateur trouvé',
     },
     403: erreur403,
+    404: erreur404,
   },
 })
 
@@ -81,7 +106,7 @@ const updateUtilisateurRoute = createRoute({
     'Réservé aux clés API de rôle `ADMIN`. Met à jour `nom`, `prenom`, `service`, `fonction`. **`email` est immuable** (clé du linking OIDC).',
   middleware: [requireAuthentication],
   request: {
-    params: updateParamsSchema,
+    params: detailParamsSchema,
     body: {
       content: { 'application/json': { schema: UpdateUtilisateurBodySchema } },
       required: true,
@@ -107,12 +132,21 @@ utilisateurRoutes.openapi(createUtilisateurRoute, async (context) => {
   )
 })
 
-utilisateurRoutes.openapi(listUtilisateursRoute, async (context) =>
-  listUtilisateurs().match(
+utilisateurRoutes.openapi(listUtilisateursRoute, async (context) => {
+  const { recherche, cursor, pageSize } = context.req.valid('query')
+  return listUtilisateurs({ recherche, cursor, pageSize }).match(
     (data) => jsonResponseOk({ context, data, schema: UtilisateurListApiModelSchema, status: 200 }),
     never,
-  ),
-)
+  )
+})
+
+utilisateurRoutes.openapi(getUtilisateurByIdRoute, async (context) => {
+  const { id } = context.req.valid('param')
+  return getUtilisateurById(id).match(
+    (data) => jsonResponseOk({ context, data, schema: UtilisateurApiModelSchema, status: 200 }),
+    never,
+  )
+})
 
 utilisateurRoutes.openapi(updateUtilisateurRoute, async (context) => {
   const { id } = context.req.valid('param')

--- a/apps/mb-api/src/utilisateur/routes.ts
+++ b/apps/mb-api/src/utilisateur/routes.ts
@@ -1,0 +1,124 @@
+import { createRoute, OpenAPIHono, z } from '@hono/zod-openapi'
+import {
+  createUtilisateurBodySchema,
+  updateUtilisateurBodySchema,
+  utilisateurApiModelSchema,
+} from '@pilote/mb-shared/utilisateur'
+
+import { requireAuthentication } from '@/framework/auth/requireAuthentication'
+import { never } from '@/framework/errors/never'
+import { jsonResponseOk } from '@/framework/openapi/jsonResponse'
+import { erreur403, erreur404, erreur409 } from '@/framework/openapi/responses'
+import { withTransaction } from '@/framework/persistence/withTransaction'
+import { createUtilisateur } from '@/utilisateur/commands/createUtilisateur'
+import { updateUtilisateur } from '@/utilisateur/commands/updateUtilisateur'
+import { listUtilisateurs } from '@/utilisateur/queries/listUtilisateurs'
+
+const UtilisateurApiModelSchema = utilisateurApiModelSchema.openapi('UtilisateurApiModel')
+const UtilisateurListApiModelSchema = z
+  .array(UtilisateurApiModelSchema)
+  .openapi('UtilisateurListApiModel')
+const CreateUtilisateurBodySchema = createUtilisateurBodySchema.openapi('CreateUtilisateurBody')
+const UpdateUtilisateurBodySchema = updateUtilisateurBodySchema.openapi('UpdateUtilisateurBody')
+
+const updateParamsSchema = z.object({
+  id: z.string().openapi({ description: "Identifiant (UUID) de l'utilisateur à modifier." }),
+})
+
+// --- POST /utilisateurs ------------------------------------------------------
+
+const createUtilisateurRoute = createRoute({
+  method: 'post',
+  path: '/utilisateurs',
+  tags: ['Utilisateur', 'Admin'],
+  summary: 'Créer un utilisateur pré-provisionné',
+  description:
+    "Réservé aux clés API de rôle `ADMIN`. Crée un utilisateur en statut `en_attente`. L'identité OIDC (ProConnect / Keycloak) est rattachée automatiquement au 1ᵉʳ login via l'email.",
+  middleware: [requireAuthentication],
+  request: {
+    body: {
+      content: { 'application/json': { schema: CreateUtilisateurBodySchema } },
+      required: true,
+    },
+  },
+  responses: {
+    201: {
+      content: { 'application/json': { schema: UtilisateurApiModelSchema } },
+      description: 'Utilisateur créé',
+    },
+    403: erreur403,
+    409: erreur409,
+  },
+})
+
+// --- GET /utilisateurs -------------------------------------------------------
+
+const listUtilisateursRoute = createRoute({
+  method: 'get',
+  path: '/utilisateurs',
+  tags: ['Utilisateur', 'Admin'],
+  summary: 'Lister les utilisateurs',
+  description:
+    'Réservé aux clés API de rôle `ADMIN`. Retourne les utilisateurs triés par date de création décroissante, avec leur statut (`en_attente` / `actif`) et la liste des providers OIDC rattachés.',
+  middleware: [requireAuthentication],
+  responses: {
+    200: {
+      content: { 'application/json': { schema: UtilisateurListApiModelSchema } },
+      description: 'Liste des utilisateurs',
+    },
+    403: erreur403,
+  },
+})
+
+// --- PATCH /utilisateurs/{id} ------------------------------------------------
+
+const updateUtilisateurRoute = createRoute({
+  method: 'patch',
+  path: '/utilisateurs/{id}',
+  tags: ['Utilisateur', 'Admin'],
+  summary: 'Mettre à jour un utilisateur',
+  description:
+    'Réservé aux clés API de rôle `ADMIN`. Met à jour `nom`, `prenom`, `service`, `fonction`. **`email` est immuable** (clé du linking OIDC).',
+  middleware: [requireAuthentication],
+  request: {
+    params: updateParamsSchema,
+    body: {
+      content: { 'application/json': { schema: UpdateUtilisateurBodySchema } },
+      required: true,
+    },
+  },
+  responses: {
+    200: {
+      content: { 'application/json': { schema: UtilisateurApiModelSchema } },
+      description: 'Utilisateur mis à jour',
+    },
+    403: erreur403,
+    404: erreur404,
+  },
+})
+
+export const utilisateurRoutes = new OpenAPIHono()
+
+utilisateurRoutes.openapi(createUtilisateurRoute, async (context) => {
+  const body = context.req.valid('json')
+  return (await withTransaction(async () => createUtilisateur(body))).match(
+    (data) => jsonResponseOk({ context, data, schema: UtilisateurApiModelSchema, status: 201 }),
+    never,
+  )
+})
+
+utilisateurRoutes.openapi(listUtilisateursRoute, async (context) =>
+  listUtilisateurs().match(
+    (data) => jsonResponseOk({ context, data, schema: UtilisateurListApiModelSchema, status: 200 }),
+    never,
+  ),
+)
+
+utilisateurRoutes.openapi(updateUtilisateurRoute, async (context) => {
+  const { id } = context.req.valid('param')
+  const body = context.req.valid('json')
+  return (await withTransaction(async () => updateUtilisateur(id, body))).match(
+    (data) => jsonResponseOk({ context, data, schema: UtilisateurApiModelSchema, status: 200 }),
+    never,
+  )
+})

--- a/apps/mb-api/src/utilisateur/routes.ts
+++ b/apps/mb-api/src/utilisateur/routes.ts
@@ -22,10 +22,7 @@ const CreateUtilisateurBodySchema = createUtilisateurBodySchema.openapi('CreateU
 const UpdateUtilisateurBodySchema = updateUtilisateurBodySchema.openapi('UpdateUtilisateurBody')
 
 const updateParamsSchema = z.object({
-  id: z
-    .string()
-    .uuid()
-    .openapi({ description: "Identifiant (UUID) de l'utilisateur à modifier." }),
+  id: z.string().uuid().openapi({ description: "Identifiant (UUID) de l'utilisateur à modifier." }),
 })
 
 // --- POST /utilisateurs ------------------------------------------------------

--- a/apps/mb-api/src/utilisateur/routes.ts
+++ b/apps/mb-api/src/utilisateur/routes.ts
@@ -22,7 +22,10 @@ const CreateUtilisateurBodySchema = createUtilisateurBodySchema.openapi('CreateU
 const UpdateUtilisateurBodySchema = updateUtilisateurBodySchema.openapi('UpdateUtilisateurBody')
 
 const updateParamsSchema = z.object({
-  id: z.string().openapi({ description: "Identifiant (UUID) de l'utilisateur à modifier." }),
+  id: z
+    .string()
+    .uuid()
+    .openapi({ description: "Identifiant (UUID) de l'utilisateur à modifier." }),
 })
 
 // --- POST /utilisateurs ------------------------------------------------------

--- a/apps/mb-api/src/utilisateur/utils.test.ts
+++ b/apps/mb-api/src/utilisateur/utils.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+
+import { toUtilisateurApiModel } from '@/utilisateur/utils'
+
+const baseRow = (identites: Array<{ provider: 'proconnect' | 'keycloak' }> = []) => ({
+  id: '00000000-0000-0000-0000-000000000010',
+  email: 'jane.doe@example.gouv.fr',
+  nom: 'Doe',
+  prenom: 'Jane',
+  service: 'DITP',
+  fonction: 'Agent',
+  createdAt: new Date('2024-01-01T00:00:00.000Z'),
+  updatedAt: new Date('2024-06-01T00:00:00.000Z'),
+  identites: identites.map((i) => ({
+    provider: i.provider,
+    providerSub: `sub-${i.provider}`,
+    utilisateurId: '00000000-0000-0000-0000-000000000010',
+    createdAt: new Date('2024-01-02T00:00:00.000Z'),
+  })),
+})
+
+describe('toUtilisateurApiModel', () => {
+  it('utilisateur sans identité → status=en_attente, providers=[]', () => {
+    const model = toUtilisateurApiModel(baseRow([]))
+    expect(model.status).toBe('en_attente')
+    expect(model.providers).toEqual([])
+    expect(model.email).toBe('jane.doe@example.gouv.fr')
+    expect(model.createdAt).toBe('2024-01-01T00:00:00Z')
+    expect(model.updatedAt).toBe('2024-06-01T00:00:00Z')
+  })
+
+  it('une identité proconnect → status=actif, providers=[proconnect]', () => {
+    const model = toUtilisateurApiModel(baseRow([{ provider: 'proconnect' }]))
+    expect(model.status).toBe('actif')
+    expect(model.providers).toEqual(['proconnect'])
+  })
+
+  it('deux identités → providers ordre stable proconnect avant keycloak', () => {
+    const model = toUtilisateurApiModel(
+      baseRow([{ provider: 'keycloak' }, { provider: 'proconnect' }]),
+    )
+    expect(model.status).toBe('actif')
+    expect(model.providers).toEqual(['proconnect', 'keycloak'])
+  })
+})

--- a/apps/mb-api/src/utilisateur/utils.ts
+++ b/apps/mb-api/src/utilisateur/utils.ts
@@ -1,0 +1,26 @@
+import { type UtilisateurApiModel } from '@pilote/mb-shared/utilisateur'
+
+import { fromDate } from '@/framework/date'
+import { ProviderType } from '@/generated/prisma/enums'
+import { type IdentiteExterneModel, type UtilisateurModel } from '@/generated/prisma/models'
+
+const PROVIDER_ORDER: ProviderType[] = [ProviderType.proconnect, ProviderType.keycloak]
+
+type UtilisateurWithIdentites = UtilisateurModel & { identites: IdentiteExterneModel[] }
+
+export const toUtilisateurApiModel = (row: UtilisateurWithIdentites): UtilisateurApiModel => {
+  const providersSet = new Set(row.identites.map((i) => i.provider))
+  const providers = PROVIDER_ORDER.filter((p) => providersSet.has(p))
+  return {
+    id: row.id,
+    email: row.email,
+    nom: row.nom,
+    prenom: row.prenom,
+    service: row.service,
+    fonction: row.fonction,
+    status: providers.length === 0 ? 'en_attente' : 'actif',
+    providers,
+    createdAt: fromDate(row.createdAt).toString(),
+    updatedAt: fromDate(row.updatedAt).toString(),
+  }
+}

--- a/apps/mb-api/tsconfig.json
+++ b/apps/mb-api/tsconfig.json
@@ -28,6 +28,7 @@
       "@/widget/*": ["./src/widget/*"],
       "@/panier/*": ["./src/panier/*"],
       "@/shared/*": ["./src/shared/*"],
+      "@/utilisateur/*": ["./src/utilisateur/*"],
       "@/whoami/*": ["./src/whoami/*"],
       "@/generated/*": ["./src/generated/*"],
       "@/test/*": ["./src/test/*"],

--- a/packages/mb-shared/package.json
+++ b/packages/mb-shared/package.json
@@ -87,6 +87,10 @@
     "./panierContactUtile": {
       "types": "./src/panierContactUtile.ts",
       "default": "./src/panierContactUtile.ts"
+    },
+    "./utilisateur": {
+      "types": "./src/utilisateur.ts",
+      "default": "./src/utilisateur.ts"
     }
   },
   "files": [

--- a/packages/mb-shared/src/utilisateur.ts
+++ b/packages/mb-shared/src/utilisateur.ts
@@ -1,0 +1,45 @@
+import { z } from 'zod'
+
+export const providerTypeSchema = z.enum(['proconnect', 'keycloak'])
+export type ProviderTypeValue = z.infer<typeof providerTypeSchema>
+
+export const utilisateurStatusSchema = z.enum(['en_attente', 'actif'])
+export type UtilisateurStatus = z.infer<typeof utilisateurStatusSchema>
+
+export const utilisateurApiModelSchema = z.object({
+  id: z.string().describe("Identifiant unique de l'utilisateur (UUID)."),
+  email: z.string().email().describe('Adresse email (clé du linking OIDC, immuable).'),
+  nom: z.string().describe('Nom.'),
+  prenom: z.string().describe('Prénom.'),
+  service: z.string().describe('Service métier.'),
+  fonction: z.string().describe('Fonction.'),
+  status: utilisateurStatusSchema.describe(
+    "Statut dérivé : `en_attente` tant qu'aucune identité OIDC n'est rattachée, `actif` sinon.",
+  ),
+  providers: z
+    .array(providerTypeSchema)
+    .describe('Providers OIDC rattachés (vide si `status = en_attente`).'),
+  createdAt: z.string().datetime().describe('Date ISO 8601 de création.'),
+  updatedAt: z.string().datetime().describe('Date ISO 8601 de dernière mise à jour.'),
+})
+export type UtilisateurApiModel = z.infer<typeof utilisateurApiModelSchema>
+
+export const utilisateurListApiModelSchema = z.array(utilisateurApiModelSchema)
+export type UtilisateurListApiModel = z.infer<typeof utilisateurListApiModelSchema>
+
+export const createUtilisateurBodySchema = z.object({
+  email: z.string().email().describe('Adresse email (clé du linking OIDC).'),
+  nom: z.string().trim().min(1).describe('Nom.'),
+  prenom: z.string().trim().min(1).describe('Prénom.'),
+  service: z.string().trim().min(1).describe('Service métier.'),
+  fonction: z.string().trim().min(1).describe('Fonction.'),
+})
+export type CreateUtilisateurBody = z.infer<typeof createUtilisateurBodySchema>
+
+export const updateUtilisateurBodySchema = z.object({
+  nom: z.string().trim().min(1).describe('Nom.'),
+  prenom: z.string().trim().min(1).describe('Prénom.'),
+  service: z.string().trim().min(1).describe('Service métier.'),
+  fonction: z.string().trim().min(1).describe('Fonction.'),
+})
+export type UpdateUtilisateurBody = z.infer<typeof updateUtilisateurBodySchema>

--- a/packages/mb-shared/src/utilisateur.ts
+++ b/packages/mb-shared/src/utilisateur.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod'
 
+import { createPaginatedApiListSchema, listQuerySchema } from './pagination'
+
 export const providerTypeSchema = z.enum(['proconnect', 'keycloak'])
 export type ProviderTypeValue = z.infer<typeof providerTypeSchema>
 
@@ -7,7 +9,7 @@ export const utilisateurStatusSchema = z.enum(['en_attente', 'actif'])
 export type UtilisateurStatus = z.infer<typeof utilisateurStatusSchema>
 
 export const utilisateurApiModelSchema = z.object({
-  id: z.string().describe("Identifiant unique de l'utilisateur (UUID)."),
+  id: z.string().uuid().describe("Identifiant unique de l'utilisateur (UUID)."),
   email: z.string().email().describe('Adresse email (clé du linking OIDC, immuable).'),
   nom: z.string().describe('Nom.'),
   prenom: z.string().describe('Prénom.'),
@@ -24,8 +26,11 @@ export const utilisateurApiModelSchema = z.object({
 })
 export type UtilisateurApiModel = z.infer<typeof utilisateurApiModelSchema>
 
-export const utilisateurListApiModelSchema = z.array(utilisateurApiModelSchema)
+export const utilisateurListApiModelSchema = createPaginatedApiListSchema(utilisateurApiModelSchema)
 export type UtilisateurListApiModel = z.infer<typeof utilisateurListApiModelSchema>
+
+export const listUtilisateursQuerySchema = listQuerySchema
+export type ListUtilisateursQuery = z.infer<typeof listUtilisateursQuerySchema>
 
 export const createUtilisateurBodySchema = z.object({
   email: z.string().email().describe('Adresse email (clé du linking OIDC).'),


### PR DESCRIPTION
## Summary

- **mb-api** : module `utilisateur/` complet (commands `createUtilisateur` / `updateUtilisateur`, query `listUtilisateurs`, mapper, routes `POST/GET/PATCH /utilisateurs` — réservé aux clés API `ADMIN`, email figé, statut/providers dérivés).
- **mb-admin** : pages `Utilisateurs` (liste, création, édition), composant `UtilisateurForm` (RHF + Zod), fetchers/queries, whitelist BFF, carte d'accès dans `fonctionnalites.tsx`.
- **mb-shared** : schémas partagés `utilisateur` (create/update body, api-model avec `status: 'en_attente' | 'actif'` + `providers: ['proconnect' | 'keycloak']`).

Le linking par email au 1ᵉʳ login OIDC (`getUtilisateurByProvider.ts`) existait déjà et est **inchangé** — un utilisateur pré-provisionné devient automatiquement "actif" au premier ProConnect / Keycloak.

Pattern strictement calqué sur le CRUD clés API livré en `b5c861fc9`.

## Test plan
- [ ] `pnpm --filter @pilote/mb-api test` — 449 tests PASS (dont 14 nouveaux sur `utilisateur/`)
- [ ] `pnpm --filter @pilote/mb-admin exec tsc --noEmit` — PASS
- [ ] IHM : `Fonctionnalités` → carte "Gérer les utilisateurs" → création (formulaire complet) → liste (statut "En attente") → édition (email en readonly) → 409 si email dupliqué
- [ ] Login OIDC avec l'email pré-provisionné → l'utilisateur passe automatiquement "Actif" avec le provider correspondant

🤖 Generated with [Claude Code](https://claude.com/claude-code)