### PR TITLE
chore(mb-shared): config prettier + enforcement CI

### DIFF
--- a/.github/workflows/testAndLint.yml
+++ b/.github/workflows/testAndLint.yml
@@ -220,6 +220,24 @@ jobs:
         env:
           APP_PACKAGE: '@pilote/mb-webapp'
 
+  lint-mb-shared:
+    name: Run linters for mb-shared
+    needs: changes
+    if: needs.changes.outputs['mb-shared'] == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node and packages
+        uses: ./.github/actions/setupNodeAndPackages
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Run lint command
+        run: pnpm lint
+        env:
+          APP_PACKAGE: '@pilote/mb-shared'
+
   lint-sql:
     name: Run SQL linter on dbt models
     needs: changes

--- a/packages/mb-shared/.prettierrc
+++ b/packages/mb-shared/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "semi": false,
+  "singleQuote": true,
+  "trailingComma": "all",
+  "printWidth": 100,
+  "arrowParens": "always"
+}

--- a/packages/mb-shared/package.json
+++ b/packages/mb-shared/package.json
@@ -104,7 +104,15 @@
   "files": [
     "src"
   ],
+  "scripts": {
+    "lint": "prettier --check .",
+    "format": "prettier --write .",
+    "format:check": "prettier --check ."
+  },
   "peerDependencies": {
     "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "prettier": "^3.6.2"
   }
 }

--- a/packages/mb-shared/src/auteur.ts
+++ b/packages/mb-shared/src/auteur.ts
@@ -1,21 +1,18 @@
-import { z } from "zod";
+import { z } from 'zod'
 
 const auteurUtilisateurApiModelSchema = z.object({
-  type: z.literal("utilisateur"),
-  id: z.string().uuid().describe("Identifiant du principal."),
-  email: z.string().email().describe("Email de l’utilisateur."),
-});
+  type: z.literal('utilisateur'),
+  id: z.string().uuid().describe('Identifiant du principal.'),
+  email: z.string().email().describe('Email de l’utilisateur.'),
+})
 
 const auteurApiKeyApiModelSchema = z.object({
-  type: z.literal("apiKey"),
-  id: z.string().uuid().describe("Identifiant du principal."),
-  label: z.string().describe("Libellé de la clé API."),
-});
+  type: z.literal('apiKey'),
+  id: z.string().uuid().describe('Identifiant du principal.'),
+  label: z.string().describe('Libellé de la clé API.'),
+})
 
 export const auteurApiModelSchema = z
-  .discriminatedUnion("type", [
-    auteurUtilisateurApiModelSchema,
-    auteurApiKeyApiModelSchema,
-  ])
-  .describe("Auteur (utilisateur ou clé API).");
-export type AuteurApiModel = z.infer<typeof auteurApiModelSchema>;
+  .discriminatedUnion('type', [auteurUtilisateurApiModelSchema, auteurApiKeyApiModelSchema])
+  .describe('Auteur (utilisateur ou clé API).')
+export type AuteurApiModel = z.infer<typeof auteurApiModelSchema>

--- a/packages/mb-shared/src/commentaire.ts
+++ b/packages/mb-shared/src/commentaire.ts
@@ -1,135 +1,109 @@
-import { z } from "zod";
+import { z } from 'zod'
 
-import { auteurApiModelSchema } from "./auteur";
-import {
-  createPaginatedApiListSchema,
-  pageSizeSchema,
-  paginationCursorSchema,
-} from "./pagination";
+import { auteurApiModelSchema } from './auteur'
+import { createPaginatedApiListSchema, pageSizeSchema, paginationCursorSchema } from './pagination'
 
 export const commentaireStatutSchema = z
-  .enum(["BROUILLON", "PUBLIE"])
-  .describe(
-    "Statut du commentaire : BROUILLON (en cours de rédaction) ou PUBLIE (visible).",
-  );
-export type CommentaireStatut = z.infer<typeof commentaireStatutSchema>;
+  .enum(['BROUILLON', 'PUBLIE'])
+  .describe('Statut du commentaire : BROUILLON (en cours de rédaction) ou PUBLIE (visible).')
+export type CommentaireStatut = z.infer<typeof commentaireStatutSchema>
 
 // Enums `type` par sujet (chaque sujet a ses propres valeurs).
-export const indicateurIndividuCommentaireTypeSchema = z.enum([
-  "DEFAUT",
-  "CONFIANCE",
-]);
-export const panierCommentaireTypeSchema = z.enum([
-  "DEFAUT",
-  "CONFIANCE",
-  "OBJECTIF",
-]);
+export const indicateurIndividuCommentaireTypeSchema = z.enum(['DEFAUT', 'CONFIANCE'])
+export const panierCommentaireTypeSchema = z.enum(['DEFAUT', 'CONFIANCE', 'OBJECTIF'])
 
 export const commentaireApiModelSchema = z
   .object({
-    id: z.string().uuid().describe("Identifiant du commentaire."),
-    type: z
-      .string()
-      .describe("Catégorie du commentaire (enum propre au sujet)."),
+    id: z.string().uuid().describe('Identifiant du commentaire.'),
+    type: z.string().describe('Catégorie du commentaire (enum propre au sujet).'),
     individuId: z
       .string()
       .nullable()
       .describe(
-        "Identifiant public de l’individu rattaché, ou null pour un commentaire global de panier.",
+        'Identifiant public de l’individu rattaché, ou null pour un commentaire global de panier.',
       ),
-    contenu: z.string().describe("Contenu HTML riche (peut être vide)."),
+    contenu: z.string().describe('Contenu HTML riche (peut être vide).'),
     statut: commentaireStatutSchema,
     auteurCreation: auteurApiModelSchema,
     auteurModification: auteurApiModelSchema,
-    createdAt: z.string().datetime().describe("Date ISO 8601 de création."),
-    updatedAt: z
-      .string()
-      .datetime()
-      .describe("Date ISO 8601 de dernière modification."),
+    createdAt: z.string().datetime().describe('Date ISO 8601 de création.'),
+    updatedAt: z.string().datetime().describe('Date ISO 8601 de dernière modification.'),
   })
-  .describe("Commentaire.");
-export type CommentaireApiModel = z.infer<typeof commentaireApiModelSchema>;
+  .describe('Commentaire.')
+export type CommentaireApiModel = z.infer<typeof commentaireApiModelSchema>
 
 // Body de création : `type` est contraint par le sujet (cf. factory ci-dessous).
 const creerCommentaireBodySchema = <T extends z.ZodTypeAny>(typeSchema: T) =>
   z.object({
-    type: typeSchema.describe("Catégorie du commentaire."),
-    contenu: z
-      .string()
-      .describe("Contenu HTML riche (la chaîne vide est autorisée)."),
+    type: typeSchema.describe('Catégorie du commentaire.'),
+    contenu: z.string().describe('Contenu HTML riche (la chaîne vide est autorisée).'),
     statut: commentaireStatutSchema,
-  });
+  })
 
-export const creerIndicateurIndividuCommentaireBodySchema =
-  creerCommentaireBodySchema(indicateurIndividuCommentaireTypeSchema);
+export const creerIndicateurIndividuCommentaireBodySchema = creerCommentaireBodySchema(
+  indicateurIndividuCommentaireTypeSchema,
+)
 export const creerPanierCommentaireBodySchema = creerCommentaireBodySchema(
   panierCommentaireTypeSchema,
-);
+)
 // `type` est paramétré par sujet (cf. schémas ci-dessus) ; le générique permet
 // au consommateur de fixer l'enum exact attendu (sinon `string`).
 export type CreerCommentaireBody<T extends string = string> = {
-  type: T;
-  contenu: string;
-  statut: CommentaireStatut;
-};
+  type: T
+  contenu: string
+  statut: CommentaireStatut
+}
 
 // Body de modification (socle, par id) : type non modifiable, individu/sujet figés.
 export const modifierCommentaireBodySchema = z
   .object({
-    contenu: z
-      .string()
-      .optional()
-      .describe("Nouveau contenu HTML (optionnel)."),
-    statut: commentaireStatutSchema
-      .optional()
-      .describe("Nouveau statut (optionnel)."),
+    contenu: z.string().optional().describe('Nouveau contenu HTML (optionnel).'),
+    statut: commentaireStatutSchema.optional().describe('Nouveau statut (optionnel).'),
   })
-  .describe("Modification du contenu et/ou du statut d’un commentaire.");
-export type ModifierCommentaireBody = z.infer<
-  typeof modifierCommentaireBodySchema
->;
+  .describe('Modification du contenu et/ou du statut d’un commentaire.')
+export type ModifierCommentaireBody = z.infer<typeof modifierCommentaireBodySchema>
 
 // Query de listing : `type` obligatoire, contraint par le sujet (cf. factory ci-dessous).
 // Le listing ne renvoie que les commentaires PUBLIE (tous auteurs). Les brouillons
 // passent par un endpoint dédié (`/commentaires/brouillon`).
 const listerCommentairesQuerySchema = <T extends z.ZodTypeAny>(typeSchema: T) =>
   z.object({
-    type: typeSchema.describe("Catégorie du commentaire."),
+    type: typeSchema.describe('Catégorie du commentaire.'),
     cursor: paginationCursorSchema.optional(),
     pageSize: pageSizeSchema,
-  });
+  })
 
-export const listerIndicateurIndividuCommentairesQuerySchema =
-  listerCommentairesQuerySchema(indicateurIndividuCommentaireTypeSchema);
-export const listerPanierCommentairesQuerySchema =
-  listerCommentairesQuerySchema(panierCommentaireTypeSchema);
+export const listerIndicateurIndividuCommentairesQuerySchema = listerCommentairesQuerySchema(
+  indicateurIndividuCommentaireTypeSchema,
+)
+export const listerPanierCommentairesQuerySchema = listerCommentairesQuerySchema(
+  panierCommentaireTypeSchema,
+)
 // Type « élargi » consommé par la couche générique : le `type` est déjà validé
 // par le schéma propre au sujet (route).
 export type ListerCommentairesQuery = {
-  type: string;
-  cursor?: string | undefined;
-  pageSize?: number | undefined;
-};
+  type: string
+  cursor?: string | undefined
+  pageSize?: number | undefined
+}
 
 // Query du brouillon courant (par sujet) : juste le type.
 const recupererBrouillonQuerySchema = <T extends z.ZodTypeAny>(typeSchema: T) =>
-  z.object({ type: typeSchema.describe("Catégorie du commentaire.") });
+  z.object({ type: typeSchema.describe('Catégorie du commentaire.') })
 
-export const recupererIndicateurIndividuBrouillonQuerySchema =
-  recupererBrouillonQuerySchema(indicateurIndividuCommentaireTypeSchema);
-export const recupererPanierBrouillonQuerySchema =
-  recupererBrouillonQuerySchema(panierCommentaireTypeSchema);
-export type RecupererBrouillonQuery = { type: string };
+export const recupererIndicateurIndividuBrouillonQuerySchema = recupererBrouillonQuerySchema(
+  indicateurIndividuCommentaireTypeSchema,
+)
+export const recupererPanierBrouillonQuerySchema = recupererBrouillonQuerySchema(
+  panierCommentaireTypeSchema,
+)
+export type RecupererBrouillonQuery = { type: string }
 
 // Réponse du brouillon : le commentaire, ou null s'il n'y en a pas.
 export const brouillonApiModelSchema = commentaireApiModelSchema
   .nullable()
-  .describe("Brouillon courant de l'utilisateur, ou null s'il n'en a pas.");
-export type BrouillonApiModel = z.infer<typeof brouillonApiModelSchema>;
+  .describe("Brouillon courant de l'utilisateur, ou null s'il n'en a pas.")
+export type BrouillonApiModel = z.infer<typeof brouillonApiModelSchema>
 
-export const commentaireListApiModelSchema = createPaginatedApiListSchema(
-  commentaireApiModelSchema,
-);
-export type CommentaireListApiModel = z.infer<
-  typeof commentaireListApiModelSchema
->;
+export const commentaireListApiModelSchema = createPaginatedApiListSchema(commentaireApiModelSchema)
+export type CommentaireListApiModel = z.infer<typeof commentaireListApiModelSchema>

--- a/packages/mb-shared/src/dates.ts
+++ b/packages/mb-shared/src/dates.ts
@@ -9,9 +9,7 @@ const isValidCalendarDate = (value: string): boolean => {
   const day = Number(dayStr)
   const date = new Date(Date.UTC(year, month - 1, day))
   return (
-    date.getUTCFullYear() === year &&
-    date.getUTCMonth() === month - 1 &&
-    date.getUTCDate() === day
+    date.getUTCFullYear() === year && date.getUTCMonth() === month - 1 && date.getUTCDate() === day
   )
 }
 
@@ -24,8 +22,8 @@ export const dateSchema = z
 export const dateTruncSchema = z
   .enum(['day', 'week', 'month', 'quarter', 'year'])
   .describe(
-    "Granularité temporelle de troncature appliquée aux dates des points. `day` = pas de " +
-      "troncature ; `week` = lundi ISO 8601 ; `month` = 1er du mois ; `quarter` = 1er des " +
+    'Granularité temporelle de troncature appliquée aux dates des points. `day` = pas de ' +
+      'troncature ; `week` = lundi ISO 8601 ; `month` = 1er du mois ; `quarter` = 1er des ' +
       'trimestres calendaires (janvier, avril, juillet, octobre) ; `year` = 1er janvier. ' +
       'Quand plusieurs saisies tombent dans le même bucket pour un individu, la plus récente ' +
       'est retenue.',

--- a/packages/mb-shared/src/error.ts
+++ b/packages/mb-shared/src/error.ts
@@ -3,10 +3,8 @@ import { z } from 'zod'
 export const errorApiModelSchema = z.object({
   code: z
     .string()
-    .describe('Code stable identifiant la classe d\'erreur (ex: INDICATEUR_NOT_FOUND).'),
-  message: z
-    .string()
-    .describe('Message lisible en français destiné à l\'UI ou à un agent IA.'),
+    .describe("Code stable identifiant la classe d'erreur (ex: INDICATEUR_NOT_FOUND)."),
+  message: z.string().describe("Message lisible en français destiné à l'UI ou à un agent IA."),
   details: z
     .unknown()
     .optional()

--- a/packages/mb-shared/src/indicateur.ts
+++ b/packages/mb-shared/src/indicateur.ts
@@ -91,12 +91,7 @@ export const indicateurMetadonneesSchema = z.object({
     .nullable()
     .describe('URL de la source des données. Doit utiliser le protocole http ou https.'),
   periodeMiseAJour: periodeMiseAJourSchema.nullable().describe('Période de mise à jour.'),
-  jourMiseAJour: z
-    .int()
-    .min(1)
-    .max(31)
-    .nullable()
-    .describe('Jour de mise à jour entre 1 et 31.'),
+  jourMiseAJour: z.int().min(1).max(31).nullable().describe('Jour de mise à jour entre 1 et 31.'),
 })
 export type IndicateurMetadonnees = z.infer<typeof indicateurMetadonneesSchema>
 

--- a/packages/mb-shared/src/individu.ts
+++ b/packages/mb-shared/src/individu.ts
@@ -29,4 +29,6 @@ export const individuListApiModelSchema = createPaginatedApiListSchema(individuA
 export type IndividuListApiModel = z.infer<typeof individuListApiModelSchema>
 
 export const listIndividusForReferentielQuerySchema = listQuerySchema
-export type ListIndividusForReferentielQuery = z.infer<typeof listIndividusForReferentielQuerySchema>
+export type ListIndividusForReferentielQuery = z.infer<
+  typeof listIndividusForReferentielQuerySchema
+>

--- a/packages/mb-shared/src/mePermissions.ts
+++ b/packages/mb-shared/src/mePermissions.ts
@@ -5,11 +5,15 @@ import { permissionActionSchema } from './permission'
 const permissionEntrySchema = z.object({
   id: z
     .string()
-    .describe('Identifiant public de la ressource (`PAN-…` pour un panier, `IND-…` pour un indicateur).'),
+    .describe(
+      'Identifiant public de la ressource (`PAN-…` pour un panier, `IND-…` pour un indicateur).',
+    ),
   actions: z
     .array(permissionActionSchema)
     .min(1)
-    .describe('Actions accordées au principal courant sur cette ressource. Trié `READ` avant `WRITE`.'),
+    .describe(
+      'Actions accordées au principal courant sur cette ressource. Trié `READ` avant `WRITE`.',
+    ),
 })
 
 export const mePermissionsApiModelSchema = z.object({
@@ -25,7 +29,7 @@ export const mePermissionsApiModelSchema = z.object({
     .array(permissionEntrySchema)
     .describe(
       "Permissions explicites du principal sur les paniers, triées par `id` ASC. N'inclut PAS " +
-        "le READ implicite des paniers `PUBLIC` (le client le sait en affichant le panier).",
+        'le READ implicite des paniers `PUBLIC` (le client le sait en affichant le panier).',
     ),
   indicateurs: z
     .array(permissionEntrySchema)

--- a/packages/mb-shared/src/niveauConfiance.ts
+++ b/packages/mb-shared/src/niveauConfiance.ts
@@ -1,83 +1,60 @@
-import { z } from "zod";
+import { z } from 'zod'
 
-import { auteurApiModelSchema } from "./auteur";
-import { commentaireApiModelSchema } from "./commentaire";
-import { createPaginatedApiListSchema } from "./pagination";
+import { auteurApiModelSchema } from './auteur'
+import { commentaireApiModelSchema } from './commentaire'
+import { createPaginatedApiListSchema } from './pagination'
 
 export const indiceConfianceSchema = z
-  .enum([
-    "OBJECTIF_COMPROMIS",
-    "APPUIS_NECESSAIRE",
-    "OBJECTIF_ATTEIGNABLE",
-    "OBJECTIF_SECURISE",
-  ])
-  .describe("Indice de confiance (état d’avancement vis-à-vis des objectifs).");
-export type IndiceConfiance = z.infer<typeof indiceConfianceSchema>;
+  .enum(['OBJECTIF_COMPROMIS', 'APPUIS_NECESSAIRE', 'OBJECTIF_ATTEIGNABLE', 'OBJECTIF_SECURISE'])
+  .describe('Indice de confiance (état d’avancement vis-à-vis des objectifs).')
+export type IndiceConfiance = z.infer<typeof indiceConfianceSchema>
 
 export const niveauConfianceApiModelSchema = z
   .object({
-    id: z.string().uuid().describe("Identifiant du niveau de confiance."),
+    id: z.string().uuid().describe('Identifiant du niveau de confiance.'),
     indice: indiceConfianceSchema,
-    commentaire: commentaireApiModelSchema.describe(
-      "Commentaire CONFIANCE qui justifie l’indice.",
-    ),
+    commentaire: commentaireApiModelSchema.describe('Commentaire CONFIANCE qui justifie l’indice.'),
     auteurCreation: auteurApiModelSchema,
     auteurModification: auteurApiModelSchema,
-    createdAt: z.string().datetime().describe("Date ISO 8601 de création."),
-    updatedAt: z
-      .string()
-      .datetime()
-      .describe("Date ISO 8601 de dernière modification."),
+    createdAt: z.string().datetime().describe('Date ISO 8601 de création.'),
+    updatedAt: z.string().datetime().describe('Date ISO 8601 de dernière modification.'),
   })
-  .describe("Niveau de confiance attaché à un commentaire CONFIANCE.");
-export type NiveauConfianceApiModel = z.infer<
-  typeof niveauConfianceApiModelSchema
->;
+  .describe('Niveau de confiance attaché à un commentaire CONFIANCE.')
+export type NiveauConfianceApiModel = z.infer<typeof niveauConfianceApiModelSchema>
 
 export const creerNiveauConfianceBodySchema = z
   .object({
-    commentaireId: z
-      .string()
-      .uuid()
-      .describe("Identifiant du commentaire CONFIANCE déjà créé."),
+    commentaireId: z.string().uuid().describe('Identifiant du commentaire CONFIANCE déjà créé.'),
     indice: indiceConfianceSchema,
   })
-  .describe("Création d’un niveau de confiance.");
-export type CreerNiveauConfianceBody = z.infer<
-  typeof creerNiveauConfianceBodySchema
->;
+  .describe('Création d’un niveau de confiance.')
+export type CreerNiveauConfianceBody = z.infer<typeof creerNiveauConfianceBodySchema>
 
 export const modifierNiveauConfianceBodySchema = z
   .object({
     indice: indiceConfianceSchema,
   })
-  .describe("Modification d’un niveau de confiance (indice).");
-export type ModifierNiveauConfianceBody = z.infer<
-  typeof modifierNiveauConfianceBodySchema
->;
+  .describe('Modification d’un niveau de confiance (indice).')
+export type ModifierNiveauConfianceBody = z.infer<typeof modifierNiveauConfianceBodySchema>
 
 // Query batch : récupère les niveaux des commentaires passés (CSV d'UUID).
 export const listerNiveauxConfianceQuerySchema = z.object({
   commentaires: z
     .preprocess((val) => {
-      if (typeof val !== "string") return val;
+      if (typeof val !== 'string') return val
       const parts = val
-        .split(",")
+        .split(',')
         .map((p) => p.trim())
-        .filter(Boolean);
-      return parts;
+        .filter(Boolean)
+      return parts
     }, z.array(z.string().uuid()).default([]))
     .describe(
-      "Identifiants des commentaires concernés (CSV, ex. `uuid1,uuid2`). Vide = aucun résultat.",
+      'Identifiants des commentaires concernés (CSV, ex. `uuid1,uuid2`). Vide = aucun résultat.',
     ),
-});
-export type ListerNiveauxConfianceQuery = z.infer<
-  typeof listerNiveauxConfianceQuerySchema
->;
+})
+export type ListerNiveauxConfianceQuery = z.infer<typeof listerNiveauxConfianceQuerySchema>
 
 export const niveauConfianceListApiModelSchema = createPaginatedApiListSchema(
   niveauConfianceApiModelSchema,
-);
-export type NiveauConfianceListApiModel = z.infer<
-  typeof niveauConfianceListApiModelSchema
->;
+)
+export type NiveauConfianceListApiModel = z.infer<typeof niveauConfianceListApiModelSchema>

--- a/packages/mb-shared/src/objectifIndicateurIndividu.ts
+++ b/packages/mb-shared/src/objectifIndicateurIndividu.ts
@@ -13,13 +13,17 @@ export const upsertObjectifIndicateurIndividuBodySchema = z.object({
   dateCible: dateSchema,
   valeurCible: z.number(),
 })
-export type UpsertObjectifIndicateurIndividuBody = z.infer<typeof upsertObjectifIndicateurIndividuBodySchema>
+export type UpsertObjectifIndicateurIndividuBody = z.infer<
+  typeof upsertObjectifIndicateurIndividuBodySchema
+>
 
 export const deleteObjectifIndicateurIndividuBodySchema = z.object({
   individu: individuPublicIdSchema,
   dateCible: dateSchema,
 })
-export type DeleteObjectifIndicateurIndividuBody = z.infer<typeof deleteObjectifIndicateurIndividuBodySchema>
+export type DeleteObjectifIndicateurIndividuBody = z.infer<
+  typeof deleteObjectifIndicateurIndividuBodySchema
+>
 
 export const listObjectifsForIndicateurQuerySchema = z.object({
   individus: individusCsvSchema.describe(
@@ -39,13 +43,13 @@ export const contributionObjectifApiModelSchema = z.object({
   individu: individuPublicIdSchema,
   valeurCible: z.number(),
   dateCible: dateSchema.describe(
-    "Bucket de la valeur portée (carry-forward) retenue pour cet enfant au moment du bucket parent.",
+    'Bucket de la valeur portée (carry-forward) retenue pour cet enfant au moment du bucket parent.',
   ),
   source: z
     .enum(['saisie', 'derivee'])
     .describe(
       "`saisie` : l'enfant est une feuille avec un objectif saisi. `derivee` : l'enfant est " +
-        "lui-même agrégé depuis ses propres enfants.",
+        'lui-même agrégé depuis ses propres enfants.',
     ),
 })
 export type ContributionObjectifApiModel = z.infer<typeof contributionObjectifApiModelSchema>
@@ -68,10 +72,12 @@ export const objectifDeriveeApiModelSchema = z.object({
   fonctionAgregation: fonctionAgregationSchema.describe(
     "Fonction d'agrégation appliquée pour ce couple (indicateur, référentiel de l'individu).",
   ),
-  contributions: z.array(contributionObjectifApiModelSchema).describe(
-    "Une entrée par enfant direct, triée par publicId. Pour chaque enfant on porte sa dernière " +
-      "valeur connue ≤ dateCible du bucket (carry-forward). Permet le drill-down et l'audit.",
-  ),
+  contributions: z
+    .array(contributionObjectifApiModelSchema)
+    .describe(
+      'Une entrée par enfant direct, triée par publicId. Pour chaque enfant on porte sa dernière ' +
+        "valeur connue ≤ dateCible du bucket (carry-forward). Permet le drill-down et l'audit.",
+    ),
 })
 export type ObjectifDeriveeApiModel = z.infer<typeof objectifDeriveeApiModelSchema>
 
@@ -79,9 +85,13 @@ export const objectifIndicateurIndividuApiModelSchema = z.discriminatedUnion('ty
   objectifSaisieApiModelSchema,
   objectifDeriveeApiModelSchema,
 ])
-export type ObjectifIndicateurIndividuApiModel = z.infer<typeof objectifIndicateurIndividuApiModelSchema>
+export type ObjectifIndicateurIndividuApiModel = z.infer<
+  typeof objectifIndicateurIndividuApiModelSchema
+>
 
 export const objectifIndicateurIndividuListApiModelSchema = z.object({
   items: z.array(objectifIndicateurIndividuApiModelSchema),
 })
-export type ObjectifIndicateurIndividuListApiModel = z.infer<typeof objectifIndicateurIndividuListApiModelSchema>
+export type ObjectifIndicateurIndividuListApiModel = z.infer<
+  typeof objectifIndicateurIndividuListApiModelSchema
+>

--- a/packages/mb-shared/src/pagination.ts
+++ b/packages/mb-shared/src/pagination.ts
@@ -3,9 +3,7 @@ import { z } from 'zod'
 export const paginationCursorSchema = z
   .string()
   .min(1)
-  .describe(
-    'Cursor opaque (base64) renvoyé par la réponse précédente. Vide pour la première page.',
-  )
+  .describe('Cursor opaque (base64) renvoyé par la réponse précédente. Vide pour la première page.')
 
 export const paginationSchema = z.object({
   cursor: paginationCursorSchema
@@ -18,7 +16,7 @@ export const createPaginatedApiListSchema = <T extends z.ZodTypeAny>(itemSchema:
   z.object({
     items: z.array(itemSchema).describe('Items de la page courante'),
     pagination: paginationSchema.describe('Métadonnées de pagination'),
-    total: z.number().describe('Nombre total d\'items après filtres (toutes pages confondues)'),
+    total: z.number().describe("Nombre total d'items après filtres (toutes pages confondues)"),
   })
 
 export type PaginatedApiList<T extends z.ZodTypeAny> = z.infer<

--- a/packages/mb-shared/src/panierResponsable.ts
+++ b/packages/mb-shared/src/panierResponsable.ts
@@ -1,10 +1,10 @@
 import { z } from 'zod'
 
 export const panierResponsableApiModelSchema = z.object({
-  email:    z.string().email(),
-  nom:      z.string(),
-  prenom:   z.string(),
-  service:  z.string(),
+  email: z.string().email(),
+  nom: z.string(),
+  prenom: z.string(),
+  service: z.string(),
   fonction: z.string(),
 })
 export type PanierResponsableApiModel = z.infer<typeof panierResponsableApiModelSchema>

--- a/packages/mb-shared/src/panierTauxProgression.ts
+++ b/packages/mb-shared/src/panierTauxProgression.ts
@@ -17,13 +17,15 @@ export const panierTauxProgressionContributionApiModelSchema = z.object({
     .number()
     .nullable()
     .describe(
-      "Dernier taux de progression connu pour cet indicateur et cet individu. " +
+      'Dernier taux de progression connu pour cet indicateur et cet individu. ' +
         "null si l'indicateur n'a aucun point calculable (pas d'objectif, pas de valeur, " +
         'ou dernier point avec valeurCible = 0).',
     ),
-  date: dateSchema.nullable().describe(
-    'Bucket (YYYY-MM-DD) du dernier point retenu pour cet indicateur. null si aucun point.',
-  ),
+  date: dateSchema
+    .nullable()
+    .describe(
+      'Bucket (YYYY-MM-DD) du dernier point retenu pour cet indicateur. null si aucun point.',
+    ),
   ponderation: z
     .number()
     .describe(
@@ -41,7 +43,7 @@ export const panierTauxProgressionApiModelSchema = z.object({
     .number()
     .nullable()
     .describe(
-      "Moyenne pondérée des taux de progression des indicateurs du panier, tronquée à 2 décimales. " +
+      'Moyenne pondérée des taux de progression des indicateurs du panier, tronquée à 2 décimales. ' +
         "null si au moins un indicateur du panier n'est pas calculable (règle tout-ou-rien) ou si " +
         'le panier est vide.',
     ),
@@ -49,7 +51,7 @@ export const panierTauxProgressionApiModelSchema = z.object({
     .array(panierTauxProgressionContributionApiModelSchema)
     .describe(
       "Détail par indicateur du panier (dernier taux connu pour l'individu, date, pondération). " +
-        "Toujours renseigné même si la moyenne globale est null — utile pour expliciter au client " +
+        'Toujours renseigné même si la moyenne globale est null — utile pour expliciter au client ' +
         'quels indicateurs bloquent le calcul.',
     ),
 })

--- a/packages/mb-shared/src/publicIds.ts
+++ b/packages/mb-shared/src/publicIds.ts
@@ -16,13 +16,15 @@ export const referentielPublicIdSchema = z
     /^REF-[A-Z0-9-]{1,16}$/,
     'Identifiant public attendu au format REF-<SLUG> (max 20 caractères)',
   )
-  .describe('Identifiant public du référentiel (format REF-<SLUG>, ex. REF-DEPT). Max 20 caractères.')
+  .describe(
+    'Identifiant public du référentiel (format REF-<SLUG>, ex. REF-DEPT). Max 20 caractères.',
+  )
 
 export const individuPublicIdSchema = z
   .string()
   .regex(
     /^[A-Z][A-Z0-9-]{0,19}$/,
-    'Identifiant public d\'individu attendu (lettre majuscule suivie de lettres/chiffres/tirets, max 20 caractères)',
+    "Identifiant public d'individu attendu (lettre majuscule suivie de lettres/chiffres/tirets, max 20 caractères)",
   )
   .describe(
     "Identifiant public d'individu, format humain-friendly (ex. DEPT-84, REG-93, FR). Lettre majuscule puis lettres/chiffres/tirets, max 20 caractères.",

--- a/packages/mb-shared/src/tauxProgression.ts
+++ b/packages/mb-shared/src/tauxProgression.ts
@@ -10,27 +10,33 @@ export const listTauxProgressionQuerySchema = z
     individus: individusCsvSchema.describe(
       `Liste d'identifiants d'individus séparés par une virgule (ex. DEPT-84,DEPT-13). 1..${MAX_INDIVIDUS_PAR_REQUETE} identifiants.`,
     ),
-    dateDebut: dateSchema.optional().describe(
-      'Date ISO YYYY-MM-DD inclusive (filtre les points dont le bucket est >= dateDebut).',
-    ),
-    dateFin: dateSchema.optional().describe(
-      'Date ISO YYYY-MM-DD inclusive (filtre les points dont le bucket est <= dateFin).',
-    ),
-    dateTruncValeur: dateTruncSchema.optional().describe(
-      'Granularité de bucket appliquée aux valeurs (défaut `month`). Détermine la fréquence ' +
-        'des points retournés : un point par bucket de valeur résolu.',
-    ),
-    dateTruncObjectif: dateTruncSchema.optional().describe(
-      'Granularité de bucket appliquée aux objectifs (défaut `month`). Doit être >= ' +
-        '`dateTruncValeur` : un objectif qui change plus souvent que les mesures ne peut pas ' +
-        "être évalué. Cas d'usage typique : `dateTruncValeur=month` + `dateTruncObjectif=year` " +
-        "pour suivre l'évolution mensuelle des valeurs contre un objectif annuel.",
-    ),
+    dateDebut: dateSchema
+      .optional()
+      .describe(
+        'Date ISO YYYY-MM-DD inclusive (filtre les points dont le bucket est >= dateDebut).',
+      ),
+    dateFin: dateSchema
+      .optional()
+      .describe('Date ISO YYYY-MM-DD inclusive (filtre les points dont le bucket est <= dateFin).'),
+    dateTruncValeur: dateTruncSchema
+      .optional()
+      .describe(
+        'Granularité de bucket appliquée aux valeurs (défaut `month`). Détermine la fréquence ' +
+          'des points retournés : un point par bucket de valeur résolu.',
+      ),
+    dateTruncObjectif: dateTruncSchema
+      .optional()
+      .describe(
+        'Granularité de bucket appliquée aux objectifs (défaut `month`). Doit être >= ' +
+          '`dateTruncValeur` : un objectif qui change plus souvent que les mesures ne peut pas ' +
+          "être évalué. Cas d'usage typique : `dateTruncValeur=month` + `dateTruncObjectif=year` " +
+          "pour suivre l'évolution mensuelle des valeurs contre un objectif annuel.",
+      ),
   })
-  .refine(
-    (value) => !value.dateDebut || !value.dateFin || value.dateDebut <= value.dateFin,
-    { message: 'dateDebut doit être <= dateFin', path: ['dateDebut'] },
-  )
+  .refine((value) => !value.dateDebut || !value.dateFin || value.dateDebut <= value.dateFin, {
+    message: 'dateDebut doit être <= dateFin',
+    path: ['dateDebut'],
+  })
   .refine(
     (value) => {
       const v = value.dateTruncValeur ?? 'month'
@@ -53,7 +59,9 @@ export const tauxProgressionPointApiModelSchema = z.object({
   ),
   valeur: z
     .number()
-    .describe("Valeur d'avancement résolue à ce bucket (saisie directe ou agrégation hiérarchique)."),
+    .describe(
+      "Valeur d'avancement résolue à ce bucket (saisie directe ou agrégation hiérarchique).",
+    ),
   valeurCible: z
     .number()
     .describe(

--- a/packages/mb-shared/src/valeurAvancement.ts
+++ b/packages/mb-shared/src/valeurAvancement.ts
@@ -10,11 +10,7 @@ export { MAX_INDICATEURS_PAR_REQUETE } from './indicateursCsv'
 import { indicateurPublicIdSchema } from './publicIds'
 import { individuApiModelSchema, individuPublicIdSchema } from './individu'
 import { individusCsvSchema, MAX_INDIVIDUS_PAR_REQUETE } from './individusCsv'
-import {
-  createPaginatedApiListSchema,
-  pageSizeSchema,
-  paginationCursorSchema,
-} from './pagination'
+import { createPaginatedApiListSchema, pageSizeSchema, paginationCursorSchema } from './pagination'
 import { referentielPublicIdSchema } from './referentiel'
 
 export const valeurSchema = z.number().describe('Valeur observée.')
@@ -127,33 +123,33 @@ export type BatchInvalidErrorDetailsApiModel = z.infer<
   typeof batchInvalidErrorDetailsApiModelSchema
 >
 
-
 export const listValeursForIndicateurQuerySchema = z
   .object({
     individus: individusCsvSchema.describe(
       `Liste d'identifiants d'individus séparés par une virgule (ex. DEPT-84,DEPT-13). 1..${MAX_INDIVIDUS_PAR_REQUETE} identifiants.`,
     ),
-    dateDebut: dateSchema.optional().describe(
-      'Date ISO YYYY-MM-DD inclusive (filtre les points dont la date de bucket est >= dateDebut).',
-    ),
-    dateFin: dateSchema.optional().describe(
-      'Date ISO YYYY-MM-DD inclusive (filtre les points dont la date de bucket est <= dateFin).',
-    ),
+    dateDebut: dateSchema
+      .optional()
+      .describe(
+        'Date ISO YYYY-MM-DD inclusive (filtre les points dont la date de bucket est >= dateDebut).',
+      ),
+    dateFin: dateSchema
+      .optional()
+      .describe(
+        'Date ISO YYYY-MM-DD inclusive (filtre les points dont la date de bucket est <= dateFin).',
+      ),
     dateTrunc: dateTruncSchema
       .optional()
       .describe(
         'Granularité de troncature des dates des points. Par défaut `month` (limite la taille ' +
-          "de réponse en regroupant les saisies du même mois). Voir `DateTrunc` pour la " +
+          'de réponse en regroupant les saisies du même mois). Voir `DateTrunc` pour la ' +
           "sémantique des unités. S'applique aux séries saisies comme aux séries dérivées.",
       ),
   })
-  .refine(
-    (value) => !value.dateDebut || !value.dateFin || value.dateDebut <= value.dateFin,
-    {
-      message: 'dateDebut doit être <= dateFin',
-      path: ['dateDebut'],
-    },
-  )
+  .refine((value) => !value.dateDebut || !value.dateFin || value.dateDebut <= value.dateFin, {
+    message: 'dateDebut doit être <= dateFin',
+    path: ['dateDebut'],
+  })
 export type ListValeursForIndicateurQuery = z.infer<typeof listValeursForIndicateurQuerySchema>
 
 const MAX_REFERENTIELS_PAR_REQUETE = 100
@@ -189,14 +185,14 @@ export const valeursRemarquablesContributionApiModelSchema = z.object({
   date: z
     .string()
     .describe(
-      "Date du bucket de la dernière valeur connue (post-troncature mensuelle), " +
+      'Date du bucket de la dernière valeur connue (post-troncature mensuelle), ' +
         "alignée sur l'unité de regroupement utilisée pour les indicateurs dérivés.",
     ),
   source: z
     .enum(['saisie', 'derivee'])
     .describe(
       "`saisie` : la valeur provient d'une saisie directe sur cet individu. " +
-        "`derivee` : la valeur est reconstruite par agrégation hiérarchique des descendants.",
+        '`derivee` : la valeur est reconstruite par agrégation hiérarchique des descendants.',
     ),
 })
 export type ValeursRemarquablesContributionApiModel = z.infer<
@@ -209,31 +205,31 @@ export const valeursRemarquablesReferentielApiModelSchema = z.object({
     .number()
     .nullable()
     .describe(
-      "Plus petite valeur la plus récente parmi les individus du référentiel ayant au moins une valeur " +
+      'Plus petite valeur la plus récente parmi les individus du référentiel ayant au moins une valeur ' +
         "pour l'indicateur. null si aucun individu n'a de valeur.",
     ),
   max: z
     .number()
     .nullable()
     .describe(
-      "Plus grande valeur la plus récente parmi les individus du référentiel ayant au moins une valeur " +
+      'Plus grande valeur la plus récente parmi les individus du référentiel ayant au moins une valeur ' +
         "pour l'indicateur. null si aucun individu n'a de valeur.",
     ),
   mediane: z
     .number()
     .nullable()
     .describe(
-      "Médiane des valeurs les plus récentes des individus du référentiel ayant au moins une valeur " +
+      'Médiane des valeurs les plus récentes des individus du référentiel ayant au moins une valeur ' +
         "pour l'indicateur. Moyenne des deux valeurs centrales si le nombre d'individus est pair. " +
         "null si aucun individu n'a de valeur.",
     ),
   contributions: z
     .array(valeursRemarquablesContributionApiModelSchema)
     .describe(
-      "Dernière valeur connue de chaque individu du référentiel ayant au moins une valeur " +
+      'Dernière valeur connue de chaque individu du référentiel ayant au moins une valeur ' +
         "pour l'indicateur (triée par publicId d'individu, asc). Permet au client de reconstruire " +
-        "min/max/médiane ou de faire son propre top-N / drill-down. Les individus sans aucune valeur " +
-        "ne figurent pas.",
+        'min/max/médiane ou de faire son propre top-N / drill-down. Les individus sans aucune valeur ' +
+        'ne figurent pas.',
     ),
 })
 export type ValeursRemarquablesReferentielApiModel = z.infer<
@@ -245,9 +241,7 @@ export const valeursRemarquablesListApiModelSchema = z.object({
     .array(valeursRemarquablesReferentielApiModelSchema)
     .describe('Valeurs remarquables agrégées pour chaque référentiel demandé existant.'),
 })
-export type ValeursRemarquablesListApiModel = z.infer<
-  typeof valeursRemarquablesListApiModelSchema
->
+export type ValeursRemarquablesListApiModel = z.infer<typeof valeursRemarquablesListApiModelSchema>
 
 export const listValeursRemarquablesForIndicateurQuerySchema = z.object({
   referentiels: referentielsCsvSchema.describe(
@@ -271,7 +265,7 @@ export const syntheseIndividuApiModelSchema = z.object({
     .number()
     .nullable()
     .describe(
-      "Variation absolue entre la valeur la plus récente et la précédente (par date de la valeur). " +
+      'Variation absolue entre la valeur la plus récente et la précédente (par date de la valeur). ' +
         "null si l'individu n'a aucune valeur ; égale à la valeur la plus récente s'il n'en a qu'une (comparée à 0).",
     ),
   ecartMediane: z
@@ -300,7 +294,7 @@ export const listSyntheseIndividusQuerySchema = z.object({
     .optional()
     .describe(
       'Granularité de troncature des dates des points. Par défaut `month`. Détermine les ' +
-        "buckets retenus comme « dernière » et « précédente » valeur pour le calcul de la " +
+        'buckets retenus comme « dernière » et « précédente » valeur pour le calcul de la ' +
         "variation. S'applique aux séries saisies comme aux séries dérivées.",
     ),
 })
@@ -338,10 +332,10 @@ export type ListIndividusWithValeursQuery = z.infer<typeof listIndividusWithVale
 export const contributionSourceSchema = z
   .enum(['saisie', 'derivee', 'manquante'])
   .describe(
-    "Origine de la valeur portée par un enfant direct à la date du point dérivé : `saisie` " +
+    'Origine de la valeur portée par un enfant direct à la date du point dérivé : `saisie` ' +
       "(l'enfant est une feuille, valeur saisie connue ≤ date du bucket), `derivee` (l'enfant " +
-      "est lui-même agrégé, valeur dérivée connue ≤ date du bucket), `manquante` (aucune " +
-      "valeur connue pour cet enfant ≤ date du bucket).",
+      'est lui-même agrégé, valeur dérivée connue ≤ date du bucket), `manquante` (aucune ' +
+      'valeur connue pour cet enfant ≤ date du bucket).',
   )
 export type ContributionSource = z.infer<typeof contributionSourceSchema>
 
@@ -357,7 +351,7 @@ export const contributionApiModelSchema = z.object({
   date: dateSchema
     .nullable()
     .describe(
-      "Date associée à la valeur retenue, à des fins de debug et drill-down. Pour `saisie` : " +
+      'Date associée à la valeur retenue, à des fins de debug et drill-down. Pour `saisie` : ' +
         "date d'origine pré-troncature de la saisie feuille. Pour `derivee` : date du bucket du " +
         'point dérivé enfant le plus récent ≤ date du bucket courant (déjà tronquée). null si ' +
         '`manquante`.',
@@ -388,7 +382,7 @@ export const valeurSaisieApiModelSchema = z.object({
   individu: individuPublicIdSchema,
   date: dateSchema.describe(
     "Date du point. Égale à la date de la saisie d'origine si `dateTrunc=day`, sinon date du " +
-      "bucket post-troncature (la valeur retenue dans le bucket est la plus récente).",
+      'bucket post-troncature (la valeur retenue dans le bucket est la plus récente).',
   ),
   valeur: valeurSchema,
   type: z.literal('saisie'),
@@ -411,7 +405,7 @@ export const valeurDeriveeApiModelSchema = z.object({
   contributions: z
     .array(contributionApiModelSchema)
     .describe(
-      "Une entrée par enfant direct du parent, triée par publicId. Pour chaque enfant on porte " +
+      'Une entrée par enfant direct du parent, triée par publicId. Pour chaque enfant on porte ' +
         "sa dernière valeur connue ≤ date du bucket (carry-forward) et la date d'origine de cette " +
         'valeur. Permet le drill-down et l’audit.',
     ),
@@ -429,12 +423,12 @@ export const valeurAvancementListApiModelSchema = z.object({
   items: z
     .array(valeurAvancementApiModelSchema)
     .describe(
-      "Points pour les individus demandés sur la plage de dates. Chaque point porte " +
+      'Points pour les individus demandés sur la plage de dates. Chaque point porte ' +
         "`type: 'saisie' | 'derivee'` (discriminé). Pour les individus agrégés " +
-        "(`fonctionAgregation` ≠ `NONE` sur leur référentiel pour cet indicateur), les points " +
+        '(`fonctionAgregation` ≠ `NONE` sur leur référentiel pour cet indicateur), les points ' +
         "sont calculés par combineLatest permissif sur les enfants directs : on émet dès qu'au " +
         'moins un enfant a une valeur connue au bucket courant. Pour les feuilles (ou ' +
-        "indicateurs non agrégés), les points reflètent les saisies tronquées selon `dateTrunc`. " +
+        'indicateurs non agrégés), les points reflètent les saisies tronquées selon `dateTrunc`. ' +
         'Triés par individu puis par date croissante.',
     ),
 })
@@ -444,13 +438,13 @@ export const dernierValeurIndividuApiModelSchema = z.object({
   indicateur: indicateurPublicIdSchema,
   valeur: valeurSchema.describe("Dernière valeur connue de l'individu pour cet indicateur."),
   date: dateSchema.describe(
-    "Date du bucket de la dernière valeur connue (post-troncature mensuelle).",
+    'Date du bucket de la dernière valeur connue (post-troncature mensuelle).',
   ),
   type: z
     .enum(['saisie', 'derivee'])
     .describe(
       "`saisie` : la valeur provient d'une saisie directe sur cet individu. " +
-        "`derivee` : la valeur est reconstruite par agrégation hiérarchique des descendants.",
+        '`derivee` : la valeur est reconstruite par agrégation hiérarchique des descendants.',
     ),
 })
 export type DernierValeurIndividuApiModel = z.infer<typeof dernierValeurIndividuApiModelSchema>
@@ -460,7 +454,7 @@ export const dernieresValeursIndividuListApiModelSchema = z.object({
     .array(dernierValeurIndividuApiModelSchema)
     .describe(
       "Dernière valeur connue de l'individu pour chaque indicateur demandé ayant au moins une " +
-        "valeur. Les indicateurs sans valeur connue pour cet individu sont omis de la réponse.",
+        'valeur. Les indicateurs sans valeur connue pour cet individu sont omis de la réponse.',
     ),
 })
 export type DernieresValeursIndividuListApiModel = z.infer<
@@ -505,8 +499,8 @@ export const tauxProgressionIndividuListApiModelSchema = z.object({
     .array(tauxProgressionIndividuApiModelSchema)
     .describe(
       'Taux de progression pour chaque indicateur demandé ayant un objectif défini et une valeur connue. ' +
-        "Les indicateurs sans objectif ou sans valeur sont omis. " +
-        "Les indicateurs dont la valeurCible est zéro sont inclus avec tauxProgression: null.",
+        'Les indicateurs sans objectif ou sans valeur sont omis. ' +
+        'Les indicateurs dont la valeurCible est zéro sont inclus avec tauxProgression: null.',
     ),
 })
 export type TauxProgressionIndividuListApiModel = z.infer<

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -932,6 +932,10 @@ importers:
       zod:
         specifier: ^4.3.6
         version: 4.3.6
+    devDependencies:
+      prettier:
+        specifier: ^3.6.2
+        version: 3.8.3
 
 packages:
 


### PR DESCRIPTION
## Contexte

`packages/mb-shared` n'avait **aucune config prettier** ni script de format, contrairement aux apps (`mb-api`, `mb-admin`, `mb-webapp`). Conséquences :
- ses fichiers n'étaient jamais vérifiés en CI ;
- un `npx prettier` lancé depuis ce package tombait sur les **défauts** (double-quotes + semicolons) et reformatait tout à l'envers du style du repo.

## Changements

- ➕ `packages/mb-shared/.prettierrc`, **identique aux apps** : `semi:false`, `singleQuote:true`, `trailingComma:all`, `printWidth:100`, `arrowParens:always`
- ➕ scripts `lint` / `format` / `format:check` + devDependency `prettier` (`^3.6.2`, résout vers `3.8.3` déjà présent — pas de duplication)
- 🎨 reformatage des **15 fichiers `src/`** existants — **formatage seul, aucun changement de logique**
- 👷 job CI `lint-mb-shared` (gaté sur le filtre `mb-shared` déjà présent) pour enforcer le check

## Vérifs

- `pnpm -F @pilote/mb-shared lint` (= `prettier --check .`) ✅
- `pnpm install --frozen-lockfile` ✅ (diff lockfile = 4 lignes, uniquement le lien devDep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)