### PR TITLE
feat(indicateur): alimentation du catalogue d'unités

### DIFF
--- a/apps/mb-admin/src/components/indicateurs/IndicateurForm.tsx
+++ b/apps/mb-admin/src/components/indicateurs/IndicateurForm.tsx
@@ -4,7 +4,12 @@ import { Plus, Trash2 } from 'lucide-react'
 import { useMemo } from 'react'
 import { useFieldArray, useForm, useWatch, type UseFormRegister } from 'react-hook-form'
 
-import { PERIODE_MISE_A_JOUR_LABELS, PERIODES_MISE_A_JOUR } from '@pilote/mb-shared/indicateur'
+import {
+  PERIODE_MISE_A_JOUR_LABELS,
+  PERIODES_MISE_A_JOUR,
+  UNITES_INDICATEUR,
+  UNITES_INDICATEUR_CONFIG,
+} from '@pilote/mb-shared/indicateur'
 
 import { fetchAllReferentiels } from '@/api/referentiels'
 import {
@@ -117,8 +122,11 @@ export function IndicateurForm({
           <div className="flex-1">
             <FieldSelect label="Unité" {...form.register('unite')}>
               <option value="">Aucune</option>
-              <option value="POURCENTAGE">Pourcentage</option>
-              <option value="ANNEES">Années</option>
+              {UNITES_INDICATEUR.map((code) => (
+                <option key={code} value={code}>
+                  {UNITES_INDICATEUR_CONFIG[code].libelle}
+                </option>
+              ))}
             </FieldSelect>
           </div>
         </div>

--- a/apps/mb-api/prisma/migrations/20260707120000_ajout_unites_indicateur/migration.sql
+++ b/apps/mb-api/prisma/migrations/20260707120000_ajout_unites_indicateur/migration.sql
@@ -1,0 +1,32 @@
+-- AlterEnum
+-- This migration adds more than one value to an enum.
+-- With PostgreSQL versions 11 and earlier, this is not possible
+-- in a single migration. This can be worked around by creating
+-- multiple migrations, each migration adding only one value to
+-- the enum.
+ALTER TYPE "unite_indicateur_enum" ADD VALUE 'VALEUR_UNITAIRE';
+ALTER TYPE "unite_indicateur_enum" ADD VALUE 'MILLIONS';
+ALTER TYPE "unite_indicateur_enum" ADD VALUE 'ETP';
+ALTER TYPE "unite_indicateur_enum" ADD VALUE 'ETPT';
+ALTER TYPE "unite_indicateur_enum" ADD VALUE 'HEURES';
+ALTER TYPE "unite_indicateur_enum" ADD VALUE 'MINUTES';
+ALTER TYPE "unite_indicateur_enum" ADD VALUE 'JOURS';
+ALTER TYPE "unite_indicateur_enum" ADD VALUE 'MOIS';
+ALTER TYPE "unite_indicateur_enum" ADD VALUE 'HECTARES';
+ALTER TYPE "unite_indicateur_enum" ADD VALUE 'METRE';
+ALTER TYPE "unite_indicateur_enum" ADD VALUE 'KILOMETRE';
+ALTER TYPE "unite_indicateur_enum" ADD VALUE 'METRE_CARRE';
+ALTER TYPE "unite_indicateur_enum" ADD VALUE 'KILOMETRE_CARRE';
+ALTER TYPE "unite_indicateur_enum" ADD VALUE 'POINTS';
+ALTER TYPE "unite_indicateur_enum" ADD VALUE 'EURO';
+ALTER TYPE "unite_indicateur_enum" ADD VALUE 'MILLIONS_EUROS';
+ALTER TYPE "unite_indicateur_enum" ADD VALUE 'MILLIARDS_EUROS';
+ALTER TYPE "unite_indicateur_enum" ADD VALUE 'MEGAWATT';
+ALTER TYPE "unite_indicateur_enum" ADD VALUE 'GIGAWATT';
+ALTER TYPE "unite_indicateur_enum" ADD VALUE 'TONNES';
+ALTER TYPE "unite_indicateur_enum" ADD VALUE 'TONNES_CO2';
+ALTER TYPE "unite_indicateur_enum" ADD VALUE 'TERAWATT';
+ALTER TYPE "unite_indicateur_enum" ADD VALUE 'LITRES';
+ALTER TYPE "unite_indicateur_enum" ADD VALUE 'ELEVES';
+ALTER TYPE "unite_indicateur_enum" ADD VALUE 'CLASSES';
+ALTER TYPE "unite_indicateur_enum" ADD VALUE 'REPAS';

--- a/apps/mb-api/prisma/schema.prisma
+++ b/apps/mb-api/prisma/schema.prisma
@@ -128,8 +128,40 @@ enum Visibilite {
 }
 
 enum UniteIndicateur {
-  POURCENTAGE
+  // Numéraires
+  VALEUR_UNITAIRE
+  MILLIONS
+  ETP
+  ETPT
+  // Durée
+  HEURES
+  MINUTES
+  JOURS
+  MOIS
   ANNEES
+  // Spatiales
+  HECTARES
+  METRE
+  KILOMETRE
+  METRE_CARRE
+  KILOMETRE_CARRE
+  // Taux
+  POINTS
+  POURCENTAGE
+  // Monétaires
+  EURO
+  MILLIONS_EUROS
+  MILLIARDS_EUROS
+  // Autres
+  MEGAWATT
+  GIGAWATT
+  TONNES
+  TONNES_CO2
+  TERAWATT
+  LITRES
+  ELEVES
+  CLASSES
+  REPAS
 
   @@map("unite_indicateur_enum")
 }

--- a/apps/mb-api/prisma/seed.ts
+++ b/apps/mb-api/prisma/seed.ts
@@ -1,7 +1,7 @@
 import { PrismaPg } from '@prisma/adapter-pg'
 import { uuidv7 } from 'uuidv7'
 
-import { type PeriodeMiseAJour } from '@pilote/mb-shared/indicateur'
+import { type PeriodeMiseAJour, type UniteIndicateurCode } from '@pilote/mb-shared/indicateur'
 
 import { Prisma, PrismaClient } from '../src/generated/prisma/client.js'
 import { type FonctionAgregation } from '../src/generated/prisma/enums.js'
@@ -27,7 +27,7 @@ const indicateursSeed: ReadonlyArray<{
   publicId: string
   nom: string
   visibilite?: 'PUBLIC' | 'PRIVE'
-  unite?: 'POURCENTAGE' | 'ANNEES'
+  unite?: UniteIndicateurCode
   description?: string
   methodeCalcul?: string
   sourceDonnees?: string
@@ -50,6 +50,7 @@ const indicateursSeed: ReadonlyArray<{
   {
     publicId: 'IND-002',
     nom: 'Émissions de CO2',
+    unite: 'TONNES_CO2',
     description: "Émissions totales de dioxyde de carbone d'origine anthropique sur le territoire.",
     methodeCalcul: 'Inventaire national selon les lignes directrices du GIEC',
     sourceDonnees: 'CITEPA — Secten',
@@ -71,24 +72,26 @@ const indicateursSeed: ReadonlyArray<{
   {
     publicId: 'IND-004',
     nom: 'Délai de traitement préfectures',
+    unite: 'JOURS',
     description: "Délai moyen d'instruction des dossiers déposés en préfecture, en jours ouvrés.",
     sourceDonnees: 'Ministère de l’Intérieur — DGCL',
     periodeMiseAJour: 'MENSUELLE',
     jourMiseAJour: 5,
   },
-  { publicId: 'IND-005', nom: 'Effectif police nationale' },
+  { publicId: 'IND-005', nom: 'Effectif police nationale', unite: 'ETP' },
   { publicId: 'IND-006', nom: 'Indicateur expérimental ancien' },
   { publicId: 'IND-007', nom: 'Indicateur en pause', periodeMiseAJour: 'AUCUNE' },
   {
     publicId: 'IND-008',
     nom: 'Satisfaction usagers services publics',
+    unite: 'POINTS',
     description: 'Note de satisfaction globale des usagers des services publics, sur 10.',
     methodeCalcul: 'Moyenne arithmétique des notes individuelles collectées par enquête',
     sourceDonnees: 'DITP — Baromètre Services Publics+',
     sourceUrl: 'https://www.plus.transformation.gouv.fr/',
     periodeMiseAJour: 'SEMESTRIELLE',
   },
-  { publicId: 'IND-009', nom: 'Délai moyen de prise en charge urgences' },
+  { publicId: 'IND-009', nom: 'Délai moyen de prise en charge urgences', unite: 'MINUTES' },
   {
     publicId: 'IND-010',
     nom: 'Taux de vaccination infantile',
@@ -100,48 +103,62 @@ const indicateursSeed: ReadonlyArray<{
     periodeMiseAJour: 'ANNUELLE',
   },
   { publicId: 'IND-011', nom: 'Accès aux soins de proximité', unite: 'POURCENTAGE' },
-  { publicId: 'IND-012', nom: 'Couverture des services France Santé' },
-  { publicId: 'IND-013', nom: 'Déploiement de France Santé' },
+  { publicId: 'IND-012', nom: 'Couverture des services France Santé', unite: 'POURCENTAGE' },
+  { publicId: 'IND-013', nom: 'Déploiement de France Santé', unite: 'POURCENTAGE' },
   { publicId: 'IND-014', nom: "Amélioration de l'orientation des élèves" },
   { publicId: 'IND-015', nom: 'Taux de réussite au baccalauréat', unite: 'POURCENTAGE' },
-  { publicId: 'IND-016', nom: 'Nombre de places en crèche' },
-  { publicId: 'IND-017', nom: 'Logements rénovés énergétiquement' },
-  { publicId: 'IND-018', nom: "Production d'énergies renouvelables" },
-  { publicId: 'IND-019', nom: 'Émissions de gaz à effet de serre' },
+  { publicId: 'IND-016', nom: 'Nombre de places en crèche', unite: 'VALEUR_UNITAIRE' },
+  { publicId: 'IND-017', nom: 'Logements rénovés énergétiquement', unite: 'VALEUR_UNITAIRE' },
+  { publicId: 'IND-018', nom: "Production d'énergies renouvelables", unite: 'TERAWATT' },
+  { publicId: 'IND-019', nom: 'Émissions de gaz à effet de serre', unite: 'TONNES_CO2' },
   { publicId: 'IND-020', nom: "Qualité de l'air en zones urbaines" },
-  { publicId: 'IND-021', nom: 'Aires protégées (terre et mer)' },
+  { publicId: 'IND-021', nom: 'Aires protégées (terre et mer)', unite: 'HECTARES' },
   { publicId: 'IND-022', nom: 'Tri et valorisation des déchets', unite: 'POURCENTAGE' },
-  { publicId: 'IND-023', nom: 'Délai de traitement CAF' },
-  { publicId: 'IND-024', nom: 'Délai de traitement Pôle emploi' },
-  { publicId: 'IND-025', nom: "Délai de délivrance des titres d'identité" },
+  { publicId: 'IND-023', nom: 'Délai de traitement CAF', unite: 'JOURS' },
+  { publicId: 'IND-024', nom: 'Délai de traitement Pôle emploi', unite: 'JOURS' },
+  { publicId: 'IND-025', nom: "Délai de délivrance des titres d'identité", unite: 'JOURS' },
   { publicId: 'IND-026', nom: 'Présence postale en zone rurale' },
-  { publicId: 'IND-027', nom: 'Maisons France Services ouvertes' },
+  { publicId: 'IND-027', nom: 'Maisons France Services ouvertes', unite: 'VALEUR_UNITAIRE' },
   { publicId: 'IND-028', nom: 'Désertification médicale' },
-  { publicId: 'IND-029', nom: 'Effectifs gendarmerie nationale' },
-  { publicId: 'IND-030', nom: 'Élucidation des cambriolages' },
-  { publicId: 'IND-031', nom: 'Sécurité routière — accidents mortels' },
-  { publicId: 'IND-032', nom: 'Délai de jugement civil' },
-  { publicId: 'IND-033', nom: 'Délai de jugement pénal' },
-  { publicId: 'IND-034', nom: 'Recettes fiscales nettes' },
+  { publicId: 'IND-029', nom: 'Effectifs gendarmerie nationale', unite: 'ETP' },
+  { publicId: 'IND-030', nom: 'Élucidation des cambriolages', unite: 'POURCENTAGE' },
+  { publicId: 'IND-031', nom: 'Sécurité routière — accidents mortels', unite: 'VALEUR_UNITAIRE' },
+  { publicId: 'IND-032', nom: 'Délai de jugement civil', unite: 'MOIS' },
+  { publicId: 'IND-033', nom: 'Délai de jugement pénal', unite: 'MOIS' },
+  { publicId: 'IND-034', nom: 'Recettes fiscales nettes', unite: 'MILLIARDS_EUROS' },
   { publicId: 'IND-035', nom: 'Dette publique / PIB', unite: 'POURCENTAGE' },
   { publicId: 'IND-036', nom: 'Croissance du PIB', unite: 'POURCENTAGE' },
   { publicId: 'IND-037', nom: 'Inflation (IPC)', unite: 'POURCENTAGE' },
   { publicId: 'IND-038', nom: "Taux d'emploi des seniors", unite: 'POURCENTAGE' },
   { publicId: 'IND-039', nom: "Taux d'emploi des jeunes", unite: 'POURCENTAGE' },
-  { publicId: 'IND-040', nom: 'Apprentissage — contrats signés' },
-  { publicId: 'IND-041', nom: "Création nette d'entreprises" },
-  { publicId: 'IND-042', nom: 'Exportations de biens' },
+  { publicId: 'IND-040', nom: 'Apprentissage — contrats signés', unite: 'VALEUR_UNITAIRE' },
+  { publicId: 'IND-041', nom: "Création nette d'entreprises", unite: 'VALEUR_UNITAIRE' },
+  { publicId: 'IND-042', nom: 'Exportations de biens', unite: 'MILLIARDS_EUROS' },
   { publicId: 'IND-043', nom: 'Couverture 5G du territoire', unite: 'POURCENTAGE' },
-  { publicId: 'IND-044', nom: 'Dématérialisation des démarches administratives' },
-  { publicId: 'IND-045', nom: "Cyberattaques traitées par l'ANSSI" },
-  { publicId: 'IND-046', nom: 'Indicateur public — Démographie', visibilite: 'PUBLIC' },
+  {
+    publicId: 'IND-044',
+    nom: 'Dématérialisation des démarches administratives',
+    unite: 'POURCENTAGE',
+  },
+  { publicId: 'IND-045', nom: "Cyberattaques traitées par l'ANSSI", unite: 'VALEUR_UNITAIRE' },
+  {
+    publicId: 'IND-046',
+    nom: 'Indicateur public — Démographie',
+    visibilite: 'PUBLIC',
+    unite: 'MILLIONS',
+  },
   {
     publicId: 'IND-047',
     nom: 'Indicateur public — Espérance de vie',
     visibilite: 'PUBLIC',
     unite: 'ANNEES',
   },
-  { publicId: 'IND-048', nom: 'Indicateur public — Pauvreté', visibilite: 'PUBLIC' },
+  {
+    publicId: 'IND-048',
+    nom: 'Indicateur public — Pauvreté',
+    visibilite: 'PUBLIC',
+    unite: 'POURCENTAGE',
+  },
   {
     publicId: 'IND-049',
     nom: "Indicateur public — Taux d'alphabétisation",

--- a/apps/mb-api/src/indicateur/utils.ts
+++ b/apps/mb-api/src/indicateur/utils.ts
@@ -15,6 +15,19 @@ export type IndicateurWithReferentiels = IndicateurModel & {
   }>
 }
 
+// Garde compile-time : l'enum Prisma `UniteIndicateur` et le catalogue mb-shared
+// `UNITES_INDICATEUR` doivent lister exactement les mêmes codes. Si une migration
+// ajoute une valeur à l'enum Prisma sans l'ajouter au catalogue (ou l'inverse),
+// `TypesUnitesSynchronises` devient `false` et cette affectation ne compile plus :
+// la divergence est signalée ici au build, avant même le `throw` runtime de
+// `toUniteIndicateurCode` ci-dessous.
+type TypesUnitesSynchronises = [UniteIndicateur] extends [UniteIndicateurCode]
+  ? [UniteIndicateurCode] extends [UniteIndicateur]
+    ? true
+    : false
+  : false
+const _assertUnitesSynchronisees: TypesUnitesSynchronises = true
+
 // Pont enum Prisma → catalogue mb-shared : on throw plutôt que de retourner null
 // silencieusement, car une divergence est un défaut de déploiement (enum Prisma
 // étendu sans mise à jour de `UNITES_INDICATEUR`), pas une donnée manquante.

--- a/apps/mb-webapp/src/components/indicateurs/IndicateurMetadonnees.tsx
+++ b/apps/mb-webapp/src/components/indicateurs/IndicateurMetadonnees.tsx
@@ -47,7 +47,9 @@ export function IndicateurMetadonnees({ indicateur }: IndicateurMetadonneesProps
       <DescriptionList.Item label="Nom">{indicateur.nom}</DescriptionList.Item>
       <DescriptionList.Item label="Unité">
         {indicateur.unite
-          ? `${indicateur.unite.libelle} (${indicateur.unite.abbreviation})`
+          ? indicateur.unite.abbreviation
+            ? `${indicateur.unite.libelle} (${indicateur.unite.abbreviation})`
+            : indicateur.unite.libelle
           : VALEUR_VIDE}
       </DescriptionList.Item>
       <DescriptionList.Item label="Description">

--- a/apps/mb-webapp/src/lib/format.ts
+++ b/apps/mb-webapp/src/lib/format.ts
@@ -22,7 +22,9 @@ export const formatNumberAvecUniteFr = (
   value: number,
   unite: UniteIndicateurApiModel | null,
 ): string =>
-  unite ? `${numberFr.format(value)}${NBSP_FINE}${unite.abbreviation}` : numberFr.format(value)
+  unite?.abbreviation
+    ? `${numberFr.format(value)}${NBSP_FINE}${unite.abbreviation}`
+    : numberFr.format(value)
 
 export const formatVariationFr = (value: number): string => variationFr.format(value)
 
@@ -30,7 +32,7 @@ export const formatVariationAvecUniteFr = (
   value: number,
   unite: UniteIndicateurApiModel | null,
 ): string =>
-  unite
+  unite?.abbreviation
     ? `${variationFr.format(value)}${NBSP_FINE}${unite.abbreviation}`
     : variationFr.format(value)
 

--- a/apps/mb-webapp/src/lib/format.ts
+++ b/apps/mb-webapp/src/lib/format.ts
@@ -18,23 +18,26 @@ export const formatNumberFr = (value: number): string => numberFr.format(value)
 // à la typographie fr-FR (`70 %`, `82 ans`).
 const NBSP_FINE = '\u202F'
 
-export const formatNumberAvecUniteFr = (
+const formatAvecUnite = (
+  format: Intl.NumberFormat,
   value: number,
   unite: UniteIndicateurApiModel | null,
 ): string =>
   unite?.abbreviation
-    ? `${numberFr.format(value)}${NBSP_FINE}${unite.abbreviation}`
-    : numberFr.format(value)
+    ? `${format.format(value)}${NBSP_FINE}${unite.abbreviation}`
+    : format.format(value)
+
+export const formatNumberAvecUniteFr = (
+  value: number,
+  unite: UniteIndicateurApiModel | null,
+): string => formatAvecUnite(numberFr, value, unite)
 
 export const formatVariationFr = (value: number): string => variationFr.format(value)
 
 export const formatVariationAvecUniteFr = (
   value: number,
   unite: UniteIndicateurApiModel | null,
-): string =>
-  unite?.abbreviation
-    ? `${variationFr.format(value)}${NBSP_FINE}${unite.abbreviation}`
-    : variationFr.format(value)
+): string => formatAvecUnite(variationFr, value, unite)
 
 export const formatDateFr = (value: Date | string): string => dateFr.format(toDate(value))
 

--- a/packages/mb-shared/src/indicateur.ts
+++ b/packages/mb-shared/src/indicateur.ts
@@ -20,7 +20,45 @@ export const fonctionAgregationSchema = z
   )
 export type FonctionAgregation = z.infer<typeof fonctionAgregationSchema>
 
-export const UNITES_INDICATEUR = ['POURCENTAGE', 'ANNEES'] as const
+// Catalogue plateforme des unités, ordonné par famille (numéraires, durée,
+// spatiales, taux, monétaires, autres) pour un affichage groupé dans les
+// sélecteurs. Catalogue fermé, étendu par déploiement.
+export const UNITES_INDICATEUR = [
+  // Numéraires
+  'VALEUR_UNITAIRE',
+  'MILLIONS',
+  'ETP',
+  'ETPT',
+  // Durée
+  'HEURES',
+  'MINUTES',
+  'JOURS',
+  'MOIS',
+  'ANNEES',
+  // Spatiales
+  'HECTARES',
+  'METRE',
+  'KILOMETRE',
+  'METRE_CARRE',
+  'KILOMETRE_CARRE',
+  // Taux
+  'POINTS',
+  'POURCENTAGE',
+  // Monétaires
+  'EURO',
+  'MILLIONS_EUROS',
+  'MILLIARDS_EUROS',
+  // Autres
+  'MEGAWATT',
+  'GIGAWATT',
+  'TONNES',
+  'TONNES_CO2',
+  'TERAWATT',
+  'LITRES',
+  'ELEVES',
+  'CLASSES',
+  'REPAS',
+] as const
 export type UniteIndicateurCode = (typeof UNITES_INDICATEUR)[number]
 
 export const uniteIndicateurCodeSchema = z
@@ -29,10 +67,45 @@ export const uniteIndicateurCodeSchema = z
     "Code de l'unité de mesure de l'indicateur. Catalogue plateforme, fermé, étendu par déploiement.",
   )
 
+// `abbreviation: null` = unité sans symbole à suffixer (compte brut, ex.
+// « Valeur unitaire »). Les unités « mots » (élèves, classes, repas) portent le
+// mot en abréviation pour rester lisibles suffixées à une valeur.
 export const UNITES_INDICATEUR_CONFIG = {
-  POURCENTAGE: { libelle: 'Pourcentage', abbreviation: '%' },
+  // Numéraires
+  VALEUR_UNITAIRE: { libelle: 'Valeur unitaire', abbreviation: null },
+  MILLIONS: { libelle: 'Millions', abbreviation: 'M' },
+  ETP: { libelle: 'ETP', abbreviation: 'ETP' },
+  ETPT: { libelle: 'ETPT', abbreviation: 'ETPT' },
+  // Durée
+  HEURES: { libelle: 'Heures', abbreviation: 'h' },
+  MINUTES: { libelle: 'Minutes', abbreviation: 'min' },
+  JOURS: { libelle: 'Jours', abbreviation: 'j' },
+  MOIS: { libelle: 'Mois', abbreviation: 'mois' },
   ANNEES: { libelle: 'Années', abbreviation: 'ans' },
-} satisfies Record<UniteIndicateurCode, { libelle: string; abbreviation: string }>
+  // Spatiales
+  HECTARES: { libelle: 'Hectares', abbreviation: 'ha' },
+  METRE: { libelle: 'Mètre', abbreviation: 'm' },
+  KILOMETRE: { libelle: 'Kilomètre', abbreviation: 'km' },
+  METRE_CARRE: { libelle: 'Mètre carré', abbreviation: 'm²' },
+  KILOMETRE_CARRE: { libelle: 'Kilomètre carré', abbreviation: 'km²' },
+  // Taux
+  POINTS: { libelle: 'Points', abbreviation: 'pts' },
+  POURCENTAGE: { libelle: 'Pourcentage', abbreviation: '%' },
+  // Monétaires
+  EURO: { libelle: 'Euro', abbreviation: '€' },
+  MILLIONS_EUROS: { libelle: "Millions d'€", abbreviation: 'M€' },
+  MILLIARDS_EUROS: { libelle: "Milliards d'€", abbreviation: 'Md€' },
+  // Autres
+  MEGAWATT: { libelle: 'Megawatt', abbreviation: 'MW' },
+  GIGAWATT: { libelle: 'Gigawatt', abbreviation: 'GW' },
+  TONNES: { libelle: 'Tonnes', abbreviation: 't' },
+  TONNES_CO2: { libelle: 'Tonnes équivalents CO2', abbreviation: 'tCO2e' },
+  TERAWATT: { libelle: 'Térawatt', abbreviation: 'TW' },
+  LITRES: { libelle: 'Litres', abbreviation: 'L' },
+  ELEVES: { libelle: 'Élèves', abbreviation: 'élèves' },
+  CLASSES: { libelle: 'Classes', abbreviation: 'classes' },
+  REPAS: { libelle: 'Repas', abbreviation: 'repas' },
+} satisfies Record<UniteIndicateurCode, { libelle: string; abbreviation: string | null }>
 
 export const uniteIndicateurApiModelSchema = z
   .object({
@@ -40,7 +113,11 @@ export const uniteIndicateurApiModelSchema = z
     libelle: z.string().describe("Libellé affichable de l'unité (français)."),
     abbreviation: z
       .string()
-      .describe("Abréviation de l'unité, à suffixer aux valeurs (ex. `%`, `ans`)."),
+      .nullable()
+      .describe(
+        "Abréviation de l'unité à suffixer aux valeurs (ex. `%`, `ans`), ou `null` " +
+          'pour une unité sans symbole (compte brut, ex. « Valeur unitaire »).',
+      ),
   })
   .describe("Unité de mesure d'un indicateur, sérialisée enrichie pour les clients API.")
 export type UniteIndicateurApiModel = z.infer<typeof uniteIndicateurApiModelSchema>


### PR DESCRIPTION
## Contexte

Alimente le catalogue d'unités du pilote MB avec l'ensemble des unités de Démarche numérique. Les unités sont un **enum Prisma** (« catalogue plateforme, fermé, étendu par déploiement ») : on étend donc l'enum + son config, sans nouvelle table.

## Changements

- **`packages/mb-shared/src/indicateur.ts`** — `UNITES_INDICATEUR` + `UNITES_INDICATEUR_CONFIG` étendus à **28 unités**, ordonnées par famille (numéraires, durée, spatiales, taux, monétaires, autres) pour un affichage groupé. `abbreviation` devient `string | null` : `null` pour les unités sans symbole (ex. « Valeur unitaire »), et les unités-mots (élèves, classes, repas) portent le mot en abréviation.
- **`apps/mb-api/prisma/schema.prisma`** + migration `20260707120000_ajout_unites_indicateur` — 26 `ALTER TYPE ... ADD VALUE` (identique à une migration générée par `prisma migrate dev`, vérifié via `prisma migrate diff`).
- **`apps/mb-admin`** — le `<select>` d'unité (auparavant 2 options codées en dur) est branché sur le catalogue partagé → toutes les unités sont sélectionnables.
- **`apps/mb-webapp`** — 2 guards d'affichage (`IndicateurMetadonnees`, `format.ts`) pour gérer l'abréviation absente.

## Vérifications

- ✅ Lint complet (eslint + `tsc --noEmit` + prettier) vert sur mb-api, mb-webapp et mb-admin.
- ✅ `prisma validate` OK ; migration alignée sur la sortie de `prisma migrate diff`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)