### PR TITLE
fix(deploy): aligne start.sh/.slugignore sur les dossiers kpilote-*-deploy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,8 +35,9 @@ qodana.yaml
 
 # build artifacts
 .next
-/mb-api-deploy
-/mb-webapp-deploy
+/kpilote-api-deploy
+/kpilote-webapp-deploy
+/kpilote-admin-deploy
 /.slugignore
 /start.sh
 /cron.json

--- a/apps/kpilote-admin/.slugignore
+++ b/apps/kpilote-admin/.slugignore
@@ -3,13 +3,13 @@
 .github
 .gitignore
 .gitmodules
-apps/mb-api
-apps/mb-webapp
+apps/kpilote-api
+apps/kpilote-webapp
 apps/pilote-ppg
 apps/pilote-ppg-auth
 apps/pilote-ppg-data-management
-mb-api-deploy
-mb-webapp-deploy
+kpilote-api-deploy
+kpilote-webapp-deploy
 node_modules
 public
 README.md

--- a/apps/kpilote-admin/deploy-prepare.sh
+++ b/apps/kpilote-admin/deploy-prepare.sh
@@ -5,4 +5,4 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
 cp "$SCRIPT_DIR/.slugignore" "$ROOT_DIR/.slugignore"
-echo "mb-admin .slugignore copié à la racine du monorepo"
+echo "kpilote-admin .slugignore copié à la racine du monorepo"

--- a/apps/kpilote-admin/src/server/index.ts
+++ b/apps/kpilote-admin/src/server/index.ts
@@ -47,5 +47,5 @@ app.get(
 )
 
 serve({ fetch: app.fetch, port: serverEnv.PORT }, (info) => {
-  console.log(`mb-admin listening on http://localhost:${info.port}`)
+  console.log(`kpilote-admin listening on http://localhost:${info.port}`)
 })

--- a/apps/kpilote-admin/start.sh
+++ b/apps/kpilote-admin/start.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-exec node mb-admin-deploy/dist/server/index.js
+exec node kpilote-admin-deploy/dist/server/index.js

--- a/apps/kpilote-api/start.sh
+++ b/apps/kpilote-api/start.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-exec node mb-api-deploy/dist/index.js
+exec node kpilote-api-deploy/dist/index.js

--- a/apps/kpilote-webapp/.slugignore
+++ b/apps/kpilote-webapp/.slugignore
@@ -3,11 +3,11 @@
 .github
 .gitignore
 .gitmodules
-apps/mb-api
+apps/kpilote-api
 apps/pilote-ppg
 apps/pilote-ppg-auth
 apps/pilote-ppg-data-management
-mb-api-deploy
+kpilote-api-deploy
 node_modules
 public
 README.md

--- a/apps/kpilote-webapp/start.sh
+++ b/apps/kpilote-webapp/start.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-exec node mb-webapp-deploy/dist/server/index.js
+exec node kpilote-webapp-deploy/dist/server/index.js


### PR DESCRIPTION
## Contexte

Suite au rename des apps \`mb-*\`/\`pmb\` → \`kpilote-*\`, des références résiduelles \`mb-*\` cassaient le déploiement.

## Le bug

Les \`deploy-bundle.sh\` produisent déjà \`kpilote-*-deploy/\`, mais les \`start.sh\` exécutaient encore \`mb-*-deploy/\` → au boot :

\`\`\`
Error: Cannot find module '/app/mb-webapp-deploy/dist/server/index.js'
\`\`\`

## Changements (config de déploiement uniquement)

**Le fix :**
- \`apps/kpilote-{webapp,api,admin}/start.sh\` → exec \`kpilote-*-deploy\`

**Cohérence des exclusions :**
- \`apps/kpilote-webapp/.slugignore\` : \`apps/mb-api\`, \`mb-api-deploy\` → \`kpilote-*\`
- \`apps/kpilote-admin/.slugignore\` : \`apps/mb-{api,webapp}\`, \`mb-{api,webapp}-deploy\` → \`kpilote-*\`
- \`.gitignore\` : \`/mb-{api,webapp}-deploy\` → \`/kpilote-*-deploy\` (+ ajout de \`/kpilote-admin-deploy\` manquant)

**Cosmétique :**
- \`apps/kpilote-admin/deploy-prepare.sh\` (echo) et \`src/server/index.ts\` (log de démarrage)

## Hors scope

- Module \`mb-sync\` dans \`pilote-ppg\` (décision à part, on ne touche pas à PPG)
- Docs/specs historiques