### PR TITLE
feat(indicateur): délai de mise à disposition + dates dérivées

### DIFF
--- a/apps/kpilote-admin/src/components/indicateurs/IndicateurForm.tsx
+++ b/apps/kpilote-admin/src/components/indicateurs/IndicateurForm.tsx
@@ -199,7 +199,11 @@ export function IndicateurForm({
               />
             </div>
             <div className="flex-1">
-              <FieldSelect label="Unité du délai" {...form.register('delaiUnite')}>
+              <FieldSelect
+                label="Unité du délai"
+                error={form.formState.errors.delaiUnite?.message}
+                {...form.register('delaiUnite')}
+              >
                 <option value="">Aucune</option>
                 {UNITES_DUREE.map((unite) => (
                   <option key={unite} value={unite}>

--- a/apps/kpilote-admin/src/components/indicateurs/IndicateurForm.tsx
+++ b/apps/kpilote-admin/src/components/indicateurs/IndicateurForm.tsx
@@ -7,6 +7,8 @@ import { useFieldArray, useForm, useWatch, type UseFormRegister } from 'react-ho
 import {
   PERIODE_MISE_A_JOUR_LABELS,
   PERIODES_MISE_A_JOUR,
+  UNITE_DUREE_LABELS,
+  UNITES_DUREE,
   UNITES_INDICATEUR,
   UNITES_INDICATEUR_CONFIG,
 } from '@pilote/kpilote-shared/indicateur'
@@ -182,6 +184,29 @@ export function IndicateurForm({
                 error={form.formState.errors.jourMiseAJour?.message}
                 {...form.register('jourMiseAJour')}
               />
+            </div>
+          </div>
+
+          <div className="mt-5 flex gap-4">
+            <div className="flex-1">
+              <FieldInput
+                label="Délai de mise à disposition"
+                type="number"
+                min={1}
+                placeholder="ex. 6"
+                error={form.formState.errors.delaiNombre?.message}
+                {...form.register('delaiNombre')}
+              />
+            </div>
+            <div className="flex-1">
+              <FieldSelect label="Unité du délai" {...form.register('delaiUnite')}>
+                <option value="">Aucune</option>
+                {UNITES_DUREE.map((unite) => (
+                  <option key={unite} value={unite}>
+                    {UNITE_DUREE_LABELS[unite]}
+                  </option>
+                ))}
+              </FieldSelect>
             </div>
           </div>
         </div>

--- a/apps/kpilote-admin/src/components/indicateurs/indicateurFormSchema.ts
+++ b/apps/kpilote-admin/src/components/indicateurs/indicateurFormSchema.ts
@@ -17,29 +17,48 @@ import { emptyToNull } from '@/lib/emptyToNull'
 // `toUpsertBody`. La validation de `id` dépend du mode (create : identifiant
 // requis et formaté ; edit : verrouillé, donc non validé).
 export const buildIndicateurFormSchema = (mode: 'create' | 'edit') =>
-  z.object({
-    id: mode === 'create' ? z.string().regex(/^IND-\d+$/, 'Format attendu : IND-001') : z.string(),
-    nom: z.string().trim().min(1, 'Le nom est requis'),
-    visibilite: indicateurVisibiliteSchema,
-    unite: z.union([z.literal(''), uniteIndicateurCodeSchema]),
-    description: z.string(),
-    methodeCalcul: z.string(),
-    sourceDonnees: z.string(),
-    sourceUrl: z.union([z.literal(''), indicateurSourceUrlSchema]),
-    periodeMiseAJour: z.union([z.literal(''), periodeMiseAJourSchema]),
-    jourMiseAJour: z
-      .string()
-      .refine(
-        (value) =>
-          value === '' || (/^\d+$/.test(value) && Number(value) >= 1 && Number(value) <= 31),
-        'Entier entre 1 et 31',
-      ),
-    delaiNombre: z
-      .string()
-      .refine((value) => value === '' || (/^\d+$/.test(value) && Number(value) >= 1), 'Entier ≥ 1'),
-    delaiUnite: z.union([z.literal(''), uniteDureeSchema]),
-    referentiels: z.array(configurationIndicateurReferentielSchema),
-  })
+  z
+    .object({
+      id:
+        mode === 'create' ? z.string().regex(/^IND-\d+$/, 'Format attendu : IND-001') : z.string(),
+      nom: z.string().trim().min(1, 'Le nom est requis'),
+      visibilite: indicateurVisibiliteSchema,
+      unite: z.union([z.literal(''), uniteIndicateurCodeSchema]),
+      description: z.string(),
+      methodeCalcul: z.string(),
+      sourceDonnees: z.string(),
+      sourceUrl: z.union([z.literal(''), indicateurSourceUrlSchema]),
+      periodeMiseAJour: z.union([z.literal(''), periodeMiseAJourSchema]),
+      jourMiseAJour: z
+        .string()
+        .refine(
+          (value) =>
+            value === '' || (/^\d+$/.test(value) && Number(value) >= 1 && Number(value) <= 31),
+          'Entier entre 1 et 31',
+        ),
+      delaiNombre: z
+        .string()
+        .refine(
+          (value) => value === '' || (/^\d+$/.test(value) && Number(value) >= 1),
+          'Entier ≥ 1',
+        ),
+      delaiUnite: z.union([z.literal(''), uniteDureeSchema]),
+      referentiels: z.array(configurationIndicateurReferentielSchema),
+    })
+    // Le délai (nombre + unité) est optionnel, mais indissociable : les deux
+    // champs doivent être remplis ensemble, sinon `toUpsertBody` effacerait
+    // silencieusement la saisie. On pose l'erreur sur le champ manquant.
+    .superRefine((values, ctx) => {
+      const nombreRempli = values.delaiNombre !== ''
+      const uniteRemplie = values.delaiUnite !== ''
+      if (nombreRempli !== uniteRemplie) {
+        ctx.addIssue({
+          code: 'custom',
+          message: 'Renseignez le nombre et l’unité, ou laissez les deux vides',
+          path: [nombreRempli ? 'delaiUnite' : 'delaiNombre'],
+        })
+      }
+    })
 
 export type IndicateurFormValues = z.infer<ReturnType<typeof buildIndicateurFormSchema>>
 

--- a/apps/kpilote-admin/src/components/indicateurs/indicateurFormSchema.ts
+++ b/apps/kpilote-admin/src/components/indicateurs/indicateurFormSchema.ts
@@ -6,6 +6,7 @@ import {
   indicateurSourceUrlSchema,
   indicateurVisibiliteSchema,
   periodeMiseAJourSchema,
+  uniteDureeSchema,
   uniteIndicateurCodeSchema,
 } from '@pilote/kpilote-shared/indicateur'
 
@@ -33,6 +34,10 @@ export const buildIndicateurFormSchema = (mode: 'create' | 'edit') =>
           value === '' || (/^\d+$/.test(value) && Number(value) >= 1 && Number(value) <= 31),
         'Entier entre 1 et 31',
       ),
+    delaiNombre: z
+      .string()
+      .refine((value) => value === '' || (/^\d+$/.test(value) && Number(value) >= 1), 'Entier ≥ 1'),
+    delaiUnite: z.union([z.literal(''), uniteDureeSchema]),
     referentiels: z.array(configurationIndicateurReferentielSchema),
   })
 
@@ -50,6 +55,11 @@ export function buildInitialValues(indicateur?: IndicateurApiModel): IndicateurF
     sourceUrl: indicateur?.sourceUrl ?? '',
     periodeMiseAJour: indicateur?.periodeMiseAJour ?? '',
     jourMiseAJour: indicateur?.jourMiseAJour != null ? String(indicateur.jourMiseAJour) : '',
+    delaiNombre:
+      indicateur?.delaiMiseADisposition != null
+        ? String(indicateur.delaiMiseADisposition.nombre)
+        : '',
+    delaiUnite: indicateur?.delaiMiseADisposition?.unite ?? '',
     referentiels: indicateur?.referentiels ?? [],
   }
 }
@@ -68,6 +78,10 @@ export function toUpsertBody(values: IndicateurFormValues): UpsertIndicateurBody
     sourceUrl: emptyToNull(values.sourceUrl),
     periodeMiseAJour: values.periodeMiseAJour === '' ? null : values.periodeMiseAJour,
     jourMiseAJour: values.jourMiseAJour === '' ? null : Number(values.jourMiseAJour),
+    delaiMiseADisposition:
+      values.delaiUnite === '' || values.delaiNombre === ''
+        ? null
+        : { nombre: Number(values.delaiNombre), unite: values.delaiUnite },
     referentiels: values.referentiels,
   }
 }

--- a/apps/kpilote-api/prisma/migrations/20260708132503_ajout_delai_mise_a_disposition/migration.sql
+++ b/apps/kpilote-api/prisma/migrations/20260708132503_ajout_delai_mise_a_disposition/migration.sql
@@ -1,0 +1,6 @@
+-- CreateEnum
+CREATE TYPE "unite_duree_enum" AS ENUM ('JOURS', 'SEMAINES', 'MOIS', 'ANNEES');
+
+-- AlterTable
+ALTER TABLE "indicateur" ADD COLUMN     "delai_mad_nombre" INTEGER,
+ADD COLUMN     "delai_mad_unite" "unite_duree_enum";

--- a/apps/kpilote-api/prisma/schema.prisma
+++ b/apps/kpilote-api/prisma/schema.prisma
@@ -100,6 +100,10 @@ model Indicateur {
   sourceUrl        String?           @map("source_url")
   periodeMiseAJour PeriodeMiseAJour? @map("periode_mise_a_jour")
   jourMiseAJour    Int?              @map("jour_mise_a_jour")
+
+  delaiMiseADispositionNombre Int?        @map("delai_mad_nombre")
+  delaiMiseADispositionUnite  UniteDuree? @map("delai_mad_unite")
+
   createdAt        DateTime          @default(now()) @map("created_at")
   updatedAt        DateTime          @updatedAt @map("updated_at")
 
@@ -179,6 +183,15 @@ enum PeriodeMiseAJour {
   AUCUNE
 
   @@map("periode_mise_a_jour_enum")
+}
+
+enum UniteDuree {
+  JOURS
+  SEMAINES
+  MOIS
+  ANNEES
+
+  @@map("unite_duree_enum")
 }
 
 model IndicateurReferentiel {

--- a/apps/kpilote-api/prisma/seed.ts
+++ b/apps/kpilote-api/prisma/seed.ts
@@ -1,7 +1,11 @@
 import { PrismaPg } from '@prisma/adapter-pg'
 import { uuidv7 } from 'uuidv7'
 
-import { type PeriodeMiseAJour, type UniteIndicateurCode } from '@pilote/kpilote-shared/indicateur'
+import {
+  type PeriodeMiseAJour,
+  type UniteDuree,
+  type UniteIndicateurCode,
+} from '@pilote/kpilote-shared/indicateur'
 
 import { Prisma, PrismaClient } from '../src/generated/prisma/client.js'
 import { type FonctionAgregation } from '../src/generated/prisma/enums.js'
@@ -34,6 +38,8 @@ const indicateursSeed: ReadonlyArray<{
   sourceUrl?: string
   periodeMiseAJour?: PeriodeMiseAJour
   jourMiseAJour?: number
+  delaiMiseADispositionNombre?: number
+  delaiMiseADispositionUnite?: UniteDuree
 }> = [
   {
     publicId: 'IND-001',
@@ -46,6 +52,9 @@ const indicateursSeed: ReadonlyArray<{
     sourceUrl: 'https://www.insee.fr/fr/statistiques/2489483',
     periodeMiseAJour: 'TRIMESTRIELLE',
     jourMiseAJour: 15,
+    // L'INSEE publie le taux de chômage BIT environ 50 jours après la fin du trimestre.
+    delaiMiseADispositionNombre: 2,
+    delaiMiseADispositionUnite: 'MOIS',
   },
   {
     publicId: 'IND-002',
@@ -56,6 +65,10 @@ const indicateursSeed: ReadonlyArray<{
     sourceDonnees: 'CITEPA — Secten',
     sourceUrl: 'https://www.citepa.org/fr/secten/',
     periodeMiseAJour: 'ANNUELLE',
+    // L'inventaire CITEPA d'une année n'est consolidé et publié qu'environ 18 mois
+    // plus tard : la donnée arrive après la valeur théorique suivante.
+    delaiMiseADispositionNombre: 18,
+    delaiMiseADispositionUnite: 'MOIS',
   },
   {
     publicId: 'IND-003',
@@ -90,6 +103,9 @@ const indicateursSeed: ReadonlyArray<{
     sourceDonnees: 'DITP — Baromètre Services Publics+',
     sourceUrl: 'https://www.plus.transformation.gouv.fr/',
     periodeMiseAJour: 'SEMESTRIELLE',
+    // Résultats du baromètre consolidés environ 2 mois après la fin de la vague.
+    delaiMiseADispositionNombre: 2,
+    delaiMiseADispositionUnite: 'MOIS',
   },
   { publicId: 'IND-009', nom: 'Délai moyen de prise en charge urgences', unite: 'MINUTES' },
   {
@@ -279,6 +295,8 @@ const main = async () => {
       sourceUrl: item.sourceUrl ?? null,
       periodeMiseAJour: item.periodeMiseAJour ?? null,
       jourMiseAJour: item.jourMiseAJour ?? null,
+      delaiMiseADispositionNombre: item.delaiMiseADispositionNombre ?? null,
+      delaiMiseADispositionUnite: item.delaiMiseADispositionUnite ?? null,
     }
     await prisma.indicateur.upsert({
       where: { publicId: item.publicId },

--- a/apps/kpilote-api/src/indicateur/commands/upsertIndicateur.test.ts
+++ b/apps/kpilote-api/src/indicateur/commands/upsertIndicateur.test.ts
@@ -30,7 +30,56 @@ const getConfigurationsReferentiels = async (publicId: string) => {
     .sort((a, b) => a.id.localeCompare(b.id))
 }
 
+const BODY_BASE = {
+  nom: 'Données fiscales',
+  visibilite: 'PRIVE' as const,
+  unite: null,
+  ...METADONNEES_VIDES,
+  referentiels: [],
+}
+
 describe.concurrent('upsertIndicateur', () => {
+  it(
+    'persiste le délai de mise à disposition à la création',
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const apiKey = await fixtures.apiKey()
+
+      await runAsAdmin(apiKey.id, () =>
+        upsertIndicateur(indId, {
+          ...BODY_BASE,
+          delaiMiseADisposition: { nombre: 6, unite: 'MOIS' },
+        }),
+      )
+
+      const row = await db().indicateur.findUniqueOrThrow({ where: { publicId: indId } })
+      expect(row.delaiMiseADispositionNombre).toBe(6)
+      expect(row.delaiMiseADispositionUnite).toBe('MOIS')
+    }),
+  )
+
+  it(
+    'efface le délai quand on envoie null',
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const apiKey = await fixtures.apiKey()
+
+      await runAsAdmin(apiKey.id, () =>
+        upsertIndicateur(indId, {
+          ...BODY_BASE,
+          delaiMiseADisposition: { nombre: 6, unite: 'MOIS' },
+        }),
+      )
+      await runAsAdmin(apiKey.id, () =>
+        upsertIndicateur(indId, { ...BODY_BASE, delaiMiseADisposition: null }),
+      )
+
+      const row = await db().indicateur.findUniqueOrThrow({ where: { publicId: indId } })
+      expect(row.delaiMiseADispositionNombre).toBeNull()
+      expect(row.delaiMiseADispositionUnite).toBeNull()
+    }),
+  )
+
   it(
     'crée un indicateur avec ses référentiels configurés et auto-grant READ+WRITE au créateur',
     integrationTest(async () => {

--- a/apps/kpilote-api/src/indicateur/commands/upsertIndicateur.ts
+++ b/apps/kpilote-api/src/indicateur/commands/upsertIndicateur.ts
@@ -120,6 +120,10 @@ const metadonneesData = (body: UpsertIndicateurBody) => ({
   ...(body.sourceUrl !== undefined && { sourceUrl: body.sourceUrl }),
   ...(body.periodeMiseAJour !== undefined && { periodeMiseAJour: body.periodeMiseAJour }),
   ...(body.jourMiseAJour !== undefined && { jourMiseAJour: body.jourMiseAJour }),
+  ...(body.delaiMiseADisposition !== undefined && {
+    delaiMiseADispositionNombre: body.delaiMiseADisposition?.nombre ?? null,
+    delaiMiseADispositionUnite: body.delaiMiseADisposition?.unite ?? null,
+  }),
 })
 
 const updateIndicateurExistant = async (

--- a/apps/kpilote-api/src/indicateur/datesMiseADisposition.test.ts
+++ b/apps/kpilote-api/src/indicateur/datesMiseADisposition.test.ts
@@ -1,0 +1,123 @@
+import { type PeriodeMiseAJour } from '@pilote/kpilote-shared/indicateur'
+import { describe, expect, it } from 'vitest'
+
+import { computeDatesMiseADisposition } from '@/indicateur/datesMiseADisposition'
+
+describe('computeDatesMiseADisposition', () => {
+  it('scénario données fiscales : annuelle + délai semestre', () => {
+    expect(
+      computeDatesMiseADisposition({
+        dateDerniereValeur: '2023-12-01',
+        periodeMiseAJour: 'ANNUELLE',
+        delai: { nombre: 6, unite: 'MOIS' },
+      }),
+    ).toEqual({
+      dateDerniereValeur: '2023-12-01',
+      dateProchaineValeur: '2024-12-01',
+      dateMiseADisposition: '2025-06-01',
+    })
+  })
+
+  it('délai annuel : mise à dispo un an après la prochaine valeur', () => {
+    expect(
+      computeDatesMiseADisposition({
+        dateDerniereValeur: '2023-12-01',
+        periodeMiseAJour: 'ANNUELLE',
+        delai: { nombre: 1, unite: 'ANNEES' },
+      }).dateMiseADisposition,
+    ).toBe('2025-12-01')
+  })
+
+  it('mappe chaque période vers le bon intervalle', () => {
+    const prochaine = (periodeMiseAJour: PeriodeMiseAJour) =>
+      computeDatesMiseADisposition({
+        dateDerniereValeur: '2024-01-15',
+        periodeMiseAJour,
+        delai: null,
+      }).dateProchaineValeur
+    expect(prochaine('QUOTIDIENNE')).toBe('2024-01-16')
+    expect(prochaine('HEBDOMADAIRE')).toBe('2024-01-22')
+    expect(prochaine('BIMENSUELLE')).toBe('2024-01-30')
+    expect(prochaine('MENSUELLE')).toBe('2024-02-15')
+    expect(prochaine('TRIMESTRIELLE')).toBe('2024-04-15')
+    expect(prochaine('SEMESTRIELLE')).toBe('2024-07-15')
+    expect(prochaine('ANNUELLE')).toBe('2025-01-15')
+  })
+
+  it('clampe le jour en cas de débordement de mois (31 janv. + 1 mois, année bissextile)', () => {
+    expect(
+      computeDatesMiseADisposition({
+        dateDerniereValeur: '2024-01-31',
+        periodeMiseAJour: 'MENSUELLE',
+        delai: null,
+      }).dateProchaineValeur,
+    ).toBe('2024-02-29')
+  })
+
+  it('applique le délai en jours et en semaines', () => {
+    expect(
+      computeDatesMiseADisposition({
+        dateDerniereValeur: '2024-01-15',
+        periodeMiseAJour: 'MENSUELLE',
+        delai: { nombre: 10, unite: 'JOURS' },
+      }).dateMiseADisposition,
+    ).toBe('2024-02-25')
+    expect(
+      computeDatesMiseADisposition({
+        dateDerniereValeur: '2024-01-15',
+        periodeMiseAJour: 'MENSUELLE',
+        delai: { nombre: 2, unite: 'SEMAINES' },
+      }).dateMiseADisposition,
+    ).toBe('2024-02-29')
+  })
+
+  it('propage les null : pas de valeur, période AUCUNE/null, délai absent', () => {
+    expect(
+      computeDatesMiseADisposition({
+        dateDerniereValeur: null,
+        periodeMiseAJour: 'ANNUELLE',
+        delai: { nombre: 6, unite: 'MOIS' },
+      }),
+    ).toEqual({
+      dateDerniereValeur: null,
+      dateProchaineValeur: null,
+      dateMiseADisposition: null,
+    })
+
+    expect(
+      computeDatesMiseADisposition({
+        dateDerniereValeur: '2023-12-01',
+        periodeMiseAJour: 'AUCUNE',
+        delai: { nombre: 6, unite: 'MOIS' },
+      }),
+    ).toEqual({
+      dateDerniereValeur: '2023-12-01',
+      dateProchaineValeur: null,
+      dateMiseADisposition: null,
+    })
+
+    expect(
+      computeDatesMiseADisposition({
+        dateDerniereValeur: '2023-12-01',
+        periodeMiseAJour: null,
+        delai: null,
+      }),
+    ).toEqual({
+      dateDerniereValeur: '2023-12-01',
+      dateProchaineValeur: null,
+      dateMiseADisposition: null,
+    })
+
+    expect(
+      computeDatesMiseADisposition({
+        dateDerniereValeur: '2023-12-01',
+        periodeMiseAJour: 'ANNUELLE',
+        delai: null,
+      }),
+    ).toEqual({
+      dateDerniereValeur: '2023-12-01',
+      dateProchaineValeur: '2024-12-01',
+      dateMiseADisposition: null,
+    })
+  })
+})

--- a/apps/kpilote-api/src/indicateur/datesMiseADisposition.ts
+++ b/apps/kpilote-api/src/indicateur/datesMiseADisposition.ts
@@ -1,0 +1,74 @@
+import { Temporal } from '@js-temporal/polyfill'
+
+import {
+  type DelaiMiseADisposition,
+  type PeriodeMiseAJour,
+  type UniteDuree,
+} from '@pilote/kpilote-shared/indicateur'
+
+export type DatesMiseADisposition = {
+  dateDerniereValeur: string | null
+  dateProchaineValeur: string | null
+  dateMiseADisposition: string | null
+}
+
+// Intervalle à ajouter à la dernière valeur connue pour obtenir la prochaine
+// occurrence théorique. `BIMENSUELLE` (2×/mois) est approximée à 15 jours ;
+// `AUCUNE` n'a pas d'occurrence suivante.
+const DUREE_PAR_PERIODE: Record<PeriodeMiseAJour, Temporal.DurationLike | null> = {
+  QUOTIDIENNE: { days: 1 },
+  HEBDOMADAIRE: { days: 7 },
+  BIMENSUELLE: { days: 15 },
+  MENSUELLE: { months: 1 },
+  TRIMESTRIELLE: { months: 3 },
+  SEMESTRIELLE: { months: 6 },
+  ANNUELLE: { years: 1 },
+  AUCUNE: null,
+}
+
+const UNITE_DUREE_TO_TEMPORAL: Record<UniteDuree, 'days' | 'weeks' | 'months' | 'years'> = {
+  JOURS: 'days',
+  SEMAINES: 'weeks',
+  MOIS: 'months',
+  ANNEES: 'years',
+}
+
+// `Temporal.PlainDate.add` utilise overflow: 'constrain' par défaut : 31 janv.
+// + 1 mois → dernier jour de février (clamp), ce qui correspond au besoin.
+const ajouter = (date: string, duree: Temporal.DurationLike): string =>
+  Temporal.PlainDate.from(date).add(duree).toString()
+
+const computeProchaineValeur = (
+  dateDerniereValeur: string | null,
+  periodeMiseAJour: PeriodeMiseAJour | null,
+): string | null => {
+  if (dateDerniereValeur === null || periodeMiseAJour === null) return null
+  const duree = DUREE_PAR_PERIODE[periodeMiseAJour]
+  if (duree === null) return null
+  return ajouter(dateDerniereValeur, duree)
+}
+
+const computeMiseADisposition = (
+  dateProchaineValeur: string | null,
+  delai: DelaiMiseADisposition | null,
+): string | null => {
+  if (dateProchaineValeur === null || delai === null) return null
+  return ajouter(dateProchaineValeur, { [UNITE_DUREE_TO_TEMPORAL[delai.unite]]: delai.nombre })
+}
+
+export const computeDatesMiseADisposition = ({
+  dateDerniereValeur,
+  periodeMiseAJour,
+  delai,
+}: {
+  dateDerniereValeur: string | null
+  periodeMiseAJour: PeriodeMiseAJour | null
+  delai: DelaiMiseADisposition | null
+}): DatesMiseADisposition => {
+  const dateProchaineValeur = computeProchaineValeur(dateDerniereValeur, periodeMiseAJour)
+  return {
+    dateDerniereValeur,
+    dateProchaineValeur,
+    dateMiseADisposition: computeMiseADisposition(dateProchaineValeur, delai),
+  }
+}

--- a/apps/kpilote-api/src/indicateur/queries/getIndicateurByPublicId.test.ts
+++ b/apps/kpilote-api/src/indicateur/queries/getIndicateurByPublicId.test.ts
@@ -56,8 +56,12 @@ describe.concurrent('getIndicateurByPublicId', () => {
         sourceUrl: null,
         periodeMiseAJour: null,
         jourMiseAJour: null,
+        delaiMiseADisposition: null,
         referentiels: referentielsTries,
         responsables: [],
+        dateDerniereValeur: null,
+        dateProchaineValeur: null,
+        dateMiseADisposition: null,
         createdAt: indicateur.createdAt.toISOString(),
         updatedAt: indicateur.updatedAt.toISOString(),
       })
@@ -109,6 +113,43 @@ describe.concurrent('getIndicateurByPublicId', () => {
       expect(indicateur.sourceUrl).toBe('https://www.insee.fr/source')
       expect(indicateur.periodeMiseAJour).toBe('TRIMESTRIELLE')
       expect(indicateur.jourMiseAJour).toBe(15)
+    }),
+  )
+
+  it(
+    'calcule les dates dérivées (dernière valeur, prochaine valeur, mise à disposition)',
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      await fixtures.valeurAvancement(
+        {
+          indicateur: {
+            publicId: indId,
+            periodeMiseAJour: 'ANNUELLE',
+            delaiMiseADispositionNombre: 6,
+            delaiMiseADispositionUnite: 'MOIS',
+          },
+          individu: {},
+          date: '2022-12-01',
+          valeur: 5,
+        },
+        {
+          indicateur: { publicId: indId },
+          individu: {},
+          date: '2023-12-01',
+          valeur: 10,
+        },
+      )
+      const apiKey = await fixtures.apiKey({
+        permissions: [{ indicateur: { publicId: indId }, action: 'READ' }],
+      })
+
+      const result = await runAsPrincipal(apiKey.id, () => getIndicateurByPublicId(indId))
+      const indicateur = result._unsafeUnwrap()
+
+      expect(indicateur.delaiMiseADisposition).toEqual({ nombre: 6, unite: 'MOIS' })
+      expect(indicateur.dateDerniereValeur).toBe('2023-12-01')
+      expect(indicateur.dateProchaineValeur).toBe('2024-12-01')
+      expect(indicateur.dateMiseADisposition).toBe('2025-06-01')
     }),
   )
 

--- a/apps/kpilote-api/src/indicateur/queries/getIndicateurByPublicId.ts
+++ b/apps/kpilote-api/src/indicateur/queries/getIndicateurByPublicId.ts
@@ -3,8 +3,28 @@ import { ResultAsync } from 'neverthrow'
 
 import { isAdminPrincipal, requireCurrentPrincipalId } from '@/framework/auth/userContext'
 import { db } from '@/framework/persistence/dbStore'
+import { type Prisma } from '@/generated/prisma/client'
 import { withIndicateurReadPermission } from '@/indicateur/permissions'
 import { toIndicateurApiModel } from '@/indicateur/utils'
+
+const loadIndicateur = async (where: Prisma.IndicateurWhereInput): Promise<IndicateurApiModel> => {
+  const indicateur = await db().indicateur.findFirstOrThrow({
+    where,
+    include: {
+      referentiels: { include: { referentiel: true } },
+      responsables: {
+        orderBy: { createdAt: 'asc' },
+        include: { utilisateur: true },
+      },
+    },
+  })
+  // La date est stockée en `YYYY-MM-DD` : le MAX lexicographique = MAX chronologique.
+  const { _max } = await db().valeurAvancement.aggregate({
+    where: { indicateurId: indicateur.id },
+    _max: { date: true },
+  })
+  return toIndicateurApiModel({ indicateur, dateDerniereValeur: _max.date })
+}
 
 export const getIndicateurByPublicId = (
   publicId: string,
@@ -16,16 +36,5 @@ export const getIndicateurByPublicId = (
   const where = withIndicateurReadPermission({ publicId }, principalId, {
     isAdmin: isAdminPrincipal(),
   })
-  return ResultAsync.fromSafePromise(
-    db().indicateur.findFirstOrThrow({
-      where,
-      include: {
-        referentiels: { include: { referentiel: true } },
-        responsables: {
-          orderBy: { createdAt: 'asc' },
-          include: { utilisateur: true },
-        },
-      },
-    }),
-  ).map(toIndicateurApiModel)
+  return ResultAsync.fromSafePromise(loadIndicateur(where))
 }

--- a/apps/kpilote-api/src/indicateur/queries/listIndicateurs.ts
+++ b/apps/kpilote-api/src/indicateur/queries/listIndicateurs.ts
@@ -44,7 +44,27 @@ export const listIndicateurs = (
   })
   const fetchTotal = db().indicateur.count({ where })
 
-  return ResultAsync.fromSafePromise(Promise.all([fetchPage, fetchTotal])).map(([rows, total]) =>
-    toPaginatedResponse(rows, total, toIndicateurApiModel, params.pageSize),
-  )
+  const loadPage = async (): Promise<IndicateurListApiModel> => {
+    const [rows, total] = await Promise.all([fetchPage, fetchTotal])
+    // Une seule requête pour toutes les dernières valeurs de la page (évite le N+1).
+    // La date est en `YYYY-MM-DD` : MAX lexicographique = MAX chronologique.
+    const maxDates = await db().valeurAvancement.groupBy({
+      by: ['indicateurId'],
+      where: { indicateurId: { in: rows.map((row) => row.id) } },
+      _max: { date: true },
+    })
+    const dateParIndicateur = new Map(maxDates.map((m) => [m.indicateurId, m._max.date]))
+    return toPaginatedResponse(
+      rows,
+      total,
+      (row) =>
+        toIndicateurApiModel({
+          indicateur: row,
+          dateDerniereValeur: dateParIndicateur.get(row.id) ?? null,
+        }),
+      params.pageSize,
+    )
+  }
+
+  return ResultAsync.fromSafePromise(loadPage())
 }

--- a/apps/kpilote-api/src/indicateur/utils.ts
+++ b/apps/kpilote-api/src/indicateur/utils.ts
@@ -1,9 +1,13 @@
 import {
+  type DelaiMiseADisposition,
   type IndicateurApiModel,
+  type UniteDuree,
   type UniteIndicateurApiModel,
   type UniteIndicateurCode,
   UNITES_INDICATEUR_CONFIG,
 } from '@pilote/kpilote-shared/indicateur'
+
+import { computeDatesMiseADisposition } from '@/indicateur/datesMiseADisposition'
 
 import { type FonctionAgregation, type UniteIndicateur } from '@/generated/prisma/enums'
 import {
@@ -52,33 +56,62 @@ const toUniteIndicateurApiModel = (
   return { code, libelle: config.libelle, abbreviation: config.abbreviation }
 }
 
-export const toIndicateurApiModel = (
-  indicateur: IndicateurWithReferentiels,
-): IndicateurApiModel => ({
-  id: indicateur.publicId,
-  nom: indicateur.nom,
-  visibilite: indicateur.visibilite,
-  unite: toUniteIndicateurApiModel(indicateur.unite),
-  description: indicateur.description,
-  methodeCalcul: indicateur.methodeCalcul,
-  sourceDonnees: indicateur.sourceDonnees,
-  sourceUrl: indicateur.sourceUrl,
-  periodeMiseAJour: indicateur.periodeMiseAJour,
-  jourMiseAJour: indicateur.jourMiseAJour,
-  referentiels: indicateur.referentiels
-    .map((configuration) => ({
-      id: configuration.referentiel.publicId,
-      nom: configuration.referentiel.nom,
-      fonctionAgregation: configuration.fonctionAgregation,
-    }))
-    .sort((a, b) => a.id.localeCompare(b.id)),
-  responsables: indicateur.responsables.map(({ utilisateur }) => ({
-    email: utilisateur.email,
-    nom: utilisateur.nom,
-    prenom: utilisateur.prenom,
-    service: utilisateur.service,
-    fonction: utilisateur.fonction,
-  })),
-  createdAt: indicateur.createdAt.toISOString(),
-  updatedAt: indicateur.updatedAt.toISOString(),
-})
+// Recompose le délai stocké en deux colonnes (nombre + unité) en objet, ou
+// `null` si l'un des deux manque (invariant les-deux-ou-aucun garanti à l'écriture).
+const toDelaiMiseADisposition = (indicateur: {
+  delaiMiseADispositionNombre: number | null
+  delaiMiseADispositionUnite: UniteDuree | null
+}): DelaiMiseADisposition | null =>
+  indicateur.delaiMiseADispositionNombre !== null && indicateur.delaiMiseADispositionUnite !== null
+    ? {
+        nombre: indicateur.delaiMiseADispositionNombre,
+        unite: indicateur.delaiMiseADispositionUnite,
+      }
+    : null
+
+export const toIndicateurApiModel = ({
+  indicateur,
+  dateDerniereValeur,
+}: {
+  indicateur: IndicateurWithReferentiels
+  dateDerniereValeur: string | null
+}): IndicateurApiModel => {
+  const delaiMiseADisposition = toDelaiMiseADisposition(indicateur)
+  const dates = computeDatesMiseADisposition({
+    dateDerniereValeur,
+    periodeMiseAJour: indicateur.periodeMiseAJour,
+    delai: delaiMiseADisposition,
+  })
+  return {
+    id: indicateur.publicId,
+    nom: indicateur.nom,
+    visibilite: indicateur.visibilite,
+    unite: toUniteIndicateurApiModel(indicateur.unite),
+    description: indicateur.description,
+    methodeCalcul: indicateur.methodeCalcul,
+    sourceDonnees: indicateur.sourceDonnees,
+    sourceUrl: indicateur.sourceUrl,
+    periodeMiseAJour: indicateur.periodeMiseAJour,
+    jourMiseAJour: indicateur.jourMiseAJour,
+    delaiMiseADisposition,
+    referentiels: indicateur.referentiels
+      .map((configuration) => ({
+        id: configuration.referentiel.publicId,
+        nom: configuration.referentiel.nom,
+        fonctionAgregation: configuration.fonctionAgregation,
+      }))
+      .sort((a, b) => a.id.localeCompare(b.id)),
+    responsables: indicateur.responsables.map(({ utilisateur }) => ({
+      email: utilisateur.email,
+      nom: utilisateur.nom,
+      prenom: utilisateur.prenom,
+      service: utilisateur.service,
+      fonction: utilisateur.fonction,
+    })),
+    dateDerniereValeur: dates.dateDerniereValeur,
+    dateProchaineValeur: dates.dateProchaineValeur,
+    dateMiseADisposition: dates.dateMiseADisposition,
+    createdAt: indicateur.createdAt.toISOString(),
+    updatedAt: indicateur.updatedAt.toISOString(),
+  }
+}

--- a/apps/kpilote-api/src/test/fixtures.ts
+++ b/apps/kpilote-api/src/test/fixtures.ts
@@ -41,6 +41,7 @@ import {
   Visibilite,
   type FonctionAgregation,
   type PeriodeMiseAJour,
+  type UniteDuree,
   type UniteIndicateur,
 } from '@/generated/prisma/enums'
 
@@ -58,6 +59,8 @@ type IndicateurOverrides = Partial<{
   sourceUrl: string | null
   periodeMiseAJour: PeriodeMiseAJour | null
   jourMiseAJour: number | null
+  delaiMiseADispositionNombre: number | null
+  delaiMiseADispositionUnite: UniteDuree | null
 }>
 
 const upsertIndicateur = async (o: IndicateurOverrides = {}) => {

--- a/apps/kpilote-webapp/src/components/indicateurs/IndicateurMetadonnees.tsx
+++ b/apps/kpilote-webapp/src/components/indicateurs/IndicateurMetadonnees.tsx
@@ -1,6 +1,8 @@
 import {
   PERIODE_MISE_A_JOUR_LABELS,
+  UNITE_DUREE_LABELS,
   type ConfigurationIndicateurReferentielApiModel,
+  type DelaiMiseADisposition,
   type PeriodeMiseAJour,
   type UniteIndicateurApiModel,
 } from '@pilote/kpilote-shared/indicateur'
@@ -9,7 +11,7 @@ import { type ResponsableApiModel } from '@pilote/kpilote-shared/responsable'
 import { DescriptionList } from '@/components/ui/DescriptionList'
 import { ResponsablesList } from '@/components/ui/ResponsablesList'
 import { Heading } from '@/components/ui/Typography'
-import { formatDateTimeFr } from '@/lib/format'
+import { formatDateTimeFr, formatMoisAnneeLongFr } from '@/lib/format'
 
 const VALEUR_VIDE = '—'
 
@@ -26,6 +28,12 @@ const formatReferentiels = (
   return referentiels.map((r) => r.nom).join(', ')
 }
 
+const formatDelai = (delai: DelaiMiseADisposition | null): string =>
+  delai ? `${delai.nombre} ${UNITE_DUREE_LABELS[delai.unite]}` : VALEUR_VIDE
+
+const formatDateMoisAnnee = (date: string | null): string =>
+  date ? formatMoisAnneeLongFr(date) : VALEUR_VIDE
+
 type IndicateurMetadonneesProps = {
   indicateur: {
     id: string
@@ -37,6 +45,9 @@ type IndicateurMetadonneesProps = {
     sourceUrl: string | null
     periodeMiseAJour: PeriodeMiseAJour | null
     jourMiseAJour: number | null
+    delaiMiseADisposition: DelaiMiseADisposition | null
+    dateProchaineValeur: string | null
+    dateMiseADisposition: string | null
     referentiels: ReadonlyArray<ConfigurationIndicateurReferentielApiModel>
     responsables: ReadonlyArray<ResponsableApiModel>
     createdAt: string
@@ -82,6 +93,15 @@ export function IndicateurMetadonnees({ indicateur }: IndicateurMetadonneesProps
         </DescriptionList.Item>
         <DescriptionList.Item label="Période de mise à jour">
           {formatPeriodeMiseAJour(indicateur.periodeMiseAJour, indicateur.jourMiseAJour)}
+        </DescriptionList.Item>
+        <DescriptionList.Item label="Délai de mise à disposition">
+          {formatDelai(indicateur.delaiMiseADisposition)}
+        </DescriptionList.Item>
+        <DescriptionList.Item label="Date de la prochaine valeur">
+          {formatDateMoisAnnee(indicateur.dateProchaineValeur)}
+        </DescriptionList.Item>
+        <DescriptionList.Item label="Date de mise à disposition">
+          {formatDateMoisAnnee(indicateur.dateMiseADisposition)}
         </DescriptionList.Item>
         <DescriptionList.Item label="Référentiels">
           {formatReferentiels(indicateur.referentiels)}

--- a/apps/kpilote-webapp/src/lib/format.test.ts
+++ b/apps/kpilote-webapp/src/lib/format.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest'
+
+import { formatMoisAnneeLongFr } from '@/lib/format'
+
+describe('formatMoisAnneeLongFr', () => {
+  it('formate une date ISO en mois-année long fr-FR', () => {
+    expect(formatMoisAnneeLongFr('2024-12-01')).toBe('décembre 2024')
+    expect(formatMoisAnneeLongFr('2025-06-15')).toBe('juin 2025')
+  })
+})

--- a/apps/kpilote-webapp/src/lib/format.ts
+++ b/apps/kpilote-webapp/src/lib/format.ts
@@ -63,3 +63,9 @@ export const formatMonthYearNumericFr = (value: Date | string | Temporal.PlainDa
   value instanceof Temporal.PlainDate
     ? value.toLocaleString('fr-FR', monthYearNumericOptions)
     : monthYearNumericFr.format(toDate(value))
+
+const moisAnneeLongOptions = { month: 'long', year: 'numeric' } as const
+
+// "décembre 2024" — entrée ISO YYYY-MM-DD (dates dérivées de l'indicateur).
+export const formatMoisAnneeLongFr = (value: string): string =>
+  Temporal.PlainDate.from(value).toLocaleString('fr-FR', moisAnneeLongOptions)

--- a/docs/superpowers/plans/2026-07-08-delai-mise-a-disposition-indicateur.md
+++ b/docs/superpowers/plans/2026-07-08-delai-mise-a-disposition-indicateur.md
@@ -1,0 +1,982 @@
+# Délai de mise à disposition d'un indicateur — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ajouter une métadonnée « délai de mise à disposition » à un indicateur et exposer/afficher trois dates dérivées (dernière valeur, prochaine valeur théorique, mise à disposition).
+
+**Architecture:** Le délai est stocké en base (deux colonnes `nombre` + `unité`). L'API calcule les dates dérivées via un helper pur (arithmétique `Temporal.PlainDate`) et les expose dans `IndicateurApiModel` (partagé liste ↔ détail). La webapp est du pur affichage ; l'admin édite le délai.
+
+**Tech Stack:** Prisma 7, Zod (`@pilote/kpilote-shared`), Hono zod-openapi, neverthrow, `@js-temporal/polyfill`, React Hook Form (admin), TanStack (webapp), Vitest.
+
+**Spec :** `docs/superpowers/specs/2026-07-08-delai-mise-a-disposition-indicateur-design.md`
+
+## Global Constraints
+
+- **Exports/imports nommés uniquement** — jamais de `default`.
+- **Params de helpers sous forme d'objet nommé**, pas de positionnels.
+- **Use cases mb-api en `ResultAsync`** (neverthrow) ; wrap des promesses via `ResultAsync.fromSafePromise`.
+- **Tests mb-api** : `integrationTest`, `uuidv7` (jamais `randomUUID`), valeurs hardcodées (isolation transactionnelle), fixtures `fixtures.<entity>(...)` variadic.
+- **Prisma** : pas de `$transaction` nesté (awaits séquentiels) ; pas de `select` granulaires.
+- **Copie FR** correcte et accentuée.
+- Le délai est un couple **les-deux-ou-aucun** : `nombre` (int ≥ 1) + `unité` renseignés ensemble, sinon `null`.
+- Dates dérivées : chaînes ISO `YYYY-MM-DD` ou `null` ; affichage webapp en **mois-année** ; `—` si `null`.
+- `periodeMiseAJour` / `jourMiseAJour` : **inchangés**, `jourMiseAJour` ignoré du calcul.
+
+---
+
+## File Structure
+
+- `apps/kpilote-api/prisma/schema.prisma` — enum `UniteDuree` + 2 champs sur `Indicateur` (Task 1).
+- `apps/kpilote-api/prisma/migrations/<ts>_ajout_delai_mise_a_disposition/` — migration (Task 1).
+- `packages/kpilote-shared/src/indicateur.ts` — schémas/types délai + dates dérivées (Task 2).
+- `apps/kpilote-api/src/indicateur/datesMiseADisposition.ts` (+ `.test.ts`) — helper pur (Task 3).
+- `apps/kpilote-api/src/indicateur/utils.ts` — mapper (Task 4).
+- `apps/kpilote-api/src/indicateur/queries/getIndicateurByPublicId.ts` — MAX date détail (Task 4).
+- `apps/kpilote-api/src/indicateur/queries/listIndicateurs.ts` — MAX date liste via `groupBy` (Task 4).
+- `apps/kpilote-api/src/indicateur/queries/getIndicateurByPublicId.test.ts` — MAJ assertions (Task 4).
+- `apps/kpilote-api/src/indicateur/commands/upsertIndicateur.ts` (+ `.test.ts`) — écriture délai (Task 5).
+- `apps/kpilote-admin/src/components/indicateurs/indicateurFormSchema.ts` + `IndicateurForm.tsx` — champ délai (Task 6).
+- `apps/kpilote-webapp/src/lib/format.ts` (+ `.test.ts`) + `components/indicateurs/IndicateurMetadonnees.tsx` — affichage (Task 7).
+
+---
+
+### Task 1 : Prisma — enum `UniteDuree` + champs délai + migration
+
+**Files:**
+- Modify: `apps/kpilote-api/prisma/schema.prisma`
+- Create: `apps/kpilote-api/prisma/migrations/<timestamp>_ajout_delai_mise_a_disposition/migration.sql` (généré)
+
+**Interfaces:**
+- Produces: colonnes Prisma `delaiMiseADispositionNombre: Int?`, `delaiMiseADispositionUnite: UniteDuree?` sur `Indicateur` ; enum `UniteDuree { JOURS | SEMAINES | MOIS | ANNEES }`. Modèle généré `IndicateurModel` porte ces champs.
+
+- [ ] **Step 1 : Ajouter les 2 champs sur `model Indicateur`**
+
+Dans `apps/kpilote-api/prisma/schema.prisma`, juste après la ligne `jourMiseAJour Int? @map("jour_mise_a_jour")` :
+
+```prisma
+  delaiMiseADispositionNombre Int?        @map("delai_mad_nombre")
+  delaiMiseADispositionUnite  UniteDuree? @map("delai_mad_unite")
+```
+
+- [ ] **Step 2 : Ajouter l'enum `UniteDuree`**
+
+Après l'enum `PeriodeMiseAJour` (bloc `@@map("periode_mise_a_jour_enum")`) :
+
+```prisma
+enum UniteDuree {
+  JOURS
+  SEMAINES
+  MOIS
+  ANNEES
+
+  @@map("unite_duree_enum")
+}
+```
+
+- [ ] **Step 3 : Générer la migration (DB de dev requise up)**
+
+Run : `pnpm -F @pilote/kpilote-api exec prisma migrate dev --name ajout_delai_mise_a_disposition`
+Expected : nouvelle migration créée + appliquée ; client Prisma régénéré.
+
+- [ ] **Step 4 : Régénérer le client au format du repo**
+
+Run : `pnpm -F @pilote/kpilote-api prisma:generate`
+Expected : `apps/kpilote-api/src/generated/prisma` à jour (types `UniteDuree`, champs `delaiMiseADisposition*`).
+
+- [ ] **Step 5 : Vérifier la compilation du client généré**
+
+Run : `pnpm -F @pilote/kpilote-api exec tsc --noEmit`
+Expected : PASS (aucun consommateur des nouveaux champs encore).
+
+- [ ] **Step 6 : Commit**
+
+```bash
+git add apps/kpilote-api/prisma/schema.prisma apps/kpilote-api/prisma/migrations apps/kpilote-api/src/generated
+git commit -m "feat(indicateur): schéma délai de mise à disposition (Prisma + migration)"
+```
+
+---
+
+### Task 2 : `kpilote-shared` — schémas délai + dates dérivées
+
+**Files:**
+- Modify: `packages/kpilote-shared/src/indicateur.ts`
+
+**Interfaces:**
+- Consumes: `dateSchema` de `./dates` (existant).
+- Produces :
+  - `UNITES_DUREE: readonly ['JOURS','SEMAINES','MOIS','ANNEES']`, `type UniteDuree`.
+  - `UNITE_DUREE_LABELS: Record<UniteDuree, string>`.
+  - `uniteDureeSchema`, `delaiMiseADispositionSchema`, `type DelaiMiseADisposition = { nombre: number; unite: UniteDuree }`.
+  - `indicateurMetadonneesSchema` gagne `delaiMiseADisposition: DelaiMiseADisposition | null` (donc éditable via upsert `.partial()` et lisible via apiModel).
+  - `indicateurApiModelSchema` gagne `dateDerniereValeur`, `dateProchaineValeur`, `dateMiseADisposition` (`string | null`).
+
+> Note : entre cette task et la Task 4, `tsc` de `kpilote-api` sera **rouge** (le mapper ne produit pas encore les nouveaux champs requis). C'est attendu ; le vert revient en Task 4. `kpilote-shared` lui-même reste vert.
+
+- [ ] **Step 1 : Importer `dateSchema`**
+
+En tête de `packages/kpilote-shared/src/indicateur.ts`, ajouter à l'import existant depuis `./dates` (ou créer l'import) :
+
+```ts
+import { dateSchema } from './dates'
+```
+
+- [ ] **Step 2 : Ajouter le catalogue + schémas de durée**
+
+Juste avant `export const indicateurMetadonneesSchema = z.object({` :
+
+```ts
+export const UNITES_DUREE = ['JOURS', 'SEMAINES', 'MOIS', 'ANNEES'] as const
+export type UniteDuree = (typeof UNITES_DUREE)[number]
+
+// Libellés d'affichage des unités de durée, partagés admin (formulaire) et
+// webapp (fiche indicateur) pour éviter la divergence.
+export const UNITE_DUREE_LABELS: Record<UniteDuree, string> = {
+  JOURS: 'jour(s)',
+  SEMAINES: 'semaine(s)',
+  MOIS: 'mois',
+  ANNEES: 'an(s)',
+}
+
+export const uniteDureeSchema = z
+  .enum(UNITES_DUREE)
+  .describe("Unité de durée d'un délai (jours, semaines, mois, années).")
+
+export const delaiMiseADispositionSchema = z
+  .object({
+    nombre: z.int().min(1).describe("Nombre d'unités du délai (entier ≥ 1)."),
+    unite: uniteDureeSchema,
+  })
+  .describe(
+    "Délai entre la date théorique d'une valeur et sa mise à disposition effective.",
+  )
+export type DelaiMiseADisposition = z.infer<typeof delaiMiseADispositionSchema>
+```
+
+- [ ] **Step 3 : Ajouter le délai aux métadonnées éditables**
+
+Dans `indicateurMetadonneesSchema = z.object({ ... })`, après le champ `jourMiseAJour` :
+
+```ts
+  delaiMiseADisposition: delaiMiseADispositionSchema
+    .nullable()
+    .describe('Délai de mise à disposition, ou `null` si non renseigné.'),
+```
+
+- [ ] **Step 4 : Ajouter les 3 dates dérivées à l'API model (lecture seule)**
+
+Dans `indicateurApiModelSchema = z.object({ ... })`, juste avant `createdAt:` :
+
+```ts
+  dateDerniereValeur: dateSchema
+    .nullable()
+    .describe(
+      'Date ISO YYYY-MM-DD de la dernière valeur connue (MAX, tous individus), ou `null` si aucune valeur.',
+    ),
+  dateProchaineValeur: dateSchema
+    .nullable()
+    .describe(
+      'Date ISO YYYY-MM-DD de la prochaine valeur théorique (dernière valeur + période), ou `null`.',
+    ),
+  dateMiseADisposition: dateSchema
+    .nullable()
+    .describe(
+      'Date ISO YYYY-MM-DD de mise à disposition (prochaine valeur + délai), ou `null`.',
+    ),
+```
+
+- [ ] **Step 5 : Vérifier le formatage/typecheck du package partagé**
+
+Run : `pnpm -F @pilote/kpilote-shared exec tsc --noEmit && pnpm -F @pilote/kpilote-shared format:check`
+Expected : PASS.
+
+- [ ] **Step 6 : Commit**
+
+```bash
+git add packages/kpilote-shared/src/indicateur.ts
+git commit -m "feat(shared): schémas délai de mise à disposition + dates dérivées indicateur"
+```
+
+---
+
+### Task 3 : mb-api — helper pur de calcul des dates (TDD)
+
+**Files:**
+- Create: `apps/kpilote-api/src/indicateur/datesMiseADisposition.ts`
+- Test: `apps/kpilote-api/src/indicateur/datesMiseADisposition.test.ts`
+
+**Interfaces:**
+- Consumes: `PeriodeMiseAJour`, `DelaiMiseADisposition` de `@pilote/kpilote-shared/indicateur`.
+- Produces: `computeDatesMiseADisposition({ dateDerniereValeur, periodeMiseAJour, delai })` → `{ dateDerniereValeur: string | null; dateProchaineValeur: string | null; dateMiseADisposition: string | null }`.
+
+- [ ] **Step 1 : Écrire les tests (qui échouent)**
+
+Créer `apps/kpilote-api/src/indicateur/datesMiseADisposition.test.ts` :
+
+```ts
+import { describe, expect, it } from 'vitest'
+
+import { computeDatesMiseADisposition } from '@/indicateur/datesMiseADisposition'
+
+describe('computeDatesMiseADisposition', () => {
+  it('scénario données fiscales : annuelle + délai semestre', () => {
+    expect(
+      computeDatesMiseADisposition({
+        dateDerniereValeur: '2023-12-01',
+        periodeMiseAJour: 'ANNUELLE',
+        delai: { nombre: 6, unite: 'MOIS' },
+      }),
+    ).toEqual({
+      dateDerniereValeur: '2023-12-01',
+      dateProchaineValeur: '2024-12-01',
+      dateMiseADisposition: '2025-06-01',
+    })
+  })
+
+  it('délai annuel : mise à dispo un an après la prochaine valeur', () => {
+    expect(
+      computeDatesMiseADisposition({
+        dateDerniereValeur: '2023-12-01',
+        periodeMiseAJour: 'ANNUELLE',
+        delai: { nombre: 1, unite: 'ANNEES' },
+      }).dateMiseADisposition,
+    ).toBe('2025-12-01')
+  })
+
+  it('mappe chaque période vers le bon intervalle', () => {
+    const base = { dateDerniereValeur: '2024-01-15', delai: null }
+    const prochaine = (periodeMiseAJour: Parameters<typeof computeDatesMiseADisposition>[0]['periodeMiseAJour']) =>
+      computeDatesMiseADisposition({ ...base, periodeMiseAJour }).dateProchaineValeur
+    expect(prochaine('QUOTIDIENNE')).toBe('2024-01-16')
+    expect(prochaine('HEBDOMADAIRE')).toBe('2024-01-22')
+    expect(prochaine('BIMENSUELLE')).toBe('2024-01-30')
+    expect(prochaine('MENSUELLE')).toBe('2024-02-15')
+    expect(prochaine('TRIMESTRIELLE')).toBe('2024-04-15')
+    expect(prochaine('SEMESTRIELLE')).toBe('2024-07-15')
+    expect(prochaine('ANNUELLE')).toBe('2025-01-15')
+  })
+
+  it('clampe le jour en cas de débordement de mois (31 janv. + 1 mois)', () => {
+    expect(
+      computeDatesMiseADisposition({
+        dateDerniereValeur: '2024-01-31',
+        periodeMiseAJour: 'MENSUELLE',
+        delai: null,
+      }).dateProchaineValeur,
+    ).toBe('2024-02-29') // 2024 bissextile
+  })
+
+  it('délai en jours et semaines', () => {
+    const commun = { dateDerniereValeur: '2024-01-15', periodeMiseAJour: 'AUCUNE' as const }
+    // AUCUNE → pas de prochaine valeur, donc on teste le délai sur une prochaine calculée
+    expect(
+      computeDatesMiseADisposition({
+        dateDerniereValeur: '2024-01-15',
+        periodeMiseAJour: 'MENSUELLE',
+        delai: { nombre: 10, unite: 'JOURS' },
+      }).dateMiseADisposition,
+    ).toBe('2024-02-25')
+    expect(
+      computeDatesMiseADisposition({
+        dateDerniereValeur: '2024-01-15',
+        periodeMiseAJour: 'MENSUELLE',
+        delai: { nombre: 2, unite: 'SEMAINES' },
+      }).dateMiseADisposition,
+    ).toBe('2024-02-29')
+    void commun
+  })
+
+  it('propage les null : pas de valeur, période AUCUNE/null, délai absent', () => {
+    expect(
+      computeDatesMiseADisposition({ dateDerniereValeur: null, periodeMiseAJour: 'ANNUELLE', delai: { nombre: 6, unite: 'MOIS' } }),
+    ).toEqual({ dateDerniereValeur: null, dateProchaineValeur: null, dateMiseADisposition: null })
+
+    expect(
+      computeDatesMiseADisposition({ dateDerniereValeur: '2023-12-01', periodeMiseAJour: 'AUCUNE', delai: { nombre: 6, unite: 'MOIS' } }),
+    ).toEqual({ dateDerniereValeur: '2023-12-01', dateProchaineValeur: null, dateMiseADisposition: null })
+
+    expect(
+      computeDatesMiseADisposition({ dateDerniereValeur: '2023-12-01', periodeMiseAJour: null, delai: null }),
+    ).toEqual({ dateDerniereValeur: '2023-12-01', dateProchaineValeur: null, dateMiseADisposition: null })
+
+    expect(
+      computeDatesMiseADisposition({ dateDerniereValeur: '2023-12-01', periodeMiseAJour: 'ANNUELLE', delai: null }),
+    ).toEqual({ dateDerniereValeur: '2023-12-01', dateProchaineValeur: '2024-12-01', dateMiseADisposition: null })
+  })
+})
+```
+
+- [ ] **Step 2 : Lancer le test → échec**
+
+Run : `pnpm -F @pilote/kpilote-api exec vitest run src/indicateur/datesMiseADisposition.test.ts`
+Expected : FAIL (`computeDatesMiseADisposition` introuvable).
+
+- [ ] **Step 3 : Implémenter le helper**
+
+Créer `apps/kpilote-api/src/indicateur/datesMiseADisposition.ts` :
+
+```ts
+import { Temporal } from '@js-temporal/polyfill'
+
+import {
+  type DelaiMiseADisposition,
+  type PeriodeMiseAJour,
+  type UniteDuree,
+} from '@pilote/kpilote-shared/indicateur'
+
+export type DatesMiseADisposition = {
+  dateDerniereValeur: string | null
+  dateProchaineValeur: string | null
+  dateMiseADisposition: string | null
+}
+
+// Intervalle à ajouter à la dernière valeur connue pour obtenir la prochaine
+// occurrence théorique. `BIMENSUELLE` (2×/mois) est approximée à 15 jours ;
+// `AUCUNE` n'a pas d'occurrence suivante.
+const DUREE_PAR_PERIODE: Record<PeriodeMiseAJour, Temporal.DurationLike | null> = {
+  QUOTIDIENNE: { days: 1 },
+  HEBDOMADAIRE: { days: 7 },
+  BIMENSUELLE: { days: 15 },
+  MENSUELLE: { months: 1 },
+  TRIMESTRIELLE: { months: 3 },
+  SEMESTRIELLE: { months: 6 },
+  ANNUELLE: { years: 1 },
+  AUCUNE: null,
+}
+
+const UNITE_DUREE_TO_TEMPORAL: Record<UniteDuree, 'days' | 'weeks' | 'months' | 'years'> = {
+  JOURS: 'days',
+  SEMAINES: 'weeks',
+  MOIS: 'months',
+  ANNEES: 'years',
+}
+
+// `Temporal.PlainDate.add` utilise overflow: 'constrain' par défaut : 31 janv.
+// + 1 mois → dernier jour de février (clamp), ce qui correspond au besoin.
+const ajouter = (date: string, duree: Temporal.DurationLike): string =>
+  Temporal.PlainDate.from(date).add(duree).toString()
+
+const computeProchaineValeur = (
+  dateDerniereValeur: string | null,
+  periodeMiseAJour: PeriodeMiseAJour | null,
+): string | null => {
+  if (dateDerniereValeur === null || periodeMiseAJour === null) return null
+  const duree = DUREE_PAR_PERIODE[periodeMiseAJour]
+  if (duree === null) return null
+  return ajouter(dateDerniereValeur, duree)
+}
+
+const computeMiseADisposition = (
+  dateProchaineValeur: string | null,
+  delai: DelaiMiseADisposition | null,
+): string | null => {
+  if (dateProchaineValeur === null || delai === null) return null
+  return ajouter(dateProchaineValeur, { [UNITE_DUREE_TO_TEMPORAL[delai.unite]]: delai.nombre })
+}
+
+export const computeDatesMiseADisposition = ({
+  dateDerniereValeur,
+  periodeMiseAJour,
+  delai,
+}: {
+  dateDerniereValeur: string | null
+  periodeMiseAJour: PeriodeMiseAJour | null
+  delai: DelaiMiseADisposition | null
+}): DatesMiseADisposition => {
+  const dateProchaineValeur = computeProchaineValeur(dateDerniereValeur, periodeMiseAJour)
+  return {
+    dateDerniereValeur,
+    dateProchaineValeur,
+    dateMiseADisposition: computeMiseADisposition(dateProchaineValeur, delai),
+  }
+}
+```
+
+- [ ] **Step 4 : Lancer le test → succès**
+
+Run : `pnpm -F @pilote/kpilote-api exec vitest run src/indicateur/datesMiseADisposition.test.ts`
+Expected : PASS.
+
+- [ ] **Step 5 : Commit**
+
+```bash
+git add apps/kpilote-api/src/indicateur/datesMiseADisposition.ts apps/kpilote-api/src/indicateur/datesMiseADisposition.test.ts
+git commit -m "feat(indicateur): helper pur de calcul des dates de mise à disposition"
+```
+
+---
+
+### Task 4 : mb-api — mapper + queries (dernière valeur + dates dérivées)
+
+**Files:**
+- Modify: `apps/kpilote-api/src/indicateur/utils.ts`
+- Modify: `apps/kpilote-api/src/indicateur/queries/getIndicateurByPublicId.ts`
+- Modify: `apps/kpilote-api/src/indicateur/queries/listIndicateurs.ts`
+- Test: `apps/kpilote-api/src/indicateur/queries/getIndicateurByPublicId.test.ts`
+
+**Interfaces:**
+- Consumes: `computeDatesMiseADisposition` (Task 3) ; `UniteDuree`, `DelaiMiseADisposition` (Task 2).
+- Produces: `toIndicateurApiModel({ indicateur, dateDerniereValeur })` (params objet) → `IndicateurApiModel` complet (délai + 3 dates).
+
+- [ ] **Step 1 : Écrire le test d'intégration (scénario fiscal) — échec attendu**
+
+Dans `getIndicateurByPublicId.test.ts`, ajouter ce cas à l'intérieur du `describe` existant (imports `fixtures`, `runAsPrincipal`, `testIndicateurId` déjà présents) :
+
+```ts
+  it(
+    'calcule les dates dérivées (dernière valeur, prochaine valeur, mise à disposition)',
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      await fixtures.valeurAvancement(
+        {
+          indicateur: {
+            publicId: indId,
+            periodeMiseAJour: 'ANNUELLE',
+            delaiMiseADispositionNombre: 6,
+            delaiMiseADispositionUnite: 'MOIS',
+          },
+          individu: {},
+          date: '2022-12-01',
+          valeur: 5,
+        },
+        {
+          indicateur: { publicId: indId },
+          individu: {},
+          date: '2023-12-01',
+          valeur: 10,
+        },
+      )
+      const apiKey = await fixtures.apiKey({
+        permissions: [{ indicateur: { publicId: indId }, action: 'READ' }],
+      })
+
+      const result = await runAsPrincipal(apiKey.id, () => getIndicateurByPublicId(indId))
+      const indicateur = result._unsafeUnwrap()
+
+      expect(indicateur.delaiMiseADisposition).toEqual({ nombre: 6, unite: 'MOIS' })
+      expect(indicateur.dateDerniereValeur).toBe('2023-12-01')
+      expect(indicateur.dateProchaineValeur).toBe('2024-12-01')
+      expect(indicateur.dateMiseADisposition).toBe('2025-06-01')
+    }),
+  )
+```
+
+- [ ] **Step 2 : Mettre à jour les assertions `toEqual` existantes (nouveaux champs `null`)**
+
+Dans les deux `expect(...).toEqual({ ... })` full-object existants de ce fichier (le cas « référentiels triés » et tout autre asserttant l'objet complet), ajouter juste avant `createdAt:` :
+
+```ts
+        delaiMiseADisposition: null,
+        dateDerniereValeur: null,
+        dateProchaineValeur: null,
+        dateMiseADisposition: null,
+```
+
+- [ ] **Step 3 : Lancer → échec (mapper pas encore mis à jour)**
+
+Run : `pnpm -F @pilote/kpilote-api exec vitest run src/indicateur/queries/getIndicateurByPublicId.test.ts`
+Expected : FAIL (champs dérivés absents / `undefined`).
+
+- [ ] **Step 4 : Mettre à jour le mapper `utils.ts`**
+
+Dans `apps/kpilote-api/src/indicateur/utils.ts` :
+
+1. Étendre les imports :
+
+```ts
+import {
+  type DelaiMiseADisposition,
+  type IndicateurApiModel,
+  type UniteDuree,
+  type UniteIndicateurApiModel,
+  type UniteIndicateurCode,
+  UNITES_INDICATEUR_CONFIG,
+} from '@pilote/kpilote-shared/indicateur'
+
+import { computeDatesMiseADisposition } from '@/indicateur/datesMiseADisposition'
+```
+
+2. Ajouter le pont délai (deux colonnes → objet), avant `toIndicateurApiModel` :
+
+```ts
+// Recompose le délai stocké en deux colonnes (nombre + unité) en objet, ou
+// `null` si l'un des deux manque (invariant les-deux-ou-aucun garanti à l'écriture).
+const toDelaiMiseADisposition = (indicateur: {
+  delaiMiseADispositionNombre: number | null
+  delaiMiseADispositionUnite: UniteDuree | null
+}): DelaiMiseADisposition | null =>
+  indicateur.delaiMiseADispositionNombre !== null && indicateur.delaiMiseADispositionUnite !== null
+    ? { nombre: indicateur.delaiMiseADispositionNombre, unite: indicateur.delaiMiseADispositionUnite }
+    : null
+```
+
+3. Remplacer la signature et le corps de `toIndicateurApiModel` (params objet + délai + dates) :
+
+```ts
+export const toIndicateurApiModel = ({
+  indicateur,
+  dateDerniereValeur,
+}: {
+  indicateur: IndicateurWithReferentiels
+  dateDerniereValeur: string | null
+}): IndicateurApiModel => {
+  const delaiMiseADisposition = toDelaiMiseADisposition(indicateur)
+  const dates = computeDatesMiseADisposition({
+    dateDerniereValeur,
+    periodeMiseAJour: indicateur.periodeMiseAJour,
+    delai: delaiMiseADisposition,
+  })
+  return {
+    id: indicateur.publicId,
+    nom: indicateur.nom,
+    visibilite: indicateur.visibilite,
+    unite: toUniteIndicateurApiModel(indicateur.unite),
+    description: indicateur.description,
+    methodeCalcul: indicateur.methodeCalcul,
+    sourceDonnees: indicateur.sourceDonnees,
+    sourceUrl: indicateur.sourceUrl,
+    periodeMiseAJour: indicateur.periodeMiseAJour,
+    jourMiseAJour: indicateur.jourMiseAJour,
+    delaiMiseADisposition,
+    referentiels: indicateur.referentiels
+      .map((configuration) => ({
+        id: configuration.referentiel.publicId,
+        nom: configuration.referentiel.nom,
+        fonctionAgregation: configuration.fonctionAgregation,
+      }))
+      .sort((a, b) => a.id.localeCompare(b.id)),
+    responsables: indicateur.responsables.map(({ utilisateur }) => ({
+      email: utilisateur.email,
+      nom: utilisateur.nom,
+      prenom: utilisateur.prenom,
+      service: utilisateur.service,
+      fonction: utilisateur.fonction,
+    })),
+    dateDerniereValeur: dates.dateDerniereValeur,
+    dateProchaineValeur: dates.dateProchaineValeur,
+    dateMiseADisposition: dates.dateMiseADisposition,
+    createdAt: indicateur.createdAt.toISOString(),
+    updatedAt: indicateur.updatedAt.toISOString(),
+  }
+}
+```
+
+> `IndicateurWithReferentiels = IndicateurModel & {...}` inclut déjà `delaiMiseADisposition*` via `IndicateurModel` (Task 1). Le type Prisma de `delaiMiseADispositionUnite` (`$Enums.UniteDuree`) et le `UniteDuree` partagé sont des unions de chaînes identiques ; l'affectation compile directement.
+
+- [ ] **Step 5 : Mettre à jour la query détail (MAX date)**
+
+Remplacer le corps de `getIndicateurByPublicId.ts` par une lecture en deux temps (indicateur puis MAX date), sans transaction :
+
+```ts
+import { type IndicateurApiModel } from '@pilote/kpilote-shared/indicateur'
+import { ResultAsync } from 'neverthrow'
+
+import { isAdminPrincipal, requireCurrentPrincipalId } from '@/framework/auth/userContext'
+import { db } from '@/framework/persistence/dbStore'
+import { type Prisma } from '@/generated/prisma/client'
+import { withIndicateurReadPermission } from '@/indicateur/permissions'
+import { toIndicateurApiModel } from '@/indicateur/utils'
+
+const loadIndicateur = async (
+  where: Prisma.IndicateurWhereInput,
+): Promise<IndicateurApiModel> => {
+  const indicateur = await db().indicateur.findFirstOrThrow({
+    where,
+    include: {
+      referentiels: { include: { referentiel: true } },
+      responsables: { orderBy: { createdAt: 'asc' }, include: { utilisateur: true } },
+    },
+  })
+  // La date est stockée en `YYYY-MM-DD` : le MAX lexicographique = MAX chronologique.
+  const { _max } = await db().valeurAvancement.aggregate({
+    where: { indicateurId: indicateur.id },
+    _max: { date: true },
+  })
+  return toIndicateurApiModel({ indicateur, dateDerniereValeur: _max.date })
+}
+
+export const getIndicateurByPublicId = (
+  publicId: string,
+): ResultAsync<IndicateurApiModel, never> => {
+  const principalId = requireCurrentPrincipalId()
+  const where = withIndicateurReadPermission({ publicId }, principalId, {
+    isAdmin: isAdminPrincipal(),
+  })
+  return ResultAsync.fromSafePromise(loadIndicateur(where))
+}
+```
+
+- [ ] **Step 6 : Mettre à jour la query liste (MAX date par page via `groupBy`)**
+
+Dans `listIndicateurs.ts`, remplacer le bloc final `ResultAsync.fromSafePromise(Promise.all([...])).map(...)` par une fonction async qui calcule les MAX de la page :
+
+```ts
+  const loadPage = async (): Promise<IndicateurListApiModel> => {
+    const [rows, total] = await Promise.all([fetchPage, fetchTotal])
+    const maxDates = await db().valeurAvancement.groupBy({
+      by: ['indicateurId'],
+      where: { indicateurId: { in: rows.map((row) => row.id) } },
+      _max: { date: true },
+    })
+    const dateParIndicateur = new Map(maxDates.map((m) => [m.indicateurId, m._max.date]))
+    return toPaginatedResponse(
+      rows,
+      total,
+      (row) =>
+        toIndicateurApiModel({ indicateur: row, dateDerniereValeur: dateParIndicateur.get(row.id) ?? null }),
+      params.pageSize,
+    )
+  }
+
+  return ResultAsync.fromSafePromise(loadPage())
+```
+
+(Supprimer l'ancien `return ResultAsync.fromSafePromise(Promise.all([fetchPage, fetchTotal])).map(...)`.)
+
+- [ ] **Step 7 : Lancer le fichier de test détail → succès**
+
+Run : `pnpm -F @pilote/kpilote-api exec vitest run src/indicateur/queries/getIndicateurByPublicId.test.ts`
+Expected : PASS.
+
+- [ ] **Step 8 : Lancer toute la suite API + le typecheck**
+
+Run : `pnpm -F @pilote/kpilote-api test && pnpm -F @pilote/kpilote-api exec tsc --noEmit`
+Expected : PASS. (Si un test de `listIndicateurs` assertait la forme complète, ajouter les 4 champs `null` comme au Step 2.)
+
+- [ ] **Step 9 : Commit**
+
+```bash
+git add apps/kpilote-api/src/indicateur/utils.ts apps/kpilote-api/src/indicateur/queries/getIndicateurByPublicId.ts apps/kpilote-api/src/indicateur/queries/listIndicateurs.ts apps/kpilote-api/src/indicateur/queries/getIndicateurByPublicId.test.ts
+git commit -m "feat(indicateur): expose délai + dates dérivées dans l'API (détail & liste)"
+```
+
+---
+
+### Task 5 : mb-api — écriture du délai (upsert)
+
+**Files:**
+- Modify: `apps/kpilote-api/src/indicateur/commands/upsertIndicateur.ts`
+- Test: `apps/kpilote-api/src/indicateur/commands/upsertIndicateur.test.ts`
+
+**Interfaces:**
+- Consumes: `UpsertIndicateurBody.delaiMiseADisposition?: DelaiMiseADisposition | null` (Task 2, via `.partial()`).
+- Produces: persistance des colonnes `delaiMiseADisposition{Nombre,Unite}` (sémantique PATCH-like : absent = ne pas toucher, `null` = effacer les deux colonnes).
+
+- [ ] **Step 1 : Écrire les tests (échec attendu)**
+
+Ajouter au `describe` de `upsertIndicateur.test.ts`. Le fichier importe déjà `runAsAdmin` de `@/test/runAsPrincipal`, `METADONNEES_VIDES`, `db`, `fixtures`, `testIndicateurId`, `integrationTest`. Comme les métadonnées sont `.partial()` à l'upsert, le délai est optionnel ; on l'ajoute explicitement dans le body. Création **et** update via le même `runAsAdmin` (l'admin obtient les grants owner READ+WRITE à la création, ce qui couvre l'update) :
+
+```ts
+  it(
+    'persiste le délai de mise à disposition à la création',
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const apiKey = await fixtures.apiKey()
+      await runAsAdmin(apiKey.id, () =>
+        upsertIndicateur(indId, {
+          nom: 'Données fiscales',
+          visibilite: 'PRIVE',
+          unite: null,
+          ...METADONNEES_VIDES,
+          delaiMiseADisposition: { nombre: 6, unite: 'MOIS' },
+          referentiels: [],
+        }),
+      )
+      const row = await db().indicateur.findUniqueOrThrow({ where: { publicId: indId } })
+      expect(row.delaiMiseADispositionNombre).toBe(6)
+      expect(row.delaiMiseADispositionUnite).toBe('MOIS')
+    }),
+  )
+
+  it(
+    'efface le délai quand on envoie null',
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const apiKey = await fixtures.apiKey()
+      const body = {
+        nom: 'Données fiscales',
+        visibilite: 'PRIVE' as const,
+        unite: null,
+        ...METADONNEES_VIDES,
+        referentiels: [],
+      }
+      await runAsAdmin(apiKey.id, () =>
+        upsertIndicateur(indId, { ...body, delaiMiseADisposition: { nombre: 6, unite: 'MOIS' } }),
+      )
+      await runAsAdmin(apiKey.id, () =>
+        upsertIndicateur(indId, { ...body, delaiMiseADisposition: null }),
+      )
+      const row = await db().indicateur.findUniqueOrThrow({ where: { publicId: indId } })
+      expect(row.delaiMiseADispositionNombre).toBeNull()
+      expect(row.delaiMiseADispositionUnite).toBeNull()
+    }),
+  )
+```
+
+- [ ] **Step 2 : Lancer → échec**
+
+Run : `pnpm -F @pilote/kpilote-api exec vitest run src/indicateur/commands/upsertIndicateur.test.ts`
+Expected : FAIL (colonnes toujours `null` après création).
+
+- [ ] **Step 3 : Décomposer le délai dans `metadonneesData`**
+
+Dans `upsertIndicateur.ts`, à la fin de l'objet retourné par `const metadonneesData = (body) => ({ ... })`, ajouter :
+
+```ts
+    ...(body.delaiMiseADisposition !== undefined && {
+      delaiMiseADispositionNombre: body.delaiMiseADisposition?.nombre ?? null,
+      delaiMiseADispositionUnite: body.delaiMiseADisposition?.unite ?? null,
+    }),
+```
+
+(Aucun autre changement : `metadonneesData(body)` est déjà spread dans le `data` de `create` et d'`update`.)
+
+- [ ] **Step 4 : Lancer → succès**
+
+Run : `pnpm -F @pilote/kpilote-api exec vitest run src/indicateur/commands/upsertIndicateur.test.ts`
+Expected : PASS.
+
+- [ ] **Step 5 : Commit**
+
+```bash
+git add apps/kpilote-api/src/indicateur/commands/upsertIndicateur.ts apps/kpilote-api/src/indicateur/commands/upsertIndicateur.test.ts
+git commit -m "feat(indicateur): écriture du délai de mise à disposition (upsert)"
+```
+
+---
+
+### Task 6 : kpilote-admin — champ délai dans le formulaire
+
+**Files:**
+- Modify: `apps/kpilote-admin/src/components/indicateurs/indicateurFormSchema.ts`
+- Modify: `apps/kpilote-admin/src/components/indicateurs/IndicateurForm.tsx`
+
+**Interfaces:**
+- Consumes: `uniteDureeSchema`, `UNITES_DUREE`, `UNITE_DUREE_LABELS`, `DelaiMiseADisposition` (Task 2).
+- Produces: `IndicateurFormValues` gagne `delaiNombre: string` + `delaiUnite: '' | UniteDuree` ; `toUpsertBody` produit `delaiMiseADisposition`.
+
+- [ ] **Step 1 : Étendre le schéma de formulaire**
+
+Dans `indicateurFormSchema.ts` :
+
+1. Import :
+
+```ts
+import {
+  configurationIndicateurReferentielSchema,
+  indicateurSourceUrlSchema,
+  indicateurVisibiliteSchema,
+  periodeMiseAJourSchema,
+  uniteDureeSchema,
+  uniteIndicateurCodeSchema,
+} from '@pilote/kpilote-shared/indicateur'
+```
+
+2. Dans `buildIndicateurFormSchema`, après `jourMiseAJour: ...` :
+
+```ts
+    delaiNombre: z
+      .string()
+      .refine(
+        (value) => value === '' || (/^\d+$/.test(value) && Number(value) >= 1),
+        'Entier ≥ 1',
+      ),
+    delaiUnite: z.union([z.literal(''), uniteDureeSchema]),
+```
+
+3. Dans `buildInitialValues`, après `jourMiseAJour: ...` :
+
+```ts
+    delaiNombre:
+      indicateur?.delaiMiseADisposition != null
+        ? String(indicateur.delaiMiseADisposition.nombre)
+        : '',
+    delaiUnite: indicateur?.delaiMiseADisposition?.unite ?? '',
+```
+
+4. Dans `toUpsertBody`, après `jourMiseAJour: ...` :
+
+```ts
+    delaiMiseADisposition:
+      values.delaiUnite === '' || values.delaiNombre === ''
+        ? null
+        : { nombre: Number(values.delaiNombre), unite: values.delaiUnite },
+```
+
+- [ ] **Step 2 : Ajouter les champs UI**
+
+Dans `IndicateurForm.tsx` :
+
+1. Import :
+
+```ts
+import {
+  PERIODE_MISE_A_JOUR_LABELS,
+  PERIODES_MISE_A_JOUR,
+  UNITE_DUREE_LABELS,
+  UNITES_DUREE,
+  UNITES_INDICATEUR,
+  UNITES_INDICATEUR_CONFIG,
+} from '@pilote/kpilote-shared/indicateur'
+```
+
+2. Après le bloc `<div className="flex gap-4">…</div>` qui contient « Période de mise à jour » + « Jour de mise à jour » (toujours dans la section « Métadonnées »), ajouter :
+
+```tsx
+          <div className="mt-5 flex gap-4">
+            <div className="flex-1">
+              <FieldInput
+                label="Délai de mise à disposition"
+                type="number"
+                min={1}
+                placeholder="ex. 6"
+                error={form.formState.errors.delaiNombre?.message}
+                {...form.register('delaiNombre')}
+              />
+            </div>
+            <div className="flex-1">
+              <FieldSelect label="Unité du délai" {...form.register('delaiUnite')}>
+                <option value="">Aucune</option>
+                {UNITES_DUREE.map((unite) => (
+                  <option key={unite} value={unite}>
+                    {UNITE_DUREE_LABELS[unite]}
+                  </option>
+                ))}
+              </FieldSelect>
+            </div>
+          </div>
+```
+
+- [ ] **Step 3 : Typecheck admin**
+
+Run : `pnpm -F @pilote/kpilote-admin exec tsc --noEmit`
+Expected : PASS.
+
+- [ ] **Step 4 : Commit**
+
+```bash
+git add apps/kpilote-admin/src/components/indicateurs/indicateurFormSchema.ts apps/kpilote-admin/src/components/indicateurs/IndicateurForm.tsx
+git commit -m "feat(admin): édition du délai de mise à disposition d'un indicateur"
+```
+
+---
+
+### Task 7 : kpilote-webapp — affichage des dates dérivées + délai
+
+**Files:**
+- Modify: `apps/kpilote-webapp/src/lib/format.ts`
+- Test: `apps/kpilote-webapp/src/lib/format.test.ts`
+- Modify: `apps/kpilote-webapp/src/components/indicateurs/IndicateurMetadonnees.tsx`
+
+**Interfaces:**
+- Consumes: `DelaiMiseADisposition`, `UNITE_DUREE_LABELS` (Task 2) ; champs `delaiMiseADisposition`, `dateProchaineValeur`, `dateMiseADisposition` de l'`IndicateurApiModel`.
+- Produces: `formatMoisAnneeLongFr(value: string): string` (« décembre 2024 »).
+
+- [ ] **Step 1 : Écrire le test du formateur (échec attendu)**
+
+Dans `apps/kpilote-webapp/src/lib/format.test.ts` (créer le fichier s'il n'existe pas), ajouter :
+
+```ts
+import { describe, expect, it } from 'vitest'
+
+import { formatMoisAnneeLongFr } from '@/lib/format'
+
+describe('formatMoisAnneeLongFr', () => {
+  it('formate une date ISO en mois-année long fr-FR', () => {
+    expect(formatMoisAnneeLongFr('2024-12-01')).toBe('décembre 2024')
+    expect(formatMoisAnneeLongFr('2025-06-15')).toBe('juin 2025')
+  })
+})
+```
+
+- [ ] **Step 2 : Lancer → échec**
+
+Run : `pnpm -F @pilote/kpilote-webapp exec vitest run src/lib/format.test.ts`
+Expected : FAIL (`formatMoisAnneeLongFr` introuvable).
+
+- [ ] **Step 3 : Ajouter le formateur**
+
+Dans `apps/kpilote-webapp/src/lib/format.ts`, après `formatMonthYearShortFr` :
+
+```ts
+const moisAnneeLongOptions = { month: 'long', year: 'numeric' } as const
+
+// "décembre 2024" — entrée ISO YYYY-MM-DD (dates dérivées de l'indicateur).
+export const formatMoisAnneeLongFr = (value: string): string =>
+  Temporal.PlainDate.from(value).toLocaleString('fr-FR', moisAnneeLongOptions)
+```
+
+- [ ] **Step 4 : Lancer → succès**
+
+Run : `pnpm -F @pilote/kpilote-webapp exec vitest run src/lib/format.test.ts`
+Expected : PASS.
+
+- [ ] **Step 5 : Ajouter les lignes dans `IndicateurMetadonnees.tsx`**
+
+1. Imports :
+
+```ts
+import {
+  PERIODE_MISE_A_JOUR_LABELS,
+  UNITE_DUREE_LABELS,
+  type ConfigurationIndicateurReferentielApiModel,
+  type DelaiMiseADisposition,
+  type PeriodeMiseAJour,
+  type UniteIndicateurApiModel,
+} from '@pilote/kpilote-shared/indicateur'
+```
+
+et ajouter `formatMoisAnneeLongFr` à l'import existant depuis `@/lib/format`.
+
+2. Helper de formatage du délai, après `formatReferentiels` :
+
+```ts
+const formatDelai = (delai: DelaiMiseADisposition | null): string =>
+  delai ? `${delai.nombre} ${UNITE_DUREE_LABELS[delai.unite]}` : VALEUR_VIDE
+
+const formatDateMoisAnnee = (date: string | null): string =>
+  date ? formatMoisAnneeLongFr(date) : VALEUR_VIDE
+```
+
+3. Étendre le type `IndicateurMetadonneesProps.indicateur`, après `jourMiseAJour: number | null` :
+
+```ts
+    delaiMiseADisposition: DelaiMiseADisposition | null
+    dateProchaineValeur: string | null
+    dateMiseADisposition: string | null
+```
+
+4. Dans la `DescriptionList`, après l'item « Période de mise à jour » :
+
+```tsx
+        <DescriptionList.Item label="Délai de mise à disposition">
+          {formatDelai(indicateur.delaiMiseADisposition)}
+        </DescriptionList.Item>
+        <DescriptionList.Item label="Date de la prochaine valeur">
+          {formatDateMoisAnnee(indicateur.dateProchaineValeur)}
+        </DescriptionList.Item>
+        <DescriptionList.Item label="Date de mise à disposition">
+          {formatDateMoisAnnee(indicateur.dateMiseADisposition)}
+        </DescriptionList.Item>
+```
+
+- [ ] **Step 6 : Typecheck + suite webapp**
+
+Run : `pnpm -F @pilote/kpilote-webapp exec tsc --noEmit && pnpm -F @pilote/kpilote-webapp test`
+Expected : PASS.
+
+- [ ] **Step 7 : Commit**
+
+```bash
+git add apps/kpilote-webapp/src/lib/format.ts apps/kpilote-webapp/src/lib/format.test.ts apps/kpilote-webapp/src/components/indicateurs/IndicateurMetadonnees.tsx
+git commit -m "feat(webapp): affiche délai + dates de mise à disposition sur la fiche indicateur"
+```
+
+---
+
+## Notes de vérification finale
+
+- Lancer une dernière fois `pnpm -F @pilote/kpilote-api test` et les typechecks des 3 fronts.
+- Vérifier manuellement (webapp) une fiche indicateur : délai en clair, prochaine valeur et mise à disposition en mois-année ; `—` si pas de valeur / période `AUCUNE` / délai absent.
+- Le seed (`prisma db seed`) n'est pas modifié : les indicateurs existants auront un délai `null` (dates dérivées de mise à dispo `null`), ce qui est le comportement attendu.
+</content>

--- a/docs/superpowers/plans/2026-07-08-delai-mise-a-disposition-indicateur.md
+++ b/docs/superpowers/plans/2026-07-08-delai-mise-a-disposition-indicateur.md
@@ -14,8 +14,8 @@
 
 - **Exports/imports nommés uniquement** — jamais de `default`.
 - **Params de helpers sous forme d'objet nommé**, pas de positionnels.
-- **Use cases mb-api en `ResultAsync`** (neverthrow) ; wrap des promesses via `ResultAsync.fromSafePromise`.
-- **Tests mb-api** : `integrationTest`, `uuidv7` (jamais `randomUUID`), valeurs hardcodées (isolation transactionnelle), fixtures `fixtures.<entity>(...)` variadic.
+- **Use cases kpilote-api en `ResultAsync`** (neverthrow) ; wrap des promesses via `ResultAsync.fromSafePromise`.
+- **Tests kpilote-api** : `integrationTest`, `uuidv7` (jamais `randomUUID`), valeurs hardcodées (isolation transactionnelle), fixtures `fixtures.<entity>(...)` variadic.
 - **Prisma** : pas de `$transaction` nesté (awaits séquentiels) ; pas de `select` granulaires.
 - **Copie FR** correcte et accentuée.
 - Le délai est un couple **les-deux-ou-aucun** : `nombre` (int ≥ 1) + `unité` renseignés ensemble, sinon `null`.
@@ -199,7 +199,7 @@ git commit -m "feat(shared): schémas délai de mise à disposition + dates dér
 
 ---
 
-### Task 3 : mb-api — helper pur de calcul des dates (TDD)
+### Task 3 : kpilote-api — helper pur de calcul des dates
 
 **Files:**
 - Create: `apps/kpilote-api/src/indicateur/datesMiseADisposition.ts`
@@ -209,7 +209,7 @@ git commit -m "feat(shared): schémas délai de mise à disposition + dates dér
 - Consumes: `PeriodeMiseAJour`, `DelaiMiseADisposition` de `@pilote/kpilote-shared/indicateur`.
 - Produces: `computeDatesMiseADisposition({ dateDerniereValeur, periodeMiseAJour, delai })` → `{ dateDerniereValeur: string | null; dateProchaineValeur: string | null; dateMiseADisposition: string | null }`.
 
-- [ ] **Step 1 : Écrire les tests (qui échouent)**
+- [ ] **Step 1 : Écrire les tests**
 
 Créer `apps/kpilote-api/src/indicateur/datesMiseADisposition.test.ts` :
 
@@ -406,7 +406,7 @@ git commit -m "feat(indicateur): helper pur de calcul des dates de mise à dispo
 
 ---
 
-### Task 4 : mb-api — mapper + queries (dernière valeur + dates dérivées)
+### Task 4 : kpilote-api — mapper + queries (dernière valeur + dates dérivées)
 
 **Files:**
 - Modify: `apps/kpilote-api/src/indicateur/utils.ts`
@@ -652,7 +652,7 @@ git commit -m "feat(indicateur): expose délai + dates dérivées dans l'API (d�
 
 ---
 
-### Task 5 : mb-api — écriture du délai (upsert)
+### Task 5 : kpilote-api — écriture du délai (upsert)
 
 **Files:**
 - Modify: `apps/kpilote-api/src/indicateur/commands/upsertIndicateur.ts`

--- a/docs/superpowers/specs/2026-07-08-delai-mise-a-disposition-indicateur-design.md
+++ b/docs/superpowers/specs/2026-07-08-delai-mise-a-disposition-indicateur-design.md
@@ -1,0 +1,165 @@
+# Délai de mise à disposition d'un indicateur — design
+
+**Date :** 2026-07-08
+**Statut :** validé, prêt pour plan d'implémentation
+
+## Contexte
+
+Un indicateur porte une **période de mise à jour** (`periodeMiseAJour` : enum
+`QUOTIDIENNE`…`ANNUELLE` + `AUCUNE`, avec un `jourMiseAJour` 1–31 optionnel).
+Aujourd'hui ces deux champs sont **purement informatifs** : ils sont affichés
+dans l'onglet Métadonnées mais n'entrent dans aucun calcul.
+
+Le besoin métier : anticiper **quand la prochaine valeur sera réellement
+disponible**. Exemple « données fiscales » :
+
+- dernière valeur connue : décembre 2023 ;
+- période de mise à jour : annuelle → prochaine valeur théorique : décembre 2024 ;
+- mais les données 2024 ne sont exploitables qu'après un délai de traitement
+  (ex. un semestre) → **date de mise à disposition ≈ juin 2025**.
+
+Si ce délai était annuel, la mise à disposition tomberait en décembre 2025.
+
+On introduit donc une **nouvelle métadonnée « délai de mise à disposition »**
+et on affiche **deux dates dérivées** dans l'onglet Métadonnées :
+
+1. **Date de la prochaine valeur** = dernière valeur connue + période de mise à jour ;
+2. **Date de mise à disposition** = prochaine valeur + délai de mise à disposition.
+
+## Principes de conception
+
+- **L'API est la source de vérité pour les dates dérivées.** La « dernière
+  valeur connue » nécessite une lecture des `ValeurAvancement` (que seule l'API
+  fait) ; on centralise donc tout le calcul côté API et on expose les dates déjà
+  calculées. La webapp est du pur affichage. Cohérent avec le principe « API
+  agnostique de l'UI » : ces dates sont de la donnée dérivée du domaine, pas un
+  défaut d'affichage.
+- **Arithmétique de dates dans un helper pur, testé côté `mb-api`.** Une seule
+  fonction, sans I/O, couverte par une table de cas (débordements de mois,
+  année bissextile, chaque période, chaque unité de délai).
+- **Changement minimal sur l'existant.** `periodeMiseAJour` et `jourMiseAJour`
+  restent inchangés. On a explicitement décidé de **ne pas** toucher au modèle de
+  la période ni de supprimer `jourMiseAJour` (qui reste informatif, ignoré du
+  calcul). Les nouveaux champs sont nullable → aucune migration de données.
+
+## Décisions actées (brainstorming)
+
+| Sujet | Décision |
+|---|---|
+| Source de la « dernière valeur » | MAX des `ValeurAvancement.date` de l'indicateur, **tous individus confondus** |
+| Modèle du délai | Couple `{ nombre: int≥1, unité }`, unité ∈ `{ JOURS, SEMAINES, MOIS, ANNEES }` |
+| `periodeMiseAJour` / `jourMiseAJour` | Conservés tels quels ; `jourMiseAJour` reste informatif, non utilisé dans le calcul |
+| Affichage | Granularité **mois-année** (« décembre 2024 ») ; « — » si incalculable |
+| Lieu du calcul | **API** calcule et expose les dates dérivées |
+| `BIMENSUELLE` | Mappé à **+15 jours** (pragmatique ; concept peu pertinent pour cette cadence rapide) |
+
+## Modèle de données (Prisma)
+
+`model Indicateur` — deux nouveaux champs nullable :
+
+```prisma
+delaiMiseADispositionNombre  Int?         @map("delai_mad_nombre")
+delaiMiseADispositionUnite   UniteDuree?  @map("delai_mad_unite")
+```
+
+Nouvel enum :
+
+```prisma
+enum UniteDuree {
+  JOURS
+  SEMAINES
+  MOIS
+  ANNEES
+
+  @@map("unite_duree_enum")
+}
+```
+
+Règle applicative : les deux champs vont **ensemble** — soit les deux
+renseignés, soit les deux `null`. Un `nombre` sans `unité` (ou l'inverse) est
+rejeté à la validation. Pas de contrainte SQL dédiée : la cohérence est garantie
+par le schéma Zod du body et par le mapping form (chaîne vide → les deux `null`).
+
+## Schémas partagés (`kpilote-shared`)
+
+- `uniteDureeSchema` : `z.enum(['JOURS', 'SEMAINES', 'MOIS', 'ANNEES'])`, avec
+  un `UNITE_DUREE_LABELS` pour l'affichage (« jour(s) », « mois »…).
+- `delaiMiseADispositionSchema` : `{ nombre: z.int().min(1), unite: uniteDureeSchema }`
+  ou `null`.
+- **Écriture** : ajout du délai à `indicateurMetadonneesSchema` (éditable via le
+  body upsert, même sémantique PATCH-like que les autres métadonnées : clé
+  absente = ne pas toucher, `null` = effacer).
+- **Lecture** : ajout à `indicateurApiModelSchema` de **trois dates dérivées,
+  lecture seule, nullable** — chaînes ISO `YYYY-MM-DD` :
+  - `dateDerniereValeur`
+  - `dateProchaineValeur`
+  - `dateMiseADisposition`
+
+  L'API renvoie la date complète (le jour = celui de la dernière valeur, propagé
+  par l'arithmétique) ; la webapp la formate en mois-année à l'affichage.
+
+## Calcul (helper pur, `mb-api`)
+
+Table période → intervalle :
+
+| Période | Intervalle |
+|---|---|
+| `QUOTIDIENNE` | +1 jour |
+| `HEBDOMADAIRE` | +7 jours |
+| `BIMENSUELLE` | +15 jours |
+| `MENSUELLE` | +1 mois |
+| `TRIMESTRIELLE` | +3 mois |
+| `SEMESTRIELLE` | +6 mois |
+| `ANNUELLE` | +1 an |
+| `AUCUNE` / `null` | pas de calcul → `null` |
+
+Logique :
+
+- `dateDerniereValeur` = MAX des `ValeurAvancement.date` de l'indicateur
+  (tous individus). `null` si aucune valeur.
+- `dateProchaineValeur` = `dateDerniereValeur + intervalle(période)`. C'est la
+  **prochaine occurrence théorique après la dernière connue**, même si elle est
+  déjà dans le passé (pas de « rattrapage » vers aujourd'hui : dernière
+  déc. 2023 + annuelle = déc. 2024, point). `null` si `dateDerniereValeur` est
+  `null` ou si la période est `AUCUNE`/absente.
+- `dateMiseADisposition` = `dateProchaineValeur + délai`. `null` si
+  `dateProchaineValeur` est `null` **ou** si le délai est absent.
+
+Arithmétique calendaire : ajout mois/année avec **clamp du jour** au dernier
+jour du mois cible en cas de débordement (31 janv. + 1 mois → 28/29 févr.).
+Ajout jours/semaines : arithmétique calendaire simple.
+
+## Formulaire admin (`kpilote-admin`)
+
+Dans la section « Métadonnées » du `IndicateurForm`, un champ **délai de mise à
+disposition** : un **input nombre** (entier ≥ 1) + un **select unité**
+(JOURS/SEMAINES/MOIS/ANNEES). Vide = pas de délai (les deux champs repassent à
+`null` via `toUpsertBody`). Les trois dates dérivées ne sont **pas** éditables.
+
+## Affichage webapp (`IndicateurMetadonnees.tsx`)
+
+Nouvelles lignes dans la `DescriptionList` :
+
+- **« Délai de mise à disposition »** : le délai en clair (« 6 mois »), « — » si absent.
+- **« Date de la prochaine valeur »** : `dateProchaineValeur` en mois-année, « — » si `null`.
+- **« Date de mise à disposition »** : `dateMiseADisposition` en mois-année, « — » si `null`.
+
+Format mois-année (« décembre 2024 ») via un helper de formatage (dérivé de
+`formatDateTimeFr` existant, ou nouveau `formatMoisAnneeFr`).
+
+## Tests & cas limites
+
+- **Helper pur (unitaire)** : chaque période → bon intervalle ; débordements de
+  mois (31 → fin de mois court) ; année bissextile ; chaque unité de délai ;
+  chaînage prochaineValeur → miseADisposition ; propagation des `null`.
+- **Intégration (query détail)** : aucune valeur → dates `null` ;
+  période `AUCUNE`/`null` → prochaineValeur & miseADisposition `null` ; délai
+  absent → miseADisposition `null` ; cas nominal « données fiscales ».
+- **Upsert** : le délai `{nombre, unité}` est persisté ; `null` l'efface ;
+  `nombre` sans `unité` rejeté.
+
+## Hors périmètre
+
+- Pas de refonte de `periodeMiseAJour` / `jourMiseAJour`.
+- Pas de « rattrapage » de la prochaine valeur vers une occurrence future.
+- Pas d'écriture des valeurs ni de recalcul déclenché ailleurs qu'au GET détail.

--- a/packages/kpilote-shared/src/indicateur.ts
+++ b/packages/kpilote-shared/src/indicateur.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod'
 
+import { dateSchema } from './dates'
 import { createPaginatedApiListSchema, listQuerySchema } from './pagination'
 import { indicateurPublicIdSchema, referentielPublicIdSchema } from './publicIds'
 import { responsableApiModelSchema } from './responsable'
@@ -174,6 +175,30 @@ export const indicateurSourceUrlSchema = z
   .url({ protocol: /^https$/, error: 'URL https invalide' })
   .describe('URL de la source des données. Doit utiliser le protocole https.')
 
+export const UNITES_DUREE = ['JOURS', 'SEMAINES', 'MOIS', 'ANNEES'] as const
+export type UniteDuree = (typeof UNITES_DUREE)[number]
+
+// Libellés d'affichage des unités de durée, partagés admin (formulaire) et
+// webapp (fiche indicateur) pour éviter la divergence.
+export const UNITE_DUREE_LABELS: Record<UniteDuree, string> = {
+  JOURS: 'jour(s)',
+  SEMAINES: 'semaine(s)',
+  MOIS: 'mois',
+  ANNEES: 'an(s)',
+}
+
+export const uniteDureeSchema = z
+  .enum(UNITES_DUREE)
+  .describe("Unité de durée d'un délai (jours, semaines, mois, années).")
+
+export const delaiMiseADispositionSchema = z
+  .object({
+    nombre: z.int().min(1).describe("Nombre d'unités du délai (entier ≥ 1)."),
+    unite: uniteDureeSchema,
+  })
+  .describe("Délai entre la date théorique d'une valeur et sa mise à disposition effective.")
+export type DelaiMiseADisposition = z.infer<typeof delaiMiseADispositionSchema>
+
 export const indicateurMetadonneesSchema = z.object({
   description: z.string().nullable().describe("Description libre de l'indicateur."),
   methodeCalcul: z
@@ -186,6 +211,9 @@ export const indicateurMetadonneesSchema = z.object({
     .describe('URL de la source des données. Doit utiliser le protocole https.'),
   periodeMiseAJour: periodeMiseAJourSchema.nullable().describe('Période de mise à jour.'),
   jourMiseAJour: z.int().min(1).max(31).nullable().describe('Jour de mise à jour entre 1 et 31.'),
+  delaiMiseADisposition: delaiMiseADispositionSchema
+    .nullable()
+    .describe('Délai de mise à disposition, ou `null` si non renseigné.'),
 })
 export type IndicateurMetadonnees = z.infer<typeof indicateurMetadonneesSchema>
 
@@ -210,6 +238,19 @@ export const indicateurApiModelSchema = z.object({
     .describe(
       "Utilisateurs désignés responsables de l'indicateur, triés par ordre d'assignation (createdAt ASC).",
     ),
+  dateDerniereValeur: dateSchema
+    .nullable()
+    .describe(
+      'Date ISO YYYY-MM-DD de la dernière valeur connue (MAX, tous individus), ou `null` si aucune valeur.',
+    ),
+  dateProchaineValeur: dateSchema
+    .nullable()
+    .describe(
+      'Date ISO YYYY-MM-DD de la prochaine valeur théorique (dernière valeur + période), ou `null`.',
+    ),
+  dateMiseADisposition: dateSchema
+    .nullable()
+    .describe('Date ISO YYYY-MM-DD de mise à disposition (prochaine valeur + délai), ou `null`.'),
   createdAt: z.string().datetime().describe('Date ISO 8601 de création.'),
   updatedAt: z.string().datetime().describe('Date ISO 8601 de dernière mise à jour.'),
 })


### PR DESCRIPTION
## Contexte

Ajoute une métadonnée **délai de mise à disposition** aux indicateurs et affiche deux dates dérivées : la **prochaine valeur théorique** et la **date de mise à disposition** effective.

Exemple « données fiscales » : dernière valeur déc. 2023, période annuelle → prochaine valeur théorique déc. 2024 ; avec un délai de traitement d'un semestre → mise à disposition ≈ juin 2025.

Spec & plan : `docs/superpowers/specs/2026-07-08-delai-mise-a-disposition-indicateur-design.md`.

## Ce que fait la PR

- **Prisma** : enum `UniteDuree` (`JOURS/SEMAINES/MOIS/ANNEES`) + colonnes `delai_mad_nombre` / `delai_mad_unite` sur `indicateur` (nullable, invariant les-deux-ou-aucun). Migration incluse.
- **kpilote-shared** : schéma `delaiMiseADisposition` (éditable) + 3 dates dérivées lecture seule (`dateDerniereValeur`, `dateProchaineValeur`, `dateMiseADisposition`) sur `IndicateurApiModel`.
- **kpilote-api** :
  - helper pur `computeDatesMiseADisposition` (arithmétique `Temporal.PlainDate`, clamp fin de mois, `BIMENSUELLE` = +15 j, propagation des `null`) ;
  - dernière valeur = `MAX(ValeurAvancement.date)` — MAX lexicographique = chronologique car dates `YYYY-MM-DD` ;
  - **détail** : un `aggregate` ; **liste** : un seul `groupBy` par page → **pas de N+1** ;
  - écriture du délai à l'upsert (PATCH-like : absent = ne pas toucher, `null` = effacer).
- **kpilote-admin** : champ délai (input nombre + select unité) dans le formulaire indicateur.
- **kpilote-webapp** : lignes « Délai de mise à disposition », « Date de la prochaine valeur », « Date de mise à disposition » (mois-année, « — » si incalculable).
- **Seed** : délais réalistes sur IND-001 (chômage, +2 mois), IND-002 (CO2, +18 mois), IND-008 (satisfaction, +2 mois).

## Choix notables

- `periodeMiseAJour` / `jourMiseAJour` **inchangés** ; `jourMiseAJour` reste informatif (ignoré du calcul), sur décision produit.
- `BIMENSUELLE` mappé à +15 j (concept peu pertinent à cette cadence, mais une valeur est nécessaire).
- Dates dérivées calculées côté API (source de vérité unique), webapp = pur affichage.

## Tests

- Helper : table de cas (chaque période, débordement de mois, année bissextile, chaque unité, propagation `null`).
- Query détail : scénario « données fiscales » + cas vides.
- Upsert : persistance et effacement du délai.
- Suite complète kpilote-api : **480 tests verts** ; lint (eslint + tsc + prettier) vert sur api / admin / webapp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
