### PR TITLE
feat(indicateur): administration des responsables d'indicateur

### DIFF
--- a/apps/kpilote-admin/src/api/utilisateurs.ts
+++ b/apps/kpilote-admin/src/api/utilisateurs.ts
@@ -10,6 +10,7 @@ import {
 } from '@pilote/kpilote-shared/utilisateur'
 
 import { bffClient } from '@/api/client'
+import { fetchAllPages } from '@/lib/fetchAllPages'
 
 export const fetchUtilisateurs = async (
   params: { recherche?: string | undefined; cursor?: string | undefined } = {},
@@ -20,6 +21,9 @@ export const fetchUtilisateurs = async (
   const json = await bffClient.get('utilisateurs', { searchParams }).json()
   return utilisateurListApiModelSchema.parse(json)
 }
+
+export const fetchAllUtilisateurs = (): Promise<UtilisateurApiModel[]> =>
+  fetchAllPages((cursor) => fetchUtilisateurs({ cursor }))
 
 export const fetchUtilisateurById = async (id: string): Promise<UtilisateurApiModel> => {
   const json = await bffClient.get(`utilisateurs/${id}`).json()

--- a/apps/kpilote-admin/src/components/indicateurs/AdminReferentiels.tsx
+++ b/apps/kpilote-admin/src/components/indicateurs/AdminReferentiels.tsx
@@ -1,0 +1,111 @@
+import { useSuspenseQuery } from '@tanstack/react-query'
+import { Plus, Trash2 } from 'lucide-react'
+import { useFieldArray, type UseFormRegister } from 'react-hook-form'
+
+import { useIndicateurFormContext } from '@/components/indicateurs/indicateurFormContext'
+import { type IndicateurFormValues } from '@/components/indicateurs/indicateurFormSchema'
+import { FieldSelect } from '@/components/ui/FieldSelect'
+import { referentielsAllQueryOptions } from '@/queries/referentiels'
+
+type FonctionAgregation = 'SUM' | 'AVG' | 'NONE'
+
+const AGREGATION_LABEL: Record<FonctionAgregation, string> = {
+  SUM: 'Somme',
+  AVG: 'Moyenne',
+  NONE: 'Aucune',
+}
+
+// Section « Référentiels liés » du formulaire indicateur. Récupère le form via
+// le contexte (`FormProvider`) et la liste des référentiels via une query
+// suspense préchargée dans le loader de route.
+export function AdminReferentiels() {
+  const form = useIndicateurFormContext()
+  const { fields, append, remove } = useFieldArray({ control: form.control, name: 'referentiels' })
+  const { data: options } = useSuspenseQuery(referentielsAllQueryOptions())
+
+  return (
+    <div className="border-t border-border pt-5">
+      <div className="mb-1 flex items-center justify-between">
+        <span className="text-sm font-bold">Référentiels liés</span>
+        <button
+          type="button"
+          onClick={() => append({ id: '', fonctionAgregation: 'SUM' })}
+          className="flex items-center gap-1 text-sm font-semibold text-primary"
+        >
+          <Plus className="size-4" /> Ajouter
+        </button>
+      </div>
+      <p className="mb-4 text-xs text-text-subtle">
+        ⚠ Cette liste remplace <b>intégralement</b> l'existant (replace-all). Retirer une ligne
+        supprime le lien.
+      </p>
+      {fields.map((field, index) => (
+        <ReferentielRow
+          key={field.id}
+          index={index}
+          register={form.register}
+          error={form.formState.errors.referentiels?.[index]?.id?.message}
+          options={options}
+          onRemove={() => remove(index)}
+        />
+      ))}
+    </div>
+  )
+}
+
+// Une ligne « référentiel lié » : sélection du référentiel + fonction
+// d'agrégation, avec message d'erreur si le référentiel n'est pas choisi. Les
+// libellés sont masqués (`hideLabel`) car la ligne est en grille horizontale.
+function ReferentielRow({
+  index,
+  register,
+  error,
+  options,
+  onRemove,
+}: {
+  index: number
+  register: UseFormRegister<IndicateurFormValues>
+  error?: string | undefined
+  options: { id: string; nom: string }[]
+  onRemove: () => void
+}) {
+  return (
+    <div className="mb-2.5 flex items-start gap-2.5 rounded-lg border border-border bg-surface-muted px-3 py-2.5">
+      <div className="flex-[2]">
+        <FieldSelect
+          label="Référentiel"
+          hideLabel
+          required
+          error={error}
+          aria-invalid={error ? true : undefined}
+          {...register(`referentiels.${index}.id`)}
+        >
+          <option value="" disabled>
+            Choisir un référentiel…
+          </option>
+          {options.map((option) => (
+            <option key={option.id} value={option.id}>
+              {option.id} · {option.nom}
+            </option>
+          ))}
+        </FieldSelect>
+      </div>
+      <div className="flex-1">
+        <FieldSelect
+          label="Fonction d'agrégation"
+          hideLabel
+          {...register(`referentiels.${index}.fonctionAgregation`)}
+        >
+          {Object.entries(AGREGATION_LABEL).map(([value, label]) => (
+            <option key={value} value={value}>
+              {label}
+            </option>
+          ))}
+        </FieldSelect>
+      </div>
+      <button type="button" onClick={onRemove} className="mt-2 text-accent" aria-label="Retirer">
+        <Trash2 className="size-4" />
+      </button>
+    </div>
+  )
+}

--- a/apps/kpilote-admin/src/components/indicateurs/AdminReferentiels.tsx
+++ b/apps/kpilote-admin/src/components/indicateurs/AdminReferentiels.tsx
@@ -15,9 +15,6 @@ const AGREGATION_LABEL: Record<FonctionAgregation, string> = {
   NONE: 'Aucune',
 }
 
-// Section « Référentiels liés » du formulaire indicateur. Récupère le form via
-// le contexte (`FormProvider`) et la liste des référentiels via une query
-// suspense préchargée dans le loader de route.
 export function AdminReferentiels() {
   const form = useIndicateurFormContext()
   const { fields, append, remove } = useFieldArray({ control: form.control, name: 'referentiels' })
@@ -53,9 +50,6 @@ export function AdminReferentiels() {
   )
 }
 
-// Une ligne « référentiel lié » : sélection du référentiel + fonction
-// d'agrégation, avec message d'erreur si le référentiel n'est pas choisi. Les
-// libellés sont masqués (`hideLabel`) car la ligne est en grille horizontale.
 function ReferentielRow({
   index,
   register,

--- a/apps/kpilote-admin/src/components/indicateurs/AdminResponsables.tsx
+++ b/apps/kpilote-admin/src/components/indicateurs/AdminResponsables.tsx
@@ -13,7 +13,14 @@ import { utilisateursAllQueryOptions } from '@/queries/utilisateurs'
 // est une clé générée par react-hook-form).
 export function AdminResponsables() {
   const form = useIndicateurFormContext()
-  const { fields, append, remove } = useFieldArray({ control: form.control, name: 'responsables' })
+  // `keyName: 'fieldId'` : sans ça, react-hook-form écrase le champ métier `id`
+  // (UUID utilisateur) par sa clé interne dans `fields`. On garde donc `id` = UUID
+  // utilisateur, et `fieldId` = clé stable pour la prop `key`.
+  const { fields, append, remove } = useFieldArray({
+    control: form.control,
+    name: 'responsables',
+    keyName: 'fieldId',
+  })
   const responsablesSelectionnes = useWatch({ control: form.control, name: 'responsables' })
   const { data: utilisateurs } = useSuspenseQuery(utilisateursAllQueryOptions())
 
@@ -59,7 +66,7 @@ export function AdminResponsables() {
       <ul className="mt-3 space-y-2">
         {fields.map((responsable, index) => (
           <li
-            key={responsable.id}
+            key={responsable.fieldId}
             className="flex items-center justify-between rounded-lg border border-border bg-surface-muted px-3 py-2 text-sm"
           >
             <span>

--- a/apps/kpilote-admin/src/components/indicateurs/AdminResponsables.tsx
+++ b/apps/kpilote-admin/src/components/indicateurs/AdminResponsables.tsx
@@ -6,21 +6,9 @@ import { useIndicateurFormContext } from '@/components/indicateurs/indicateurFor
 import { FieldSelect } from '@/components/ui/FieldSelect'
 import { utilisateursAllQueryOptions } from '@/queries/utilisateurs'
 
-// Section « Responsables » du formulaire indicateur. Récupère le form via le
-// contexte (`FormProvider`) et la liste des utilisateurs via une query suspense
-// préchargée dans le loader de route. Le select exclut les responsables déjà
-// sélectionnés (comparaison sur les valeurs du form, pas sur `fields` dont l'id
-// est une clé générée par react-hook-form).
 export function AdminResponsables() {
   const form = useIndicateurFormContext()
-  // `keyName: 'fieldId'` : sans ça, react-hook-form écrase le champ métier `id`
-  // (UUID utilisateur) par sa clé interne dans `fields`. On garde donc `id` = UUID
-  // utilisateur, et `fieldId` = clé stable pour la prop `key`.
-  const { fields, append, remove } = useFieldArray({
-    control: form.control,
-    name: 'responsables',
-    keyName: 'fieldId',
-  })
+  const { fields, append, remove } = useFieldArray({ control: form.control, name: 'responsables' })
   const responsablesSelectionnes = useWatch({ control: form.control, name: 'responsables' })
   const { data: utilisateurs } = useSuspenseQuery(utilisateursAllQueryOptions())
 
@@ -66,7 +54,7 @@ export function AdminResponsables() {
       <ul className="mt-3 space-y-2">
         {fields.map((responsable, index) => (
           <li
-            key={responsable.fieldId}
+            key={responsable.id}
             className="flex items-center justify-between rounded-lg border border-border bg-surface-muted px-3 py-2 text-sm"
           >
             <span>

--- a/apps/kpilote-admin/src/components/indicateurs/AdminResponsables.tsx
+++ b/apps/kpilote-admin/src/components/indicateurs/AdminResponsables.tsx
@@ -1,0 +1,82 @@
+import { useSuspenseQuery } from '@tanstack/react-query'
+import { Trash2 } from 'lucide-react'
+import { useFieldArray, useWatch } from 'react-hook-form'
+
+import { useIndicateurFormContext } from '@/components/indicateurs/indicateurFormContext'
+import { FieldSelect } from '@/components/ui/FieldSelect'
+import { utilisateursAllQueryOptions } from '@/queries/utilisateurs'
+
+// Section « Responsables » du formulaire indicateur. Récupère le form via le
+// contexte (`FormProvider`) et la liste des utilisateurs via une query suspense
+// préchargée dans le loader de route. Le select exclut les responsables déjà
+// sélectionnés (comparaison sur les valeurs du form, pas sur `fields` dont l'id
+// est une clé générée par react-hook-form).
+export function AdminResponsables() {
+  const form = useIndicateurFormContext()
+  const { fields, append, remove } = useFieldArray({ control: form.control, name: 'responsables' })
+  const responsablesSelectionnes = useWatch({ control: form.control, name: 'responsables' })
+  const { data: utilisateurs } = useSuspenseQuery(utilisateursAllQueryOptions())
+
+  const utilisateursDisponibles = utilisateurs.filter(
+    (utilisateur) =>
+      !(responsablesSelectionnes ?? []).some((responsable) => responsable.id === utilisateur.id),
+  )
+
+  return (
+    <div className="border-t border-border pt-5">
+      <span className="mb-1 block text-sm font-bold">Responsables</span>
+      <p className="mb-4 text-xs text-text-subtle">
+        Utilisateurs désignés responsables de l'indicateur. Cette liste remplace{' '}
+        <b>intégralement</b> l'existant à l'enregistrement.
+      </p>
+
+      <FieldSelect
+        label="Ajouter un responsable"
+        value=""
+        onChange={(event) => {
+          const utilisateur = utilisateursDisponibles.find(
+            (candidat) => candidat.id === event.target.value,
+          )
+          if (!utilisateur) return
+          append({
+            id: utilisateur.id,
+            nom: utilisateur.nom,
+            prenom: utilisateur.prenom,
+            email: utilisateur.email,
+          })
+        }}
+      >
+        <option value="" disabled>
+          Choisir un utilisateur…
+        </option>
+        {utilisateursDisponibles.map((utilisateur) => (
+          <option key={utilisateur.id} value={utilisateur.id}>
+            {utilisateur.prenom} {utilisateur.nom} · {utilisateur.email}
+          </option>
+        ))}
+      </FieldSelect>
+
+      <ul className="mt-3 space-y-2">
+        {fields.map((responsable, index) => (
+          <li
+            key={responsable.id}
+            className="flex items-center justify-between rounded-lg border border-border bg-surface-muted px-3 py-2 text-sm"
+          >
+            <span>
+              {responsable.prenom} {responsable.nom}{' '}
+              <span className="text-text-subtle">· {responsable.email}</span>
+            </span>
+            <button
+              type="button"
+              onClick={() => remove(index)}
+              className="text-accent"
+              aria-label="Retirer"
+            >
+              <Trash2 className="size-4" />
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/apps/kpilote-admin/src/components/indicateurs/IndicateurForm.tsx
+++ b/apps/kpilote-admin/src/components/indicateurs/IndicateurForm.tsx
@@ -1,8 +1,6 @@
 import { zodResolver } from '@hookform/resolvers/zod'
-import { useQuery } from '@tanstack/react-query'
-import { Plus, Trash2 } from 'lucide-react'
 import { useMemo } from 'react'
-import { useFieldArray, useForm, useWatch, type UseFormRegister } from 'react-hook-form'
+import { FormProvider, useForm, useWatch } from 'react-hook-form'
 
 import {
   PERIODE_MISE_A_JOUR_LABELS,
@@ -13,8 +11,8 @@ import {
   UNITES_INDICATEUR_CONFIG,
 } from '@pilote/kpilote-shared/indicateur'
 
-import { fetchAllReferentiels } from '@/api/referentiels'
-import { fetchAllUtilisateurs } from '@/api/utilisateurs'
+import { AdminReferentiels } from '@/components/indicateurs/AdminReferentiels'
+import { AdminResponsables } from '@/components/indicateurs/AdminResponsables'
 import {
   buildIndicateurFormSchema,
   type IndicateurFormValues,
@@ -26,14 +24,6 @@ import { FieldSelect } from '@/components/ui/FieldSelect'
 import { FieldTextarea } from '@/components/ui/FieldTextarea'
 import { SegmentedControl } from '@/components/ui/SegmentedControl'
 import { useAppConfig } from '@/context/AppConfigContext'
-
-type FonctionAgregation = 'SUM' | 'AVG' | 'NONE'
-
-const AGREGATION_LABEL: Record<FonctionAgregation, string> = {
-  SUM: 'Somme',
-  AVG: 'Moyenne',
-  NONE: 'Aucune',
-}
 
 const VISIBILITE_OPTIONS = [
   { value: 'PUBLIC', label: 'Public' },
@@ -62,333 +52,180 @@ export function IndicateurForm({
     mode: 'onChange',
     defaultValues: initial,
   })
-  const { fields, append, remove } = useFieldArray({ control: form.control, name: 'referentiels' })
-  const {
-    fields: responsablesFields,
-    append: appendResponsable,
-    remove: removeResponsable,
-  } = useFieldArray({ control: form.control, name: 'responsables' })
   const visibilite = useWatch({ control: form.control, name: 'visibilite' })
-  const responsablesSelectionnes = useWatch({ control: form.control, name: 'responsables' })
-
-  const referentielsQuery = useQuery({
-    queryKey: ['referentiels', 'all-for-select'],
-    queryFn: () => fetchAllReferentiels(),
-  })
-  const referentielsOptions = referentielsQuery.data ?? []
-
-  const utilisateursQuery = useQuery({
-    queryKey: ['utilisateurs', 'all-for-select'],
-    queryFn: () => fetchAllUtilisateurs(),
-  })
-  const utilisateursDisponibles = (utilisateursQuery.data ?? []).filter(
-    (utilisateur) =>
-      !(responsablesSelectionnes ?? []).some((responsable) => responsable.id === utilisateur.id),
-  )
 
   return (
-    <form
-      onSubmit={(event) => void form.handleSubmit(onSubmit)(event)}
-      className="mx-auto max-w-2xl"
-    >
-      <div className="rounded-xl border border-border bg-surface p-6">
-        <div className="mb-5">
-          {mode === 'edit' ? (
-            <Field label="Identifiant">
-              <span className="inline-flex items-center gap-2 rounded-md border border-primary/20 bg-surface-tinted px-3 py-2 font-mono text-sm text-primary">
-                {initial.id}{' '}
-                <span className="font-sans text-xs text-text-subtle">🔒 non modifiable</span>
-              </span>
-            </Field>
-          ) : (
-            <FieldInput
-              label="Identifiant"
-              placeholder="IND-001"
-              className="w-48 font-mono"
-              error={form.formState.errors.id?.message}
-              {...form.register('id')}
-              onChange={(event) =>
-                form.setValue('id', event.target.value.toUpperCase(), {
-                  shouldValidate: true,
-                  shouldDirty: true,
-                })
-              }
-            />
-          )}
-        </div>
-
-        <div className="mb-5">
-          <FieldInput
-            label="Nom"
-            required
-            error={form.formState.errors.nom?.message}
-            {...form.register('nom')}
-          />
-        </div>
-
-        <div className="mb-6 flex gap-4">
-          <div className="flex-1">
-            <SegmentedControl
-              label="Visibilité"
-              value={visibilite}
-              onValueChange={(value) =>
-                form.setValue('visibilite', value, { shouldValidate: true })
-              }
-              options={VISIBILITE_OPTIONS}
-            />
-          </div>
-          <div className="flex-1">
-            <FieldSelect label="Unité" {...form.register('unite')}>
-              <option value="">Aucune</option>
-              {UNITES_INDICATEUR.map((code) => (
-                <option key={code} value={code}>
-                  {UNITES_INDICATEUR_CONFIG[code].libelle}
-                </option>
-              ))}
-            </FieldSelect>
-          </div>
-        </div>
-
-        <div className="mb-6 border-t border-border pt-5">
-          <span className="mb-4 block text-sm font-bold">Métadonnées</span>
-
+    <FormProvider {...form}>
+      <form
+        onSubmit={(event) => void form.handleSubmit(onSubmit)(event)}
+        className="mx-auto max-w-2xl"
+      >
+        <div className="rounded-xl border border-border bg-surface p-6">
           <div className="mb-5">
-            <FieldTextarea label="Description" rows={3} {...form.register('description')} />
-          </div>
-
-          <div className="mb-5">
-            <FieldTextarea label="Méthode de calcul" rows={3} {...form.register('methodeCalcul')} />
-          </div>
-
-          <div className="mb-5 flex gap-4">
-            <div className="flex-1">
-              <FieldInput
-                label="Source des données"
-                error={form.formState.errors.sourceDonnees?.message}
-                {...form.register('sourceDonnees')}
-              />
-            </div>
-            <div className="flex-1">
-              <FieldInput
-                label="URL de la source"
-                type="url"
-                placeholder="https://…"
-                error={form.formState.errors.sourceUrl?.message}
-                {...form.register('sourceUrl')}
-              />
-            </div>
-          </div>
-
-          <div className="flex gap-4">
-            <div className="flex-1">
-              <FieldSelect label="Période de mise à jour" {...form.register('periodeMiseAJour')}>
-                <option value="">Non renseignée</option>
-                {PERIODES_MISE_A_JOUR.map((periode) => (
-                  <option key={periode} value={periode}>
-                    {PERIODE_MISE_A_JOUR_LABELS[periode]}
-                  </option>
-                ))}
-              </FieldSelect>
-            </div>
-            <div className="flex-1">
-              <FieldInput
-                label="Jour de mise à jour"
-                type="number"
-                min={1}
-                max={31}
-                placeholder="1–31"
-                error={form.formState.errors.jourMiseAJour?.message}
-                {...form.register('jourMiseAJour')}
-              />
-            </div>
-          </div>
-
-          <div className="mt-5 flex gap-4">
-            <div className="flex-1">
-              <FieldInput
-                label="Délai de mise à disposition"
-                type="number"
-                min={1}
-                placeholder="ex. 6"
-                error={form.formState.errors.delaiNombre?.message}
-                {...form.register('delaiNombre')}
-              />
-            </div>
-            <div className="flex-1">
-              <FieldSelect
-                label="Unité du délai"
-                error={form.formState.errors.delaiUnite?.message}
-                {...form.register('delaiUnite')}
-              >
-                <option value="">Aucune</option>
-                {UNITES_DUREE.map((unite) => (
-                  <option key={unite} value={unite}>
-                    {UNITE_DUREE_LABELS[unite]}
-                  </option>
-                ))}
-              </FieldSelect>
-            </div>
-          </div>
-        </div>
-
-        <div className="border-t border-border pt-5">
-          <div className="mb-1 flex items-center justify-between">
-            <span className="text-sm font-bold">Référentiels liés</span>
-            <button
-              type="button"
-              onClick={() => append({ id: '', fonctionAgregation: 'SUM' })}
-              className="flex items-center gap-1 text-sm font-semibold text-primary"
-            >
-              <Plus className="size-4" /> Ajouter
-            </button>
-          </div>
-          <p className="mb-4 text-xs text-text-subtle">
-            ⚠ Cette liste remplace <b>intégralement</b> l'existant (replace-all). Retirer une ligne
-            supprime le lien.
-          </p>
-          {fields.map((field, index) => (
-            <ReferentielRow
-              key={field.id}
-              index={index}
-              register={form.register}
-              error={form.formState.errors.referentiels?.[index]?.id?.message}
-              options={referentielsOptions}
-              onRemove={() => remove(index)}
-            />
-          ))}
-        </div>
-
-        <div className="border-t border-border pt-5">
-          <span className="mb-1 block text-sm font-bold">Responsables</span>
-          <p className="mb-4 text-xs text-text-subtle">
-            Utilisateurs désignés responsables de l'indicateur. Cette liste remplace{' '}
-            <b>intégralement</b> l'existant à l'enregistrement.
-          </p>
-
-          <FieldSelect
-            label="Ajouter un responsable"
-            value=""
-            disabled={utilisateursQuery.isLoading}
-            onChange={(event) => {
-              const utilisateur = utilisateursDisponibles.find(
-                (candidat) => candidat.id === event.target.value,
-              )
-              if (!utilisateur) return
-              appendResponsable({
-                id: utilisateur.id,
-                nom: utilisateur.nom,
-                prenom: utilisateur.prenom,
-                email: utilisateur.email,
-              })
-            }}
-          >
-            <option value="" disabled>
-              {utilisateursQuery.isLoading ? 'Chargement…' : 'Choisir un utilisateur…'}
-            </option>
-            {utilisateursDisponibles.map((utilisateur) => (
-              <option key={utilisateur.id} value={utilisateur.id}>
-                {utilisateur.prenom} {utilisateur.nom} · {utilisateur.email}
-              </option>
-            ))}
-          </FieldSelect>
-
-          <ul className="mt-3 space-y-2">
-            {responsablesFields.map((responsable, index) => (
-              <li
-                key={responsable.id}
-                className="flex items-center justify-between rounded-lg border border-border bg-surface-muted px-3 py-2 text-sm"
-              >
-                <span>
-                  {responsable.prenom} {responsable.nom}{' '}
-                  <span className="text-text-subtle">· {responsable.email}</span>
+            {mode === 'edit' ? (
+              <Field label="Identifiant">
+                <span className="inline-flex items-center gap-2 rounded-md border border-primary/20 bg-surface-tinted px-3 py-2 font-mono text-sm text-primary">
+                  {initial.id}{' '}
+                  <span className="font-sans text-xs text-text-subtle">🔒 non modifiable</span>
                 </span>
-                <button
-                  type="button"
-                  onClick={() => removeResponsable(index)}
-                  className="text-accent"
-                  aria-label="Retirer"
+              </Field>
+            ) : (
+              <FieldInput
+                label="Identifiant"
+                placeholder="IND-001"
+                className="w-48 font-mono"
+                error={form.formState.errors.id?.message}
+                {...form.register('id')}
+                onChange={(event) =>
+                  form.setValue('id', event.target.value.toUpperCase(), {
+                    shouldValidate: true,
+                    shouldDirty: true,
+                  })
+                }
+              />
+            )}
+          </div>
+
+          <div className="mb-5">
+            <FieldInput
+              label="Nom"
+              required
+              error={form.formState.errors.nom?.message}
+              {...form.register('nom')}
+            />
+          </div>
+
+          <div className="mb-6 flex gap-4">
+            <div className="flex-1">
+              <SegmentedControl
+                label="Visibilité"
+                value={visibilite}
+                onValueChange={(value) =>
+                  form.setValue('visibilite', value, { shouldValidate: true })
+                }
+                options={VISIBILITE_OPTIONS}
+              />
+            </div>
+            <div className="flex-1">
+              <FieldSelect label="Unité" {...form.register('unite')}>
+                <option value="">Aucune</option>
+                {UNITES_INDICATEUR.map((code) => (
+                  <option key={code} value={code}>
+                    {UNITES_INDICATEUR_CONFIG[code].libelle}
+                  </option>
+                ))}
+              </FieldSelect>
+            </div>
+          </div>
+
+          <div className="mb-6 border-t border-border pt-5">
+            <span className="mb-4 block text-sm font-bold">Métadonnées</span>
+
+            <div className="mb-5">
+              <FieldTextarea label="Description" rows={3} {...form.register('description')} />
+            </div>
+
+            <div className="mb-5">
+              <FieldTextarea
+                label="Méthode de calcul"
+                rows={3}
+                {...form.register('methodeCalcul')}
+              />
+            </div>
+
+            <div className="mb-5 flex gap-4">
+              <div className="flex-1">
+                <FieldInput
+                  label="Source des données"
+                  error={form.formState.errors.sourceDonnees?.message}
+                  {...form.register('sourceDonnees')}
+                />
+              </div>
+              <div className="flex-1">
+                <FieldInput
+                  label="URL de la source"
+                  type="url"
+                  placeholder="https://…"
+                  error={form.formState.errors.sourceUrl?.message}
+                  {...form.register('sourceUrl')}
+                />
+              </div>
+            </div>
+
+            <div className="flex gap-4">
+              <div className="flex-1">
+                <FieldSelect label="Période de mise à jour" {...form.register('periodeMiseAJour')}>
+                  <option value="">Non renseignée</option>
+                  {PERIODES_MISE_A_JOUR.map((periode) => (
+                    <option key={periode} value={periode}>
+                      {PERIODE_MISE_A_JOUR_LABELS[periode]}
+                    </option>
+                  ))}
+                </FieldSelect>
+              </div>
+              <div className="flex-1">
+                <FieldInput
+                  label="Jour de mise à jour"
+                  type="number"
+                  min={1}
+                  max={31}
+                  placeholder="1–31"
+                  error={form.formState.errors.jourMiseAJour?.message}
+                  {...form.register('jourMiseAJour')}
+                />
+              </div>
+            </div>
+
+            <div className="mt-5 flex gap-4">
+              <div className="flex-1">
+                <FieldInput
+                  label="Délai de mise à disposition"
+                  type="number"
+                  min={1}
+                  placeholder="ex. 6"
+                  error={form.formState.errors.delaiNombre?.message}
+                  {...form.register('delaiNombre')}
+                />
+              </div>
+              <div className="flex-1">
+                <FieldSelect
+                  label="Unité du délai"
+                  error={form.formState.errors.delaiUnite?.message}
+                  {...form.register('delaiUnite')}
                 >
-                  <Trash2 className="size-4" />
-                </button>
-              </li>
-            ))}
-          </ul>
+                  <option value="">Aucune</option>
+                  {UNITES_DUREE.map((unite) => (
+                    <option key={unite} value={unite}>
+                      {UNITE_DUREE_LABELS[unite]}
+                    </option>
+                  ))}
+                </FieldSelect>
+              </div>
+            </div>
+          </div>
+
+          <AdminReferentiels />
+
+          <AdminResponsables />
         </div>
-      </div>
 
-      {errorMessage ? (
-        <p className="mt-3 text-right text-sm font-medium text-accent">{errorMessage}</p>
-      ) : null}
+        {errorMessage ? (
+          <p className="mt-3 text-right text-sm font-medium text-accent">{errorMessage}</p>
+        ) : null}
 
-      <div className="mt-5 flex justify-end gap-3">
-        <Button variant="secondary" type="button" onClick={onCancel}>
-          Annuler
-        </Button>
-        <Button
-          type="submit"
-          disabled={!form.formState.isValid || pending}
-          className={isProd ? 'bg-accent hover:bg-accent' : undefined}
-        >
-          {pending ? 'Enregistrement…' : isProd ? '🚨 Enregistrer en Prod' : 'Enregistrer'}
-        </Button>
-      </div>
-    </form>
-  )
-}
-
-// Une ligne « référentiel lié » : sélection du référentiel + fonction
-// d'agrégation, avec message d'erreur si le référentiel n'est pas choisi. Les
-// libellés sont masqués (`hideLabel`) car la ligne est en grille horizontale.
-function ReferentielRow({
-  index,
-  register,
-  error,
-  options,
-  onRemove,
-}: {
-  index: number
-  register: UseFormRegister<IndicateurFormValues>
-  error?: string | undefined
-  options: { id: string; nom: string }[]
-  onRemove: () => void
-}) {
-  return (
-    <div className="mb-2.5 flex items-start gap-2.5 rounded-lg border border-border bg-surface-muted px-3 py-2.5">
-      <div className="flex-[2]">
-        <FieldSelect
-          label="Référentiel"
-          hideLabel
-          required
-          error={error}
-          aria-invalid={error ? true : undefined}
-          {...register(`referentiels.${index}.id`)}
-        >
-          <option value="" disabled>
-            Choisir un référentiel…
-          </option>
-          {options.map((option) => (
-            <option key={option.id} value={option.id}>
-              {option.id} · {option.nom}
-            </option>
-          ))}
-        </FieldSelect>
-      </div>
-      <div className="flex-1">
-        <FieldSelect
-          label="Fonction d'agrégation"
-          hideLabel
-          {...register(`referentiels.${index}.fonctionAgregation`)}
-        >
-          {Object.entries(AGREGATION_LABEL).map(([value, label]) => (
-            <option key={value} value={value}>
-              {label}
-            </option>
-          ))}
-        </FieldSelect>
-      </div>
-      <button type="button" onClick={onRemove} className="mt-2 text-accent" aria-label="Retirer">
-        <Trash2 className="size-4" />
-      </button>
-    </div>
+        <div className="mt-5 flex justify-end gap-3">
+          <Button variant="secondary" type="button" onClick={onCancel}>
+            Annuler
+          </Button>
+          <Button
+            type="submit"
+            disabled={!form.formState.isValid || pending}
+            className={isProd ? 'bg-accent hover:bg-accent' : undefined}
+          >
+            {pending ? 'Enregistrement…' : isProd ? '🚨 Enregistrer en Prod' : 'Enregistrer'}
+          </Button>
+        </div>
+      </form>
+    </FormProvider>
   )
 }

--- a/apps/kpilote-admin/src/components/indicateurs/IndicateurForm.tsx
+++ b/apps/kpilote-admin/src/components/indicateurs/IndicateurForm.tsx
@@ -14,6 +14,7 @@ import {
 } from '@pilote/kpilote-shared/indicateur'
 
 import { fetchAllReferentiels } from '@/api/referentiels'
+import { fetchAllUtilisateurs } from '@/api/utilisateurs'
 import {
   buildIndicateurFormSchema,
   type IndicateurFormValues,
@@ -62,6 +63,11 @@ export function IndicateurForm({
     defaultValues: initial,
   })
   const { fields, append, remove } = useFieldArray({ control: form.control, name: 'referentiels' })
+  const {
+    fields: responsablesFields,
+    append: appendResponsable,
+    remove: removeResponsable,
+  } = useFieldArray({ control: form.control, name: 'responsables' })
   const visibilite = useWatch({ control: form.control, name: 'visibilite' })
 
   const referentielsQuery = useQuery({
@@ -69,6 +75,14 @@ export function IndicateurForm({
     queryFn: () => fetchAllReferentiels(),
   })
   const referentielsOptions = referentielsQuery.data ?? []
+
+  const utilisateursQuery = useQuery({
+    queryKey: ['utilisateurs', 'all-for-select'],
+    queryFn: () => fetchAllUtilisateurs(),
+  })
+  const utilisateursDisponibles = (utilisateursQuery.data ?? []).filter(
+    (utilisateur) => !responsablesFields.some((responsable) => responsable.id === utilisateur.id),
+  )
 
   return (
     <form
@@ -240,6 +254,63 @@ export function IndicateurForm({
               onRemove={() => remove(index)}
             />
           ))}
+        </div>
+
+        <div className="border-t border-border pt-5">
+          <span className="mb-1 block text-sm font-bold">Responsables</span>
+          <p className="mb-4 text-xs text-text-subtle">
+            Utilisateurs désignés responsables de l'indicateur. Cette liste remplace{' '}
+            <b>intégralement</b> l'existant à l'enregistrement.
+          </p>
+
+          <FieldSelect
+            label="Ajouter un responsable"
+            value=""
+            disabled={utilisateursQuery.isLoading}
+            onChange={(event) => {
+              const utilisateur = utilisateursDisponibles.find(
+                (candidat) => candidat.id === event.target.value,
+              )
+              if (!utilisateur) return
+              appendResponsable({
+                id: utilisateur.id,
+                nom: utilisateur.nom,
+                prenom: utilisateur.prenom,
+                email: utilisateur.email,
+              })
+            }}
+          >
+            <option value="" disabled>
+              {utilisateursQuery.isLoading ? 'Chargement…' : 'Choisir un utilisateur…'}
+            </option>
+            {utilisateursDisponibles.map((utilisateur) => (
+              <option key={utilisateur.id} value={utilisateur.id}>
+                {utilisateur.prenom} {utilisateur.nom} · {utilisateur.email}
+              </option>
+            ))}
+          </FieldSelect>
+
+          <ul className="mt-3 space-y-2">
+            {responsablesFields.map((responsable, index) => (
+              <li
+                key={responsable.id}
+                className="flex items-center justify-between rounded-lg border border-border bg-surface-muted px-3 py-2 text-sm"
+              >
+                <span>
+                  {responsable.prenom} {responsable.nom}{' '}
+                  <span className="text-text-subtle">· {responsable.email}</span>
+                </span>
+                <button
+                  type="button"
+                  onClick={() => removeResponsable(index)}
+                  className="text-accent"
+                  aria-label="Retirer"
+                >
+                  <Trash2 className="size-4" />
+                </button>
+              </li>
+            ))}
+          </ul>
         </div>
       </div>
 

--- a/apps/kpilote-admin/src/components/indicateurs/IndicateurForm.tsx
+++ b/apps/kpilote-admin/src/components/indicateurs/IndicateurForm.tsx
@@ -69,6 +69,7 @@ export function IndicateurForm({
     remove: removeResponsable,
   } = useFieldArray({ control: form.control, name: 'responsables' })
   const visibilite = useWatch({ control: form.control, name: 'visibilite' })
+  const responsablesSelectionnes = useWatch({ control: form.control, name: 'responsables' })
 
   const referentielsQuery = useQuery({
     queryKey: ['referentiels', 'all-for-select'],
@@ -81,7 +82,8 @@ export function IndicateurForm({
     queryFn: () => fetchAllUtilisateurs(),
   })
   const utilisateursDisponibles = (utilisateursQuery.data ?? []).filter(
-    (utilisateur) => !responsablesFields.some((responsable) => responsable.id === utilisateur.id),
+    (utilisateur) =>
+      !(responsablesSelectionnes ?? []).some((responsable) => responsable.id === utilisateur.id),
   )
 
   return (

--- a/apps/kpilote-admin/src/components/indicateurs/indicateurFormContext.ts
+++ b/apps/kpilote-admin/src/components/indicateurs/indicateurFormContext.ts
@@ -2,7 +2,4 @@ import { useFormContext } from 'react-hook-form'
 
 import { type IndicateurFormValues } from '@/components/indicateurs/indicateurFormSchema'
 
-// Surcouche typée de `useFormContext` : les sous-composants du formulaire
-// indicateur (référentiels, responsables) récupèrent le form correctement typé
-// depuis le `FormProvider` sans qu'on ait à leur passer `control` en props.
 export const useIndicateurFormContext = () => useFormContext<IndicateurFormValues>()

--- a/apps/kpilote-admin/src/components/indicateurs/indicateurFormContext.ts
+++ b/apps/kpilote-admin/src/components/indicateurs/indicateurFormContext.ts
@@ -1,0 +1,8 @@
+import { useFormContext } from 'react-hook-form'
+
+import { type IndicateurFormValues } from '@/components/indicateurs/indicateurFormSchema'
+
+// Surcouche typée de `useFormContext` : les sous-composants du formulaire
+// indicateur (référentiels, responsables) récupèrent le form correctement typé
+// depuis le `FormProvider` sans qu'on ait à leur passer `control` en props.
+export const useIndicateurFormContext = () => useFormContext<IndicateurFormValues>()

--- a/apps/kpilote-admin/src/components/indicateurs/indicateurFormSchema.ts
+++ b/apps/kpilote-admin/src/components/indicateurs/indicateurFormSchema.ts
@@ -44,6 +44,14 @@ export const buildIndicateurFormSchema = (mode: 'create' | 'edit') =>
         ),
       delaiUnite: z.union([z.literal(''), uniteDureeSchema]),
       referentiels: z.array(configurationIndicateurReferentielSchema),
+      responsables: z.array(
+        z.object({
+          id: z.string(),
+          nom: z.string(),
+          prenom: z.string(),
+          email: z.string(),
+        }),
+      ),
     })
     // Le délai (nombre + unité) est optionnel, mais indissociable : les deux
     // champs doivent être remplis ensemble, sinon `toUpsertBody` effacerait
@@ -80,6 +88,13 @@ export function buildInitialValues(indicateur?: IndicateurApiModel): IndicateurF
         : '',
     delaiUnite: indicateur?.delaiMiseADisposition?.unite ?? '',
     referentiels: indicateur?.referentiels ?? [],
+    responsables:
+      indicateur?.responsables.map((responsable) => ({
+        id: responsable.id,
+        nom: responsable.nom,
+        prenom: responsable.prenom,
+        email: responsable.email,
+      })) ?? [],
   }
 }
 
@@ -102,5 +117,6 @@ export function toUpsertBody(values: IndicateurFormValues): UpsertIndicateurBody
         ? null
         : { nombre: Number(values.delaiNombre), unite: values.delaiUnite },
     referentiels: values.referentiels,
+    responsables: values.responsables.map((responsable) => responsable.id),
   }
 }

--- a/apps/kpilote-admin/src/queries/referentiels.ts
+++ b/apps/kpilote-admin/src/queries/referentiels.ts
@@ -10,7 +10,7 @@ import { fetchAllPages } from '@/lib/fetchAllPages'
 
 export const referentielsAllQueryOptions = () =>
   queryOptions({
-    queryKey: ['referentiels', 'all-for-select'],
+    queryKey: ['referentiels', 'all-pages'],
     queryFn: () => fetchAllReferentiels(),
   })
 

--- a/apps/kpilote-admin/src/queries/referentiels.ts
+++ b/apps/kpilote-admin/src/queries/referentiels.ts
@@ -1,11 +1,18 @@
 import { infiniteQueryOptions, queryOptions } from '@tanstack/react-query'
 
 import {
+  fetchAllReferentiels,
   fetchIndividusForReferentiel,
   fetchReferentielById,
   fetchReferentiels,
 } from '@/api/referentiels'
 import { fetchAllPages } from '@/lib/fetchAllPages'
+
+export const referentielsAllQueryOptions = () =>
+  queryOptions({
+    queryKey: ['referentiels', 'all-for-select'],
+    queryFn: () => fetchAllReferentiels(),
+  })
 
 export const referentielsInfiniteQueryOptions = (recherche: string) =>
   infiniteQueryOptions({

--- a/apps/kpilote-admin/src/queries/utilisateurs.ts
+++ b/apps/kpilote-admin/src/queries/utilisateurs.ts
@@ -4,7 +4,7 @@ import { fetchAllUtilisateurs, fetchUtilisateurById, fetchUtilisateurs } from '@
 
 export const utilisateursAllQueryOptions = () =>
   queryOptions({
-    queryKey: ['utilisateurs', 'all-for-select'],
+    queryKey: ['utilisateurs', 'all-pages'],
     queryFn: () => fetchAllUtilisateurs(),
   })
 

--- a/apps/kpilote-admin/src/queries/utilisateurs.ts
+++ b/apps/kpilote-admin/src/queries/utilisateurs.ts
@@ -1,6 +1,12 @@
 import { infiniteQueryOptions, queryOptions } from '@tanstack/react-query'
 
-import { fetchUtilisateurById, fetchUtilisateurs } from '@/api/utilisateurs'
+import { fetchAllUtilisateurs, fetchUtilisateurById, fetchUtilisateurs } from '@/api/utilisateurs'
+
+export const utilisateursAllQueryOptions = () =>
+  queryOptions({
+    queryKey: ['utilisateurs', 'all-for-select'],
+    queryFn: () => fetchAllUtilisateurs(),
+  })
 
 export const utilisateursInfiniteQueryOptions = (recherche: string) =>
   infiniteQueryOptions({

--- a/apps/kpilote-admin/src/routes/_authed/indicateurs/$id.tsx
+++ b/apps/kpilote-admin/src/routes/_authed/indicateurs/$id.tsx
@@ -13,10 +13,16 @@ import {
 import { PageHeading } from '@/components/PageHeading'
 import { extractApiError } from '@/lib/apiError'
 import { indicateurQueryOptions } from '@/queries/indicateurs'
+import { referentielsAllQueryOptions } from '@/queries/referentiels'
+import { utilisateursAllQueryOptions } from '@/queries/utilisateurs'
 
 export const Route = createFileRoute('/_authed/indicateurs/$id')({
   loader: ({ context, params }) =>
-    context.queryClient.ensureQueryData(indicateurQueryOptions(params.id)),
+    Promise.all([
+      context.queryClient.ensureQueryData(indicateurQueryOptions(params.id)),
+      context.queryClient.ensureQueryData(referentielsAllQueryOptions()),
+      context.queryClient.ensureQueryData(utilisateursAllQueryOptions()),
+    ]),
   component: EditIndicateurComponent,
 })
 

--- a/apps/kpilote-admin/src/routes/_authed/indicateurs/nouveau.tsx
+++ b/apps/kpilote-admin/src/routes/_authed/indicateurs/nouveau.tsx
@@ -12,8 +12,15 @@ import {
 } from '@/components/indicateurs/indicateurFormSchema'
 import { PageHeading } from '@/components/PageHeading'
 import { extractApiError } from '@/lib/apiError'
+import { referentielsAllQueryOptions } from '@/queries/referentiels'
+import { utilisateursAllQueryOptions } from '@/queries/utilisateurs'
 
 export const Route = createFileRoute('/_authed/indicateurs/nouveau')({
+  loader: ({ context }) =>
+    Promise.all([
+      context.queryClient.ensureQueryData(referentielsAllQueryOptions()),
+      context.queryClient.ensureQueryData(utilisateursAllQueryOptions()),
+    ]),
   component: NewIndicateurComponent,
 })
 

--- a/apps/kpilote-api/src/indicateur/commands/upsertIndicateur.test.ts
+++ b/apps/kpilote-api/src/indicateur/commands/upsertIndicateur.test.ts
@@ -616,14 +616,14 @@ describe.concurrent('upsertIndicateur', () => {
         upsertIndicateur(indId, { ...BODY_BASE, responsables: [userA.id] }),
       )
       const avant = await db().indicateurResponsable.findFirstOrThrow({
-        where: { utilisateurId: userA.id },
+        where: { utilisateurId: userA.id, indicateur: { publicId: indId } },
       })
 
       await runAsAdmin(apiKey.id, () =>
         upsertIndicateur(indId, { ...BODY_BASE, responsables: [userA.id, userB.id] }),
       )
       const apres = await db().indicateurResponsable.findFirstOrThrow({
-        where: { utilisateurId: userA.id },
+        where: { utilisateurId: userA.id, indicateur: { publicId: indId } },
       })
 
       expect(apres.createdAt).toEqual(avant.createdAt)

--- a/apps/kpilote-api/src/indicateur/commands/upsertIndicateur.test.ts
+++ b/apps/kpilote-api/src/indicateur/commands/upsertIndicateur.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+import { uuidv7 } from 'uuidv7'
 
 import { ForbiddenError, ValidationError } from '@/framework/errors/AppError'
 import { db } from '@/framework/persistence/dbStore'
@@ -7,6 +8,14 @@ import { fixtures } from '@/test/fixtures'
 import { integrationTest } from '@/test/integrationTest'
 import { testIndicateurId, testReferentielId } from '@/test/randomIds'
 import { runAsAdmin, runAsContributor, runAsUser } from '@/test/runAsPrincipal'
+
+const getResponsableUtilisateurIds = async (publicId: string): Promise<string[]> => {
+  const indicateur = await db().indicateur.findUniqueOrThrow({
+    where: { publicId },
+    include: { responsables: { orderBy: { createdAt: 'asc' } } },
+  })
+  return indicateur.responsables.map((responsable) => responsable.utilisateurId)
+}
 
 const METADONNEES_VIDES = {
   description: null,
@@ -482,6 +491,145 @@ describe.concurrent('upsertIndicateur', () => {
       expect(await getConfigurationsReferentiels(indId)).toEqual([
         { id: refDedupFn, fonctionAgregation: 'NONE' },
       ])
+    }),
+  )
+
+  it(
+    'assigne des responsables à la création',
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const apiKey = await fixtures.apiKey()
+      const userA = await fixtures.utilisateur({ email: `a-${indId}@example.com` })
+      const userB = await fixtures.utilisateur({ email: `b-${indId}@example.com` })
+
+      await runAsAdmin(apiKey.id, () =>
+        upsertIndicateur(indId, { ...BODY_BASE, responsables: [userA.id, userB.id] }),
+      )
+
+      const ids = await getResponsableUtilisateurIds(indId)
+      expect(new Set(ids)).toEqual(new Set([userA.id, userB.id]))
+    }),
+  )
+
+  it(
+    'remplace intégralement la liste des responsables (replace-all)',
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const apiKey = await fixtures.apiKey()
+      const userA = await fixtures.utilisateur({ email: `a-${indId}@example.com` })
+      const userB = await fixtures.utilisateur({ email: `b-${indId}@example.com` })
+      const userC = await fixtures.utilisateur({ email: `c-${indId}@example.com` })
+
+      await runAsAdmin(apiKey.id, () =>
+        upsertIndicateur(indId, { ...BODY_BASE, responsables: [userA.id, userB.id] }),
+      )
+      await runAsAdmin(apiKey.id, () =>
+        upsertIndicateur(indId, { ...BODY_BASE, responsables: [userB.id, userC.id] }),
+      )
+
+      const ids = await getResponsableUtilisateurIds(indId)
+      expect(new Set(ids)).toEqual(new Set([userB.id, userC.id]))
+    }),
+  )
+
+  it(
+    'laisse les responsables inchangés quand le champ est absent',
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const apiKey = await fixtures.apiKey()
+      const userA = await fixtures.utilisateur({ email: `a-${indId}@example.com` })
+
+      await runAsAdmin(apiKey.id, () =>
+        upsertIndicateur(indId, { ...BODY_BASE, responsables: [userA.id] }),
+      )
+      // Pas de clé `responsables` → ne pas toucher.
+      await runAsAdmin(apiKey.id, () => upsertIndicateur(indId, { ...BODY_BASE, nom: 'Renommé' }))
+
+      const ids = await getResponsableUtilisateurIds(indId)
+      expect(ids).toEqual([userA.id])
+    }),
+  )
+
+  it(
+    'vide les responsables quand le champ vaut []',
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const apiKey = await fixtures.apiKey()
+      const userA = await fixtures.utilisateur({ email: `a-${indId}@example.com` })
+
+      await runAsAdmin(apiKey.id, () =>
+        upsertIndicateur(indId, { ...BODY_BASE, responsables: [userA.id] }),
+      )
+      await runAsAdmin(apiKey.id, () => upsertIndicateur(indId, { ...BODY_BASE, responsables: [] }))
+
+      const ids = await getResponsableUtilisateurIds(indId)
+      expect(ids).toEqual([])
+    }),
+  )
+
+  it(
+    'déduplique les responsables en doublon',
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const apiKey = await fixtures.apiKey()
+      const userA = await fixtures.utilisateur({ email: `a-${indId}@example.com` })
+
+      await runAsAdmin(apiKey.id, () =>
+        upsertIndicateur(indId, { ...BODY_BASE, responsables: [userA.id, userA.id] }),
+      )
+
+      const ids = await getResponsableUtilisateurIds(indId)
+      expect(ids).toEqual([userA.id])
+    }),
+  )
+
+  it(
+    'échoue avec VALIDATION_ERROR quand un utilisateur est inconnu (aucun indicateur créé)',
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const apiKey = await fixtures.apiKey()
+      const inconnu = uuidv7()
+
+      await expect(
+        runAsAdmin(apiKey.id, () =>
+          upsertIndicateur(indId, { ...BODY_BASE, responsables: [inconnu] }),
+        ),
+      ).rejects.toMatchObject({
+        constructor: ValidationError,
+        details: { unknownUtilisateurIds: [inconnu] },
+      })
+
+      const created = await db().indicateur.findUnique({ where: { publicId: indId } })
+      expect(created).toBeNull()
+    }),
+  )
+
+  it(
+    "préserve le createdAt des responsables conservés lors d'un remplacement",
+    integrationTest(async () => {
+      const indId = testIndicateurId()
+      const apiKey = await fixtures.apiKey()
+      const userA = await fixtures.utilisateur({ email: `keep-a-${indId}@example.com` })
+      const userB = await fixtures.utilisateur({ email: `keep-b-${indId}@example.com` })
+
+      await runAsAdmin(apiKey.id, () =>
+        upsertIndicateur(indId, { ...BODY_BASE, responsables: [userA.id] }),
+      )
+      const avant = await db().indicateurResponsable.findFirstOrThrow({
+        where: { utilisateurId: userA.id },
+      })
+
+      await runAsAdmin(apiKey.id, () =>
+        upsertIndicateur(indId, { ...BODY_BASE, responsables: [userA.id, userB.id] }),
+      )
+      const apres = await db().indicateurResponsable.findFirstOrThrow({
+        where: { utilisateurId: userA.id },
+      })
+
+      expect(apres.createdAt).toEqual(avant.createdAt)
+      // userA (inséré en 1er, createdAt préservé) précède userB (inséré ensuite).
+      const ids = await getResponsableUtilisateurIds(indId)
+      expect(ids).toEqual([userA.id, userB.id])
     }),
   )
 })

--- a/apps/kpilote-api/src/indicateur/commands/upsertIndicateur.ts
+++ b/apps/kpilote-api/src/indicateur/commands/upsertIndicateur.ts
@@ -96,6 +96,43 @@ const remplacerConfigurationsReferentiels = async (
   await upsertConfigurationsCibles(indicateurId, configurations)
 }
 
+const resoudreResponsables = async (utilisateurIds: ReadonlyArray<string>): Promise<string[]> => {
+  const idsUniques = [...new Set(utilisateurIds)]
+  if (idsUniques.length === 0) return []
+  const utilisateurs = await db().utilisateur.findMany({ where: { id: { in: idsUniques } } })
+  const idsTrouves = new Set(utilisateurs.map((utilisateur) => utilisateur.id))
+  const idsInconnus = idsUniques.filter((id) => !idsTrouves.has(id))
+  if (idsInconnus.length > 0) {
+    throw new ValidationError('Utilisateurs inconnus', {
+      unknownUtilisateurIds: idsInconnus.sort(),
+    })
+  }
+  return idsUniques
+}
+
+const remplacerResponsables = async (
+  indicateurId: string,
+  utilisateurIdsCibles: string[],
+): Promise<void> => {
+  const cibles = new Set(utilisateurIdsCibles)
+  const existantes = await db().indicateurResponsable.findMany({ where: { indicateurId } })
+  const aSupprimer = existantes
+    .filter((liaison) => !cibles.has(liaison.utilisateurId))
+    .map((liaison) => liaison.utilisateurId)
+  if (aSupprimer.length > 0) {
+    await db().indicateurResponsable.deleteMany({
+      where: { indicateurId, utilisateurId: { in: aSupprimer } },
+    })
+  }
+  for (const utilisateurId of utilisateurIdsCibles) {
+    await db().indicateurResponsable.upsert({
+      where: { indicateurId_utilisateurId: { indicateurId, utilisateurId } },
+      update: {},
+      create: { indicateurId, utilisateurId },
+    })
+  }
+}
+
 const assertWritePermission = async (indicateurId: string, principalId: string): Promise<void> => {
   const hasWrite = await db().indicateurPermission.findUnique({
     where: {
@@ -134,6 +171,8 @@ const updateIndicateurExistant = async (
 ): Promise<void> => {
   await assertWritePermission(indicateurId, principalId)
   const configurations = await resoudreConfigurationsReferentiels(body.referentiels)
+  const responsablesCibles =
+    body.responsables === undefined ? undefined : await resoudreResponsables(body.responsables)
   await db().indicateur.update({
     where: { publicId },
     data: {
@@ -144,6 +183,9 @@ const updateIndicateurExistant = async (
     },
   })
   await remplacerConfigurationsReferentiels(indicateurId, configurations)
+  if (responsablesCibles !== undefined) {
+    await remplacerResponsables(indicateurId, responsablesCibles)
+  }
 }
 
 const grantOwnerPermissions = async (principalId: string, indicateurId: string): Promise<void> => {
@@ -161,6 +203,8 @@ const createIndicateurAvecGrants = async (
   principalId: string,
 ): Promise<void> => {
   const configurations = await resoudreConfigurationsReferentiels(body.referentiels)
+  const responsablesCibles =
+    body.responsables === undefined ? undefined : await resoudreResponsables(body.responsables)
   const indicateurId = uuidv7()
   await db().indicateur.create({
     data: {
@@ -181,6 +225,9 @@ const createIndicateurAvecGrants = async (
         fonctionAgregation: configuration.fonctionAgregation,
       })),
     })
+  }
+  if (responsablesCibles !== undefined) {
+    await remplacerResponsables(indicateurId, responsablesCibles)
   }
 }
 

--- a/apps/kpilote-api/src/indicateur/queries/getIndicateurByPublicId.test.ts
+++ b/apps/kpilote-api/src/indicateur/queries/getIndicateurByPublicId.test.ts
@@ -257,7 +257,7 @@ describe.concurrent('getIndicateurByPublicId', () => {
     "retourne tous les champs d'un responsable de l'indicateur",
     integrationTest(async () => {
       const indId = testIndicateurId()
-      await fixtures.indicateurResponsable({
+      const liaison = await fixtures.indicateurResponsable({
         indicateur: { publicId: indId, visibilite: 'PUBLIC' },
         utilisateur: {
           email: `resp-${indId}@example.com`,
@@ -273,6 +273,7 @@ describe.concurrent('getIndicateurByPublicId', () => {
 
       expect(result._unsafeUnwrap().responsables).toEqual([
         {
+          id: liaison.utilisateurId,
           email: `resp-${indId}@example.com`,
           nom: 'Martin',
           prenom: 'Alice',

--- a/apps/kpilote-api/src/indicateur/utils.ts
+++ b/apps/kpilote-api/src/indicateur/utils.ts
@@ -102,6 +102,7 @@ export const toIndicateurApiModel = ({
       }))
       .sort((a, b) => a.id.localeCompare(b.id)),
     responsables: indicateur.responsables.map(({ utilisateur }) => ({
+      id: utilisateur.id,
       email: utilisateur.email,
       nom: utilisateur.nom,
       prenom: utilisateur.prenom,

--- a/apps/kpilote-api/src/panier/queries/getPanierByPublicId.test.ts
+++ b/apps/kpilote-api/src/panier/queries/getPanierByPublicId.test.ts
@@ -99,7 +99,7 @@ describe.concurrent('getPanierByPublicId', () => {
     "retourne les responsables du panier triés par ordre d'assignation",
     integrationTest(async () => {
       const panId = testPanierId()
-      await fixtures.panierResponsable({
+      const liaison = await fixtures.panierResponsable({
         panier: { publicId: panId, visibilite: 'PUBLIC' },
         utilisateur: {
           email: `resp-a-${panId}@example.com`,
@@ -115,6 +115,7 @@ describe.concurrent('getPanierByPublicId', () => {
 
       expect(result._unsafeUnwrap().responsables).toEqual([
         {
+          id: liaison.utilisateurId,
           email: `resp-a-${panId}@example.com`,
           nom: 'Martin',
           prenom: 'Alice',

--- a/apps/kpilote-api/src/panier/utils.ts
+++ b/apps/kpilote-api/src/panier/utils.ts
@@ -56,6 +56,7 @@ export const toPanierApiModel = (panier: PanierWithIndicateurs): PanierApiModel 
   visibilite: panier.visibilite,
   indicateurIds: panier.indicateurs.map((lien) => lien.indicateur.publicId),
   responsables: panier.responsables.map(({ utilisateur }) => ({
+    id: utilisateur.id,
     email: utilisateur.email,
     nom: utilisateur.nom,
     prenom: utilisateur.prenom,

--- a/docs/superpowers/plans/2026-07-08-administration-responsables-indicateur.md
+++ b/docs/superpowers/plans/2026-07-08-administration-responsables-indicateur.md
@@ -1,0 +1,782 @@
+# Administration des responsables d'indicateur — Plan d'implémentation
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Permettre à un administrateur de gérer (ajouter / retirer) les responsables d'un indicateur depuis `kpilote-admin`, via le formulaire d'édition existant.
+
+**Architecture:** On ajoute un champ optionnel `responsables` (UUIDs, replace-all) au body du `PUT /indicateurs/:id` existant : l'écriture est atomique dans la transaction de l'upsert, aucune nouvelle route. Le modèle de lecture des responsables est enrichi de l'`id` utilisateur pour permettre le pré-remplissage côté admin. Côté admin, une section « Responsables » est ajoutée au formulaire, alimentée par un `FieldSelect` peuplé de tous les utilisateurs.
+
+**Tech Stack:** TypeScript, Zod, Prisma, Hono (API) ; React 19, React Hook Form, TanStack Query, `ky` (admin) ; Vitest (tests API intégration).
+
+## Global Constraints
+
+- **Named exports/imports uniquement** — jamais de `export default`.
+- **Paramètres de fonction** : privilégier un objet nommé pour les helpers à plusieurs paramètres (les helpers existants du fichier `upsertIndicateur.ts` prennent des positionnels ; on suit le style local du fichier).
+- **neverthrow** : les commands retournent `ResultAsync` ; on n'ajoute pas de nouvelle command, on étend `upsertIndicateur` (déjà en `ResultAsync`).
+- **Tests API** : `uuidv7` (pas `randomUUID`), valeurs hardcodées (isolation transactionnelle), fixtures `fixtures.<entity>(...)`.
+- **Prisma** : pas de `$transaction` nesté ; pas de `select` granulaires (findMany + map) ; filtres enum sans `as const`.
+- **Le champ `responsables` du body est optionnel** : absent = « ne pas toucher » ; présent (y compris `[]`) = replace-all.
+- Commandes test API : `pnpm -F @pilote/kpilote-api test <chemin-relatif>` (nécessite la base de test up, comme d'habitude). Lint API : `pnpm -F @pilote/kpilote-api lint`. Lint admin (inclut `tsc --noEmit`) : `pnpm -F @pilote/kpilote-admin lint`.
+
+---
+
+## File Structure
+
+**API (`kpilote-api` / `kpilote-shared`)**
+- `packages/kpilote-shared/src/responsable.ts` — ajout `id` au read model.
+- `packages/kpilote-shared/src/indicateur.ts` — ajout champ `responsables` au body upsert.
+- `apps/kpilote-api/src/indicateur/utils.ts` — sérialisation de `id`.
+- `apps/kpilote-api/src/panier/utils.ts` — sérialisation de `id`.
+- `apps/kpilote-api/src/indicateur/commands/upsertIndicateur.ts` — helpers `resoudreResponsables` / `remplacerResponsables` + branchement.
+- Tests : `upsertIndicateur.test.ts`, `getIndicateurByPublicId.test.ts`, `getPanierByPublicId.test.ts`.
+
+**Admin (`kpilote-admin`)**
+- `apps/kpilote-admin/src/api/utilisateurs.ts` — `fetchAllUtilisateurs`.
+- `apps/kpilote-admin/src/components/indicateurs/indicateurFormSchema.ts` — champ `responsables`, `buildInitialValues`, `toUpsertBody`.
+- `apps/kpilote-admin/src/components/indicateurs/IndicateurForm.tsx` — section « Responsables ».
+
+Les routes admin (`$id.tsx`, `nouveau.tsx`) ne changent pas : `responsables` transite par `toUpsertBody` → `upsertIndicateur`.
+
+---
+
+## Task 1: Enrichir le read model des responsables avec l'`id`
+
+**Files:**
+- Modify: `packages/kpilote-shared/src/responsable.ts`
+- Modify: `apps/kpilote-api/src/indicateur/utils.ts` (bloc `responsables:` du `toIndicateurApiModel`)
+- Modify: `apps/kpilote-api/src/panier/utils.ts` (bloc `responsables:` du `toPanierApiModel`)
+- Test: `apps/kpilote-api/src/indicateur/queries/getIndicateurByPublicId.test.ts`
+- Test: `apps/kpilote-api/src/panier/queries/getPanierByPublicId.test.ts`
+
+**Interfaces:**
+- Produces: `responsableApiModelSchema` gagne un champ `id: string` (UUID). Utilisé par le read model indicateur/panier et, plus tard, par le form admin.
+
+- [ ] **Step 1: Mettre à jour les assertions de test (indicateur) — doivent échouer**
+
+Dans `getIndicateurByPublicId.test.ts`, test « retourne tous les champs d'un responsable de l'indicateur » : capturer la liaison renvoyée par le fixture et asserter `id`.
+
+```ts
+const liaison = await fixtures.indicateurResponsable({
+  indicateur: { publicId: indId, visibilite: 'PUBLIC' },
+  utilisateur: {
+    email: `resp-${indId}@example.com`,
+    nom: 'Martin',
+    prenom: 'Alice',
+    service: 'DITP',
+    fonction: 'Chargée de mission',
+  },
+})
+const apiKey = await fixtures.apiKey()
+
+const result = await runAsPrincipal(apiKey.id, () => getIndicateurByPublicId(indId))
+
+expect(result._unsafeUnwrap().responsables).toEqual([
+  {
+    id: liaison.utilisateurId,
+    email: `resp-${indId}@example.com`,
+    nom: 'Martin',
+    prenom: 'Alice',
+    service: 'DITP',
+    fonction: 'Chargée de mission',
+  },
+])
+```
+
+- [ ] **Step 2: Mettre à jour les assertions de test (panier) — doivent échouer**
+
+Dans `getPanierByPublicId.test.ts`, test « retourne les responsables du panier triés par ordre d'assignation » : idem.
+
+```ts
+const liaison = await fixtures.panierResponsable({
+  panier: { publicId: panId, visibilite: 'PUBLIC' },
+  utilisateur: {
+    email: `resp-a-${panId}@example.com`,
+    nom: 'Martin',
+    prenom: 'Alice',
+    service: 'DITP',
+    fonction: 'Chargée de mission',
+  },
+})
+const apiKey = await fixtures.apiKey()
+
+const result = await runAsPrincipal(apiKey.id, () => getPanierByPublicId(panId))
+
+expect(result._unsafeUnwrap().responsables).toEqual([
+  {
+    id: liaison.utilisateurId,
+    email: `resp-a-${panId}@example.com`,
+    nom: 'Martin',
+    prenom: 'Alice',
+    service: 'DITP',
+    fonction: 'Chargée de mission',
+  },
+])
+```
+
+- [ ] **Step 3: Lancer les tests pour vérifier l'échec**
+
+Run:
+```bash
+pnpm -F @pilote/kpilote-api test src/indicateur/queries/getIndicateurByPublicId.test.ts src/panier/queries/getPanierByPublicId.test.ts
+```
+Expected: FAIL — les objets responsables ne contiennent pas encore `id`.
+
+- [ ] **Step 4: Ajouter `id` au schéma partagé**
+
+Dans `packages/kpilote-shared/src/responsable.ts` :
+
+```ts
+import { z } from 'zod'
+
+export const responsableApiModelSchema = z.object({
+  id: z.string().uuid().describe("Identifiant (UUID) de l'utilisateur responsable."),
+  email: z.string().email(),
+  nom: z.string(),
+  prenom: z.string(),
+  service: z.string(),
+  fonction: z.string(),
+})
+export type ResponsableApiModel = z.infer<typeof responsableApiModelSchema>
+```
+
+- [ ] **Step 5: Sérialiser `id` côté indicateur**
+
+Dans `apps/kpilote-api/src/indicateur/utils.ts`, bloc `responsables:` :
+
+```ts
+responsables: indicateur.responsables.map(({ utilisateur }) => ({
+  id: utilisateur.id,
+  email: utilisateur.email,
+  nom: utilisateur.nom,
+  prenom: utilisateur.prenom,
+  service: utilisateur.service,
+  fonction: utilisateur.fonction,
+})),
+```
+
+- [ ] **Step 6: Sérialiser `id` côté panier**
+
+Dans `apps/kpilote-api/src/panier/utils.ts`, bloc `responsables:` :
+
+```ts
+responsables: panier.responsables.map(({ utilisateur }) => ({
+  id: utilisateur.id,
+  email: utilisateur.email,
+  nom: utilisateur.nom,
+  prenom: utilisateur.prenom,
+  service: utilisateur.service,
+  fonction: utilisateur.fonction,
+})),
+```
+
+- [ ] **Step 7: Lancer les tests pour vérifier le succès**
+
+Run:
+```bash
+pnpm -F @pilote/kpilote-api test src/indicateur/queries/getIndicateurByPublicId.test.ts src/panier/queries/getPanierByPublicId.test.ts
+```
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/kpilote-shared/src/responsable.ts apps/kpilote-api/src/indicateur/utils.ts apps/kpilote-api/src/panier/utils.ts apps/kpilote-api/src/indicateur/queries/getIndicateurByPublicId.test.ts apps/kpilote-api/src/panier/queries/getPanierByPublicId.test.ts
+git commit -m "feat(responsable): expose l'id utilisateur dans le read model responsable"
+```
+
+---
+
+## Task 2: Ajouter le champ `responsables` au body d'upsert
+
+**Files:**
+- Modify: `packages/kpilote-shared/src/indicateur.ts` (`upsertIndicateurBodySchema`)
+
+**Interfaces:**
+- Produces: `upsertIndicateurBodySchema` gagne `responsables?: string[]` (UUIDs). Consommé par la command (Task 3) et le form admin (Task 5).
+
+- [ ] **Step 1: Ajouter le champ au schéma**
+
+Dans `packages/kpilote-shared/src/indicateur.ts`, dans `upsertIndicateurBodySchema`, après le champ `referentiels` :
+
+```ts
+  responsables: z
+    .array(z.string().uuid())
+    .optional()
+    .describe(
+      'UUIDs des utilisateurs responsables (replace-all quand présent). ' +
+        'Champ optionnel : absent = inchangé ; `[]` = aucun responsable. Doublons dédupliqués.',
+    ),
+```
+
+- [ ] **Step 2: Vérifier la compilation du package partagé**
+
+Run:
+```bash
+pnpm -F @pilote/kpilote-api exec tsc --noEmit
+```
+Expected: PASS (aucune erreur de type introduite ; `responsables` optionnel n'impacte pas les appelants existants).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/kpilote-shared/src/indicateur.ts
+git commit -m "feat(indicateur): champ responsables optionnel dans le body d'upsert"
+```
+
+---
+
+## Task 3: Gérer les responsables dans la command `upsertIndicateur`
+
+**Files:**
+- Modify: `apps/kpilote-api/src/indicateur/commands/upsertIndicateur.ts`
+- Test: `apps/kpilote-api/src/indicateur/commands/upsertIndicateur.test.ts`
+
+**Interfaces:**
+- Consumes: `upsertIndicateurBodySchema.responsables` (Task 2).
+- Produces: `upsertIndicateur(publicId, body)` applique désormais les responsables (replace-all quand `body.responsables !== undefined`). Signature inchangée (`ResultAsync<void, never>`).
+
+- [ ] **Step 1: Écrire les tests d'échec**
+
+Dans `apps/kpilote-api/src/indicateur/commands/upsertIndicateur.test.ts`, ajouter en haut l'import `uuidv7` et un helper de lecture :
+
+```ts
+import { uuidv7 } from 'uuidv7'
+
+const getResponsableUtilisateurIds = async (publicId: string): Promise<string[]> => {
+  const indicateur = await db().indicateur.findUniqueOrThrow({
+    where: { publicId },
+    include: { responsables: { orderBy: { createdAt: 'asc' } } },
+  })
+  return indicateur.responsables.map((responsable) => responsable.utilisateurId)
+}
+```
+
+Puis, dans le `describe('upsertIndicateur')`, ajouter les tests suivants :
+
+```ts
+it(
+  'assigne des responsables à la création',
+  integrationTest(async () => {
+    const indId = testIndicateurId()
+    const apiKey = await fixtures.apiKey()
+    const userA = await fixtures.utilisateur({ email: `a-${indId}@example.com` })
+    const userB = await fixtures.utilisateur({ email: `b-${indId}@example.com` })
+
+    await runAsAdmin(apiKey.id, () =>
+      upsertIndicateur(indId, { ...BODY_BASE, responsables: [userA.id, userB.id] }),
+    )
+
+    const ids = await getResponsableUtilisateurIds(indId)
+    expect(new Set(ids)).toEqual(new Set([userA.id, userB.id]))
+  }),
+)
+
+it(
+  'remplace intégralement la liste des responsables (replace-all)',
+  integrationTest(async () => {
+    const indId = testIndicateurId()
+    const apiKey = await fixtures.apiKey()
+    const userA = await fixtures.utilisateur({ email: `a-${indId}@example.com` })
+    const userB = await fixtures.utilisateur({ email: `b-${indId}@example.com` })
+    const userC = await fixtures.utilisateur({ email: `c-${indId}@example.com` })
+
+    await runAsAdmin(apiKey.id, () =>
+      upsertIndicateur(indId, { ...BODY_BASE, responsables: [userA.id, userB.id] }),
+    )
+    await runAsAdmin(apiKey.id, () =>
+      upsertIndicateur(indId, { ...BODY_BASE, responsables: [userB.id, userC.id] }),
+    )
+
+    const ids = await getResponsableUtilisateurIds(indId)
+    expect(new Set(ids)).toEqual(new Set([userB.id, userC.id]))
+  }),
+)
+
+it(
+  'laisse les responsables inchangés quand le champ est absent',
+  integrationTest(async () => {
+    const indId = testIndicateurId()
+    const apiKey = await fixtures.apiKey()
+    const userA = await fixtures.utilisateur({ email: `a-${indId}@example.com` })
+
+    await runAsAdmin(apiKey.id, () =>
+      upsertIndicateur(indId, { ...BODY_BASE, responsables: [userA.id] }),
+    )
+    // Pas de clé `responsables` → ne pas toucher.
+    await runAsAdmin(apiKey.id, () => upsertIndicateur(indId, { ...BODY_BASE, nom: 'Renommé' }))
+
+    const ids = await getResponsableUtilisateurIds(indId)
+    expect(ids).toEqual([userA.id])
+  }),
+)
+
+it(
+  'vide les responsables quand le champ vaut []',
+  integrationTest(async () => {
+    const indId = testIndicateurId()
+    const apiKey = await fixtures.apiKey()
+    const userA = await fixtures.utilisateur({ email: `a-${indId}@example.com` })
+
+    await runAsAdmin(apiKey.id, () =>
+      upsertIndicateur(indId, { ...BODY_BASE, responsables: [userA.id] }),
+    )
+    await runAsAdmin(apiKey.id, () => upsertIndicateur(indId, { ...BODY_BASE, responsables: [] }))
+
+    const ids = await getResponsableUtilisateurIds(indId)
+    expect(ids).toEqual([])
+  }),
+)
+
+it(
+  'déduplique les responsables en doublon',
+  integrationTest(async () => {
+    const indId = testIndicateurId()
+    const apiKey = await fixtures.apiKey()
+    const userA = await fixtures.utilisateur({ email: `a-${indId}@example.com` })
+
+    await runAsAdmin(apiKey.id, () =>
+      upsertIndicateur(indId, { ...BODY_BASE, responsables: [userA.id, userA.id] }),
+    )
+
+    const ids = await getResponsableUtilisateurIds(indId)
+    expect(ids).toEqual([userA.id])
+  }),
+)
+
+it(
+  'échoue avec VALIDATION_ERROR quand un utilisateur est inconnu (aucun indicateur créé)',
+  integrationTest(async () => {
+    const indId = testIndicateurId()
+    const apiKey = await fixtures.apiKey()
+    const inconnu = uuidv7()
+
+    await expect(
+      runAsAdmin(apiKey.id, () =>
+        upsertIndicateur(indId, { ...BODY_BASE, responsables: [inconnu] }),
+      ),
+    ).rejects.toMatchObject({
+      constructor: ValidationError,
+      details: { unknownUtilisateurIds: [inconnu] },
+    })
+
+    const created = await db().indicateur.findUnique({ where: { publicId: indId } })
+    expect(created).toBeNull()
+  }),
+)
+
+it(
+  'préserve le createdAt des responsables conservés lors d’un remplacement',
+  integrationTest(async () => {
+    const indId = testIndicateurId()
+    const apiKey = await fixtures.apiKey()
+    const userA = await fixtures.utilisateur({ email: `keep-a-${indId}@example.com` })
+    const userB = await fixtures.utilisateur({ email: `keep-b-${indId}@example.com` })
+
+    await runAsAdmin(apiKey.id, () =>
+      upsertIndicateur(indId, { ...BODY_BASE, responsables: [userA.id] }),
+    )
+    const avant = await db().indicateurResponsable.findFirstOrThrow({
+      where: { utilisateurId: userA.id },
+    })
+
+    await runAsAdmin(apiKey.id, () =>
+      upsertIndicateur(indId, { ...BODY_BASE, responsables: [userA.id, userB.id] }),
+    )
+    const apres = await db().indicateurResponsable.findFirstOrThrow({
+      where: { utilisateurId: userA.id },
+    })
+
+    expect(apres.createdAt).toEqual(avant.createdAt)
+    // userA (inséré en 1er, createdAt préservé) précède userB (inséré ensuite).
+    const ids = await getResponsableUtilisateurIds(indId)
+    expect(ids).toEqual([userA.id, userB.id])
+  }),
+)
+```
+
+Note : `BODY_BASE` (déjà défini dans le fichier) contient `referentiels: []` et les métadonnées vides ; il ne contient pas de clé `responsables`.
+
+- [ ] **Step 2: Lancer les tests pour vérifier l'échec**
+
+Run:
+```bash
+pnpm -F @pilote/kpilote-api test src/indicateur/commands/upsertIndicateur.test.ts
+```
+Expected: FAIL — les responsables ne sont pas encore gérés par la command (les assertions sur la liste échouent ; le test d'utilisateur inconnu ne lève pas encore).
+
+- [ ] **Step 3: Ajouter les helpers responsables dans la command**
+
+Dans `apps/kpilote-api/src/indicateur/commands/upsertIndicateur.ts`, ajouter après `remplacerConfigurationsReferentiels` (les helpers réutilisent `db()` et `ValidationError`, déjà importés) :
+
+```ts
+const resoudreResponsables = async (
+  utilisateurIds: ReadonlyArray<string>,
+): Promise<string[]> => {
+  const idsUniques = [...new Set(utilisateurIds)]
+  if (idsUniques.length === 0) return []
+  const utilisateurs = await db().utilisateur.findMany({ where: { id: { in: idsUniques } } })
+  const idsTrouves = new Set(utilisateurs.map((utilisateur) => utilisateur.id))
+  const idsInconnus = idsUniques.filter((id) => !idsTrouves.has(id))
+  if (idsInconnus.length > 0) {
+    throw new ValidationError('Utilisateurs inconnus', {
+      unknownUtilisateurIds: idsInconnus.sort(),
+    })
+  }
+  return idsUniques
+}
+
+const remplacerResponsables = async (
+  indicateurId: string,
+  utilisateurIdsCibles: string[],
+): Promise<void> => {
+  const cibles = new Set(utilisateurIdsCibles)
+  const existantes = await db().indicateurResponsable.findMany({ where: { indicateurId } })
+  const aSupprimer = existantes
+    .filter((liaison) => !cibles.has(liaison.utilisateurId))
+    .map((liaison) => liaison.utilisateurId)
+  if (aSupprimer.length > 0) {
+    await db().indicateurResponsable.deleteMany({
+      where: { indicateurId, utilisateurId: { in: aSupprimer } },
+    })
+  }
+  for (const utilisateurId of utilisateurIdsCibles) {
+    await db().indicateurResponsable.upsert({
+      where: { indicateurId_utilisateurId: { indicateurId, utilisateurId } },
+      update: {},
+      create: { indicateurId, utilisateurId },
+    })
+  }
+}
+```
+
+- [ ] **Step 4: Brancher dans le chemin de mise à jour**
+
+Dans `updateIndicateurExistant`, résoudre les responsables juste après les référentiels (fail-fast avant toute écriture), puis les appliquer après `remplacerConfigurationsReferentiels` :
+
+```ts
+const updateIndicateurExistant = async (
+  publicId: string,
+  indicateurId: string,
+  body: UpsertIndicateurBody,
+  principalId: string,
+): Promise<void> => {
+  await assertWritePermission(indicateurId, principalId)
+  const configurations = await resoudreConfigurationsReferentiels(body.referentiels)
+  const responsablesCibles =
+    body.responsables === undefined ? undefined : await resoudreResponsables(body.responsables)
+  await db().indicateur.update({
+    where: { publicId },
+    data: {
+      nom: body.nom,
+      visibilite: body.visibilite,
+      unite: body.unite,
+      ...metadonneesData(body),
+    },
+  })
+  await remplacerConfigurationsReferentiels(indicateurId, configurations)
+  if (responsablesCibles !== undefined) {
+    await remplacerResponsables(indicateurId, responsablesCibles)
+  }
+}
+```
+
+- [ ] **Step 5: Brancher dans le chemin de création**
+
+Dans `createIndicateurAvecGrants`, résoudre les responsables avant de créer (pour que « utilisateur inconnu » n'ait créé aucun indicateur), puis les appliquer après les référentiels :
+
+```ts
+const createIndicateurAvecGrants = async (
+  publicId: string,
+  body: UpsertIndicateurBody,
+  principalId: string,
+): Promise<void> => {
+  const configurations = await resoudreConfigurationsReferentiels(body.referentiels)
+  const responsablesCibles =
+    body.responsables === undefined ? undefined : await resoudreResponsables(body.responsables)
+  const indicateurId = uuidv7()
+  await db().indicateur.create({
+    data: {
+      id: indicateurId,
+      publicId,
+      nom: body.nom,
+      visibilite: body.visibilite,
+      unite: body.unite,
+      ...metadonneesData(body),
+    },
+  })
+  await grantOwnerPermissions(principalId, indicateurId)
+  if (configurations.length > 0) {
+    await db().indicateurReferentiel.createMany({
+      data: configurations.map((configuration) => ({
+        indicateurId,
+        referentielId: configuration.referentielId,
+        fonctionAgregation: configuration.fonctionAgregation,
+      })),
+    })
+  }
+  if (responsablesCibles !== undefined) {
+    await remplacerResponsables(indicateurId, responsablesCibles)
+  }
+}
+```
+
+- [ ] **Step 6: Lancer les tests pour vérifier le succès**
+
+Run:
+```bash
+pnpm -F @pilote/kpilote-api test src/indicateur/commands/upsertIndicateur.test.ts
+```
+Expected: PASS (nouveaux tests + tests existants).
+
+- [ ] **Step 7: Lint API**
+
+Run:
+```bash
+pnpm -F @pilote/kpilote-api lint
+```
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/kpilote-api/src/indicateur/commands/upsertIndicateur.ts apps/kpilote-api/src/indicateur/commands/upsertIndicateur.test.ts
+git commit -m "feat(indicateur): applique les responsables (replace-all) dans l'upsert"
+```
+
+---
+
+## Task 4: Charger tous les utilisateurs côté admin (`fetchAllUtilisateurs`)
+
+**Files:**
+- Modify: `apps/kpilote-admin/src/api/utilisateurs.ts`
+
+**Interfaces:**
+- Consumes: `fetchUtilisateurs` (existant), `fetchAllPages` (`@/lib/fetchAllPages`, existant).
+- Produces: `fetchAllUtilisateurs(): Promise<UtilisateurApiModel[]>` — agrège toutes les pages de `GET /utilisateurs`. Consommé par le form admin (Task 6).
+
+- [ ] **Step 1: Ajouter `fetchAllUtilisateurs`**
+
+Dans `apps/kpilote-admin/src/api/utilisateurs.ts`, ajouter l'import et le helper (miroir de `fetchAllReferentiels`) :
+
+```ts
+import { fetchAllPages } from '@/lib/fetchAllPages'
+```
+
+```ts
+export const fetchAllUtilisateurs = (): Promise<UtilisateurApiModel[]> =>
+  fetchAllPages((cursor) => fetchUtilisateurs({ cursor }))
+```
+
+Placer le helper juste après `fetchUtilisateurs`. `UtilisateurApiModel` est déjà importé (type) dans le fichier.
+
+- [ ] **Step 2: Vérifier le typecheck admin**
+
+Run:
+```bash
+pnpm -F @pilote/kpilote-admin exec tsc --noEmit
+```
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/kpilote-admin/src/api/utilisateurs.ts
+git commit -m "feat(admin): fetchAllUtilisateurs pour peupler le select des responsables"
+```
+
+---
+
+## Task 5: Étendre le schéma de formulaire indicateur (admin)
+
+**Files:**
+- Modify: `apps/kpilote-admin/src/components/indicateurs/indicateurFormSchema.ts`
+
+**Interfaces:**
+- Consumes: `responsableApiModelSchema.id` (Task 1) via `IndicateurApiModel.responsables[].id` ; `upsertIndicateurBodySchema.responsables` (Task 2).
+- Produces: `IndicateurFormValues.responsables: { id; nom; prenom; email }[]`. `buildInitialValues` le pré-remplit ; `toUpsertBody` renvoie `responsables: string[]`.
+
+- [ ] **Step 1: Ajouter le champ `responsables` au schéma du formulaire**
+
+Dans `buildIndicateurFormSchema`, ajouter au `z.object({ ... })` (à côté de `referentiels`) :
+
+```ts
+      responsables: z.array(
+        z.object({
+          id: z.string(),
+          nom: z.string(),
+          prenom: z.string(),
+          email: z.string(),
+        }),
+      ),
+```
+
+- [ ] **Step 2: Pré-remplir dans `buildInitialValues`**
+
+Ajouter au retour de `buildInitialValues`, après `referentiels` :
+
+```ts
+    responsables:
+      indicateur?.responsables.map((responsable) => ({
+        id: responsable.id,
+        nom: responsable.nom,
+        prenom: responsable.prenom,
+        email: responsable.email,
+      })) ?? [],
+```
+
+- [ ] **Step 3: Mapper vers le body dans `toUpsertBody`**
+
+Ajouter au retour de `toUpsertBody`, après `referentiels` :
+
+```ts
+    responsables: values.responsables.map((responsable) => responsable.id),
+```
+
+- [ ] **Step 4: Vérifier le typecheck admin**
+
+Run:
+```bash
+pnpm -F @pilote/kpilote-admin exec tsc --noEmit
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/kpilote-admin/src/components/indicateurs/indicateurFormSchema.ts
+git commit -m "feat(admin): champ responsables dans le schéma du formulaire indicateur"
+```
+
+---
+
+## Task 6: Section « Responsables » dans le formulaire (admin)
+
+**Files:**
+- Modify: `apps/kpilote-admin/src/components/indicateurs/IndicateurForm.tsx`
+
+**Interfaces:**
+- Consumes: `fetchAllUtilisateurs` (Task 4) ; `IndicateurFormValues.responsables` (Task 5).
+
+- [ ] **Step 1: Importer les dépendances**
+
+En haut de `IndicateurForm.tsx`, ajouter :
+
+```ts
+import { fetchAllUtilisateurs } from '@/api/utilisateurs'
+```
+
+- [ ] **Step 2: Déclarer le field array et la query utilisateurs**
+
+Dans le composant `IndicateurForm`, après le `useFieldArray` des `referentiels` :
+
+```ts
+  const {
+    fields: responsablesFields,
+    append: appendResponsable,
+    remove: removeResponsable,
+  } = useFieldArray({ control: form.control, name: 'responsables' })
+
+  const utilisateursQuery = useQuery({
+    queryKey: ['utilisateurs', 'all-for-select'],
+    queryFn: () => fetchAllUtilisateurs(),
+  })
+  const utilisateursDisponibles = (utilisateursQuery.data ?? []).filter(
+    (utilisateur) => !responsablesFields.some((responsable) => responsable.id === utilisateur.id),
+  )
+```
+
+- [ ] **Step 3: Rendre la section « Responsables »**
+
+Juste après le bloc `<div className="border-t border-border pt-5">…Référentiels liés…</div>` (avant la fermeture de la carte du formulaire), ajouter une section jumelle :
+
+```tsx
+        <div className="border-t border-border pt-5">
+          <span className="mb-1 block text-sm font-bold">Responsables</span>
+          <p className="mb-4 text-xs text-text-subtle">
+            Utilisateurs désignés responsables de l'indicateur. Cette liste remplace{' '}
+            <b>intégralement</b> l'existant à l'enregistrement.
+          </p>
+
+          <FieldSelect
+            label="Ajouter un responsable"
+            value=""
+            disabled={utilisateursQuery.isLoading}
+            onChange={(event) => {
+              const utilisateur = utilisateursDisponibles.find(
+                (candidat) => candidat.id === event.target.value,
+              )
+              if (!utilisateur) return
+              appendResponsable({
+                id: utilisateur.id,
+                nom: utilisateur.nom,
+                prenom: utilisateur.prenom,
+                email: utilisateur.email,
+              })
+            }}
+          >
+            <option value="" disabled>
+              {utilisateursQuery.isLoading ? 'Chargement…' : 'Choisir un utilisateur…'}
+            </option>
+            {utilisateursDisponibles.map((utilisateur) => (
+              <option key={utilisateur.id} value={utilisateur.id}>
+                {utilisateur.prenom} {utilisateur.nom} · {utilisateur.email}
+              </option>
+            ))}
+          </FieldSelect>
+
+          <ul className="mt-3 space-y-2">
+            {responsablesFields.map((responsable, index) => (
+              <li
+                key={responsable.id}
+                className="flex items-center justify-between rounded-lg border border-border bg-surface-muted px-3 py-2 text-sm"
+              >
+                <span>
+                  {responsable.prenom} {responsable.nom}{' '}
+                  <span className="text-text-subtle">· {responsable.email}</span>
+                </span>
+                <button
+                  type="button"
+                  onClick={() => removeResponsable(index)}
+                  className="text-accent"
+                  aria-label="Retirer"
+                >
+                  <Trash2 className="size-4" />
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+```
+
+Note : `FieldSelect`, `Trash2`, `useFieldArray`, `useQuery` sont déjà importés dans le fichier. La `key` de la liste utilise `responsable.id` de `useFieldArray` (identifiant de field RHF, stable).
+
+- [ ] **Step 4: Vérifier le lint admin (inclut tsc)**
+
+Run:
+```bash
+pnpm -F @pilote/kpilote-admin lint
+```
+Expected: PASS.
+
+- [ ] **Step 5: Vérification manuelle**
+
+Lancer l'admin, ouvrir un indicateur en édition :
+- les responsables déjà assignés apparaissent dans la liste ;
+- le select ne propose pas les utilisateurs déjà sélectionnés ;
+- ajouter puis retirer un responsable, enregistrer, rouvrir : la liste reflète les changements ;
+- créer un nouvel indicateur avec des responsables : ils sont bien persistés.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/kpilote-admin/src/components/indicateurs/IndicateurForm.tsx
+git commit -m "feat(admin): section responsables dans le formulaire d'indicateur"
+```
+
+---
+
+## Self-Review
+
+- **Couverture spec** : read model `id` (Task 1) ✓ ; champ body optionnel replace-all (Task 2) ✓ ; command diff préservant createdAt + validation ids inconnus + dédup (Task 3) ✓ ; autorisation inchangée (déjà couverte par `assertWritePermission` et les tests de permission existants du fichier, non ré-implémentée) ✓ ; `fetchAllUtilisateurs` (Task 4) ✓ ; form schema + initial + body (Task 5) ✓ ; section UI FieldSelect + chips (Task 6) ✓ ; pas de changement de route ni de flux de mutation ✓ ; whitelist BFF inchangée (pas de nouveau path) ✓.
+- **Type consistency** : `responsables` = `string[]` (UUIDs) partout dans le body ; `IndicateurFormValues.responsables` = `{ id; nom; prenom; email }[]` ; `toUpsertBody` mappe vers `string[]`. `responsableApiModelSchema` gagne `id` en premier champ, cohérent entre sérialisation indicateur/panier et assertions de test.
+- **Placeholders** : aucun — tout le code est fourni.

--- a/docs/superpowers/specs/2026-07-08-administration-responsables-indicateur-design.md
+++ b/docs/superpowers/specs/2026-07-08-administration-responsables-indicateur-design.md
@@ -1,0 +1,177 @@
+# Administration des responsables d'indicateur
+
+Date : 2026-07-08
+
+## Contexte
+
+Les responsables d'indicateur existent déjà en base (`indicateur_responsable`,
+clé composée `(indicateurId, utilisateurId)`, `createdAt`) et sont **lus** en
+embarqué dans `GET /indicateurs` et `GET /indicateurs/:id`. Il n'existe aucun
+endpoint d'écriture : impossible aujourd'hui d'ajouter ou retirer un responsable.
+
+Objectif : permettre à un administrateur, depuis `kpilote-admin`, de gérer la
+liste des responsables d'un indicateur (ajout / retrait), en réutilisant
+l'écran d'édition d'indicateur existant.
+
+## Décisions de cadrage
+
+- **Assignation** : uniquement parmi les `Utilisateur` déjà en base. Pas de
+  création à la volée (l'utilisateur se crée via l'écran utilisateurs existant).
+- **Forme API** : on ajoute un champ `responsables` au **body du
+  `PUT /indicateurs/:id` existant** (pas d'endpoint dédié). Une seule mutation,
+  écriture **atomique** dans la transaction de l'upsert.
+- **Sémantique du champ** : **optionnel, replace-all quand présent** (absent =
+  « ne pas toucher », comme les champs de métadonnées). Choix additif et
+  non-cassant pour les appelants existants du PUT qui n'envoient pas ce champ.
+- **Identifiant** : les responsables sont désignés par **id utilisateur (UUID)**,
+  clé primaire stable (l'email est mutable côté linking OIDC).
+- **Read model** : on enrichit `responsableApiModel` avec l'`id` utilisateur pour
+  permettre le pré-remplissage et le dirty check côté admin.
+- **UX admin** : section « Responsables » intégrée au formulaire d'indicateur
+  existant, visible en création **et** édition. Sauvegarde via le bouton
+  Enregistrer existant, sans mutation supplémentaire (le champ part dans le body
+  de l'upsert).
+- **Picker (v0)** : `FieldSelect` natif peuplé avec **tous** les utilisateurs
+  (toutes les pages agrégées). Un combobox cherchable remplacera ce v0 plus tard.
+
+## Architecture
+
+### A. API — `kpilote-api`
+
+#### A1. Modèle de lecture partagé (`packages/kpilote-shared/src/responsable.ts`)
+
+Ajouter `id` à `responsableApiModelSchema` :
+
+```ts
+export const responsableApiModelSchema = z.object({
+  id: z.string().uuid().describe("Identifiant (UUID) de l'utilisateur responsable."),
+  email: z.string().email(),
+  nom: z.string(),
+  prenom: z.string(),
+  service: z.string(),
+  fonction: z.string(),
+})
+```
+
+Peupler `id` depuis `utilisateur.id` dans la sérialisation :
+- `apps/kpilote-api/src/indicateur/utils.ts`
+- `apps/kpilote-api/src/panier/utils.ts`
+
+Changement **additif rétrocompatible** : s'applique aux réponses indicateur et
+panier.
+
+#### A2. Champ `responsables` dans le body d'upsert (`packages/kpilote-shared/src/indicateur.ts`)
+
+Ajouter au `upsertIndicateurBodySchema` :
+
+```ts
+responsables: z
+  .array(z.string().uuid())
+  .optional()
+  .describe(
+    "UUIDs des utilisateurs responsables (replace-all). Champ optionnel : absent = inchangé.",
+  ),
+```
+
+#### A3. Command `upsertIndicateur` (`apps/kpilote-api/src/indicateur/commands/upsertIndicateur.ts`)
+
+Étendre la command existante pour gérer les responsables dans la **même
+transaction** que le reste de l'upsert (chemins création **et** mise à jour).
+
+- Autorisation inchangée : `ensurePrincipal(isApiKeyAdmin || isOidcUser)` +
+  `assertWritePermission` (déjà en place pour l'update).
+- Ne traiter les responsables que si `body.responsables !== undefined`
+  (sémantique « absent = ne pas toucher »).
+- Dédupliquer les `utilisateurIds`.
+- Valider l'existence des utilisateurs
+  (`db().utilisateur.findMany({ where: { id: { in } } })`) ; si des ids manquent →
+  `ValidationError('Utilisateurs inconnus', { unknownUtilisateurIds })`.
+- **Diff replace-all préservant l'ordre `createdAt`**, en miroir de
+  `remplacerConfigurationsReferentiels` :
+  - supprimer les liaisons dont l'`utilisateurId` n'est plus dans la cible ;
+  - `upsert` les cibles (`update: {}` → conserve le `createdAt` des liaisons
+    déjà présentes ; `create` pour les nouvelles).
+
+Découper en helpers dédiés (`resoudreResponsables`,
+`remplacerResponsables`) alignés sur le style des helpers référentiels du fichier.
+
+#### A4. Route `PUT /indicateurs/{id}`
+
+Aucune nouvelle route. Le handler existant renvoie déjà l'`IndicateurApiModel`
+complet via `getIndicateurByPublicId`, qui embarque les responsables (désormais
+avec `id`). Rien à changer dans `routes.ts` hormis, si nécessaire, la description
+OpenAPI de la route pour mentionner le champ `responsables`.
+
+#### A5. Tests (`kpilote-api`)
+
+- `upsertIndicateur.test.ts` :
+  - assigne des responsables à la création ;
+  - remplace la liste en update (ajout + retrait) ;
+  - `responsables` absent → liste inchangée ;
+  - `responsables: []` → vide la liste ;
+  - déduplique les ids en doublon ;
+  - id utilisateur inconnu → `ValidationError` avec `unknownUtilisateurIds` ;
+  - **préserve l'ordre `createdAt`** des responsables conservés après un replace.
+- Mise à jour des tests de lecture (`getIndicateurByPublicId.test.ts`,
+  `getPanierByPublicId.test.ts`) : asserter la présence de `id` dans les
+  responsables.
+- Fixtures `fixtures.indicateurResponsable` déjà disponibles.
+
+### B. Admin — `kpilote-admin`
+
+#### B1. Chargement de tous les utilisateurs (`apps/kpilote-admin/src/api/utilisateurs.ts`)
+
+Helper `fetchAllUtilisateurs()` qui boucle sur les curseurs de `GET /utilisateurs`
+et agrège toutes les pages. Exposé via un `queryOptions` (`['utilisateurs', 'all']`)
+pour alimenter le select. Solution v0 assumée (volume modéré) ; remplacée par la
+recherche serveur quand le combobox arrivera.
+
+#### B2. Schéma de formulaire (`indicateurFormSchema.ts`)
+
+- Ajouter `responsables: { id: string; nom: string; prenom: string; email: string }[]`
+  (id pour la soumission, reste pour l'affichage).
+- `buildInitialValues` : mapper `indicateur.responsables` (désormais avec `id`).
+- `toUpsertBody` : ajouter `responsables: values.responsables.map(r => r.id)` au
+  body envoyé au PUT.
+
+#### B3. Section « Responsables » (`IndicateurForm.tsx`)
+
+Visible en création et édition. Composée de :
+- un `FieldSelect` listant les utilisateurs non encore sélectionnés
+  (option choisie → ajoutée à la liste, retirée des choix restants, select reset) ;
+- la liste des responsables sélectionnés sous forme de lignes/chips avec bouton
+  retirer.
+
+Petit composant local, sur primitives existantes (`FieldSelect`, `Button`,
+`Table`/chips). Pas de nouvelle abstraction framework.
+
+#### B4. Soumission (`routes/_authed/indicateurs/$id.tsx` et `nouveau.tsx`)
+
+**Aucun changement de flux** : le champ `responsables` part dans le body de
+`upsertIndicateur` existant. Une seule mutation, écriture atomique côté serveur,
+invalidation `['indicateur', id]` + `['indicateurs']` déjà en place.
+
+## Non-objectifs
+
+- Pas de gestion des responsables de **panier** en écriture (hors périmètre ;
+  seul le read model panier est enrichi de l'`id` par cohérence).
+- Pas de création d'utilisateur à la volée depuis l'écran indicateur.
+- Pas de combobox cherchable (v0 = `FieldSelect` + chargement complet).
+- Pas de « type » de responsable (le modèle reste homogène).
+
+## Fichiers impactés
+
+**API**
+- `packages/kpilote-shared/src/responsable.ts` (ajout `id`)
+- `packages/kpilote-shared/src/indicateur.ts` (champ `responsables` dans le body)
+- `apps/kpilote-api/src/indicateur/utils.ts` (sérialisation `id`)
+- `apps/kpilote-api/src/panier/utils.ts` (sérialisation `id`)
+- `apps/kpilote-api/src/indicateur/commands/upsertIndicateur.ts` (gestion responsables)
+- `apps/kpilote-api/src/indicateur/routes.ts` (description OpenAPI éventuelle)
+- tests associés
+
+**Admin**
+- `apps/kpilote-admin/src/api/utilisateurs.ts` (fetch all)
+- `apps/kpilote-admin/src/queries/utilisateurs.ts` (query options all)
+- `apps/kpilote-admin/src/components/indicateurs/indicateurFormSchema.ts`
+- `apps/kpilote-admin/src/components/indicateurs/IndicateurForm.tsx`

--- a/packages/kpilote-shared/src/indicateur.ts
+++ b/packages/kpilote-shared/src/indicateur.ts
@@ -295,5 +295,12 @@ export const upsertIndicateurBodySchema = z.object({
         'Tableau vide pour aucun référentiel. Doublons silencieusement dédupliqués sur `id` ; ' +
         "en cas de fonctions différentes, la dernière occurrence l'emporte.",
     ),
+  responsables: z
+    .array(z.string().uuid())
+    .optional()
+    .describe(
+      'UUIDs des utilisateurs responsables (replace-all quand présent). ' +
+        'Champ optionnel : absent = inchangé ; `[]` = aucun responsable. Doublons dédupliqués.',
+    ),
 })
 export type UpsertIndicateurBody = z.infer<typeof upsertIndicateurBodySchema>

--- a/packages/kpilote-shared/src/responsable.ts
+++ b/packages/kpilote-shared/src/responsable.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod'
 
 export const responsableApiModelSchema = z.object({
+  id: z.string().uuid().describe("Identifiant (UUID) de l'utilisateur responsable."),
   email: z.string().email(),
   nom: z.string(),
   prenom: z.string(),


### PR DESCRIPTION
## Objectif

Permettre à un administrateur de gérer (ajouter / retirer) les responsables d'un indicateur depuis `kpilote-admin`, via le formulaire d'édition existant.

## Approche

- **API** : champ `responsables` optionnel (UUIDs, replace-all) ajouté au body du `PUT /indicateurs/:id` existant — écriture atomique dans la transaction de l'upsert, aucun nouvel endpoint. Absent = inchangé, `[]` = vide la liste.
- **Read model** : `responsableApiModel` enrichi de l'`id` utilisateur (additif, rétrocompatible ; s'applique aux réponses indicateur ET panier).
- **Command** : `upsertIndicateur` applique les responsables via un diff replace-all qui **préserve le `createdAt`** des liaisons conservées ; validation fail-fast des ids inconnus (`ValidationError` + `unknownUtilisateurIds`) avant toute écriture ; dédup.
- **Admin** : helper `fetchAllUtilisateurs` (agrège les pages), section « Responsables » dans `IndicateurForm` (`FieldSelect` de tous les utilisateurs, exclusion des déjà-sélectionnés, chips retirables), visible en création et édition. Le champ transite par le body de l'upsert existant — pas de mutation supplémentaire.

## Tests

- Suite API : **487/487** verts. 7 nouveaux tests sur `upsertIndicateur` (assign à la création, replace-all, absent = inchangé, `[]` = vide, dédup, id inconnu → 404/ValidationError sans indicateur créé, préservation du `createdAt`).
- Tests de lecture indicateur + panier mis à jour pour asserter le nouvel `id`.
- Admin : lint (tsc + eslint + prettier) vert.

## Notes

- Pas de migration : la table `indicateur_responsable` existe déjà.
- Le sélecteur v0 utilise un `FieldSelect` peuplé de tous les utilisateurs ; un combobox cherchable est prévu en suivi.
- Docs : `docs/superpowers/specs/…-design.md` et `docs/superpowers/plans/…`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)