### PR TITLE
feat(indicateur): import de valeurs CSV/Excel dans la webapp (PIL-1470)

### DIFF
--- a/apps/kpilote-api/src/apiKey/routes.ts
+++ b/apps/kpilote-api/src/apiKey/routes.ts
@@ -1,4 +1,4 @@
-import { createRoute, OpenAPIHono, z } from '@hono/zod-openapi'
+import { createRoute, z } from '@hono/zod-openapi'
 import {
   apiKeyApiModelSchema,
   createApiKeyBodySchema,
@@ -11,6 +11,7 @@ import { getApiKeyById } from '@/apiKey/queries/getApiKeyById'
 import { listApiKeys } from '@/apiKey/queries/listApiKeys'
 import { requireAuthentication } from '@/framework/auth/requireAuthentication'
 import { never } from '@/framework/errors/never'
+import { createOpenApiHono } from '@/framework/openapi/createOpenApiHono'
 import { jsonResponseOk } from '@/framework/openapi/jsonResponse'
 import { erreur403, erreur404, erreur409, succes200 } from '@/framework/openapi/responses'
 import { withTransaction } from '@/framework/persistence/withTransaction'
@@ -109,7 +110,7 @@ const revokeApiKeyRoute = createRoute({
   },
 })
 
-export const apiKeyRoutes = new OpenAPIHono()
+export const apiKeyRoutes = createOpenApiHono()
 
 apiKeyRoutes.openapi(createApiKeyRoute, async (context) => {
   const body = context.req.valid('json')

--- a/apps/kpilote-api/src/commentaire/routes.ts
+++ b/apps/kpilote-api/src/commentaire/routes.ts
@@ -1,4 +1,4 @@
-import { createRoute, OpenAPIHono, z } from '@hono/zod-openapi'
+import { createRoute, z } from '@hono/zod-openapi'
 import { modifierCommentaireBodySchema } from '@pilote/kpilote-shared/commentaire'
 
 import { modifierCommentaire } from '@/commentaire/commands/modifierCommentaire'
@@ -6,11 +6,12 @@ import { supprimerCommentaire } from '@/commentaire/commands/supprimerCommentair
 import { CommentaireApiModelSchema, reponseCommentaire } from '@/commentaire/openapi'
 import { requireAuthentication } from '@/framework/auth/requireAuthentication'
 import { never } from '@/framework/errors/never'
+import { createOpenApiHono } from '@/framework/openapi/createOpenApiHono'
 import { jsonResponseOk } from '@/framework/openapi/jsonResponse'
 import { erreur403, erreur404 } from '@/framework/openapi/responses'
 import { withTransaction } from '@/framework/persistence/withTransaction'
 
-export const commentaireRoutes = new OpenAPIHono()
+export const commentaireRoutes = createOpenApiHono()
 
 // --- PUT /commentaires/:commentaireId ----------------------------------------
 

--- a/apps/kpilote-api/src/framework/openapi/createOpenApiHono.test.ts
+++ b/apps/kpilote-api/src/framework/openapi/createOpenApiHono.test.ts
@@ -1,0 +1,67 @@
+import { createRoute, z } from '@hono/zod-openapi'
+import { describe, expect, it } from 'vitest'
+
+import { registerErrorHandler } from '@/framework/errors/errorHandler'
+import { createOpenApiHono } from '@/framework/openapi/createOpenApiHono'
+
+const buildApp = () => {
+  const routes = createOpenApiHono()
+
+  routes.openapi(
+    createRoute({
+      method: 'post',
+      path: '/test-validation',
+      request: {
+        body: {
+          content: {
+            'application/json': {
+              schema: z.object({ date: z.string().date() }),
+            },
+          },
+        },
+      },
+      responses: {
+        200: { description: 'ok', content: { 'application/json': { schema: z.object({ ok: z.boolean() }) } } },
+      },
+    }),
+    (c) => c.json({ ok: true }, 200),
+  )
+
+  const app = createOpenApiHono()
+  app.route('/', routes)
+  registerErrorHandler(app)
+  return app
+}
+
+describe('createOpenApiHono — defaultHook route les ZodError vers onError', () => {
+  it('renvoie 400 avec code VALIDATION_ERROR et details.issues quand le body est invalide', async () => {
+    const app = buildApp()
+
+    const response = await app.request('/test-validation', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ date: 'pas-une-date' }),
+    })
+
+    expect(response.status).toBe(400)
+    const body = await response.json()
+    expect(body).not.toHaveProperty('success')
+    expect(body.code).toBe('VALIDATION_ERROR')
+    expect(body.details.issues).toBeDefined()
+    expect(body.details.issues.length).toBeGreaterThan(0)
+  })
+
+  it('renvoie 200 quand le body est valide', async () => {
+    const app = buildApp()
+
+    const response = await app.request('/test-validation', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ date: '2024-01-15' }),
+    })
+
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body.ok).toBe(true)
+  })
+})

--- a/apps/kpilote-api/src/framework/openapi/createOpenApiHono.test.ts
+++ b/apps/kpilote-api/src/framework/openapi/createOpenApiHono.test.ts
@@ -1,5 +1,6 @@
 import { createRoute, z } from '@hono/zod-openapi'
 import { describe, expect, it } from 'vitest'
+import { validationErrorApiModelSchema } from '@pilote/kpilote-shared/error'
 
 import { registerErrorHandler } from '@/framework/errors/errorHandler'
 import { createOpenApiHono } from '@/framework/openapi/createOpenApiHono'
@@ -21,7 +22,10 @@ const buildApp = () => {
         },
       },
       responses: {
-        200: { description: 'ok', content: { 'application/json': { schema: z.object({ ok: z.boolean() }) } } },
+        200: {
+          description: 'ok',
+          content: { 'application/json': { schema: z.object({ ok: z.boolean() }) } },
+        },
       },
     }),
     (c) => c.json({ ok: true }, 200),
@@ -44,7 +48,7 @@ describe('createOpenApiHono — defaultHook route les ZodError vers onError', ()
     })
 
     expect(response.status).toBe(400)
-    const body = await response.json()
+    const body = validationErrorApiModelSchema.parse(await response.json())
     expect(body).not.toHaveProperty('success')
     expect(body.code).toBe('VALIDATION_ERROR')
     expect(body.details.issues).toBeDefined()
@@ -61,7 +65,7 @@ describe('createOpenApiHono — defaultHook route les ZodError vers onError', ()
     })
 
     expect(response.status).toBe(200)
-    const body = await response.json()
+    const body = (await response.json()) as { ok: boolean }
     expect(body.ok).toBe(true)
   })
 })

--- a/apps/kpilote-api/src/framework/openapi/createOpenApiHono.ts
+++ b/apps/kpilote-api/src/framework/openapi/createOpenApiHono.ts
@@ -1,0 +1,11 @@
+import { OpenAPIHono } from '@hono/zod-openapi'
+
+export const createOpenApiHono = (): OpenAPIHono =>
+  new OpenAPIHono({
+    defaultHook: (result) => {
+      // Laisse la ZodError remonter jusqu'à onError (errorHandler.ts) qui produit
+      // le VALIDATION_ERROR structuré partagé. Sans ce hook, zod-openapi renvoie
+      // un { success:false, error:{ name, message } } non typé.
+      if (!result.success) throw result.error
+    },
+  })

--- a/apps/kpilote-api/src/healthcheck/routes/health.ts
+++ b/apps/kpilote-api/src/healthcheck/routes/health.ts
@@ -1,5 +1,6 @@
-import { createRoute, OpenAPIHono, z } from '@hono/zod-openapi'
+import { createRoute, z } from '@hono/zod-openapi'
 
+import { createOpenApiHono } from '@/framework/openapi/createOpenApiHono'
 import { jsonResponseError, jsonResponseOk } from '@/framework/openapi/jsonResponse'
 import { getHealth } from '@/healthcheck/queries/getHealth'
 
@@ -35,7 +36,7 @@ const healthRoute = createRoute({
   },
 })
 
-export const health = new OpenAPIHono()
+export const health = createOpenApiHono()
 
 health.openapi(healthRoute, async (context) => {
   return getHealth().match(

--- a/apps/kpilote-api/src/indicateur/routes.ts
+++ b/apps/kpilote-api/src/indicateur/routes.ts
@@ -1,4 +1,4 @@
-import { createRoute, OpenAPIHono, z } from '@hono/zod-openapi'
+import { createRoute, z } from '@hono/zod-openapi'
 import {
   creerIndicateurIndividuCommentaireBodySchema,
   listerIndicateurIndividuCommentairesQuerySchema,
@@ -24,6 +24,7 @@ import {
 import { getDernierBrouillon } from '@/commentaire/queries/getDernierBrouillon'
 import { requireAuthentication } from '@/framework/auth/requireAuthentication'
 import { never } from '@/framework/errors/never'
+import { createOpenApiHono } from '@/framework/openapi/createOpenApiHono'
 import { jsonResponseOk } from '@/framework/openapi/jsonResponse'
 import { erreur400, erreur403, erreur404 } from '@/framework/openapi/responses'
 import { withTransaction } from '@/framework/persistence/withTransaction'
@@ -119,7 +120,7 @@ const upsertIndicateurRoute = createRoute({
 
 // --- App registration --------------------------------------------------------
 
-export const indicateurRoutes = new OpenAPIHono()
+export const indicateurRoutes = createOpenApiHono()
 
 indicateurRoutes.openapi(getIndicateursRoute, async (context) => {
   const { recherche, rechercheIdentifiant, cursor, pageSize, ids } = context.req.valid('query')

--- a/apps/kpilote-api/src/individu/routes.ts
+++ b/apps/kpilote-api/src/individu/routes.ts
@@ -1,8 +1,9 @@
-import { createRoute, OpenAPIHono, z } from '@hono/zod-openapi'
+import { createRoute, z } from '@hono/zod-openapi'
 import { individuApiModelSchema, individuPublicIdSchema } from '@pilote/kpilote-shared/individu'
 
 import { requireAuthentication } from '@/framework/auth/requireAuthentication'
 import { never } from '@/framework/errors/never'
+import { createOpenApiHono } from '@/framework/openapi/createOpenApiHono'
 import { jsonResponseOk } from '@/framework/openapi/jsonResponse'
 import { getIndividuByPublicId } from '@/individu/queries/getIndividuByPublicId'
 
@@ -29,7 +30,7 @@ const getIndividuByIdRoute = createRoute({
   },
 })
 
-export const individuRoutes = new OpenAPIHono()
+export const individuRoutes = createOpenApiHono()
 
 individuRoutes.openapi(getIndividuByIdRoute, async (context) => {
   const { id } = context.req.valid('param')

--- a/apps/kpilote-api/src/me/routes.ts
+++ b/apps/kpilote-api/src/me/routes.ts
@@ -1,10 +1,11 @@
-import { createRoute, OpenAPIHono } from '@hono/zod-openapi'
+import { createRoute } from '@hono/zod-openapi'
 import { meApiModelSchema } from '@pilote/kpilote-shared/me'
 import { mePermissionsApiModelSchema } from '@pilote/kpilote-shared/mePermissions'
 
 import { requireAuthentication } from '@/framework/auth/requireAuthentication'
 import { requireUser } from '@/framework/auth/userContext'
 import { never } from '@/framework/errors/never'
+import { createOpenApiHono } from '@/framework/openapi/createOpenApiHono'
 import { jsonResponseOk } from '@/framework/openapi/jsonResponse'
 import { listerMesPermissions } from '@/me/queries/listerMesPermissions'
 
@@ -44,7 +45,7 @@ const mePermissionsRoute = createRoute({
   },
 })
 
-export const meRoutes = new OpenAPIHono()
+export const meRoutes = createOpenApiHono()
 
 meRoutes.openapi(meRoute, (context) => {
   const user = requireUser()

--- a/apps/kpilote-api/src/niveauConfiance/routes.ts
+++ b/apps/kpilote-api/src/niveauConfiance/routes.ts
@@ -1,4 +1,4 @@
-import { createRoute, OpenAPIHono, z } from '@hono/zod-openapi'
+import { createRoute, z } from '@hono/zod-openapi'
 import {
   creerNiveauConfianceBodySchema,
   modifierNiveauConfianceBodySchema,
@@ -9,10 +9,11 @@ import { modifierNiveauConfiance } from '@/niveauConfiance/commands/modifierNive
 import { NiveauConfianceApiModelSchema, reponseNiveauConfiance } from '@/niveauConfiance/openapi'
 import { requireAuthentication } from '@/framework/auth/requireAuthentication'
 import { never } from '@/framework/errors/never'
+import { createOpenApiHono } from '@/framework/openapi/createOpenApiHono'
 import { jsonResponseOk } from '@/framework/openapi/jsonResponse'
 import { withTransaction } from '@/framework/persistence/withTransaction'
 
-export const niveauConfianceRoutes = new OpenAPIHono()
+export const niveauConfianceRoutes = createOpenApiHono()
 
 // --- POST /niveau-confiance --------------------------------------------------
 

--- a/apps/kpilote-api/src/objectifIndicateurIndividu/routes.ts
+++ b/apps/kpilote-api/src/objectifIndicateurIndividu/routes.ts
@@ -1,4 +1,4 @@
-import { createRoute, OpenAPIHono, z } from '@hono/zod-openapi'
+import { createRoute, z } from '@hono/zod-openapi'
 import { indicateurPublicIdSchema } from '@pilote/kpilote-shared/publicIds'
 import {
   deleteObjectifIndicateurIndividuBodySchema,
@@ -10,6 +10,7 @@ import {
 
 import { requireAuthentication } from '@/framework/auth/requireAuthentication'
 import { never } from '@/framework/errors/never'
+import { createOpenApiHono } from '@/framework/openapi/createOpenApiHono'
 import { jsonResponseError, jsonResponseOk } from '@/framework/openapi/jsonResponse'
 import { ErrorApiModelSchema, erreur400, erreur403 } from '@/framework/openapi/responses'
 import { withTransaction } from '@/framework/persistence/withTransaction'
@@ -115,7 +116,7 @@ const deleteObjectifIndicateurIndividuRoute = createRoute({
 
 // --- App registration --------------------------------------------------------
 
-export const objectifIndicateurIndividuRoutes = new OpenAPIHono()
+export const objectifIndicateurIndividuRoutes = createOpenApiHono()
 
 objectifIndicateurIndividuRoutes.openapi(getObjectifsForIndicateurRoute, async (context) => {
   const { id } = context.req.valid('param')

--- a/apps/kpilote-api/src/panier/routes.ts
+++ b/apps/kpilote-api/src/panier/routes.ts
@@ -1,4 +1,4 @@
-import { createRoute, OpenAPIHono, z } from '@hono/zod-openapi'
+import { createRoute, z } from '@hono/zod-openapi'
 import {
   creerPanierCommentaireBodySchema,
   listerPanierCommentairesQuerySchema,
@@ -32,6 +32,7 @@ import {
 import { getDernierBrouillon } from '@/commentaire/queries/getDernierBrouillon'
 import { requireAuthentication } from '@/framework/auth/requireAuthentication'
 import { never } from '@/framework/errors/never'
+import { createOpenApiHono } from '@/framework/openapi/createOpenApiHono'
 import { jsonResponseOk } from '@/framework/openapi/jsonResponse'
 import { erreur400, erreur404 } from '@/framework/openapi/responses'
 import { withTransaction } from '@/framework/persistence/withTransaction'
@@ -124,7 +125,7 @@ const getPanierTauxProgressionRoute = createRoute({
 
 // --- App registration --------------------------------------------------------
 
-export const panierRoutes = new OpenAPIHono()
+export const panierRoutes = createOpenApiHono()
 
 panierRoutes.openapi(getPaniersRoute, async (context) => {
   const { recherche, rechercheIdentifiant, cursor, pageSize } = context.req.valid('query')

--- a/apps/kpilote-api/src/permission/routes.ts
+++ b/apps/kpilote-api/src/permission/routes.ts
@@ -1,4 +1,4 @@
-import { createRoute, OpenAPIHono } from '@hono/zod-openapi'
+import { createRoute } from '@hono/zod-openapi'
 import {
   grantIndicateurPermissionBodySchema,
   grantPanierPermissionBodySchema,
@@ -10,6 +10,7 @@ import {
 
 import { requireAuthentication } from '@/framework/auth/requireAuthentication'
 import { never } from '@/framework/errors/never'
+import { createOpenApiHono } from '@/framework/openapi/createOpenApiHono'
 import { jsonResponseOk } from '@/framework/openapi/jsonResponse'
 import { erreur400, erreur403, erreur404, succes200 } from '@/framework/openapi/responses'
 import { withTransaction } from '@/framework/persistence/withTransaction'
@@ -131,7 +132,7 @@ const revokePanierPermissionRoute = createRoute({
   },
 })
 
-export const permissionRoutes = new OpenAPIHono()
+export const permissionRoutes = createOpenApiHono()
 
 permissionRoutes.openapi(getPermissionsRoute, async (context) => {
   const { principalId } = context.req.valid('query')

--- a/apps/kpilote-api/src/referentiel/routes.ts
+++ b/apps/kpilote-api/src/referentiel/routes.ts
@@ -1,4 +1,4 @@
-import { createRoute, OpenAPIHono, z } from '@hono/zod-openapi'
+import { createRoute, z } from '@hono/zod-openapi'
 import {
   individuApiModelSchema,
   listIndividusForReferentielQuerySchema,
@@ -13,6 +13,7 @@ import {
 
 import { requireAuthentication } from '@/framework/auth/requireAuthentication'
 import { never } from '@/framework/errors/never'
+import { createOpenApiHono } from '@/framework/openapi/createOpenApiHono'
 import { jsonResponseError, jsonResponseOk } from '@/framework/openapi/jsonResponse'
 import { ErrorApiModelSchema, erreur400, erreur403, erreur409 } from '@/framework/openapi/responses'
 import { withTransaction } from '@/framework/persistence/withTransaction'
@@ -123,7 +124,7 @@ const getIndividusForReferentielRoute = createRoute({
 
 // --- App registration --------------------------------------------------------
 
-export const referentielRoutes = new OpenAPIHono()
+export const referentielRoutes = createOpenApiHono()
 
 referentielRoutes.openapi(getReferentielsRoute, async (context) => {
   const { recherche, cursor, pageSize } = context.req.valid('query')

--- a/apps/kpilote-api/src/utilisateur/routes.ts
+++ b/apps/kpilote-api/src/utilisateur/routes.ts
@@ -1,4 +1,4 @@
-import { createRoute, OpenAPIHono, z } from '@hono/zod-openapi'
+import { createRoute, z } from '@hono/zod-openapi'
 import { createPaginatedApiListSchema } from '@pilote/kpilote-shared/pagination'
 import {
   createUtilisateurBodySchema,
@@ -9,6 +9,7 @@ import {
 
 import { requireAuthentication } from '@/framework/auth/requireAuthentication'
 import { never } from '@/framework/errors/never'
+import { createOpenApiHono } from '@/framework/openapi/createOpenApiHono'
 import { jsonResponseOk } from '@/framework/openapi/jsonResponse'
 import { erreur400, erreur403, erreur404, erreur409 } from '@/framework/openapi/responses'
 import { withTransaction } from '@/framework/persistence/withTransaction'
@@ -122,7 +123,7 @@ const updateUtilisateurRoute = createRoute({
   },
 })
 
-export const utilisateurRoutes = new OpenAPIHono()
+export const utilisateurRoutes = createOpenApiHono()
 
 utilisateurRoutes.openapi(createUtilisateurRoute, async (context) => {
   const body = context.req.valid('json')

--- a/apps/kpilote-api/src/valeurAvancement/routes.ts
+++ b/apps/kpilote-api/src/valeurAvancement/routes.ts
@@ -1,4 +1,4 @@
-import { createRoute, OpenAPIHono, z } from '@hono/zod-openapi'
+import { createRoute, z } from '@hono/zod-openapi'
 import { errorApiModelSchema } from '@pilote/kpilote-shared/error'
 import { indicateurPublicIdSchema, individuPublicIdSchema } from '@pilote/kpilote-shared/publicIds'
 import { createPaginatedApiListSchema } from '@pilote/kpilote-shared/pagination'
@@ -29,6 +29,7 @@ import {
 
 import { requireAuthentication } from '@/framework/auth/requireAuthentication'
 import { never } from '@/framework/errors/never'
+import { createOpenApiHono } from '@/framework/openapi/createOpenApiHono'
 import { jsonResponseError, jsonResponseOk } from '@/framework/openapi/jsonResponse'
 import { ErrorApiModelSchema, erreur400, erreur403 } from '@/framework/openapi/responses'
 import { withTransaction } from '@/framework/persistence/withTransaction'
@@ -394,7 +395,7 @@ const getTauxProgressionRoute = createRoute({
 
 // --- App registration --------------------------------------------------------
 
-export const valeurAvancementRoutes = new OpenAPIHono()
+export const valeurAvancementRoutes = createOpenApiHono()
 
 valeurAvancementRoutes.openapi(getValeursForIndicateurRoute, async (context) => {
   const { id } = context.req.valid('param')

--- a/apps/kpilote-api/src/valeurAvancement/routes.ts
+++ b/apps/kpilote-api/src/valeurAvancement/routes.ts
@@ -67,9 +67,8 @@ const BatchInvalidErrorDetailsApiModelSchema = batchInvalidErrorDetailsApiModelS
 const BatchInvalidErrorApiModelSchema = errorApiModelSchema
   .extend({ details: BatchInvalidErrorDetailsApiModelSchema })
   .openapi('BatchInvalidErrorApiModel')
-const ValidationErrorApiModelSchema = validationErrorApiModelSchema.openapi(
-  'ValidationErrorApiModel',
-)
+const ValidationErrorApiModelSchema =
+  validationErrorApiModelSchema.openapi('ValidationErrorApiModel')
 const IndividusWithValeursListApiModelSchema = createPaginatedApiListSchema(
   individuAvecValeursApiModelSchema,
 ).openapi('IndividusWithValeursListApiModel')

--- a/apps/kpilote-api/src/valeurAvancement/routes.ts
+++ b/apps/kpilote-api/src/valeurAvancement/routes.ts
@@ -1,5 +1,5 @@
 import { createRoute, z } from '@hono/zod-openapi'
-import { errorApiModelSchema } from '@pilote/kpilote-shared/error'
+import { errorApiModelSchema, validationErrorApiModelSchema } from '@pilote/kpilote-shared/error'
 import { indicateurPublicIdSchema, individuPublicIdSchema } from '@pilote/kpilote-shared/publicIds'
 import { createPaginatedApiListSchema } from '@pilote/kpilote-shared/pagination'
 import {
@@ -67,6 +67,9 @@ const BatchInvalidErrorDetailsApiModelSchema = batchInvalidErrorDetailsApiModelS
 const BatchInvalidErrorApiModelSchema = errorApiModelSchema
   .extend({ details: BatchInvalidErrorDetailsApiModelSchema })
   .openapi('BatchInvalidErrorApiModel')
+const ValidationErrorApiModelSchema = validationErrorApiModelSchema.openapi(
+  'ValidationErrorApiModel',
+)
 const IndividusWithValeursListApiModelSchema = createPaginatedApiListSchema(
   individuAvecValeursApiModelSchema,
 ).openapi('IndividusWithValeursListApiModel')
@@ -208,7 +211,7 @@ const upsertValeursAvancementBatchRoute = createRoute({
     400: {
       content: {
         'application/json': {
-          schema: z.union([BatchInvalidErrorApiModelSchema, ErrorApiModelSchema]),
+          schema: z.union([BatchInvalidErrorApiModelSchema, ValidationErrorApiModelSchema]),
         },
       },
       description:

--- a/apps/kpilote-api/src/whoami/routes.ts
+++ b/apps/kpilote-api/src/whoami/routes.ts
@@ -1,7 +1,8 @@
-import { createRoute, OpenAPIHono, z } from '@hono/zod-openapi'
+import { createRoute, z } from '@hono/zod-openapi'
 
 import { requireAuthentication } from '@/framework/auth/requireAuthentication'
 import { requirePrincipal } from '@/framework/auth/userContext'
+import { createOpenApiHono } from '@/framework/openapi/createOpenApiHono'
 import { jsonResponseOk } from '@/framework/openapi/jsonResponse'
 
 const WhoamiOkSchema = z
@@ -29,7 +30,7 @@ const whoamiRoute = createRoute({
   },
 })
 
-export const whoamiRoutes = new OpenAPIHono()
+export const whoamiRoutes = createOpenApiHono()
 
 whoamiRoutes.openapi(whoamiRoute, (context) => {
   const principal = requirePrincipal()

--- a/apps/kpilote-webapp/package.json
+++ b/apps/kpilote-webapp/package.json
@@ -61,6 +61,7 @@
     "react-dom": "^19.2.5",
     "react-hook-form": "^7.78.0",
     "tailwind-merge": "^3.5.0",
+    "xlsx": "^0.18.5",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/apps/kpilote-webapp/src/api/valeursImport.test.ts
+++ b/apps/kpilote-webapp/src/api/valeursImport.test.ts
@@ -1,10 +1,10 @@
 import { http, HttpResponse } from 'msw'
 import { describe, expect, it } from 'vitest'
-import { importValeursBatch, ImportBatchInvalidError } from '@/api/valeursImport'
+import { importValeursBatch } from '@/api/valeursImport'
 import { apiUrl, server } from '@/tests/server'
 
 describe('importValeursBatch', () => {
-  it('retourne le résultat en cas de succès', async () => {
+  it('retourne ok avec le résultat en cas de succès', async () => {
     server.use(
       http.put(apiUrl('/indicateurs/IND-1/valeurs:batch'), () =>
         HttpResponse.json({ total: 2, created: 1, updated: 1 }),
@@ -14,10 +14,13 @@ describe('importValeursBatch', () => {
       indicateurId: 'IND-1',
       rows: [{ individu: 'DEPT-84', date: '2024-01-15', valeur: 7.2 }],
     })
-    expect(result).toEqual({ total: 2, created: 1, updated: 1 })
+    expect(result.isOk()).toBe(true)
+    if (result.isOk()) {
+      expect(result.value).toEqual({ total: 2, created: 1, updated: 1 })
+    }
   })
 
-  it('lève ImportBatchInvalidError avec les détails sur 400 BATCH_INVALID', async () => {
+  it('retourne err BATCH_INVALID sur 400 BATCH_INVALID', async () => {
     server.use(
       http.put(apiUrl('/indicateurs/IND-1/valeurs:batch'), () =>
         HttpResponse.json(
@@ -30,11 +33,46 @@ describe('importValeursBatch', () => {
         ),
       ),
     )
-    await expect(
-      importValeursBatch({
-        indicateurId: 'IND-1',
-        rows: [{ individu: 'DEPT-99', date: '2024-01-15', valeur: 7.2 }],
-      }),
-    ).rejects.toBeInstanceOf(ImportBatchInvalidError)
+    const result = await importValeursBatch({
+      indicateurId: 'IND-1',
+      rows: [{ individu: 'DEPT-99', date: '2024-01-15', valeur: 7.2 }],
+    })
+    expect(result.isErr()).toBe(true)
+    if (result.isErr()) {
+      expect(result.error.type).toBe('BATCH_INVALID')
+      if (result.error.type === 'BATCH_INVALID') {
+        expect(result.error.details.errors).toHaveLength(1)
+      }
+    }
+  })
+
+  it('retourne err VALIDATION_ERROR sur 400 VALIDATION_ERROR', async () => {
+    server.use(
+      http.put(apiUrl('/indicateurs/IND-1/valeurs:batch'), () =>
+        HttpResponse.json(
+          {
+            code: 'VALIDATION_ERROR',
+            message: 'Corps de requête invalide.',
+            details: {
+              issues: [
+                { path: ['items', 2, 'date'], message: 'Date calendaire invalide', code: 'custom' },
+              ],
+            },
+          },
+          { status: 400 },
+        ),
+      ),
+    )
+    const result = await importValeursBatch({
+      indicateurId: 'IND-1',
+      rows: [{ individu: 'DEPT-84', date: '2024-01-15', valeur: 7.2 }],
+    })
+    expect(result.isErr()).toBe(true)
+    if (result.isErr()) {
+      expect(result.error.type).toBe('VALIDATION_ERROR')
+      if (result.error.type === 'VALIDATION_ERROR') {
+        expect(result.error.issues).toHaveLength(1)
+      }
+    }
   })
 })

--- a/apps/kpilote-webapp/src/api/valeursImport.test.ts
+++ b/apps/kpilote-webapp/src/api/valeursImport.test.ts
@@ -1,0 +1,40 @@
+import { http, HttpResponse } from 'msw'
+import { describe, expect, it } from 'vitest'
+import { importValeursBatch, ImportBatchInvalidError } from '@/api/valeursImport'
+import { apiUrl, server } from '@/tests/server'
+
+describe('importValeursBatch', () => {
+  it('retourne le résultat en cas de succès', async () => {
+    server.use(
+      http.put(apiUrl('/indicateurs/IND-1/valeurs:batch'), () =>
+        HttpResponse.json({ total: 2, created: 1, updated: 1 }),
+      ),
+    )
+    const result = await importValeursBatch({
+      indicateurId: 'IND-1',
+      rows: [{ individu: 'DEPT-84', date: '2024-01-15', valeur: 7.2 }],
+    })
+    expect(result).toEqual({ total: 2, created: 1, updated: 1 })
+  })
+
+  it('lève ImportBatchInvalidError avec les détails sur 400 BATCH_INVALID', async () => {
+    server.use(
+      http.put(apiUrl('/indicateurs/IND-1/valeurs:batch'), () =>
+        HttpResponse.json(
+          {
+            code: 'BATCH_INVALID',
+            message: "Aucune valeur n'a été appliquée.",
+            details: { errors: [{ code: 'INDIVIDU_INCONNU', indices: [0], individu: 'DEPT-99' }] },
+          },
+          { status: 400 },
+        ),
+      ),
+    )
+    await expect(
+      importValeursBatch({
+        indicateurId: 'IND-1',
+        rows: [{ individu: 'DEPT-99', date: '2024-01-15', valeur: 7.2 }],
+      }),
+    ).rejects.toBeInstanceOf(ImportBatchInvalidError)
+  })
+})

--- a/apps/kpilote-webapp/src/api/valeursImport.ts
+++ b/apps/kpilote-webapp/src/api/valeursImport.ts
@@ -18,6 +18,13 @@ export type ImportBatchError =
   | { type: 'VALIDATION_ERROR'; issues: ValidationIssueApiModel[] }
   | { type: 'UNKNOWN' }
 
+export class ImportError extends Error {
+  constructor(readonly detail: ImportBatchError) {
+    super(detail.type)
+    this.name = 'ImportError'
+  }
+}
+
 export async function importValeursBatch({
   indicateurId,
   rows,

--- a/apps/kpilote-webapp/src/api/valeursImport.ts
+++ b/apps/kpilote-webapp/src/api/valeursImport.ts
@@ -1,19 +1,22 @@
 import { HTTPError } from 'ky'
+import { type Result, ok, err } from 'neverthrow'
 import {
   batchInvalidErrorDetailsApiModelSchema,
   type BatchInvalidErrorDetailsApiModel,
   upsertValeursAvancementBatchResultApiModelSchema,
   type UpsertValeursAvancementBatchResultApiModel,
 } from '@pilote/kpilote-shared/valeurAvancement'
+import {
+  validationErrorApiModelSchema,
+  type ValidationIssueApiModel,
+} from '@pilote/kpilote-shared/error'
 import { apiClient } from '@/api/client'
 import type { ParsedRow } from '@/components/import-valeurs/parseFichierValeurs'
 
-export class ImportBatchInvalidError extends Error {
-  constructor(readonly details: BatchInvalidErrorDetailsApiModel) {
-    super('BATCH_INVALID')
-    this.name = 'ImportBatchInvalidError'
-  }
-}
+export type ImportBatchError =
+  | { type: 'BATCH_INVALID'; details: BatchInvalidErrorDetailsApiModel }
+  | { type: 'VALIDATION_ERROR'; issues: ValidationIssueApiModel[] }
+  | { type: 'UNKNOWN' }
 
 export async function importValeursBatch({
   indicateurId,
@@ -21,19 +24,31 @@ export async function importValeursBatch({
 }: {
   indicateurId: string
   rows: ParsedRow[]
-}): Promise<UpsertValeursAvancementBatchResultApiModel> {
+}): Promise<Result<UpsertValeursAvancementBatchResultApiModel, ImportBatchError>> {
   try {
     const json = await apiClient
       .put(`indicateurs/${indicateurId}/valeurs:batch`, { json: { items: rows } })
       .json()
-    return upsertValeursAvancementBatchResultApiModelSchema.parse(json)
+    return ok(upsertValeursAvancementBatchResultApiModelSchema.parse(json))
   } catch (error) {
     if (error instanceof HTTPError && error.response.status === 400) {
       const body: unknown = await error.response.json()
-      const details = (body as { details?: unknown } | null)?.details
-      const parsed = batchInvalidErrorDetailsApiModelSchema.safeParse(details)
-      if (parsed.success) throw new ImportBatchInvalidError(parsed.data)
+
+      const batchInvalidParsed = batchInvalidErrorDetailsApiModelSchema.safeParse(
+        (body as { details?: unknown } | null)?.details,
+      )
+      if (batchInvalidParsed.success) {
+        return err({ type: 'BATCH_INVALID', details: batchInvalidParsed.data })
+      }
+
+      const validationErrorParsed = validationErrorApiModelSchema.safeParse(body)
+      if (validationErrorParsed.success) {
+        return err({
+          type: 'VALIDATION_ERROR',
+          issues: validationErrorParsed.data.details.issues,
+        })
+      }
     }
-    throw error
+    return err({ type: 'UNKNOWN' })
   }
 }

--- a/apps/kpilote-webapp/src/api/valeursImport.ts
+++ b/apps/kpilote-webapp/src/api/valeursImport.ts
@@ -1,0 +1,39 @@
+import { HTTPError } from 'ky'
+import {
+  batchInvalidErrorDetailsApiModelSchema,
+  type BatchInvalidErrorDetailsApiModel,
+  upsertValeursAvancementBatchResultApiModelSchema,
+  type UpsertValeursAvancementBatchResultApiModel,
+} from '@pilote/kpilote-shared/valeurAvancement'
+import { apiClient } from '@/api/client'
+import type { ParsedRow } from '@/components/import-valeurs/parseFichierValeurs'
+
+export class ImportBatchInvalidError extends Error {
+  constructor(readonly details: BatchInvalidErrorDetailsApiModel) {
+    super('BATCH_INVALID')
+    this.name = 'ImportBatchInvalidError'
+  }
+}
+
+export async function importValeursBatch({
+  indicateurId,
+  rows,
+}: {
+  indicateurId: string
+  rows: ParsedRow[]
+}): Promise<UpsertValeursAvancementBatchResultApiModel> {
+  try {
+    const json = await apiClient
+      .put(`indicateurs/${indicateurId}/valeurs:batch`, { json: { items: rows } })
+      .json()
+    return upsertValeursAvancementBatchResultApiModelSchema.parse(json)
+  } catch (error) {
+    if (error instanceof HTTPError && error.response.status === 400) {
+      const body: unknown = await error.response.json()
+      const details = (body as { details?: unknown } | null)?.details
+      const parsed = batchInvalidErrorDetailsApiModelSchema.safeParse(details)
+      if (parsed.success) throw new ImportBatchInvalidError(parsed.data)
+    }
+    throw error
+  }
+}

--- a/apps/kpilote-webapp/src/components/HeaderNav.tsx
+++ b/apps/kpilote-webapp/src/components/HeaderNav.tsx
@@ -1,6 +1,6 @@
 import { Link, useLocation, useNavigate, useSearch } from '@tanstack/react-router'
 import { Search } from 'lucide-react'
-import { useState, type ReactNode } from 'react'
+import { Suspense, useState, type ReactNode } from 'react'
 
 import { CommandPalette } from '@/components/command-palette/CommandPalette'
 import { RaccourciKbd } from '@/components/command-palette/RaccourciKbd'
@@ -52,7 +52,9 @@ export function HeaderNav({ auth }: { auth: Auth }) {
       </nav>
 
       {auth.isAuthenticated ? (
-        <CommandPalette open={paletteOpen} onOpenChange={setPaletteOpen} />
+        <Suspense fallback={null}>
+          <CommandPalette open={paletteOpen} onOpenChange={setPaletteOpen} />
+        </Suspense>
       ) : null}
     </>
   )

--- a/apps/kpilote-webapp/src/components/command-palette/CommandPalette.tsx
+++ b/apps/kpilote-webapp/src/components/command-palette/CommandPalette.tsx
@@ -62,17 +62,13 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
 
   const navigationCommands = filterCommands(useNavigationCommands(close), query)
   const recentCommands = useRecentlyVisitedCommands(open, close)
-  const { commands: indicateurCommands, isLoading: isLoadingIndicateurs } = useIndicateurCommands(
-    query,
-    open,
-    close,
-  )
+  const indicateurCommands = useIndicateurCommands(query, open, close)
   const { commands: panierCommands, isLoading: isLoadingPaniers } = usePanierCommands(
     query,
     open,
     close,
   )
-  const isLoading = isLoadingIndicateurs || isLoadingPaniers
+  const isLoading = isLoadingPaniers
 
   // Les fiches récentes servent de point de départ : on les masque dès que
   // l'utilisateur tape, les résultats de recherche (indicateurs, paniers)

--- a/apps/kpilote-webapp/src/components/command-palette/indicateurActions.ts
+++ b/apps/kpilote-webapp/src/components/command-palette/indicateurActions.ts
@@ -86,7 +86,7 @@ export function buildIndicateurActions(
               search: (prev) => ({
                 individu: prev.individu,
                 referentiel: prev.referentiel,
-                onglet: 'valeurs',
+                onglet: 'resultats',
               }),
             })
           },

--- a/apps/kpilote-webapp/src/components/command-palette/indicateurActions.ts
+++ b/apps/kpilote-webapp/src/components/command-palette/indicateurActions.ts
@@ -78,8 +78,7 @@ export function buildIndicateurActions(
       keywords: ['import', 'csv', 'excel', 'charger'],
       run: () => {
         openImport({
-          indicateurId: indicateur.id,
-          indicateurNom: indicateur.nom,
+          indicateur: { id: indicateur.id, nom: indicateur.nom },
           onSuccess: () => {
             void navigate({
               to: '/indicateurs/$id',

--- a/apps/kpilote-webapp/src/components/command-palette/indicateurActions.ts
+++ b/apps/kpilote-webapp/src/components/command-palette/indicateurActions.ts
@@ -1,11 +1,13 @@
 import type { useNavigate } from '@tanstack/react-router'
-import { BarChart2, FileText, Info, MessageSquare, ShieldCheck } from 'lucide-react'
+import { BarChart2, FileText, Info, MessageSquare, ShieldCheck, Upload } from 'lucide-react'
 
 import type { CommandAction } from '@/lib/commands/types'
 
 type BuildActionsContext = {
   navigate: ReturnType<typeof useNavigate>
   close: () => void
+  openImport?: (input: { indicateurId: string; indicateurNom: string }) => void
+  canImport?: (indicateurId: string) => boolean
 }
 
 /**
@@ -15,7 +17,7 @@ type BuildActionsContext = {
  */
 export function buildIndicateurActions(
   indicateur: { id: string; nom: string },
-  { navigate, close }: BuildActionsContext,
+  { navigate, close, openImport, canImport }: BuildActionsContext,
 ): CommandAction[] {
   const goTo =
     (onglet: 'resultats' | 'metadonnees', sousOnglet?: 'confiance' | 'evolution' | 'commentaire') =>
@@ -33,7 +35,7 @@ export function buildIndicateurActions(
       close()
     }
 
-  return [
+  const actions: CommandAction[] = [
     {
       id: `indicateur:${indicateur.id}:fiche`,
       label: 'Voir la fiche',
@@ -66,4 +68,19 @@ export function buildIndicateurActions(
       run: goTo('metadonnees'),
     },
   ]
+
+  if (openImport && canImport?.(indicateur.id)) {
+    actions.push({
+      id: `indicateur:${indicateur.id}:import`,
+      label: 'Importer des valeurs',
+      icon: Upload,
+      keywords: ['import', 'csv', 'excel', 'charger'],
+      run: () => {
+        openImport({ indicateurId: indicateur.id, indicateurNom: indicateur.nom })
+        close()
+      },
+    })
+  }
+
+  return actions
 }

--- a/apps/kpilote-webapp/src/components/command-palette/indicateurActions.ts
+++ b/apps/kpilote-webapp/src/components/command-palette/indicateurActions.ts
@@ -1,12 +1,13 @@
 import type { useNavigate } from '@tanstack/react-router'
 import { BarChart2, FileText, Info, MessageSquare, ShieldCheck, Upload } from 'lucide-react'
 
+import type { ImportTarget } from '@/components/import-valeurs/useImportModal'
 import type { CommandAction } from '@/lib/commands/types'
 
 type BuildActionsContext = {
   navigate: ReturnType<typeof useNavigate>
   close: () => void
-  openImport?: (input: { indicateurId: string; indicateurNom: string }) => void
+  openImport?: (target: ImportTarget) => void
   canImport?: (indicateurId: string) => boolean
 }
 
@@ -76,16 +77,21 @@ export function buildIndicateurActions(
       icon: Upload,
       keywords: ['import', 'csv', 'excel', 'charger'],
       run: () => {
-        void navigate({
-          to: '/indicateurs/$id',
-          params: { id: indicateur.id },
-          search: (prev) => ({
-            individu: prev.individu,
-            referentiel: prev.referentiel,
-            onglet: 'valeurs',
-          }),
+        openImport({
+          indicateurId: indicateur.id,
+          indicateurNom: indicateur.nom,
+          onSuccess: () => {
+            void navigate({
+              to: '/indicateurs/$id',
+              params: { id: indicateur.id },
+              search: (prev) => ({
+                individu: prev.individu,
+                referentiel: prev.referentiel,
+                onglet: 'valeurs',
+              }),
+            })
+          },
         })
-        openImport({ indicateurId: indicateur.id, indicateurNom: indicateur.nom })
         close()
       },
     })

--- a/apps/kpilote-webapp/src/components/command-palette/indicateurActions.ts
+++ b/apps/kpilote-webapp/src/components/command-palette/indicateurActions.ts
@@ -76,6 +76,15 @@ export function buildIndicateurActions(
       icon: Upload,
       keywords: ['import', 'csv', 'excel', 'charger'],
       run: () => {
+        void navigate({
+          to: '/indicateurs/$id',
+          params: { id: indicateur.id },
+          search: (prev) => ({
+            individu: prev.individu,
+            referentiel: prev.referentiel,
+            onglet: 'valeurs',
+          }),
+        })
         openImport({ indicateurId: indicateur.id, indicateurNom: indicateur.nom })
         close()
       },

--- a/apps/kpilote-webapp/src/components/command-palette/useCanImport.ts
+++ b/apps/kpilote-webapp/src/components/command-palette/useCanImport.ts
@@ -1,0 +1,12 @@
+import { useMemo } from 'react'
+import { useSuspenseQuery } from '@tanstack/react-query'
+
+import { canWriteIndicateur, mePermissionsQueryOptions } from '@/queries/mePermissions'
+
+export function useCanImport(): (indicateurId: string) => boolean {
+  const { data: permissions } = useSuspenseQuery(mePermissionsQueryOptions())
+  return useMemo(
+    () => (indicateurId: string) => canWriteIndicateur({ permissions, indicateurId }),
+    [permissions],
+  )
+}

--- a/apps/kpilote-webapp/src/components/command-palette/useIndicateurCommands.ts
+++ b/apps/kpilote-webapp/src/components/command-palette/useIndicateurCommands.ts
@@ -5,6 +5,8 @@ import { useMemo } from 'react'
 
 import { filterCommands, type Command } from '@/lib/commands/types'
 import { allIndicateursQueryOptions } from '@/queries/indicateurs'
+import { canWriteIndicateur, mePermissionsQueryOptions } from '@/queries/mePermissions'
+import { useImportModal } from '@/components/import-valeurs/useImportModal'
 
 import { buildIndicateurActions } from './indicateurActions'
 
@@ -23,6 +25,15 @@ export function useIndicateurCommands(
 ): { commands: Command[]; isLoading: boolean } {
   const navigate = useNavigate()
   const { data, isLoading } = useQuery({ ...allIndicateursQueryOptions(), enabled: open })
+  const { data: permissions } = useQuery({ ...mePermissionsQueryOptions(), enabled: open })
+  const { open: openImport } = useImportModal()
+
+  const canImport = useMemo(
+    () =>
+      (indicateurId: string) =>
+        permissions ? canWriteIndicateur({ permissions, indicateurId }) : false,
+    [permissions],
+  )
 
   const allCommands = useMemo<Command[]>(() => {
     if (!data) return []
@@ -37,9 +48,9 @@ export function useIndicateurCommands(
         void navigate({ to: '/indicateurs/$id', params: { id: indicateur.id } })
         close()
       },
-      actions: buildIndicateurActions(indicateur, { navigate, close }),
+      actions: buildIndicateurActions(indicateur, { navigate, close, openImport, canImport }),
     }))
-  }, [data, navigate, close])
+  }, [data, navigate, close, openImport, canImport])
 
   // On ne surface les résultats que lorsqu'une recherche est saisie : à vide, la
   // palette affiche navigation + fiches récentes, pas tout le catalogue.

--- a/apps/kpilote-webapp/src/components/command-palette/useIndicateurCommands.ts
+++ b/apps/kpilote-webapp/src/components/command-palette/useIndicateurCommands.ts
@@ -29,9 +29,8 @@ export function useIndicateurCommands(
   const { open: openImport } = useImportModal()
 
   const canImport = useMemo(
-    () =>
-      (indicateurId: string) =>
-        permissions ? canWriteIndicateur({ permissions, indicateurId }) : false,
+    () => (indicateurId: string) =>
+      permissions ? canWriteIndicateur({ permissions, indicateurId }) : false,
     [permissions],
   )
 

--- a/apps/kpilote-webapp/src/components/command-palette/useIndicateurCommands.ts
+++ b/apps/kpilote-webapp/src/components/command-palette/useIndicateurCommands.ts
@@ -1,14 +1,14 @@
 import { useNavigate } from '@tanstack/react-router'
-import { useQuery } from '@tanstack/react-query'
+import { useSuspenseQuery } from '@tanstack/react-query'
 import { BarChart3 } from 'lucide-react'
 import { useMemo } from 'react'
 
 import { filterCommands, type Command } from '@/lib/commands/types'
 import { allIndicateursQueryOptions } from '@/queries/indicateurs'
-import { canWriteIndicateur, mePermissionsQueryOptions } from '@/queries/mePermissions'
 import { useImportModal } from '@/components/import-valeurs/useImportModal'
 
 import { buildIndicateurActions } from './indicateurActions'
+import { useCanImport } from './useCanImport'
 
 const MAX_RESULTS = 8
 
@@ -17,46 +17,38 @@ const MAX_RESULTS = 8
  * l'ouverture de la palette (`open`) et filtrées côté client (insensible casse +
  * accents) sur le nom et le publicId. Chaque résultat navigue vers la fiche
  * `/indicateurs/$id` puis ferme la palette.
+ *
+ * Les données (indicateurs + permissions) sont prefetchées dans le loader
+ * `_authenticated` : `useSuspenseQuery` lit le cache sans suspendre en pratique.
  */
-export function useIndicateurCommands(
-  query: string,
-  open: boolean,
-  close: () => void,
-): { commands: Command[]; isLoading: boolean } {
+export function useIndicateurCommands(query: string, _open: boolean, close: () => void): Command[] {
   const navigate = useNavigate()
-  const { data, isLoading } = useQuery({ ...allIndicateursQueryOptions(), enabled: open })
-  const { data: permissions } = useQuery({ ...mePermissionsQueryOptions(), enabled: open })
+  const { data } = useSuspenseQuery(allIndicateursQueryOptions())
+  const canImport = useCanImport()
   const { open: openImport } = useImportModal()
 
-  const canImport = useMemo(
-    () => (indicateurId: string) =>
-      permissions ? canWriteIndicateur({ permissions, indicateurId }) : false,
-    [permissions],
+  const allCommands = useMemo<Command[]>(
+    () =>
+      data.map((indicateur) => ({
+        id: `indicateur:${indicateur.id}`,
+        label: indicateur.nom,
+        group: 'indicateurs',
+        keywords: [indicateur.id],
+        hint: indicateur.id,
+        icon: BarChart3,
+        run: () => {
+          void navigate({ to: '/indicateurs/$id', params: { id: indicateur.id } })
+          close()
+        },
+        actions: buildIndicateurActions(indicateur, { navigate, close, openImport, canImport }),
+      })),
+    [data, navigate, close, openImport, canImport],
   )
-
-  const allCommands = useMemo<Command[]>(() => {
-    if (!data) return []
-    return data.map((indicateur) => ({
-      id: `indicateur:${indicateur.id}`,
-      label: indicateur.nom,
-      group: 'indicateurs',
-      keywords: [indicateur.id],
-      hint: indicateur.id,
-      icon: BarChart3,
-      run: () => {
-        void navigate({ to: '/indicateurs/$id', params: { id: indicateur.id } })
-        close()
-      },
-      actions: buildIndicateurActions(indicateur, { navigate, close, openImport, canImport }),
-    }))
-  }, [data, navigate, close, openImport, canImport])
 
   // On ne surface les résultats que lorsqu'une recherche est saisie : à vide, la
   // palette affiche navigation + fiches récentes, pas tout le catalogue.
-  const commands = useMemo<Command[]>(() => {
+  return useMemo<Command[]>(() => {
     if (query.trim().length === 0) return []
     return filterCommands(allCommands, query).slice(0, MAX_RESULTS)
   }, [allCommands, query])
-
-  return { commands, isLoading: open && isLoading }
 }

--- a/apps/kpilote-webapp/src/components/command-palette/useRecentlyVisitedCommands.ts
+++ b/apps/kpilote-webapp/src/components/command-palette/useRecentlyVisitedCommands.ts
@@ -27,9 +27,8 @@ export function useRecentlyVisitedCommands(open: boolean, close: () => void): Co
   const { open: openImport } = useImportModal()
 
   const canImport = useMemo(
-    () =>
-      (indicateurId: string) =>
-        permissions ? canWriteIndicateur({ permissions, indicateurId }) : false,
+    () => (indicateurId: string) =>
+      permissions ? canWriteIndicateur({ permissions, indicateurId }) : false,
     [permissions],
   )
 

--- a/apps/kpilote-webapp/src/components/command-palette/useRecentlyVisitedCommands.ts
+++ b/apps/kpilote-webapp/src/components/command-palette/useRecentlyVisitedCommands.ts
@@ -1,9 +1,12 @@
 import { useNavigate } from '@tanstack/react-router'
+import { useQuery } from '@tanstack/react-query'
 import { BarChart3, ShoppingBasket } from 'lucide-react'
 import { useMemo } from 'react'
 
 import type { Command } from '@/lib/commands/types'
 import { getRecentlyVisited } from '@/lib/recentlyVisited'
+import { canWriteIndicateur, mePermissionsQueryOptions } from '@/queries/mePermissions'
+import { useImportModal } from '@/components/import-valeurs/useImportModal'
 
 import { buildIndicateurActions } from './indicateurActions'
 import { buildPanierActions } from './panierActions'
@@ -20,6 +23,15 @@ const ICON_BY_TYPE = {
  */
 export function useRecentlyVisitedCommands(open: boolean, close: () => void): Command[] {
   const navigate = useNavigate()
+  const { data: permissions } = useQuery({ ...mePermissionsQueryOptions(), enabled: open })
+  const { open: openImport } = useImportModal()
+
+  const canImport = useMemo(
+    () =>
+      (indicateurId: string) =>
+        permissions ? canWriteIndicateur({ permissions, indicateurId }) : false,
+    [permissions],
+  )
 
   // Relu à chaque (ré)ouverture de la palette : `open` en dépendance suffit à
   // rafraîchir la liste sans effet ni setState.
@@ -31,7 +43,7 @@ export function useRecentlyVisitedCommands(open: boolean, close: () => void): Co
         const cible = { id: entry.id, nom: entry.label }
         const actions =
           entry.type === 'indicateur'
-            ? buildIndicateurActions(cible, { navigate, close })
+            ? buildIndicateurActions(cible, { navigate, close, openImport, canImport })
             : buildPanierActions(cible, { navigate, close })
         return {
           id: `recent:${entry.type}:${entry.id}`,
@@ -51,6 +63,6 @@ export function useRecentlyVisitedCommands(open: boolean, close: () => void): Co
           actions,
         }
       }),
-    [entries, navigate, close],
+    [entries, navigate, close, openImport, canImport],
   )
 }

--- a/apps/kpilote-webapp/src/components/command-palette/useRecentlyVisitedCommands.ts
+++ b/apps/kpilote-webapp/src/components/command-palette/useRecentlyVisitedCommands.ts
@@ -1,15 +1,14 @@
 import { useNavigate } from '@tanstack/react-router'
-import { useQuery } from '@tanstack/react-query'
 import { BarChart3, ShoppingBasket } from 'lucide-react'
 import { useMemo } from 'react'
 
 import type { Command } from '@/lib/commands/types'
 import { getRecentlyVisited } from '@/lib/recentlyVisited'
-import { canWriteIndicateur, mePermissionsQueryOptions } from '@/queries/mePermissions'
 import { useImportModal } from '@/components/import-valeurs/useImportModal'
 
 import { buildIndicateurActions } from './indicateurActions'
 import { buildPanierActions } from './panierActions'
+import { useCanImport } from './useCanImport'
 
 const ICON_BY_TYPE = {
   indicateur: BarChart3,
@@ -20,17 +19,14 @@ const ICON_BY_TYPE = {
  * Commandes reconstruites depuis les 5 dernières fiches visitées (localStorage).
  * La liste est relue à chaque ouverture de la palette pour refléter les visites
  * les plus récentes sans instrumenter chaque navigation.
+ *
+ * Les permissions sont prefetchées dans le loader `_authenticated` :
+ * `useCanImport` lit le cache via `useSuspenseQuery` sans suspendre en pratique.
  */
 export function useRecentlyVisitedCommands(open: boolean, close: () => void): Command[] {
   const navigate = useNavigate()
-  const { data: permissions } = useQuery({ ...mePermissionsQueryOptions(), enabled: open })
+  const canImport = useCanImport()
   const { open: openImport } = useImportModal()
-
-  const canImport = useMemo(
-    () => (indicateurId: string) =>
-      permissions ? canWriteIndicateur({ permissions, indicateurId }) : false,
-    [permissions],
-  )
 
   // Relu à chaque (ré)ouverture de la palette : `open` en dépendance suffit à
   // rafraîchir la liste sans effet ni setState.

--- a/apps/kpilote-webapp/src/components/import-valeurs/ImportModalProvider.tsx
+++ b/apps/kpilote-webapp/src/components/import-valeurs/ImportModalProvider.tsx
@@ -1,0 +1,19 @@
+import { useCallback, useMemo, useState, type ReactNode } from 'react'
+import { ImportModalContext, type ImportTarget } from './useImportModal'
+import { ImportValeursModal } from './ImportValeursModal'
+
+export function ImportModalProvider({ children }: { children: ReactNode }) {
+  const [target, setTarget] = useState<ImportTarget | null>(null)
+
+  const open = useCallback((next: ImportTarget) => setTarget(next), [])
+  const close = useCallback(() => setTarget(null), [])
+
+  const value = useMemo(() => ({ target, open, close }), [target, open, close])
+
+  return (
+    <ImportModalContext.Provider value={value}>
+      {children}
+      {target ? <ImportValeursModal target={target} onClose={close} /> : null}
+    </ImportModalContext.Provider>
+  )
+}

--- a/apps/kpilote-webapp/src/components/import-valeurs/ImportPreviewTable.tsx
+++ b/apps/kpilote-webapp/src/components/import-valeurs/ImportPreviewTable.tsx
@@ -1,3 +1,6 @@
+import type { DataTableColumn } from '@/components/ui/DataTable'
+import { DataTable } from '@/components/ui/DataTable'
+
 import type { ParsedRow } from './parseFichierValeurs'
 
 const MAX_LIGNES_AFFICHEES = 100
@@ -6,33 +9,42 @@ export function ImportPreviewTable({ rows }: { rows: ParsedRow[] }) {
   const visibles = rows.slice(0, MAX_LIGNES_AFFICHEES)
   const reste = rows.length - visibles.length
 
+  const columns: DataTableColumn<ParsedRow>[] = [
+    {
+      key: '#',
+      header: '#',
+      cell: (_, index) => <span className="text-text-subtle">{index + 2}</span>,
+    },
+    {
+      key: 'individu',
+      header: 'individu',
+      cell: (row) => <span className="font-mono text-[13px]">{row.individu}</span>,
+    },
+    {
+      key: 'date',
+      header: 'date',
+      cell: (row) => <span className="font-mono text-[13px]">{row.date}</span>,
+    },
+    {
+      key: 'valeur',
+      header: 'valeur',
+      cell: (row) => <span className="font-mono text-[13px]">{String(row.valeur)}</span>,
+    },
+  ]
+
+  const footer =
+    reste > 0 ? (
+      <div className="border-t border-border bg-surface px-5 py-3 text-center text-xs text-text-subtle">
+        … et {reste} autre{reste > 1 ? 's' : ''} ligne{reste > 1 ? 's' : ''}
+      </div>
+    ) : null
+
   return (
-    <div className="overflow-hidden rounded-lg border border-border">
-      <table className="w-full text-left text-sm">
-        <thead className="bg-background text-xs uppercase tracking-wide text-text-subtle">
-          <tr>
-            <th className="px-4 py-2 font-medium">#</th>
-            <th className="px-4 py-2 font-medium">individu</th>
-            <th className="px-4 py-2 font-medium">date</th>
-            <th className="px-4 py-2 font-medium">valeur</th>
-          </tr>
-        </thead>
-        <tbody className="divide-y divide-border font-mono text-[13px]">
-          {visibles.map((row, index) => (
-            <tr key={index}>
-              <td className="px-4 py-2 text-text-subtle">{index + 2}</td>
-              <td className="px-4 py-2">{row.individu}</td>
-              <td className="px-4 py-2">{row.date}</td>
-              <td className="px-4 py-2">{String(row.valeur)}</td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-      {reste > 0 ? (
-        <div className="border-t border-border bg-background px-4 py-2 text-center text-xs text-text-subtle">
-          … et {reste} autre{reste > 1 ? 's' : ''} ligne{reste > 1 ? 's' : ''}
-        </div>
-      ) : null}
-    </div>
+    <DataTable<ParsedRow>
+      columns={columns}
+      rows={visibles}
+      getRowKey={(_, i) => i}
+      footer={footer}
+    />
   )
 }

--- a/apps/kpilote-webapp/src/components/import-valeurs/ImportPreviewTable.tsx
+++ b/apps/kpilote-webapp/src/components/import-valeurs/ImportPreviewTable.tsx
@@ -1,0 +1,38 @@
+import type { ParsedRow } from './parseFichierValeurs'
+
+const MAX_LIGNES_AFFICHEES = 100
+
+export function ImportPreviewTable({ rows }: { rows: ParsedRow[] }) {
+  const visibles = rows.slice(0, MAX_LIGNES_AFFICHEES)
+  const reste = rows.length - visibles.length
+
+  return (
+    <div className="overflow-hidden rounded-lg border border-border">
+      <table className="w-full text-left text-sm">
+        <thead className="bg-background text-xs uppercase tracking-wide text-text-subtle">
+          <tr>
+            <th className="px-4 py-2 font-medium">#</th>
+            <th className="px-4 py-2 font-medium">individu</th>
+            <th className="px-4 py-2 font-medium">date</th>
+            <th className="px-4 py-2 font-medium">valeur</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-border font-mono text-[13px]">
+          {visibles.map((row, index) => (
+            <tr key={index}>
+              <td className="px-4 py-2 text-text-subtle">{index + 2}</td>
+              <td className="px-4 py-2">{row.individu}</td>
+              <td className="px-4 py-2">{row.date}</td>
+              <td className="px-4 py-2">{String(row.valeur)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      {reste > 0 ? (
+        <div className="border-t border-border bg-background px-4 py-2 text-center text-xs text-text-subtle">
+          … et {reste} autre{reste > 1 ? 's' : ''} ligne{reste > 1 ? 's' : ''}
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/apps/kpilote-webapp/src/components/import-valeurs/ImportValeursModal.tsx
+++ b/apps/kpilote-webapp/src/components/import-valeurs/ImportValeursModal.tsx
@@ -3,7 +3,7 @@ import { useEffect, useRef, useState, type ChangeEvent, type DragEvent } from 'r
 import { Upload, X } from 'lucide-react'
 import { Button } from '@/components/ui/Button'
 import { useToast } from '@/components/ui/Toast'
-import type { ImportBatchError } from '@/api/valeursImport'
+import { ImportError } from '@/api/valeursImport'
 import { useImportValeursBatch } from '@/mutations/valeursImport'
 import { parseFichierValeurs, type ParseResult } from './parseFichierValeurs'
 import { traduireErreursBatch } from './traduireErreursBatch'
@@ -85,9 +85,17 @@ export function ImportValeursModal({
         onClose()
       },
       onError: (error) => {
-        const batchError = error as unknown as ImportBatchError
-        if (batchError.type === 'BATCH_INVALID') {
-          setErreursServeur(traduireErreursBatch({ details: batchError.details }))
+        if (error instanceof ImportError) {
+          const detail = error.detail
+          if (detail.type === 'BATCH_INVALID') {
+            setErreursServeur(traduireErreursBatch({ details: detail.details }))
+          } else {
+            toast({
+              title: 'Import impossible.',
+              description: 'Une erreur est survenue.',
+              variant: 'error',
+            })
+          }
         } else {
           toast({
             title: 'Import impossible.',

--- a/apps/kpilote-webapp/src/components/import-valeurs/ImportValeursModal.tsx
+++ b/apps/kpilote-webapp/src/components/import-valeurs/ImportValeursModal.tsx
@@ -1,6 +1,167 @@
-import { type ImportTarget } from './useImportModal'
+import { Dialog as DialogPrimitive } from 'radix-ui'
+import { useEffect, useState, type ChangeEvent, type DragEvent } from 'react'
+import { Upload, X } from 'lucide-react'
+import { Button } from '@/components/ui/Button'
+import { useToast } from '@/components/ui/Toast'
+import { ImportBatchInvalidError } from '@/api/valeursImport'
+import { useImportValeursBatch } from '@/mutations/valeursImport'
+import { parseFichierValeurs, type ParseResult } from './parseFichierValeurs'
+import { traduireErreursBatch } from './traduireErreursBatch'
+import { ImportPreviewTable } from './ImportPreviewTable'
+import type { ImportTarget } from './useImportModal'
 
-// Stub temporaire — sera remplacé en Task 7
-export function ImportValeursModal(_props: { target: ImportTarget; onClose: () => void }) {
-  return null
+const messageParseError = (result: Extract<ParseResult, { ok: false }>): string => {
+  switch (result.error.code) {
+    case 'EMPTY':
+      return 'Le fichier ne contient aucune ligne de données.'
+    case 'TOO_MANY_ROWS':
+      return `${result.error.count} lignes — la limite est de ${result.error.max} lignes par import. Scindez le fichier.`
+    case 'MISSING_COLUMNS':
+      return `Colonne(s) manquante(s) : ${result.error.missing.join(', ')}. Attendu : individu, date, valeur.`
+    case 'UNREADABLE':
+      return "Fichier illisible. Vérifiez qu'il s'agit d'un CSV ou d'un Excel valide."
+  }
+}
+
+export function ImportValeursModal({ target, onClose }: { target: ImportTarget; onClose: () => void }) {
+  const toast = useToast()
+  const mutation = useImportValeursBatch({ indicateurId: target.indicateurId })
+  const [nomFichier, setNomFichier] = useState<string | null>(null)
+  const [parseResult, setParseResult] = useState<ParseResult | null>(null)
+  const [erreursServeur, setErreursServeur] = useState<string[]>([])
+
+  const traiterFichier = async (file: File) => {
+    setNomFichier(file.name)
+    setErreursServeur([])
+    setParseResult(await parseFichierValeurs({ file }))
+  }
+
+  useEffect(() => {
+    if (target.initialFile) void traiterFichier(target.initialFile)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const onInputChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0]
+    if (file) void traiterFichier(file)
+  }
+
+  const onDrop = (event: DragEvent<HTMLLabelElement>) => {
+    event.preventDefault()
+    const file = event.dataTransfer.files?.[0]
+    if (file) void traiterFichier(file)
+  }
+
+  const rows = parseResult?.ok ? parseResult.rows : null
+
+  const onSubmit = () => {
+    if (!rows) return
+    setErreursServeur([])
+    mutation.mutate(rows, {
+      onSuccess: (result) => {
+        toast({
+          title: 'Import réussi.',
+          description: `${result.created} créée(s) · ${result.updated} mise(s) à jour`,
+        })
+        onClose()
+      },
+      onError: (error) => {
+        if (error instanceof ImportBatchInvalidError) {
+          setErreursServeur(traduireErreursBatch({ details: error.details }))
+        } else {
+          toast({ title: 'Import impossible.', description: 'Une erreur est survenue.', variant: 'error' })
+        }
+      },
+    })
+  }
+
+  return (
+    <DialogPrimitive.Root open onOpenChange={(ouvert) => (ouvert ? undefined : onClose())}>
+      <DialogPrimitive.Portal>
+        <DialogPrimitive.Overlay className="fixed inset-0 z-40 bg-black/40 backdrop-blur-sm" />
+        <DialogPrimitive.Content className="fixed left-1/2 top-[8vh] z-50 flex max-h-[84vh] w-[min(44rem,calc(100vw-2rem))] -translate-x-1/2 flex-col overflow-hidden rounded-2xl border border-border bg-surface shadow-[0_20px_60px_rgba(0,0,0,0.22)] focus:outline-none">
+          <div className="flex items-start justify-between border-b border-border px-6 py-4">
+            <div>
+              <DialogPrimitive.Title className="text-base font-semibold text-text">
+                Importer des valeurs
+              </DialogPrimitive.Title>
+              <DialogPrimitive.Description className="mt-0.5 text-sm text-text-muted">
+                {target.indicateurNom} · CSV ou Excel
+              </DialogPrimitive.Description>
+            </div>
+            <button
+              type="button"
+              aria-label="Fermer"
+              onClick={onClose}
+              className="rounded-md p-1.5 text-text-subtle hover:bg-background hover:text-text"
+            >
+              <X className="size-[18px]" />
+            </button>
+          </div>
+
+          <div className="flex-1 overflow-y-auto px-6 py-5">
+            {rows ? (
+              <>
+                <div className="mb-3 flex items-center justify-between text-sm">
+                  <span className="font-medium text-text">
+                    {nomFichier} · {rows.length} ligne{rows.length > 1 ? 's' : ''}
+                  </span>
+                </div>
+                {erreursServeur.length > 0 ? (
+                  <div className="mb-3 rounded-lg border border-accent-rouge/30 bg-accent-rouge/5 px-4 py-3 text-sm">
+                    <p className="font-medium text-accent-rouge">
+                      Aucune valeur n'a été appliquée. Corrigez puis réessayez :
+                    </p>
+                    <ul className="mt-2 space-y-1">
+                      {erreursServeur.map((message, index) => (
+                        <li key={index} className="text-text-muted">
+                          {message}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                ) : null}
+                <ImportPreviewTable rows={rows} />
+              </>
+            ) : (
+              <>
+                <label
+                  onDragOver={(event) => event.preventDefault()}
+                  onDrop={onDrop}
+                  className="flex cursor-pointer flex-col items-center justify-center gap-3 rounded-xl border border-dashed border-border bg-background/60 px-6 py-12 text-center hover:bg-background"
+                >
+                  <Upload className="size-10 text-text-subtle" />
+                  <div>
+                    <p className="text-sm font-medium text-text">Glissez un fichier ou parcourez</p>
+                    <p className="mt-1 text-xs text-text-subtle">
+                      CSV ou Excel · colonnes individu, date, valeur · 1000 lignes max
+                    </p>
+                  </div>
+                  <input type="file" accept=".csv,.xlsx" className="hidden" onChange={onInputChange} />
+                </label>
+                {parseResult && !parseResult.ok ? (
+                  <p className="mt-3 rounded-lg border border-accent-rouge/30 bg-accent-rouge/5 px-4 py-3 text-sm text-accent-rouge">
+                    {messageParseError(parseResult)}
+                  </p>
+                ) : null}
+              </>
+            )}
+          </div>
+
+          <div className="flex items-center justify-end gap-2 border-t border-border bg-background/60 px-6 py-4">
+            <Button variant="secondary" size="md" onClick={onClose}>
+              Annuler
+            </Button>
+            <Button variant="primary" size="md" disabled={!rows || mutation.isPending} onClick={onSubmit}>
+              {mutation.isPending
+                ? 'Import en cours…'
+                : rows
+                  ? `Importer ${rows.length} valeur${rows.length > 1 ? 's' : ''}`
+                  : 'Importer'}
+            </Button>
+          </div>
+        </DialogPrimitive.Content>
+      </DialogPrimitive.Portal>
+    </DialogPrimitive.Root>
+  )
 }

--- a/apps/kpilote-webapp/src/components/import-valeurs/ImportValeursModal.tsx
+++ b/apps/kpilote-webapp/src/components/import-valeurs/ImportValeursModal.tsx
@@ -1,0 +1,6 @@
+import { type ImportTarget } from './useImportModal'
+
+// Stub temporaire — sera remplacé en Task 7
+export function ImportValeursModal(_props: { target: ImportTarget; onClose: () => void }) {
+  return null
+}

--- a/apps/kpilote-webapp/src/components/import-valeurs/ImportValeursModal.tsx
+++ b/apps/kpilote-webapp/src/components/import-valeurs/ImportValeursModal.tsx
@@ -1,14 +1,23 @@
-import { Dialog as DialogPrimitive } from 'radix-ui'
-import { useEffect, useRef, useState, type ChangeEvent, type DragEvent } from 'react'
-import { Upload, X } from 'lucide-react'
-import { Button } from '@/components/ui/Button'
+import { useState, type ChangeEvent, type DragEvent } from 'react'
+import { Upload } from 'lucide-react'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { z } from 'zod'
+import { useQuery } from '@tanstack/react-query'
+import { ModaleForm } from '@/components/ui/ModaleForm'
 import { useToast } from '@/components/ui/Toast'
 import { ImportError } from '@/api/valeursImport'
 import { useImportValeursBatch } from '@/mutations/valeursImport'
 import { parseFichierValeurs, type ParseResult } from './parseFichierValeurs'
-import { traduireErreursBatch } from './traduireErreursBatch'
+import { traduireErreursBatch, traduireIssuesValidation } from './traduireErreursBatch'
 import { ImportPreviewTable } from './ImportPreviewTable'
 import type { ImportTarget } from './useImportModal'
+
+const schema = z.object({
+  file: z.instanceof(File, { message: 'Sélectionnez un fichier.' }),
+})
+
+type FormValues = z.infer<typeof schema>
 
 const messageParseError = (result: Extract<ParseResult, { ok: false }>): string => {
   switch (result.error.code) {
@@ -32,178 +41,141 @@ export function ImportValeursModal({
 }) {
   const toast = useToast()
   const mutation = useImportValeursBatch({ indicateurId: target.indicateur.id })
-  const [nomFichier, setNomFichier] = useState<string | null>(null)
-  const [parseResult, setParseResult] = useState<ParseResult | null>(null)
   const [erreursServeur, setErreursServeur] = useState<string[]>([])
 
-  const generationRef = useRef(0)
+  const form = useForm<FormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: { file: target.initialFile ?? null } as unknown as FormValues,
+  })
 
-  const traiterFichier = async (file: File) => {
-    const generation = ++generationRef.current
-    setNomFichier(file.name)
+  const file = form.watch('file')
+
+  const parseQuery = useQuery({
+    queryKey: ['import-parse', file?.name, file?.size, file?.lastModified],
+    queryFn: () => {
+      // `enabled: file != null` guarantees file is defined when queryFn runs
+      if (!file) throw new Error('file attendu')
+      return parseFichierValeurs({ file })
+    },
+    enabled: file != null,
+  })
+
+  const parseResult = parseQuery.data
+  const rows = parseResult?.ok ? parseResult.rows : null
+
+  const onFileChange = (newFile: File) => {
+    form.setValue('file', newFile, { shouldValidate: true })
     setErreursServeur([])
-    const result = await parseFichierValeurs({ file })
-    if (generation !== generationRef.current) return
-    setParseResult(result)
   }
 
-  const initialFile = target.initialFile
-  useEffect(() => {
-    if (!initialFile) return
-    const generation = ++generationRef.current
-    void parseFichierValeurs({ file: initialFile }).then((result) => {
-      if (generation !== generationRef.current) return
-      setNomFichier(initialFile.name)
-      setErreursServeur([])
-      setParseResult(result)
-    })
-  }, [initialFile])
-
   const onInputChange = (event: ChangeEvent<HTMLInputElement>) => {
-    const file = event.target.files?.[0]
-    if (file) void traiterFichier(file)
+    const picked = event.target.files?.[0]
+    if (picked) onFileChange(picked)
   }
 
   const onDrop = (event: DragEvent<HTMLLabelElement>) => {
     event.preventDefault()
-    const file = event.dataTransfer.files?.[0]
-    if (file) void traiterFichier(file)
+    const dropped = event.dataTransfer.files?.[0]
+    if (dropped) onFileChange(dropped)
   }
 
-  const rows = parseResult?.ok ? parseResult.rows : null
-
-  const onSubmit = () => {
-    if (!rows) return
-    setErreursServeur([])
-    mutation.mutate(rows, {
-      onSuccess: (result) => {
-        toast({
-          title: 'Import réussi.',
-          description: `${result.created} créée(s) · ${result.updated} mise(s) à jour`,
-        })
-        target.onSuccess?.()
-        onClose()
-      },
-      onError: (error) => {
-        if (error instanceof ImportError) {
-          const detail = error.detail
-          if (detail.type === 'BATCH_INVALID') {
-            setErreursServeur(traduireErreursBatch({ details: detail.details }))
-          } else {
-            toast({
-              title: 'Import impossible.',
-              description: 'Une erreur est survenue.',
-              variant: 'error',
-            })
-          }
-        } else {
-          toast({
-            title: 'Import impossible.',
-            description: 'Une erreur est survenue.',
-            variant: 'error',
-          })
-        }
-      },
+  const genericToast = () => {
+    toast({
+      title: 'Import impossible.',
+      description: 'Une erreur est survenue.',
+      variant: 'error',
     })
   }
 
+  const onSubmit = async () => {
+    if (!rows) return
+    setErreursServeur([])
+    try {
+      const result = await mutation.mutateAsync(rows)
+      toast({
+        title: 'Import réussi.',
+        description: `${result.created} créée(s) · ${result.updated} mise(s) à jour`,
+      })
+      target.onSuccess?.()
+      onClose()
+    } catch (error) {
+      if (error instanceof ImportError) {
+        const d = error.detail
+        if (d.type === 'BATCH_INVALID') {
+          setErreursServeur(traduireErreursBatch({ details: d.details }))
+        } else if (d.type === 'VALIDATION_ERROR') {
+          setErreursServeur(traduireIssuesValidation({ issues: d.issues }))
+        } else {
+          genericToast()
+        }
+      } else {
+        genericToast()
+      }
+    }
+  }
+
+  const submitLabel = rows
+    ? `Importer ${rows.length} valeur${rows.length > 1 ? 's' : ''}`
+    : 'Importer'
+
   return (
-    <DialogPrimitive.Root open onOpenChange={(ouvert) => (ouvert ? undefined : onClose())}>
-      <DialogPrimitive.Portal>
-        <DialogPrimitive.Overlay className="fixed inset-0 z-40 bg-black/40 backdrop-blur-sm" />
-        <DialogPrimitive.Content className="fixed left-1/2 top-[8vh] z-50 flex max-h-[84vh] w-[min(44rem,calc(100vw-2rem))] -translate-x-1/2 flex-col overflow-hidden rounded-2xl border border-border bg-surface shadow-[0_20px_60px_rgba(0,0,0,0.22)] focus:outline-none">
-          <div className="flex items-start justify-between border-b border-border px-6 py-4">
-            <div>
-              <DialogPrimitive.Title className="text-base font-semibold text-text">
-                Importer des valeurs
-              </DialogPrimitive.Title>
-              <DialogPrimitive.Description className="mt-0.5 text-sm text-text-muted">
-                {target.indicateur.nom} · CSV ou Excel
-              </DialogPrimitive.Description>
+    <ModaleForm
+      open
+      onClose={onClose}
+      titre="Importer des valeurs"
+      description={`${target.indicateur.nom} · CSV ou Excel`}
+      form={form}
+      onSubmit={onSubmit}
+      submitLabel={submitLabel}
+      submitPendingLabel="Import en cours…"
+      submitDisabled={!rows}
+    >
+      {rows ? (
+        <>
+          <div className="mb-3 flex items-center justify-between text-sm">
+            <span className="font-medium text-text">
+              {file?.name} · {rows.length} ligne{rows.length > 1 ? 's' : ''}
+            </span>
+          </div>
+          {erreursServeur.length > 0 ? (
+            <div className="mb-3 rounded-lg border border-accent-rouge/30 bg-accent-rouge/5 px-4 py-3 text-sm">
+              <p className="font-medium text-accent-rouge">
+                Aucune valeur n'a été appliquée. Corrigez puis réessayez :
+              </p>
+              <ul className="mt-2 space-y-1">
+                {erreursServeur.map((message, index) => (
+                  <li key={index} className="text-text-muted">
+                    {message}
+                  </li>
+                ))}
+              </ul>
             </div>
-            <button
-              type="button"
-              aria-label="Fermer"
-              onClick={onClose}
-              className="rounded-md p-1.5 text-text-subtle hover:bg-background hover:text-text"
-            >
-              <X className="size-[18px]" />
-            </button>
-          </div>
-
-          <div className="flex-1 overflow-y-auto px-6 py-5">
-            {rows ? (
-              <>
-                <div className="mb-3 flex items-center justify-between text-sm">
-                  <span className="font-medium text-text">
-                    {nomFichier} · {rows.length} ligne{rows.length > 1 ? 's' : ''}
-                  </span>
-                </div>
-                {erreursServeur.length > 0 ? (
-                  <div className="mb-3 rounded-lg border border-accent-rouge/30 bg-accent-rouge/5 px-4 py-3 text-sm">
-                    <p className="font-medium text-accent-rouge">
-                      Aucune valeur n'a été appliquée. Corrigez puis réessayez :
-                    </p>
-                    <ul className="mt-2 space-y-1">
-                      {erreursServeur.map((message, index) => (
-                        <li key={index} className="text-text-muted">
-                          {message}
-                        </li>
-                      ))}
-                    </ul>
-                  </div>
-                ) : null}
-                <ImportPreviewTable rows={rows} />
-              </>
-            ) : (
-              <>
-                <label
-                  onDragOver={(event) => event.preventDefault()}
-                  onDrop={onDrop}
-                  className="flex cursor-pointer flex-col items-center justify-center gap-3 rounded-xl border border-dashed border-border bg-background/60 px-6 py-12 text-center hover:bg-background"
-                >
-                  <Upload className="size-10 text-text-subtle" />
-                  <div>
-                    <p className="text-sm font-medium text-text">Glissez un fichier ou parcourez</p>
-                    <p className="mt-1 text-xs text-text-subtle">
-                      CSV ou Excel · colonnes individu, date, valeur · 1000 lignes max
-                    </p>
-                  </div>
-                  <input
-                    type="file"
-                    accept=".csv,.xlsx"
-                    className="hidden"
-                    onChange={onInputChange}
-                  />
-                </label>
-                {parseResult && !parseResult.ok ? (
-                  <p className="mt-3 rounded-lg border border-accent-rouge/30 bg-accent-rouge/5 px-4 py-3 text-sm text-accent-rouge">
-                    {messageParseError(parseResult)}
-                  </p>
-                ) : null}
-              </>
-            )}
-          </div>
-
-          <div className="flex items-center justify-end gap-2 border-t border-border bg-background/60 px-6 py-4">
-            <Button variant="secondary" size="md" onClick={onClose}>
-              Annuler
-            </Button>
-            <Button
-              variant="primary"
-              size="md"
-              disabled={!rows || mutation.isPending}
-              onClick={onSubmit}
-            >
-              {mutation.isPending
-                ? 'Import en cours…'
-                : rows
-                  ? `Importer ${rows.length} valeur${rows.length > 1 ? 's' : ''}`
-                  : 'Importer'}
-            </Button>
-          </div>
-        </DialogPrimitive.Content>
-      </DialogPrimitive.Portal>
-    </DialogPrimitive.Root>
+          ) : null}
+          <ImportPreviewTable rows={rows} />
+        </>
+      ) : (
+        <>
+          <label
+            onDragOver={(event) => event.preventDefault()}
+            onDrop={onDrop}
+            className="flex cursor-pointer flex-col items-center justify-center gap-3 rounded-xl border border-dashed border-border bg-background/60 px-6 py-12 text-center hover:bg-background"
+          >
+            <Upload className="size-10 text-text-subtle" />
+            <div>
+              <p className="text-sm font-medium text-text">Glissez un fichier ou parcourez</p>
+              <p className="mt-1 text-xs text-text-subtle">
+                CSV ou Excel · colonnes individu, date, valeur · 1000 lignes max
+              </p>
+            </div>
+            <input type="file" accept=".csv,.xlsx" className="hidden" onChange={onInputChange} />
+          </label>
+          {parseResult && !parseResult.ok ? (
+            <p className="mt-3 rounded-lg border border-accent-rouge/30 bg-accent-rouge/5 px-4 py-3 text-sm text-accent-rouge">
+              {messageParseError(parseResult)}
+            </p>
+          ) : null}
+        </>
+      )}
+    </ModaleForm>
   )
 }

--- a/apps/kpilote-webapp/src/components/import-valeurs/ImportValeursModal.tsx
+++ b/apps/kpilote-webapp/src/components/import-valeurs/ImportValeursModal.tsx
@@ -31,7 +31,7 @@ export function ImportValeursModal({
   onClose: () => void
 }) {
   const toast = useToast()
-  const mutation = useImportValeursBatch({ indicateurId: target.indicateurId })
+  const mutation = useImportValeursBatch({ indicateurId: target.indicateur.id })
   const [nomFichier, setNomFichier] = useState<string | null>(null)
   const [parseResult, setParseResult] = useState<ParseResult | null>(null)
   const [erreursServeur, setErreursServeur] = useState<string[]>([])
@@ -118,7 +118,7 @@ export function ImportValeursModal({
                 Importer des valeurs
               </DialogPrimitive.Title>
               <DialogPrimitive.Description className="mt-0.5 text-sm text-text-muted">
-                {target.indicateurNom} · CSV ou Excel
+                {target.indicateur.nom} · CSV ou Excel
               </DialogPrimitive.Description>
             </div>
             <button

--- a/apps/kpilote-webapp/src/components/import-valeurs/ImportValeursModal.tsx
+++ b/apps/kpilote-webapp/src/components/import-valeurs/ImportValeursModal.tsx
@@ -23,7 +23,13 @@ const messageParseError = (result: Extract<ParseResult, { ok: false }>): string 
   }
 }
 
-export function ImportValeursModal({ target, onClose }: { target: ImportTarget; onClose: () => void }) {
+export function ImportValeursModal({
+  target,
+  onClose,
+}: {
+  target: ImportTarget
+  onClose: () => void
+}) {
   const toast = useToast()
   const mutation = useImportValeursBatch({ indicateurId: target.indicateurId })
   const [nomFichier, setNomFichier] = useState<string | null>(null)
@@ -81,7 +87,11 @@ export function ImportValeursModal({ target, onClose }: { target: ImportTarget; 
         if (error instanceof ImportBatchInvalidError) {
           setErreursServeur(traduireErreursBatch({ details: error.details }))
         } else {
-          toast({ title: 'Import impossible.', description: 'Une erreur est survenue.', variant: 'error' })
+          toast({
+            title: 'Import impossible.',
+            description: 'Une erreur est survenue.',
+            variant: 'error',
+          })
         }
       },
     })
@@ -149,7 +159,12 @@ export function ImportValeursModal({ target, onClose }: { target: ImportTarget; 
                       CSV ou Excel · colonnes individu, date, valeur · 1000 lignes max
                     </p>
                   </div>
-                  <input type="file" accept=".csv,.xlsx" className="hidden" onChange={onInputChange} />
+                  <input
+                    type="file"
+                    accept=".csv,.xlsx"
+                    className="hidden"
+                    onChange={onInputChange}
+                  />
                 </label>
                 {parseResult && !parseResult.ok ? (
                   <p className="mt-3 rounded-lg border border-accent-rouge/30 bg-accent-rouge/5 px-4 py-3 text-sm text-accent-rouge">
@@ -164,7 +179,12 @@ export function ImportValeursModal({ target, onClose }: { target: ImportTarget; 
             <Button variant="secondary" size="md" onClick={onClose}>
               Annuler
             </Button>
-            <Button variant="primary" size="md" disabled={!rows || mutation.isPending} onClick={onSubmit}>
+            <Button
+              variant="primary"
+              size="md"
+              disabled={!rows || mutation.isPending}
+              onClick={onSubmit}
+            >
               {mutation.isPending
                 ? 'Import en cours…'
                 : rows

--- a/apps/kpilote-webapp/src/components/import-valeurs/ImportValeursModal.tsx
+++ b/apps/kpilote-webapp/src/components/import-valeurs/ImportValeursModal.tsx
@@ -1,6 +1,6 @@
 import { useState, type ChangeEvent, type DragEvent } from 'react'
 import { Upload } from 'lucide-react'
-import { useForm } from 'react-hook-form'
+import { useForm, useWatch } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
 import { useQuery } from '@tanstack/react-query'
@@ -48,7 +48,7 @@ export function ImportValeursModal({
     defaultValues: { file: target.initialFile ?? null } as unknown as FormValues,
   })
 
-  const file = form.watch('file')
+  const file = useWatch({ control: form.control, name: 'file' })
 
   const parseQuery = useQuery({
     queryKey: ['import-parse', file?.name, file?.size, file?.lastModified],

--- a/apps/kpilote-webapp/src/components/import-valeurs/ImportValeursModal.tsx
+++ b/apps/kpilote-webapp/src/components/import-valeurs/ImportValeursModal.tsx
@@ -1,5 +1,5 @@
 import { Dialog as DialogPrimitive } from 'radix-ui'
-import { useEffect, useState, type ChangeEvent, type DragEvent } from 'react'
+import { useEffect, useRef, useState, type ChangeEvent, type DragEvent } from 'react'
 import { Upload, X } from 'lucide-react'
 import { Button } from '@/components/ui/Button'
 import { useToast } from '@/components/ui/Toast'
@@ -30,16 +30,28 @@ export function ImportValeursModal({ target, onClose }: { target: ImportTarget; 
   const [parseResult, setParseResult] = useState<ParseResult | null>(null)
   const [erreursServeur, setErreursServeur] = useState<string[]>([])
 
+  const generationRef = useRef(0)
+
   const traiterFichier = async (file: File) => {
+    const generation = ++generationRef.current
     setNomFichier(file.name)
     setErreursServeur([])
-    setParseResult(await parseFichierValeurs({ file }))
+    const result = await parseFichierValeurs({ file })
+    if (generation !== generationRef.current) return
+    setParseResult(result)
   }
 
+  const initialFile = target.initialFile
   useEffect(() => {
-    if (target.initialFile) void traiterFichier(target.initialFile)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
+    if (!initialFile) return
+    const generation = ++generationRef.current
+    void parseFichierValeurs({ file: initialFile }).then((result) => {
+      if (generation !== generationRef.current) return
+      setNomFichier(initialFile.name)
+      setErreursServeur([])
+      setParseResult(result)
+    })
+  }, [initialFile])
 
   const onInputChange = (event: ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0]

--- a/apps/kpilote-webapp/src/components/import-valeurs/ImportValeursModal.tsx
+++ b/apps/kpilote-webapp/src/components/import-valeurs/ImportValeursModal.tsx
@@ -3,7 +3,7 @@ import { useEffect, useRef, useState, type ChangeEvent, type DragEvent } from 'r
 import { Upload, X } from 'lucide-react'
 import { Button } from '@/components/ui/Button'
 import { useToast } from '@/components/ui/Toast'
-import { ImportBatchInvalidError } from '@/api/valeursImport'
+import type { ImportBatchError } from '@/api/valeursImport'
 import { useImportValeursBatch } from '@/mutations/valeursImport'
 import { parseFichierValeurs, type ParseResult } from './parseFichierValeurs'
 import { traduireErreursBatch } from './traduireErreursBatch'
@@ -85,8 +85,9 @@ export function ImportValeursModal({
         onClose()
       },
       onError: (error) => {
-        if (error instanceof ImportBatchInvalidError) {
-          setErreursServeur(traduireErreursBatch({ details: error.details }))
+        const batchError = error as unknown as ImportBatchError
+        if (batchError.type === 'BATCH_INVALID') {
+          setErreursServeur(traduireErreursBatch({ details: batchError.details }))
         } else {
           toast({
             title: 'Import impossible.',

--- a/apps/kpilote-webapp/src/components/import-valeurs/ImportValeursModal.tsx
+++ b/apps/kpilote-webapp/src/components/import-valeurs/ImportValeursModal.tsx
@@ -81,6 +81,7 @@ export function ImportValeursModal({
           title: 'Import réussi.',
           description: `${result.created} créée(s) · ${result.updated} mise(s) à jour`,
         })
+        target.onSuccess?.()
         onClose()
       },
       onError: (error) => {

--- a/apps/kpilote-webapp/src/components/import-valeurs/parseFichierValeurs.test.ts
+++ b/apps/kpilote-webapp/src/components/import-valeurs/parseFichierValeurs.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest'
+import * as XLSX from 'xlsx'
+import {
+  formatDateCell,
+  parseValeurCell,
+  parseFichierValeurs,
+} from '@/components/import-valeurs/parseFichierValeurs'
+
+const csvFile = (contenu: string) =>
+  new File([contenu], 'valeurs.csv', { type: 'text/csv' })
+
+describe('formatDateCell', () => {
+  it('formate un objet Date en YYYY-MM-DD (UTC)', () => {
+    expect(formatDateCell({ cell: new Date(Date.UTC(2024, 0, 15)) })).toBe('2024-01-15')
+  })
+
+  it('laisse une chaîne telle quelle (trim)', () => {
+    expect(formatDateCell({ cell: ' 2024-01-15 ' })).toBe('2024-01-15')
+  })
+})
+
+describe('parseValeurCell', () => {
+  it('garde un nombre tel quel', () => {
+    expect(parseValeurCell({ cell: 7.2 })).toBe(7.2)
+  })
+
+  it('convertit une décimale à virgule en nombre', () => {
+    expect(parseValeurCell({ cell: '1,5' })).toBe(1.5)
+  })
+
+  it('renvoie la chaîne brute si non numérique', () => {
+    expect(parseValeurCell({ cell: 'abc' })).toBe('abc')
+  })
+})
+
+describe('parseFichierValeurs', () => {
+  it('parse un CSV valide en lignes normalisées', async () => {
+    const result = await parseFichierValeurs({
+      file: csvFile('individu,date,valeur\nDEPT-84,2024-01-15,7.2\nDEPT-13,2024-01-15,8.1\n'),
+    })
+    expect(result).toEqual({
+      ok: true,
+      rows: [
+        { individu: 'DEPT-84', date: '2024-01-15', valeur: 7.2 },
+        { individu: 'DEPT-13', date: '2024-01-15', valeur: 8.1 },
+      ],
+    })
+  })
+
+  it('remonte MISSING_COLUMNS si une colonne manque', async () => {
+    const result = await parseFichierValeurs({
+      file: csvFile('individu,valeur\nDEPT-84,7.2\n'),
+    })
+    expect(result).toEqual({ ok: false, error: { code: 'MISSING_COLUMNS', missing: ['date'] } })
+  })
+
+  it('remonte EMPTY si aucune ligne de données', async () => {
+    const result = await parseFichierValeurs({ file: csvFile('individu,date,valeur\n') })
+    expect(result).toEqual({ ok: false, error: { code: 'EMPTY' } })
+  })
+
+  it('remonte TOO_MANY_ROWS au-delà de 1000 lignes', async () => {
+    const lignes = Array.from({ length: 1001 }, () => 'DEPT-84,2024-01-15,7.2').join('\n')
+    const result = await parseFichierValeurs({ file: csvFile(`individu,date,valeur\n${lignes}\n`) })
+    expect(result).toEqual({ ok: false, error: { code: 'TOO_MANY_ROWS', count: 1001, max: 1000 } })
+  })
+
+  it('parse un fichier XLSX', async () => {
+    const worksheet = XLSX.utils.aoa_to_sheet([
+      ['individu', 'date', 'valeur'],
+      ['REG-93', '2024-01-15', 7.8],
+    ])
+    const workbook = XLSX.utils.book_new()
+    XLSX.utils.book_append_sheet(workbook, worksheet, 'Feuille1')
+    const buffer = XLSX.write(workbook, { type: 'array', bookType: 'xlsx' }) as ArrayBuffer
+    const file = new File([buffer], 'valeurs.xlsx', {
+      type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    })
+    const result = await parseFichierValeurs({ file })
+    expect(result).toEqual({
+      ok: true,
+      rows: [{ individu: 'REG-93', date: '2024-01-15', valeur: 7.8 }],
+    })
+  })
+})

--- a/apps/kpilote-webapp/src/components/import-valeurs/parseFichierValeurs.test.ts
+++ b/apps/kpilote-webapp/src/components/import-valeurs/parseFichierValeurs.test.ts
@@ -81,4 +81,23 @@ describe('parseFichierValeurs', () => {
       rows: [{ individu: 'REG-93', date: '2024-01-15', valeur: 7.8 }],
     })
   })
+
+  it('convertit une cellule Date (UTC) en YYYY-MM-DD dans un XLSX', async () => {
+    const dateCell = new Date(Date.UTC(2025, 5, 3)) // 2025-06-03
+    const worksheet = XLSX.utils.aoa_to_sheet([
+      ['individu', 'date', 'valeur'],
+      ['DEPT-01', dateCell, 42],
+    ])
+    const workbook = XLSX.utils.book_new()
+    XLSX.utils.book_append_sheet(workbook, worksheet, 'Feuille1')
+    const buffer = XLSX.write(workbook, { type: 'array', bookType: 'xlsx' }) as ArrayBuffer
+    const file = new File([buffer], 'valeurs.xlsx', {
+      type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    })
+    const result = await parseFichierValeurs({ file })
+    expect(result).toEqual({
+      ok: true,
+      rows: [{ individu: 'DEPT-01', date: '2025-06-03', valeur: 42 }],
+    })
+  })
 })

--- a/apps/kpilote-webapp/src/components/import-valeurs/parseFichierValeurs.test.ts
+++ b/apps/kpilote-webapp/src/components/import-valeurs/parseFichierValeurs.test.ts
@@ -6,8 +6,7 @@ import {
   parseFichierValeurs,
 } from '@/components/import-valeurs/parseFichierValeurs'
 
-const csvFile = (contenu: string) =>
-  new File([contenu], 'valeurs.csv', { type: 'text/csv' })
+const csvFile = (contenu: string) => new File([contenu], 'valeurs.csv', { type: 'text/csv' })
 
 describe('formatDateCell', () => {
   it('formate un objet Date en YYYY-MM-DD (UTC)', () => {

--- a/apps/kpilote-webapp/src/components/import-valeurs/parseFichierValeurs.ts
+++ b/apps/kpilote-webapp/src/components/import-valeurs/parseFichierValeurs.ts
@@ -1,0 +1,69 @@
+import { MAX_VALEURS_PAR_BATCH } from '@pilote/kpilote-shared/valeurAvancement'
+
+export type ParsedRow = { individu: string; date: string; valeur: number | string }
+
+export type ParseError =
+  | { code: 'EMPTY' }
+  | { code: 'TOO_MANY_ROWS'; count: number; max: number }
+  | { code: 'MISSING_COLUMNS'; missing: string[] }
+  | { code: 'UNREADABLE' }
+
+export type ParseResult = { ok: true; rows: ParsedRow[] } | { ok: false; error: ParseError }
+
+const COLONNES = ['individu', 'date', 'valeur'] as const
+
+const pad = (valeur: number): string => String(valeur).padStart(2, '0')
+
+export function formatDateCell({ cell }: { cell: unknown }): string {
+  if (cell instanceof Date) {
+    return `${cell.getUTCFullYear()}-${pad(cell.getUTCMonth() + 1)}-${pad(cell.getUTCDate())}`
+  }
+  return String(cell ?? '').trim()
+}
+
+export function parseValeurCell({ cell }: { cell: unknown }): number | string {
+  if (typeof cell === 'number') return cell
+  const texte = String(cell ?? '').trim()
+  const normalise = Number(texte.replace(',', '.'))
+  return texte.length > 0 && Number.isFinite(normalise) ? normalise : texte
+}
+
+export async function parseFichierValeurs({ file }: { file: File }): Promise<ParseResult> {
+  const XLSX = await import('xlsx')
+  let matrice: unknown[][]
+  try {
+    const data = await file.arrayBuffer()
+    const workbook = XLSX.read(data, { type: 'array', cellDates: true })
+    const feuille = workbook.Sheets[workbook.SheetNames[0]]
+    matrice = XLSX.utils.sheet_to_json<unknown[]>(feuille, { header: 1, raw: true, blankrows: false })
+  } catch {
+    return { ok: false, error: { code: 'UNREADABLE' } }
+  }
+
+  if (matrice.length === 0) return { ok: false, error: { code: 'EMPTY' } }
+
+  const entetes = matrice[0].map((cellule) => String(cellule ?? '').trim().toLowerCase())
+  const indexParColonne = new Map(COLONNES.map((nom) => [nom, entetes.indexOf(nom)]))
+  const missing = COLONNES.filter((nom) => (indexParColonne.get(nom) ?? -1) < 0)
+  if (missing.length > 0) return { ok: false, error: { code: 'MISSING_COLUMNS', missing } }
+
+  const lignesData = matrice
+    .slice(1)
+    .filter((ligne) => ligne.some((cellule) => String(cellule ?? '').trim().length > 0))
+
+  if (lignesData.length === 0) return { ok: false, error: { code: 'EMPTY' } }
+  if (lignesData.length > MAX_VALEURS_PAR_BATCH) {
+    return {
+      ok: false,
+      error: { code: 'TOO_MANY_ROWS', count: lignesData.length, max: MAX_VALEURS_PAR_BATCH },
+    }
+  }
+
+  const rows = lignesData.map((ligne) => ({
+    individu: String(ligne[indexParColonne.get('individu') as number] ?? '').trim(),
+    date: formatDateCell({ cell: ligne[indexParColonne.get('date') as number] }),
+    valeur: parseValeurCell({ cell: ligne[indexParColonne.get('valeur') as number] }),
+  }))
+
+  return { ok: true, rows }
+}

--- a/apps/kpilote-webapp/src/components/import-valeurs/parseFichierValeurs.ts
+++ b/apps/kpilote-webapp/src/components/import-valeurs/parseFichierValeurs.ts
@@ -14,16 +14,25 @@ const COLONNES = ['individu', 'date', 'valeur'] as const
 
 const pad = (valeur: number): string => String(valeur).padStart(2, '0')
 
+const celluleVersTexte = (cellule: unknown): string => {
+  if (cellule == null) return ''
+  if (typeof cellule === 'string') return cellule
+  if (typeof cellule === 'number' || typeof cellule === 'boolean' || typeof cellule === 'bigint') {
+    return String(cellule)
+  }
+  return ''
+}
+
 export function formatDateCell({ cell }: { cell: unknown }): string {
   if (cell instanceof Date) {
     return `${cell.getUTCFullYear()}-${pad(cell.getUTCMonth() + 1)}-${pad(cell.getUTCDate())}`
   }
-  return String(cell ?? '').trim()
+  return celluleVersTexte(cell).trim()
 }
 
 export function parseValeurCell({ cell }: { cell: unknown }): number | string {
   if (typeof cell === 'number') return cell
-  const texte = String(cell ?? '').trim()
+  const texte = celluleVersTexte(cell).trim()
   const normalise = Number(texte.replace(',', '.'))
   return texte.length > 0 && Number.isFinite(normalise) ? normalise : texte
 }
@@ -38,7 +47,11 @@ export async function parseFichierValeurs({ file }: { file: File }): Promise<Par
     if (nomFeuille === undefined) return { ok: false, error: { code: 'UNREADABLE' } }
     const feuille = workbook.Sheets[nomFeuille]
     if (feuille === undefined) return { ok: false, error: { code: 'UNREADABLE' } }
-    matrice = XLSX.utils.sheet_to_json<unknown[]>(feuille, { header: 1, raw: true, blankrows: false })
+    matrice = XLSX.utils.sheet_to_json<unknown[]>(feuille, {
+      header: 1,
+      raw: true,
+      blankrows: false,
+    })
   } catch {
     return { ok: false, error: { code: 'UNREADABLE' } }
   }
@@ -46,7 +59,7 @@ export async function parseFichierValeurs({ file }: { file: File }): Promise<Par
   const [ligneEntetes, ...lignesSuivantes] = matrice
   if (ligneEntetes === undefined) return { ok: false, error: { code: 'EMPTY' } }
 
-  const entetes = ligneEntetes.map((cellule) => String(cellule ?? '').trim().toLowerCase())
+  const entetes = ligneEntetes.map((cellule) => celluleVersTexte(cellule).trim().toLowerCase())
   const indexParColonne = new Map(COLONNES.map((nom) => [nom, entetes.indexOf(nom)]))
   const missing = COLONNES.filter((nom) => (indexParColonne.get(nom) ?? -1) < 0)
   if (missing.length > 0) return { ok: false, error: { code: 'MISSING_COLUMNS', missing } }
@@ -59,7 +72,7 @@ export async function parseFichierValeurs({ file }: { file: File }): Promise<Par
   }
 
   const lignesData = lignesSuivantes.filter((ligne) =>
-    ligne.some((cellule) => String(cellule ?? '').trim().length > 0),
+    ligne.some((cellule) => celluleVersTexte(cellule).trim().length > 0),
   )
 
   if (lignesData.length === 0) return { ok: false, error: { code: 'EMPTY' } }
@@ -71,7 +84,7 @@ export async function parseFichierValeurs({ file }: { file: File }): Promise<Par
   }
 
   const rows = lignesData.map((ligne) => ({
-    individu: String(ligne[indices.individu] ?? '').trim(),
+    individu: celluleVersTexte(ligne[indices.individu]).trim(),
     date: formatDateCell({ cell: ligne[indices.date] }),
     valeur: parseValeurCell({ cell: ligne[indices.valeur] }),
   }))

--- a/apps/kpilote-webapp/src/components/import-valeurs/parseFichierValeurs.ts
+++ b/apps/kpilote-webapp/src/components/import-valeurs/parseFichierValeurs.ts
@@ -1,6 +1,5 @@
+import { z } from 'zod'
 import { MAX_VALEURS_PAR_BATCH } from '@pilote/kpilote-shared/valeurAvancement'
-
-export type ParsedRow = { individu: string; date: string; valeur: number | string }
 
 export type ParseError =
   | { code: 'EMPTY' }
@@ -36,6 +35,14 @@ export function parseValeurCell({ cell }: { cell: unknown }): number | string {
   const normalise = Number(texte.replace(',', '.'))
   return texte.length > 0 && Number.isFinite(normalise) ? normalise : texte
 }
+
+const rowSchema = z.object({
+  individu: z.preprocess((cell) => celluleVersTexte(cell).trim(), z.string()),
+  date: z.preprocess((cell) => formatDateCell({ cell }), z.string()),
+  valeur: z.preprocess((cell) => parseValeurCell({ cell }), z.union([z.number(), z.string()])),
+})
+
+export type ParsedRow = z.infer<typeof rowSchema>
 
 export async function parseFichierValeurs({ file }: { file: File }): Promise<ParseResult> {
   const XLSX = await import('xlsx')
@@ -83,11 +90,13 @@ export async function parseFichierValeurs({ file }: { file: File }): Promise<Par
     }
   }
 
-  const rows = lignesData.map((ligne) => ({
-    individu: celluleVersTexte(ligne[indices.individu]).trim(),
-    date: formatDateCell({ cell: ligne[indices.date] }),
-    valeur: parseValeurCell({ cell: ligne[indices.valeur] }),
-  }))
+  const rows = lignesData.map((ligne) =>
+    rowSchema.parse({
+      individu: ligne[indices.individu],
+      date: ligne[indices.date],
+      valeur: ligne[indices.valeur],
+    }),
+  )
 
   return { ok: true, rows }
 }

--- a/apps/kpilote-webapp/src/components/import-valeurs/parseFichierValeurs.ts
+++ b/apps/kpilote-webapp/src/components/import-valeurs/parseFichierValeurs.ts
@@ -34,22 +34,33 @@ export async function parseFichierValeurs({ file }: { file: File }): Promise<Par
   try {
     const data = await file.arrayBuffer()
     const workbook = XLSX.read(data, { type: 'array', cellDates: true })
-    const feuille = workbook.Sheets[workbook.SheetNames[0]]
+    const nomFeuille = workbook.SheetNames[0]
+    if (nomFeuille === undefined) return { ok: false, error: { code: 'UNREADABLE' } }
+    const feuille = workbook.Sheets[nomFeuille]
+    if (feuille === undefined) return { ok: false, error: { code: 'UNREADABLE' } }
     matrice = XLSX.utils.sheet_to_json<unknown[]>(feuille, { header: 1, raw: true, blankrows: false })
   } catch {
     return { ok: false, error: { code: 'UNREADABLE' } }
   }
 
-  if (matrice.length === 0) return { ok: false, error: { code: 'EMPTY' } }
+  const [ligneEntetes, ...lignesSuivantes] = matrice
+  if (ligneEntetes === undefined) return { ok: false, error: { code: 'EMPTY' } }
 
-  const entetes = matrice[0].map((cellule) => String(cellule ?? '').trim().toLowerCase())
+  const entetes = ligneEntetes.map((cellule) => String(cellule ?? '').trim().toLowerCase())
   const indexParColonne = new Map(COLONNES.map((nom) => [nom, entetes.indexOf(nom)]))
   const missing = COLONNES.filter((nom) => (indexParColonne.get(nom) ?? -1) < 0)
   if (missing.length > 0) return { ok: false, error: { code: 'MISSING_COLUMNS', missing } }
 
-  const lignesData = matrice
-    .slice(1)
-    .filter((ligne) => ligne.some((cellule) => String(cellule ?? '').trim().length > 0))
+  // After the missing check, all three columns are guaranteed present — indexOf returns a valid number
+  const indices = {
+    individu: entetes.indexOf('individu'),
+    date: entetes.indexOf('date'),
+    valeur: entetes.indexOf('valeur'),
+  }
+
+  const lignesData = lignesSuivantes.filter((ligne) =>
+    ligne.some((cellule) => String(cellule ?? '').trim().length > 0),
+  )
 
   if (lignesData.length === 0) return { ok: false, error: { code: 'EMPTY' } }
   if (lignesData.length > MAX_VALEURS_PAR_BATCH) {
@@ -60,9 +71,9 @@ export async function parseFichierValeurs({ file }: { file: File }): Promise<Par
   }
 
   const rows = lignesData.map((ligne) => ({
-    individu: String(ligne[indexParColonne.get('individu') as number] ?? '').trim(),
-    date: formatDateCell({ cell: ligne[indexParColonne.get('date') as number] }),
-    valeur: parseValeurCell({ cell: ligne[indexParColonne.get('valeur') as number] }),
+    individu: String(ligne[indices.individu] ?? '').trim(),
+    date: formatDateCell({ cell: ligne[indices.date] }),
+    valeur: parseValeurCell({ cell: ligne[indices.valeur] }),
   }))
 
   return { ok: true, rows }

--- a/apps/kpilote-webapp/src/components/import-valeurs/traduireErreursBatch.test.ts
+++ b/apps/kpilote-webapp/src/components/import-valeurs/traduireErreursBatch.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest'
-import { traduireErreursBatch, traduireIssuesValidation } from '@/components/import-valeurs/traduireErreursBatch'
+import {
+  traduireErreursBatch,
+  traduireIssuesValidation,
+} from '@/components/import-valeurs/traduireErreursBatch'
 import type { ValidationIssueApiModel } from '@pilote/kpilote-shared/error'
 
 describe('traduireErreursBatch', () => {
@@ -38,9 +41,7 @@ describe('traduireIssuesValidation', () => {
       },
     ]
     const messages = traduireIssuesValidation({ issues })
-    expect(messages).toEqual([
-      'Ligne 4 : champ « date » invalide — Date calendaire invalide',
-    ])
+    expect(messages).toEqual(['Ligne 4 : champ « date » invalide — Date calendaire invalide'])
   })
 
   it('fallback "Ligne inconnue" si pas d\'index numérique dans le path', () => {

--- a/apps/kpilote-webapp/src/components/import-valeurs/traduireErreursBatch.test.ts
+++ b/apps/kpilote-webapp/src/components/import-valeurs/traduireErreursBatch.test.ts
@@ -2,6 +2,13 @@ import { describe, expect, it } from 'vitest'
 import { traduireErreursBatch } from '@/components/import-valeurs/traduireErreursBatch'
 
 describe('traduireErreursBatch', () => {
+  it('utilise le singulier « ligne » pour un seul indice', () => {
+    const messages = traduireErreursBatch({
+      details: { errors: [{ code: 'INDIVIDU_INCONNU', indices: [0], individu: 'DEPT-1' }] },
+    })
+    expect(messages).toEqual(['Individu inconnu « DEPT-1 » (ligne 2).'])
+  })
+
   it('traduit chaque code en message FR avec numéro de ligne (index + 2)', () => {
     const messages = traduireErreursBatch({
       details: {

--- a/apps/kpilote-webapp/src/components/import-valeurs/traduireErreursBatch.test.ts
+++ b/apps/kpilote-webapp/src/components/import-valeurs/traduireErreursBatch.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
-import { traduireErreursBatch } from '@/components/import-valeurs/traduireErreursBatch'
+import { traduireErreursBatch, traduireIssuesValidation } from '@/components/import-valeurs/traduireErreursBatch'
+import type { ValidationIssueApiModel } from '@pilote/kpilote-shared/error'
 
 describe('traduireErreursBatch', () => {
   it('utilise le singulier « ligne » pour un seul indice', () => {
@@ -23,6 +24,54 @@ describe('traduireErreursBatch', () => {
       'Ligne 4 : champ « date » invalide.',
       'Individu inconnu « DEPT-99 » (lignes 2, 7).',
       'Doublon DEPT-84 / 2024-01-15 (lignes 3, 5).',
+    ])
+  })
+})
+
+describe('traduireIssuesValidation', () => {
+  it('traduit les issues zod avec path ["items", index, champ]', () => {
+    const issues: ValidationIssueApiModel[] = [
+      {
+        path: ['items', 2, 'date'],
+        message: 'Date calendaire invalide',
+        code: 'custom',
+      },
+    ]
+    const messages = traduireIssuesValidation({ issues })
+    expect(messages).toEqual([
+      'Ligne 4 : champ « date » invalide — Date calendaire invalide',
+    ])
+  })
+
+  it('fallback "Ligne inconnue" si pas d\'index numérique dans le path', () => {
+    const issues: ValidationIssueApiModel[] = [
+      {
+        path: ['root'],
+        message: 'Erreur de validation globale',
+        code: 'custom',
+      },
+    ]
+    const messages = traduireIssuesValidation({ issues })
+    expect(messages).toEqual(['Ligne inconnue : Erreur de validation globale'])
+  })
+
+  it('traite plusieurs issues', () => {
+    const issues: ValidationIssueApiModel[] = [
+      {
+        path: ['items', 0, 'individu'],
+        message: 'Requis',
+        code: 'required',
+      },
+      {
+        path: ['items', 1, 'date'],
+        message: 'Format de date invalide',
+        code: 'invalid_date',
+      },
+    ]
+    const messages = traduireIssuesValidation({ issues })
+    expect(messages).toEqual([
+      'Ligne 2 : champ « individu » invalide — Requis',
+      'Ligne 3 : champ « date » invalide — Format de date invalide',
     ])
   })
 })

--- a/apps/kpilote-webapp/src/components/import-valeurs/traduireErreursBatch.test.ts
+++ b/apps/kpilote-webapp/src/components/import-valeurs/traduireErreursBatch.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import { traduireErreursBatch } from '@/components/import-valeurs/traduireErreursBatch'
+
+describe('traduireErreursBatch', () => {
+  it('traduit chaque code en message FR avec numéro de ligne (index + 2)', () => {
+    const messages = traduireErreursBatch({
+      details: {
+        errors: [
+          { code: 'INVALID_ITEM', indices: [2], issues: [{ path: 'date', message: 'x' }] },
+          { code: 'INDIVIDU_INCONNU', indices: [0, 5], individu: 'DEPT-99' },
+          { code: 'DUPLICATE_KEY', indices: [1, 3], individu: 'DEPT-84', date: '2024-01-15' },
+        ],
+      },
+    })
+    expect(messages).toEqual([
+      'Ligne 4 : champ « date » invalide.',
+      'Individu inconnu « DEPT-99 » (lignes 2, 7).',
+      'Doublon DEPT-84 / 2024-01-15 (lignes 3, 5).',
+    ])
+  })
+})

--- a/apps/kpilote-webapp/src/components/import-valeurs/traduireErreursBatch.ts
+++ b/apps/kpilote-webapp/src/components/import-valeurs/traduireErreursBatch.ts
@@ -46,13 +46,13 @@ export function traduireIssuesValidation({
   return issues.map((issue) => {
     // Extraire l'index numérique du path (ex: ['items', 2, 'date'] -> 2)
     const numericIndex = issue.path.find(
-      (segment) => typeof segment === 'number'
-    ) as number | undefined
+      (segment): segment is number => typeof segment === 'number',
+    )
 
     // Extraire le dernier segment string du path (le nom du champ)
     const fieldName = issue.path.findLast(
-      (segment) => typeof segment === 'string'
-    ) as string | undefined
+      (segment): segment is string => typeof segment === 'string',
+    )
 
     if (numericIndex !== undefined && fieldName) {
       const ligne = numeroLigne(numericIndex)

--- a/apps/kpilote-webapp/src/components/import-valeurs/traduireErreursBatch.ts
+++ b/apps/kpilote-webapp/src/components/import-valeurs/traduireErreursBatch.ts
@@ -21,6 +21,10 @@ const traduireEntree = (entree: BatchInvalidErrorEntryApiModel): string => {
       return `Individu inconnu « ${entree.individu} » (${libelleLignes(entree.indices)}).`
     case 'DUPLICATE_KEY':
       return `Doublon ${entree.individu} / ${entree.date} (${libelleLignes(entree.indices)}).`
+    default: {
+      const exhaustif: never = entree
+      return exhaustif
+    }
   }
 }
 

--- a/apps/kpilote-webapp/src/components/import-valeurs/traduireErreursBatch.ts
+++ b/apps/kpilote-webapp/src/components/import-valeurs/traduireErreursBatch.ts
@@ -15,7 +15,8 @@ const traduireEntree = (entree: BatchInvalidErrorEntryApiModel): string => {
   switch (entree.code) {
     case 'INVALID_ITEM': {
       const champs = entree.issues.map((issue) => issue.path).join(', ')
-      return `Ligne ${numeroLigne(entree.indices[0])} : champ « ${champs} » invalide.`
+      const [premierIndice = 0] = entree.indices
+      return `Ligne ${numeroLigne(premierIndice)} : champ « ${champs} » invalide.`
     }
     case 'INDIVIDU_INCONNU':
       return `Individu inconnu « ${entree.individu} » (${libelleLignes(entree.indices)}).`

--- a/apps/kpilote-webapp/src/components/import-valeurs/traduireErreursBatch.ts
+++ b/apps/kpilote-webapp/src/components/import-valeurs/traduireErreursBatch.ts
@@ -2,6 +2,7 @@ import type {
   BatchInvalidErrorDetailsApiModel,
   BatchInvalidErrorEntryApiModel,
 } from '@pilote/kpilote-shared/valeurAvancement'
+import type { ValidationIssueApiModel } from '@pilote/kpilote-shared/error'
 
 const numeroLigne = (index: number): number => index + 2
 
@@ -35,4 +36,29 @@ export function traduireErreursBatch({
   details: BatchInvalidErrorDetailsApiModel
 }): string[] {
   return details.errors.map(traduireEntree)
+}
+
+export function traduireIssuesValidation({
+  issues,
+}: {
+  issues: ValidationIssueApiModel[]
+}): string[] {
+  return issues.map((issue) => {
+    // Extraire l'index numérique du path (ex: ['items', 2, 'date'] -> 2)
+    const numericIndex = issue.path.find(
+      (segment) => typeof segment === 'number'
+    ) as number | undefined
+
+    // Extraire le dernier segment string du path (le nom du champ)
+    const fieldName = issue.path.findLast(
+      (segment) => typeof segment === 'string'
+    ) as string | undefined
+
+    if (numericIndex !== undefined && fieldName) {
+      const ligne = numeroLigne(numericIndex)
+      return `Ligne ${ligne} : champ « ${fieldName} » invalide — ${issue.message}`
+    }
+
+    return `Ligne inconnue : ${issue.message}`
+  })
 }

--- a/apps/kpilote-webapp/src/components/import-valeurs/traduireErreursBatch.ts
+++ b/apps/kpilote-webapp/src/components/import-valeurs/traduireErreursBatch.ts
@@ -1,0 +1,33 @@
+import type {
+  BatchInvalidErrorDetailsApiModel,
+  BatchInvalidErrorEntryApiModel,
+} from '@pilote/kpilote-shared/valeurAvancement'
+
+const numeroLigne = (index: number): number => index + 2
+
+const libelleLignes = (indices: number[]): string => {
+  const numeros = indices.map(numeroLigne)
+  const mot = numeros.length > 1 ? 'lignes' : 'ligne'
+  return `${mot} ${numeros.join(', ')}`
+}
+
+const traduireEntree = (entree: BatchInvalidErrorEntryApiModel): string => {
+  switch (entree.code) {
+    case 'INVALID_ITEM': {
+      const champs = entree.issues.map((issue) => issue.path).join(', ')
+      return `Ligne ${numeroLigne(entree.indices[0])} : champ « ${champs} » invalide.`
+    }
+    case 'INDIVIDU_INCONNU':
+      return `Individu inconnu « ${entree.individu} » (${libelleLignes(entree.indices)}).`
+    case 'DUPLICATE_KEY':
+      return `Doublon ${entree.individu} / ${entree.date} (${libelleLignes(entree.indices)}).`
+  }
+}
+
+export function traduireErreursBatch({
+  details,
+}: {
+  details: BatchInvalidErrorDetailsApiModel
+}): string[] {
+  return details.errors.map(traduireEntree)
+}

--- a/apps/kpilote-webapp/src/components/import-valeurs/useImportModal.ts
+++ b/apps/kpilote-webapp/src/components/import-valeurs/useImportModal.ts
@@ -1,6 +1,12 @@
 import { createContext, useContext } from 'react'
 
-export type ImportTarget = { indicateurId: string; indicateurNom: string; initialFile?: File }
+export type ImportTarget = {
+  indicateurId: string
+  indicateurNom: string
+  initialFile?: File
+  /** Effet optionnel joué après un import réussi, avant la fermeture (ex. navigation). */
+  onSuccess?: () => void
+}
 
 export type ImportModalContextValue = {
   target: ImportTarget | null

--- a/apps/kpilote-webapp/src/components/import-valeurs/useImportModal.ts
+++ b/apps/kpilote-webapp/src/components/import-valeurs/useImportModal.ts
@@ -1,0 +1,17 @@
+import { createContext, useContext } from 'react'
+
+export type ImportTarget = { indicateurId: string; indicateurNom: string; initialFile?: File }
+
+export type ImportModalContextValue = {
+  target: ImportTarget | null
+  open: (target: ImportTarget) => void
+  close: () => void
+}
+
+export const ImportModalContext = createContext<ImportModalContextValue | null>(null)
+
+export function useImportModal(): ImportModalContextValue {
+  const value = useContext(ImportModalContext)
+  if (!value) throw new Error('useImportModal doit être utilisé dans ImportModalProvider')
+  return value
+}

--- a/apps/kpilote-webapp/src/components/import-valeurs/useImportModal.ts
+++ b/apps/kpilote-webapp/src/components/import-valeurs/useImportModal.ts
@@ -1,8 +1,7 @@
 import { createContext, useContext } from 'react'
 
 export type ImportTarget = {
-  indicateurId: string
-  indicateurNom: string
+  indicateur: { id: string; nom: string }
   initialFile?: File
   /** Effet optionnel joué après un import réussi, avant la fermeture (ex. navigation). */
   onSuccess?: () => void

--- a/apps/kpilote-webapp/src/components/import-valeurs/usePageFileDrop.ts
+++ b/apps/kpilote-webapp/src/components/import-valeurs/usePageFileDrop.ts
@@ -1,0 +1,53 @@
+import { useEffect, useRef, useState } from 'react'
+
+const contientFichier = (event: DragEvent): boolean =>
+  Array.from(event.dataTransfer?.types ?? []).includes('Files')
+
+export function usePageFileDrop({
+  enabled,
+  onFile,
+}: {
+  enabled: boolean
+  onFile: (file: File) => void
+}): { isDragging: boolean } {
+  const [isDragging, setIsDragging] = useState(false)
+  const compteur = useRef(0)
+
+  useEffect(() => {
+    if (!enabled) return
+
+    const onDragEnter = (event: DragEvent) => {
+      if (!contientFichier(event)) return
+      compteur.current += 1
+      setIsDragging(true)
+    }
+    const onDragOver = (event: DragEvent) => {
+      if (contientFichier(event)) event.preventDefault()
+    }
+    const onDragLeave = () => {
+      compteur.current = Math.max(0, compteur.current - 1)
+      if (compteur.current === 0) setIsDragging(false)
+    }
+    const onDrop = (event: DragEvent) => {
+      if (!contientFichier(event)) return
+      event.preventDefault()
+      compteur.current = 0
+      setIsDragging(false)
+      const file = event.dataTransfer?.files?.[0]
+      if (file) onFile(file)
+    }
+
+    window.addEventListener('dragenter', onDragEnter)
+    window.addEventListener('dragover', onDragOver)
+    window.addEventListener('dragleave', onDragLeave)
+    window.addEventListener('drop', onDrop)
+    return () => {
+      window.removeEventListener('dragenter', onDragEnter)
+      window.removeEventListener('dragover', onDragOver)
+      window.removeEventListener('dragleave', onDragLeave)
+      window.removeEventListener('drop', onDrop)
+    }
+  }, [enabled, onFile])
+
+  return { isDragging }
+}

--- a/apps/kpilote-webapp/src/components/ui/DataTable.tsx
+++ b/apps/kpilote-webapp/src/components/ui/DataTable.tsx
@@ -1,0 +1,45 @@
+import type { ReactNode } from 'react'
+
+import { Table } from './Table'
+
+export type DataTableColumn<T> = {
+  key: string
+  header: ReactNode
+  cell: (row: T, index: number) => ReactNode
+}
+
+export function DataTable<T>({
+  columns,
+  rows,
+  getRowKey,
+  footer,
+}: {
+  columns: DataTableColumn<T>[]
+  rows: T[]
+  getRowKey: (row: T, index: number) => string | number
+  footer?: ReactNode
+}): React.JSX.Element {
+  return (
+    <div className="overflow-hidden rounded-xl bg-surface">
+      <Table>
+        <Table.Head>
+          <Table.Row>
+            {columns.map((col) => (
+              <Table.HeaderCell key={col.key}>{col.header}</Table.HeaderCell>
+            ))}
+          </Table.Row>
+        </Table.Head>
+        <Table.Body>
+          {rows.map((row, i) => (
+            <Table.Row key={getRowKey(row, i)}>
+              {columns.map((col) => (
+                <Table.Cell key={col.key}>{col.cell(row, i)}</Table.Cell>
+              ))}
+            </Table.Row>
+          ))}
+        </Table.Body>
+      </Table>
+      {footer != null ? footer : null}
+    </div>
+  )
+}

--- a/apps/kpilote-webapp/src/components/ui/Dialog.tsx
+++ b/apps/kpilote-webapp/src/components/ui/Dialog.tsx
@@ -1,0 +1,69 @@
+import { Dialog as DialogPrimitive } from 'radix-ui'
+import type { ComponentProps } from 'react'
+
+import { clsxm } from '@/lib/clsxm'
+
+function Root(props: ComponentProps<typeof DialogPrimitive.Root>) {
+  return <DialogPrimitive.Root {...props} />
+}
+
+function Trigger(props: ComponentProps<typeof DialogPrimitive.Trigger>) {
+  return <DialogPrimitive.Trigger {...props} />
+}
+
+function Portal(props: ComponentProps<typeof DialogPrimitive.Portal>) {
+  return <DialogPrimitive.Portal {...props} />
+}
+
+function Overlay({ className, ...props }: ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      className={clsxm('fixed inset-0 z-40 bg-black/40 backdrop-blur-sm', className)}
+      {...props}
+    />
+  )
+}
+
+function Content({ className, ...props }: ComponentProps<typeof DialogPrimitive.Content>) {
+  return (
+    <DialogPrimitive.Content
+      className={clsxm(
+        'fixed left-1/2 top-[8vh] z-50 flex max-h-[84vh] w-[min(44rem,calc(100vw-2rem))] -translate-x-1/2 flex-col overflow-hidden rounded-2xl border border-border bg-surface shadow-[0_20px_60px_rgba(0,0,0,0.22)] focus:outline-none',
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+function Title({ className, ...props }: ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      className={clsxm('text-base font-semibold text-text', className)}
+      {...props}
+    />
+  )
+}
+
+function Description({ className, ...props }: ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      className={clsxm('mt-0.5 text-sm text-text-muted', className)}
+      {...props}
+    />
+  )
+}
+
+function Close(props: ComponentProps<typeof DialogPrimitive.Close>) {
+  return <DialogPrimitive.Close {...props} />
+}
+
+export const Dialog = Object.assign(Root, {
+  Trigger,
+  Portal,
+  Overlay,
+  Content,
+  Title,
+  Description,
+  Close,
+})

--- a/apps/kpilote-webapp/src/components/ui/Modale.tsx
+++ b/apps/kpilote-webapp/src/components/ui/Modale.tsx
@@ -1,0 +1,54 @@
+import { X } from 'lucide-react'
+import type { ReactNode } from 'react'
+
+import { Dialog } from '@/components/ui/Dialog'
+
+export function Modale({
+  open,
+  onClose,
+  titre,
+  description,
+  children,
+  footer,
+}: {
+  open: boolean
+  onClose: () => void
+  titre: string
+  description?: ReactNode
+  children: ReactNode
+  footer?: ReactNode
+}): React.JSX.Element {
+  return (
+    <Dialog open={open} onOpenChange={(ouvert: boolean) => (ouvert ? undefined : onClose())}>
+      <Dialog.Portal>
+        <Dialog.Overlay />
+        <Dialog.Content>
+          <div className="flex items-start justify-between border-b border-border px-6 py-4">
+            <div>
+              <Dialog.Title>{titre}</Dialog.Title>
+              {description !== undefined ? (
+                <Dialog.Description>{description}</Dialog.Description>
+              ) : null}
+            </div>
+            <button
+              type="button"
+              aria-label="Fermer"
+              onClick={onClose}
+              className="rounded-md p-1.5 text-text-subtle hover:bg-background hover:text-text"
+            >
+              <X className="size-[18px]" />
+            </button>
+          </div>
+
+          <div className="flex-1 overflow-y-auto px-6 py-5">{children}</div>
+
+          {footer !== undefined ? (
+            <div className="flex items-center justify-end gap-2 border-t border-border bg-background/60 px-6 py-4">
+              {footer}
+            </div>
+          ) : null}
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog>
+  )
+}

--- a/apps/kpilote-webapp/src/components/ui/ModaleForm.tsx
+++ b/apps/kpilote-webapp/src/components/ui/ModaleForm.tsx
@@ -1,0 +1,64 @@
+import { useEffect, useId } from 'react'
+import type { ReactNode } from 'react'
+import type { FieldValues, UseFormReturn } from 'react-hook-form'
+
+import { Button } from '@/components/ui/Button'
+import { Modale } from '@/components/ui/Modale'
+
+export function ModaleForm<TValues extends FieldValues>({
+  open,
+  onClose,
+  titre,
+  description,
+  form,
+  onSubmit,
+  submitLabel,
+  submitPendingLabel,
+  submitDisabled,
+  children,
+}: {
+  open: boolean
+  onClose: () => void
+  titre: string
+  description?: ReactNode
+  form: UseFormReturn<TValues>
+  onSubmit: (values: TValues) => void | Promise<void>
+  submitLabel: string
+  submitPendingLabel?: string
+  submitDisabled?: boolean
+  children: ReactNode
+}): React.JSX.Element {
+  const formId = useId()
+  const { isSubmitting } = form.formState
+  const buttonsDisabled = isSubmitting || submitDisabled === true
+
+  useEffect(() => {
+    if (!open) {
+      form.reset()
+    }
+  }, [open, form])
+
+  const footer = (
+    <>
+      <Button variant="secondary" type="button" onClick={onClose} disabled={buttonsDisabled}>
+        Annuler
+      </Button>
+      <Button variant="primary" type="submit" form={formId} disabled={buttonsDisabled}>
+        {isSubmitting && submitPendingLabel !== undefined ? submitPendingLabel : submitLabel}
+      </Button>
+    </>
+  )
+
+  return (
+    <Modale open={open} onClose={onClose} titre={titre} description={description} footer={footer}>
+      <form
+        id={formId}
+        onSubmit={(e) => {
+          void form.handleSubmit(onSubmit)(e)
+        }}
+      >
+        {children}
+      </form>
+    </Modale>
+  )
+}

--- a/apps/kpilote-webapp/src/main.tsx
+++ b/apps/kpilote-webapp/src/main.tsx
@@ -4,6 +4,7 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 
 import { auth } from '@/auth'
+import { ImportModalProvider } from '@/components/import-valeurs/ImportModalProvider'
 import { ToastProvider } from '@/components/ui/Toast'
 import '@/index.css'
 import { routeTree } from '@/routeTree.gen'
@@ -35,7 +36,9 @@ void auth.bootstrap().then(() => {
     <StrictMode>
       <QueryClientProvider client={queryClient}>
         <ToastProvider>
-          <RouterProvider router={router} />
+          <ImportModalProvider>
+            <RouterProvider router={router} />
+          </ImportModalProvider>
         </ToastProvider>
       </QueryClientProvider>
     </StrictMode>,

--- a/apps/kpilote-webapp/src/mutations/valeursImport.ts
+++ b/apps/kpilote-webapp/src/mutations/valeursImport.ts
@@ -5,7 +5,11 @@ import type { ParsedRow } from '@/components/import-valeurs/parseFichierValeurs'
 export function useImportValeursBatch({ indicateurId }: { indicateurId: string }) {
   const queryClient = useQueryClient()
   return useMutation({
-    mutationFn: (rows: ParsedRow[]) => importValeursBatch({ indicateurId, rows }),
+    mutationFn: async (rows: ParsedRow[]) => {
+      const res = await importValeursBatch({ indicateurId, rows })
+      if (res.isErr()) throw res.error
+      return res.value
+    },
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ['indicateur', indicateurId] })
     },

--- a/apps/kpilote-webapp/src/mutations/valeursImport.ts
+++ b/apps/kpilote-webapp/src/mutations/valeursImport.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { importValeursBatch } from '@/api/valeursImport'
+import { importValeursBatch, ImportError } from '@/api/valeursImport'
 import type { ParsedRow } from '@/components/import-valeurs/parseFichierValeurs'
 
 export function useImportValeursBatch({ indicateurId }: { indicateurId: string }) {
@@ -7,7 +7,7 @@ export function useImportValeursBatch({ indicateurId }: { indicateurId: string }
   return useMutation({
     mutationFn: async (rows: ParsedRow[]) => {
       const res = await importValeursBatch({ indicateurId, rows })
-      if (res.isErr()) throw res.error
+      if (res.isErr()) throw new ImportError(res.error)
       return res.value
     },
     onSuccess: () => {

--- a/apps/kpilote-webapp/src/mutations/valeursImport.ts
+++ b/apps/kpilote-webapp/src/mutations/valeursImport.ts
@@ -1,0 +1,13 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { importValeursBatch } from '@/api/valeursImport'
+import type { ParsedRow } from '@/components/import-valeurs/parseFichierValeurs'
+
+export function useImportValeursBatch({ indicateurId }: { indicateurId: string }) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (rows: ParsedRow[]) => importValeursBatch({ indicateurId, rows }),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['indicateur', indicateurId] })
+    },
+  })
+}

--- a/apps/kpilote-webapp/src/queries/indicateurs.ts
+++ b/apps/kpilote-webapp/src/queries/indicateurs.ts
@@ -32,6 +32,9 @@ export const allIndicateursQueryOptions = () =>
     staleTime: DEFAULT_STALE_TIME,
   })
 
+export const loadAllIndicateurs = ({ queryClient }: { queryClient: QueryClient }) =>
+  queryClient.ensureQueryData(allIndicateursQueryOptions())
+
 export const loadIndicateurs = ({
   queryClient,
   query,

--- a/apps/kpilote-webapp/src/queries/mePermissions.test.ts
+++ b/apps/kpilote-webapp/src/queries/mePermissions.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+
+import type { MePermissionsApiModel } from '@pilote/kpilote-shared/mePermissions'
+
+import { canWriteIndicateur } from '@/queries/mePermissions'
+
+const base: MePermissionsApiModel = { indicateurs: [], paniers: [] }
+
+describe('canWriteIndicateur', () => {
+  it("autorise un admin sur n'importe quel indicateur", () => {
+    expect(canWriteIndicateur({ permissions: { ...base, isAdmin: true }, indicateurId: 'IND-1' })).toBe(true)
+  })
+
+  it("autorise si une entree WRITE existe pour l'indicateur", () => {
+    const permissions: MePermissionsApiModel = {
+      ...base,
+      indicateurs: [{ id: 'IND-1', actions: ['WRITE'] }],
+    }
+    expect(canWriteIndicateur({ permissions, indicateurId: 'IND-1' })).toBe(true)
+  })
+
+  it("refuse sans entree WRITE", () => {
+    const permissions: MePermissionsApiModel = {
+      ...base,
+      indicateurs: [{ id: 'IND-1', actions: ['READ'] }],
+    }
+    expect(canWriteIndicateur({ permissions, indicateurId: 'IND-1' })).toBe(false)
+  })
+})

--- a/apps/kpilote-webapp/src/queries/mePermissions.test.ts
+++ b/apps/kpilote-webapp/src/queries/mePermissions.test.ts
@@ -8,7 +8,9 @@ const base: MePermissionsApiModel = { indicateurs: [], paniers: [] }
 
 describe('canWriteIndicateur', () => {
   it("autorise un admin sur n'importe quel indicateur", () => {
-    expect(canWriteIndicateur({ permissions: { ...base, isAdmin: true }, indicateurId: 'IND-1' })).toBe(true)
+    expect(
+      canWriteIndicateur({ permissions: { ...base, isAdmin: true }, indicateurId: 'IND-1' }),
+    ).toBe(true)
   })
 
   it("autorise si une entree WRITE existe pour l'indicateur", () => {
@@ -19,7 +21,7 @@ describe('canWriteIndicateur', () => {
     expect(canWriteIndicateur({ permissions, indicateurId: 'IND-1' })).toBe(true)
   })
 
-  it("refuse sans entree WRITE", () => {
+  it('refuse sans entree WRITE', () => {
     const permissions: MePermissionsApiModel = {
       ...base,
       indicateurs: [{ id: 'IND-1', actions: ['READ'] }],

--- a/apps/kpilote-webapp/src/queries/mePermissions.ts
+++ b/apps/kpilote-webapp/src/queries/mePermissions.ts
@@ -1,4 +1,4 @@
-import { type PermissionEntryApiModel } from '@pilote/kpilote-shared/mePermissions'
+import { type MePermissionsApiModel, type PermissionEntryApiModel } from '@pilote/kpilote-shared/mePermissions'
 import { type QueryClient, queryOptions, useSuspenseQuery } from '@tanstack/react-query'
 
 import { fetchMePermissions } from '@/api/mePermissions'
@@ -18,9 +18,17 @@ export const loadMePermissions = ({ queryClient }: { queryClient: QueryClient })
 const hasWrite = (entries: PermissionEntryApiModel[], publicId: string): boolean =>
   entries.some((entry) => entry.id === publicId && entry.actions.includes('WRITE'))
 
+export const canWriteIndicateur = ({
+  permissions,
+  indicateurId,
+}: {
+  permissions: MePermissionsApiModel
+  indicateurId: string
+}): boolean => permissions.isAdmin === true || hasWrite(permissions.indicateurs, indicateurId)
+
 export const useCanWriteIndicateur = (indicateurId: string): boolean => {
   const { data } = useSuspenseQuery(mePermissionsQueryOptions())
-  return data.isAdmin === true || hasWrite(data.indicateurs, indicateurId)
+  return canWriteIndicateur({ permissions: data, indicateurId })
 }
 
 // WRITE panier reste strictement direct (jamais propagé) — cf. me-permissions-design.md.

--- a/apps/kpilote-webapp/src/queries/mePermissions.ts
+++ b/apps/kpilote-webapp/src/queries/mePermissions.ts
@@ -1,4 +1,7 @@
-import { type MePermissionsApiModel, type PermissionEntryApiModel } from '@pilote/kpilote-shared/mePermissions'
+import {
+  type MePermissionsApiModel,
+  type PermissionEntryApiModel,
+} from '@pilote/kpilote-shared/mePermissions'
 import { type QueryClient, queryOptions, useSuspenseQuery } from '@tanstack/react-query'
 
 import { fetchMePermissions } from '@/api/mePermissions'

--- a/apps/kpilote-webapp/src/routes/_authenticated.tsx
+++ b/apps/kpilote-webapp/src/routes/_authenticated.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute, Outlet, redirect } from '@tanstack/react-router'
 
+import { loadAllIndicateurs } from '@/queries/indicateurs'
 import { loadMePermissions } from '@/queries/mePermissions'
 
 export const Route = createFileRoute('/_authenticated')({
@@ -10,6 +11,10 @@ export const Route = createFileRoute('/_authenticated')({
       throw redirect({ to: '/login', search: { redirect: target } })
     }
   },
-  loader: ({ context }) => loadMePermissions({ queryClient: context.queryClient }),
+  loader: ({ context }) =>
+    Promise.all([
+      loadMePermissions({ queryClient: context.queryClient }),
+      loadAllIndicateurs({ queryClient: context.queryClient }),
+    ]),
   component: () => <Outlet />,
 })

--- a/apps/kpilote-webapp/src/routes/_authenticated/indicateurs/$id.tsx
+++ b/apps/kpilote-webapp/src/routes/_authenticated/indicateurs/$id.tsx
@@ -106,13 +106,6 @@ function IndicateurDetailComponent() {
   // viser la dropzone de la modale, pas déclencher un second overlay par-dessus.
   const { isDragging } = usePageFileDrop({ enabled: canWrite && target === null, onFile })
 
-  const onFile = useCallback(
-    (file: File) =>
-      open({ indicateurId: indicateur.id, indicateurNom: indicateur.nom, initialFile: file }),
-    [open, indicateur.id, indicateur.nom],
-  )
-  const { isDragging } = usePageFileDrop({ enabled: canWrite, onFile })
-
   const actionsFiche = canWrite ? (
     <Button
       variant="secondary"

--- a/apps/kpilote-webapp/src/routes/_authenticated/indicateurs/$id.tsx
+++ b/apps/kpilote-webapp/src/routes/_authenticated/indicateurs/$id.tsx
@@ -3,7 +3,8 @@ import { individuPublicIdSchema } from '@pilote/kpilote-shared/individu'
 import { referentielPublicIdSchema } from '@pilote/kpilote-shared/referentiel'
 import { useSuspenseQuery } from '@tanstack/react-query'
 import { createFileRoute, Link, redirect, useNavigate } from '@tanstack/react-router'
-import { startTransition, useId } from 'react'
+import { Upload } from 'lucide-react'
+import { startTransition, useCallback, useId } from 'react'
 import { z } from 'zod'
 
 import { RouteError } from '@/components/RouteError'
@@ -11,7 +12,10 @@ import { RouteLoading } from '@/components/RouteLoading'
 import { IndicateurMetadonnees } from '@/components/indicateurs/IndicateurMetadonnees'
 import { IndicateurResultatsTab } from '@/components/indicateurs/IndicateurResultatsTab'
 import { IndividuSelect } from '@/components/indicateurs/IndividuSelect'
+import { useImportModal } from '@/components/import-valeurs/useImportModal'
+import { usePageFileDrop } from '@/components/import-valeurs/usePageFileDrop'
 import { BackLink } from '@/components/ui/BackLink'
+import { Button } from '@/components/ui/Button'
 import { EmptyState } from '@/components/ui/EmptyState'
 import { FormField } from '@/components/ui/FormField'
 import { Page } from '@/components/ui/Page'
@@ -23,6 +27,7 @@ import {
   loadIndicateur,
   prefetchIndicateurValeursForIndividu,
 } from '@/queries/indicateurs'
+import { useCanWriteIndicateur } from '@/queries/mePermissions'
 
 const paramsSchema = z.object({
   id: indicateurPublicIdSchema,
@@ -89,6 +94,29 @@ function IndicateurDetailComponent() {
   const { data: indicateur } = useSuspenseQuery(indicateurQueryOptions(id))
   useRecordVisit({ type: 'indicateur', id: indicateur.id, label: indicateur.nom })
 
+  const canWrite = useCanWriteIndicateur(id)
+  const { open, target } = useImportModal()
+
+  const onFile = useCallback(
+    (file: File) =>
+      open({ indicateur: { id: indicateur.id, nom: indicateur.nom }, initialFile: file }),
+    [open, indicateur.id, indicateur.nom],
+  )
+  // Désactive le drop de page quand la modale d'import est ouverte : le drop doit
+  // viser la dropzone de la modale, pas déclencher un second overlay par-dessus.
+  const { isDragging } = usePageFileDrop({ enabled: canWrite && target === null, onFile })
+
+  const actionsFiche = canWrite ? (
+    <Button
+      variant="secondary"
+      size="md"
+      onClick={() => open({ indicateur: { id: indicateur.id, nom: indicateur.nom } })}
+    >
+      <Upload />
+      Importer des valeurs
+    </Button>
+  ) : null
+
   const back = (
     <BackLink asChild>
       <Link
@@ -122,7 +150,7 @@ function IndicateurDetailComponent() {
   const referentielNom = indicateur.referentiels.find((c) => c.id === referentielId)?.nom ?? null
 
   return (
-    <Page title={indicateur.nom} back={back}>
+    <Page title={indicateur.nom} back={back} actions={actionsFiche}>
       <div className="max-w-md">
         <FormField label="Individu" htmlFor={selectId}>
           <IndividuSelect
@@ -171,6 +199,15 @@ function IndicateurDetailComponent() {
           <IndicateurMetadonnees indicateur={indicateur} />
         </TabsContent>
       </Tabs>
+
+      {isDragging ? (
+        <div className="pointer-events-none fixed inset-0 z-40 flex items-center justify-center bg-primary/10 p-8 backdrop-blur-sm">
+          <div className="flex h-full w-full flex-col items-center justify-center rounded-2xl border-2 border-dashed border-primary/40 bg-surface/70">
+            <p className="text-lg font-semibold text-primary">Déposez votre fichier CSV ou Excel</p>
+            <p className="text-sm text-primary/70">Il sera chargé dans la fenêtre d'import</p>
+          </div>
+        </div>
+      ) : null}
     </Page>
   )
 }

--- a/apps/kpilote-webapp/src/routes/_authenticated/indicateurs/$id.tsx
+++ b/apps/kpilote-webapp/src/routes/_authenticated/indicateurs/$id.tsx
@@ -107,7 +107,8 @@ function IndicateurDetailComponent() {
   const { isDragging } = usePageFileDrop({ enabled: canWrite && target === null, onFile })
 
   const onFile = useCallback(
-    (file: File) => open({ indicateurId: indicateur.id, indicateurNom: indicateur.nom, initialFile: file }),
+    (file: File) =>
+      open({ indicateurId: indicateur.id, indicateurNom: indicateur.nom, initialFile: file }),
     [open, indicateur.id, indicateur.nom],
   )
   const { isDragging } = usePageFileDrop({ enabled: canWrite, onFile })

--- a/apps/kpilote-webapp/src/routes/_authenticated/indicateurs/$id.tsx
+++ b/apps/kpilote-webapp/src/routes/_authenticated/indicateurs/$id.tsx
@@ -106,6 +106,12 @@ function IndicateurDetailComponent() {
   // viser la dropzone de la modale, pas déclencher un second overlay par-dessus.
   const { isDragging } = usePageFileDrop({ enabled: canWrite && target === null, onFile })
 
+  const onFile = useCallback(
+    (file: File) => open({ indicateurId: indicateur.id, indicateurNom: indicateur.nom, initialFile: file }),
+    [open, indicateur.id, indicateur.nom],
+  )
+  const { isDragging } = usePageFileDrop({ enabled: canWrite, onFile })
+
   const actionsFiche = canWrite ? (
     <Button
       variant="secondary"

--- a/apps/kpilote-webapp/src/tests/routing.test.tsx
+++ b/apps/kpilote-webapp/src/tests/routing.test.tsx
@@ -7,6 +7,8 @@ import type { MeApiModel } from '@pilote/kpilote-shared/me'
 
 import type { Auth } from '@/auth'
 import { tokenStore } from '@/auth/tokenStore'
+import { ImportModalProvider } from '@/components/import-valeurs/ImportModalProvider'
+import { ToastProvider } from '@/components/ui/Toast'
 import { routeTree } from '@/routeTree.gen'
 
 const stubAuth = (user: MeApiModel | null): Auth => ({
@@ -32,7 +34,11 @@ const renderAt = (initialPath: string, authImpl: Auth) => {
   })
   return render(
     <QueryClientProvider client={queryClient}>
-      <RouterProvider router={router} />
+      <ToastProvider>
+        <ImportModalProvider>
+          <RouterProvider router={router} />
+        </ImportModalProvider>
+      </ToastProvider>
     </QueryClientProvider>,
   )
 }

--- a/packages/kpilote-shared/src/error.test.ts
+++ b/packages/kpilote-shared/src/error.test.ts
@@ -6,7 +6,11 @@ describe('error schemas', () => {
     const parsed = validationErrorApiModelSchema.safeParse({
       code: 'VALIDATION_ERROR',
       message: 'Les données fournies sont invalides',
-      details: { issues: [{ path: ['items', 2, 'date'], message: 'Date calendaire invalide', code: 'custom' }] },
+      details: {
+        issues: [
+          { path: ['items', 2, 'date'], message: 'Date calendaire invalide', code: 'custom' },
+        ],
+      },
     })
     expect(parsed.success).toBe(true)
   })

--- a/packages/kpilote-shared/src/error.test.ts
+++ b/packages/kpilote-shared/src/error.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from 'vitest'
+import { validationErrorApiModelSchema } from './error'
+
+describe('error schemas', () => {
+  test('valide un VALIDATION_ERROR structuré', () => {
+    const parsed = validationErrorApiModelSchema.safeParse({
+      code: 'VALIDATION_ERROR',
+      message: 'Les données fournies sont invalides',
+      details: { issues: [{ path: ['items', 2, 'date'], message: 'Date calendaire invalide', code: 'custom' }] },
+    })
+    expect(parsed.success).toBe(true)
+  })
+})

--- a/packages/kpilote-shared/src/error.ts
+++ b/packages/kpilote-shared/src/error.ts
@@ -12,3 +12,19 @@ export const errorApiModelSchema = z.object({
 })
 
 export type ErrorApiModel = z.infer<typeof errorApiModelSchema>
+
+export const validationIssueApiModelSchema = z.object({
+  path: z
+    .array(z.union([z.string(), z.number()]))
+    .describe('Chemin Zod de la donnée invalide (ex. ["items", 2, "date"]).'),
+  message: z.string().describe('Message Zod en français.'),
+  code: z.string().describe('Code Zod (ex. custom, invalid_type).'),
+})
+export type ValidationIssueApiModel = z.infer<typeof validationIssueApiModelSchema>
+
+export const validationErrorApiModelSchema = z.object({
+  code: z.literal('VALIDATION_ERROR'),
+  message: z.string(),
+  details: z.object({ issues: z.array(validationIssueApiModelSchema) }),
+})
+export type ValidationErrorApiModel = z.infer<typeof validationErrorApiModelSchema>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -356,6 +356,9 @@ importers:
       tailwind-merge:
         specifier: ^3.5.0
         version: 3.5.0
+      xlsx:
+        specifier: ^0.18.5
+        version: 0.18.5
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -4618,6 +4621,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  adler-32@1.3.1:
+    resolution: {integrity: sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==}
+    engines: {node: '>=0.8'}
+
   agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
@@ -4913,6 +4920,10 @@ packages:
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
 
+  cfb@1.2.2:
+    resolution: {integrity: sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==}
+    engines: {node: '>=0.8'}
+
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
@@ -4997,6 +5008,10 @@ packages:
 
   code-block-writer@13.0.3:
     resolution: {integrity: sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==}
+
+  codepage@1.15.0:
+    resolution: {integrity: sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==}
+    engines: {node: '>=0.8'}
 
   collapse-white-space@2.1.0:
     resolution: {integrity: sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==}
@@ -5097,6 +5112,11 @@ packages:
   cosmiconfig@7.1.0:
     resolution: {integrity: sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==}
     engines: {node: '>=10'}
+
+  crc-32@1.2.2:
+    resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
+    engines: {node: '>=0.8'}
+    hasBin: true
 
   create-require@1.1.1:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
@@ -6011,6 +6031,10 @@ packages:
   formidable@3.5.4:
     resolution: {integrity: sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==}
     engines: {node: '>=14.0.0'}
+
+  frac@1.1.2:
+    resolution: {integrity: sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==}
+    engines: {node: '>=0.8'}
 
   fresh@0.5.2:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
@@ -8649,6 +8673,10 @@ packages:
     resolution: {integrity: sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg==}
     engines: {node: '>= 0.6'}
 
+  ssf@0.11.2:
+    resolution: {integrity: sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==}
+    engines: {node: '>=0.8'}
+
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
 
@@ -9485,9 +9513,17 @@ packages:
   wkt-parser@1.5.5:
     resolution: {integrity: sha512-/zMYi94/7D7fxcOSlVmWn6vnOMj3Gq5d1xvVjaYOS9n6h0qOJ4I7YYVxBWYcH1vq9+suhqzXkn05Yx47zQNUIA==}
 
+  wmf@1.0.2:
+    resolution: {integrity: sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==}
+    engines: {node: '>=0.8'}
+
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
+
+  word@0.3.0:
+    resolution: {integrity: sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==}
+    engines: {node: '>=0.8'}
 
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
@@ -9507,6 +9543,11 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+
+  xlsx@0.18.5:
+    resolution: {integrity: sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==}
+    engines: {node: '>=0.8'}
+    hasBin: true
 
   xml-but-prettier@1.0.1:
     resolution: {integrity: sha512-C2CJaadHrZTqESlH03WOyw0oZTtoy2uEg6dSDF6YRg+9GnYNub53RRemLpnvtbHDFelxMx4LajiFsYeR6XJHgQ==}
@@ -13563,6 +13604,8 @@ snapshots:
 
   acorn@8.16.0: {}
 
+  adler-32@1.3.1: {}
+
   agent-base@6.0.2:
     dependencies:
       debug: 4.4.3
@@ -13890,6 +13933,11 @@ snapshots:
 
   ccount@2.0.1: {}
 
+  cfb@1.2.2:
+    dependencies:
+      adler-32: 1.3.1
+      crc-32: 1.2.2
+
   chai@6.2.2: {}
 
   chalk@4.1.2:
@@ -13972,6 +14020,8 @@ snapshots:
       - '@types/react-dom'
 
   code-block-writer@13.0.3: {}
+
+  codepage@1.15.0: {}
 
   collapse-white-space@2.1.0: {}
 
@@ -14060,6 +14110,8 @@ snapshots:
       parse-json: 5.2.0
       path-type: 4.0.0
       yaml: 1.10.3
+
+  crc-32@1.2.2: {}
 
   create-require@1.1.1: {}
 
@@ -15231,6 +15283,8 @@ snapshots:
       '@paralleldrive/cuid2': 2.3.1
       dezalgo: 1.0.4
       once: 1.4.0
+
+  frac@1.1.2: {}
 
   fresh@0.5.2: {}
 
@@ -18567,6 +18621,10 @@ snapshots:
 
   sqlstring@2.3.3: {}
 
+  ssf@0.11.2:
+    dependencies:
+      frac: 1.1.2
+
   stable-hash@0.0.5: {}
 
   stackback@0.0.2: {}
@@ -19539,7 +19597,11 @@ snapshots:
 
   wkt-parser@1.5.5: {}
 
+  wmf@1.0.2: {}
+
   word-wrap@1.2.5: {}
+
+  word@0.3.0: {}
 
   wrap-ansi@7.0.0:
     dependencies:
@@ -19550,6 +19612,16 @@ snapshots:
   wrappy@1.0.2: {}
 
   ws@8.18.0: {}
+
+  xlsx@0.18.5:
+    dependencies:
+      adler-32: 1.3.1
+      cfb: 1.2.2
+      codepage: 1.15.0
+      crc-32: 1.2.2
+      ssf: 0.11.2
+      wmf: 1.0.2
+      word: 0.3.0
 
   xml-but-prettier@1.0.1:
     dependencies:


### PR DESCRIPTION
## Objectif

Permettre à un utilisateur ayant le droit d'écriture sur un indicateur d'**importer des valeurs en masse** depuis un fichier **CSV ou Excel**, via une modale avec preview, en s'appuyant sur la route batch existante `PUT /indicateurs/{id}/valeurs:batch`.

## Fonctionnement

- **3 points d'entrée** (tous gatés par la permission `WRITE`, en *hide* — rendu `null` si pas de droit) :
  - bouton « Importer des valeurs » sur la fiche indicateur ;
  - **drag & drop** d'un fichier n'importe où sur la page (overlay visuel) ;
  - **command palette ⌘K** (sous-action par indicateur). Depuis la palette, un import réussi **navigue vers la fiche** de l'indicateur avant de fermer la modale.
- Parsing **CSV + Excel** côté client via **SheetJS** (`xlsx`, chargé en import dynamique → hors bundle principal).
- Validation **« serveur seul »** : le fichier est parsé → `PUT …/valeurs:batch` → les erreurs structurées de l'API (`INVALID_ITEM`, `INDIVIDU_INCONNU`, `DUPLICATE_KEY`) sont **traduites en messages FR** avec numéros de ligne.
- Garde-fous client : rejet net au-delà de **1000 lignes**, colonnes manquantes, fichier vide/illisible.
- Succès → toast `{créées / mises à jour}` + invalidation des queries de l'indicateur (rafraîchit graphe/stats).

## Architecture

- Store global `ImportModalProvider` (monté dans `main.tsx`) : une seule modale partagée, déclenchable depuis les 3 entrées. Comme la modale est montée hors `RouterProvider`, la navigation au succès passe par un callback `onSuccess` fourni par l'appelant (la palette).
- Réutilise les schémas partagés `@pilote/kpilote-shared/valeurAvancement` (résultat + erreurs batch), la constante `MAX_VALEURS_PAR_BATCH`, et le helper de permission `canWriteIndicateur`.

## Tests

- Unitaires ciblés : `parseFichierValeurs` (CSV/XLSX, colonnes, >1000, dates sérialisées, décimales), `traduireErreursBatch` (3 codes + n° de ligne), `importValeursBatch` (succès + 400 via msw), `canWriteIndicateur`.
- Harness routing enrichi (Toast + ImportModalProvider).
- `pnpm lint` (eslint + tsc + prettier) exit 0 · **54/54 tests** verts.
- Pas d'E2E pour ce v0.

## Suivi (non bloquant)

- ⚠️ `xlsx@0.18.5` porte des advisories connues (prototype pollution / ReDoS). Ici l'entrée est le fichier local de l'utilisateur, parsé côté client (pas d'exposition serveur ni cross-user) → blast radius limité. À tracer comme dette de dépendance (bump ou install via CDN SheetJS).

## Hors scope (v0)

Résolution nom → publicId, highlight inline par cellule, découpage auto > 1000, template à télécharger, pré-validation métier côté client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
