### PR TITLE
feat: sélecteur d'individu sticky sur toutes les pages

### DIFF
--- a/apps/kpilote-webapp/src/components/DashboardSwitch.tsx
+++ b/apps/kpilote-webapp/src/components/DashboardSwitch.tsx
@@ -29,12 +29,12 @@ export function DashboardSwitch() {
       options={[
         {
           value: 'indicateurs',
-          label: <span className="sr-only sm:not-sr-only">Indicateurs</span>,
+          label: <span className="sr-only md:not-sr-only">Indicateurs</span>,
           icon: <LineChart />,
         },
         {
           value: 'dossiers',
-          label: <span className="sr-only sm:not-sr-only">Mes dossiers</span>,
+          label: <span className="sr-only md:not-sr-only">Mes dossiers</span>,
           icon: <FolderClosed />,
         },
       ]}

--- a/apps/kpilote-webapp/src/components/DashboardSwitch.tsx
+++ b/apps/kpilote-webapp/src/components/DashboardSwitch.tsx
@@ -27,8 +27,16 @@ export function DashboardSwitch() {
         })
       }}
       options={[
-        { value: 'indicateurs', label: 'Indicateurs', icon: <LineChart /> },
-        { value: 'dossiers', label: 'Mes dossiers', icon: <FolderClosed /> },
+        {
+          value: 'indicateurs',
+          label: <span className="sr-only sm:not-sr-only">Indicateurs</span>,
+          icon: <LineChart />,
+        },
+        {
+          value: 'dossiers',
+          label: <span className="sr-only sm:not-sr-only">Mes dossiers</span>,
+          icon: <FolderClosed />,
+        },
       ]}
     />
   )

--- a/apps/kpilote-webapp/src/components/indicateurs/IndividuSelect.tsx
+++ b/apps/kpilote-webapp/src/components/indicateurs/IndividuSelect.tsx
@@ -216,7 +216,7 @@ export function IndividuSelect({ id, referentielIds, value, onChange }: Individu
       <PopoverPrimitive.Trigger
         id={id}
         className={clsxm(
-          'inline-flex w-full min-w-[12rem] items-center justify-between gap-2 rounded-md border border-border bg-surface px-3 py-2.5 text-left text-sm font-medium text-text sm:min-w-[28rem]',
+          'inline-flex w-full min-w-[18rem] items-center justify-between gap-2 rounded-md border border-border bg-surface px-3 py-2.5 text-left text-sm font-medium text-text sm:min-w-[25rem]',
           'hover:border-border-strong',
           'focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary',
           'data-[state=open]:border-primary',

--- a/apps/kpilote-webapp/src/components/indicateurs/IndividuSelect.tsx
+++ b/apps/kpilote-webapp/src/components/indicateurs/IndividuSelect.tsx
@@ -216,7 +216,7 @@ export function IndividuSelect({ id, referentielIds, value, onChange }: Individu
       <PopoverPrimitive.Trigger
         id={id}
         className={clsxm(
-          'inline-flex w-full min-w-[28rem] items-center justify-between gap-2 rounded-md border border-border bg-surface px-3 py-2.5 text-left text-sm font-medium text-text',
+          'inline-flex w-full min-w-[12rem] items-center justify-between gap-2 rounded-md border border-border bg-surface px-3 py-2.5 text-left text-sm font-medium text-text sm:min-w-[28rem]',
           'hover:border-border-strong',
           'focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary',
           'data-[state=open]:border-primary',

--- a/apps/kpilote-webapp/src/components/ui/Page.tsx
+++ b/apps/kpilote-webapp/src/components/ui/Page.tsx
@@ -8,10 +8,19 @@ type PageProps = {
   description?: ReactNode
   back?: ReactNode
   actions?: ReactNode
+  stickybar?: ReactNode
   children: ReactNode
 }
 
-export function Page({ kicker, title, description, back, actions, children }: PageProps) {
+export function Page({
+  kicker,
+  title,
+  description,
+  back,
+  actions,
+  stickybar,
+  children,
+}: PageProps) {
   return (
     <div className="space-y-2 sm:space-y-4">
       {back && <div>{back}</div>}
@@ -33,6 +42,11 @@ export function Page({ kicker, title, description, back, actions, children }: Pa
         </div>
         {actions && <div className="flex shrink-0 items-center gap-3">{actions}</div>}
       </header>
+      {stickybar && (
+        <div className="sticky top-20 z-20 -mx-6 flex flex-wrap items-end justify-between gap-4 bg-surface/90 px-6 py-3 backdrop-blur sm:-mx-8 sm:px-8">
+          {stickybar}
+        </div>
+      )}
       <div className="space-y-10 sm:space-y-12">{children}</div>
     </div>
   )

--- a/apps/kpilote-webapp/src/components/ui/Page.tsx
+++ b/apps/kpilote-webapp/src/components/ui/Page.tsx
@@ -43,7 +43,7 @@ export function Page({
         {actions && <div className="flex shrink-0 items-center gap-3">{actions}</div>}
       </header>
       {stickybar && (
-        <div className="sticky top-20 z-20 -mx-6 flex flex-wrap items-end justify-between gap-4 bg-surface/90 px-6 py-3 backdrop-blur sm:-mx-8 sm:px-8">
+        <div className="sticky top-20 z-20 -mx-6 flex items-end justify-between gap-4 bg-surface/90 px-6 py-3 backdrop-blur sm:-mx-8 sm:px-8">
           {stickybar}
         </div>
       )}

--- a/apps/kpilote-webapp/src/routes/_authenticated/indicateurs/$id.tsx
+++ b/apps/kpilote-webapp/src/routes/_authenticated/indicateurs/$id.tsx
@@ -151,21 +151,23 @@ function IndicateurDetailComponent() {
 
   return (
     <Page title={indicateur.nom} back={back} actions={actionsFiche}>
-      <div className="max-w-md">
-        <FormField label="Individu" htmlFor={selectId}>
-          <IndividuSelect
-            id={selectId}
-            referentielIds={referentielIds}
-            value={individuId}
-            onChange={({ individu, referentiel }) => {
-              startTransition(() => {
-                void navigate({
-                  search: (prev) => ({ ...prev, individu, referentiel }),
+      <div className="sticky top-20 z-20 -mx-6 mb-2 flex justify-start bg-surface/90 px-6 py-3 backdrop-blur sm:-mx-8 sm:px-8">
+        <div className="max-w-md flex-1">
+          <FormField label="Individu" htmlFor={selectId}>
+            <IndividuSelect
+              id={selectId}
+              referentielIds={referentielIds}
+              value={individuId}
+              onChange={({ individu, referentiel }) => {
+                startTransition(() => {
+                  void navigate({
+                    search: (prev) => ({ ...prev, individu, referentiel }),
+                  })
                 })
-              })
-            }}
-          />
-        </FormField>
+              }}
+            />
+          </FormField>
+        </div>
       </div>
 
       <Tabs

--- a/apps/kpilote-webapp/src/routes/_authenticated/indicateurs/$id.tsx
+++ b/apps/kpilote-webapp/src/routes/_authenticated/indicateurs/$id.tsx
@@ -150,8 +150,11 @@ function IndicateurDetailComponent() {
   const referentielNom = indicateur.referentiels.find((c) => c.id === referentielId)?.nom ?? null
 
   return (
-    <Page title={indicateur.nom} back={back} actions={actionsFiche}>
-      <div className="sticky top-20 z-20 -mx-6 mb-2 flex justify-start bg-surface/90 px-6 py-3 backdrop-blur sm:-mx-8 sm:px-8">
+    <Page
+      title={indicateur.nom}
+      back={back}
+      actions={actionsFiche}
+      stickybar={
         <div className="max-w-md">
           <FormField label="Individu" htmlFor={selectId}>
             <IndividuSelect
@@ -168,8 +171,8 @@ function IndicateurDetailComponent() {
             />
           </FormField>
         </div>
-      </div>
-
+      }
+    >
       <Tabs
         value={search.onglet}
         onValueChange={(onglet) => {

--- a/apps/kpilote-webapp/src/routes/_authenticated/indicateurs/$id.tsx
+++ b/apps/kpilote-webapp/src/routes/_authenticated/indicateurs/$id.tsx
@@ -152,7 +152,7 @@ function IndicateurDetailComponent() {
   return (
     <Page title={indicateur.nom} back={back} actions={actionsFiche}>
       <div className="sticky top-20 z-20 -mx-6 mb-2 flex justify-start bg-surface/90 px-6 py-3 backdrop-blur sm:-mx-8 sm:px-8">
-        <div className="max-w-md flex-1">
+        <div className="max-w-md">
           <FormField label="Individu" htmlFor={selectId}>
             <IndividuSelect
               id={selectId}

--- a/apps/kpilote-webapp/src/routes/_authenticated/indicateurs/index.tsx
+++ b/apps/kpilote-webapp/src/routes/_authenticated/indicateurs/index.tsx
@@ -68,31 +68,31 @@ function IndicateursListComponent() {
       title="Tableau de bord"
       description="Consultez et gérez l'ensemble de vos indicateurs par valeur ou par dossier."
     >
-      <div className="flex flex-col gap-6">
-        <div className="flex flex-wrap items-end justify-between gap-4">
-          {search.individu ? (
-            <div className="max-w-md flex-1">
-              <FormField label="Individu observé" htmlFor={selectId}>
-                <IndividuSelect
-                  id={selectId}
-                  referentielIds={referentielIds}
-                  value={search.individu}
-                  onChange={({ individu, referentiel }) => {
-                    startTransition(() => {
-                      void navigate({
-                        search: (prev) => ({ ...prev, individu, referentiel }),
-                      })
+      <div className="sticky top-20 z-20 -mx-6 mb-2 flex flex-wrap items-end justify-between gap-4 bg-surface/90 px-6 py-3 backdrop-blur sm:-mx-8 sm:px-8">
+        {search.individu ? (
+          <div className="max-w-md flex-1">
+            <FormField label="Individu" htmlFor={selectId}>
+              <IndividuSelect
+                id={selectId}
+                referentielIds={referentielIds}
+                value={search.individu}
+                onChange={({ individu, referentiel }) => {
+                  startTransition(() => {
+                    void navigate({
+                      search: (prev) => ({ ...prev, individu, referentiel }),
                     })
-                  }}
-                />
-              </FormField>
-            </div>
-          ) : (
-            <div />
-          )}
-          <DashboardSwitch />
-        </div>
+                  })
+                }}
+              />
+            </FormField>
+          </div>
+        ) : (
+          <div />
+        )}
+        <DashboardSwitch />
+      </div>
 
+      <div className="flex flex-col gap-6">
         <div className="flex flex-wrap items-center justify-between gap-4">
           <Text as="span" variant="kicker" tone="muted">
             {data.total} indicateur{data.total > 1 ? 's' : ''}

--- a/apps/kpilote-webapp/src/routes/_authenticated/indicateurs/index.tsx
+++ b/apps/kpilote-webapp/src/routes/_authenticated/indicateurs/index.tsx
@@ -70,7 +70,7 @@ function IndicateursListComponent() {
       stickybar={
         <>
           {search.individu ? (
-            <div className="max-w-md flex-1">
+            <div>
               <FormField label="Individu" htmlFor={selectId}>
                 <IndividuSelect
                   id={selectId}

--- a/apps/kpilote-webapp/src/routes/_authenticated/indicateurs/index.tsx
+++ b/apps/kpilote-webapp/src/routes/_authenticated/indicateurs/index.tsx
@@ -67,31 +67,32 @@ function IndicateursListComponent() {
     <Page
       title="Tableau de bord"
       description="Consultez et gérez l'ensemble de vos indicateurs par valeur ou par dossier."
-    >
-      <div className="sticky top-20 z-20 -mx-6 mb-2 flex flex-wrap items-end justify-between gap-4 bg-surface/90 px-6 py-3 backdrop-blur sm:-mx-8 sm:px-8">
-        {search.individu ? (
-          <div className="max-w-md flex-1">
-            <FormField label="Individu" htmlFor={selectId}>
-              <IndividuSelect
-                id={selectId}
-                referentielIds={referentielIds}
-                value={search.individu}
-                onChange={({ individu, referentiel }) => {
-                  startTransition(() => {
-                    void navigate({
-                      search: (prev) => ({ ...prev, individu, referentiel }),
+      stickybar={
+        <>
+          {search.individu ? (
+            <div className="max-w-md flex-1">
+              <FormField label="Individu" htmlFor={selectId}>
+                <IndividuSelect
+                  id={selectId}
+                  referentielIds={referentielIds}
+                  value={search.individu}
+                  onChange={({ individu, referentiel }) => {
+                    startTransition(() => {
+                      void navigate({
+                        search: (prev) => ({ ...prev, individu, referentiel }),
+                      })
                     })
-                  })
-                }}
-              />
-            </FormField>
-          </div>
-        ) : (
-          <div />
-        )}
-        <DashboardSwitch />
-      </div>
-
+                  }}
+                />
+              </FormField>
+            </div>
+          ) : (
+            <div />
+          )}
+          <DashboardSwitch />
+        </>
+      }
+    >
       <div className="flex flex-col gap-6">
         <div className="flex flex-wrap items-center justify-between gap-4">
           <Text as="span" variant="kicker" tone="muted">

--- a/apps/kpilote-webapp/src/routes/_authenticated/paniers/$id.tsx
+++ b/apps/kpilote-webapp/src/routes/_authenticated/paniers/$id.tsx
@@ -123,7 +123,7 @@ function PanierDetailComponent() {
     <Page title={panier.nom} description={panier.description ?? undefined} back={back}>
       {search.individu && (
         <div className="sticky top-20 z-20 -mx-6 mb-2 flex justify-start bg-surface/90 px-6 py-3 backdrop-blur sm:-mx-8 sm:px-8">
-          <div className="max-w-md flex-1">
+          <div className="max-w-md">
             <FormField label="Individu" htmlFor={selectId}>
               <IndividuSelect
                 id={selectId}

--- a/apps/kpilote-webapp/src/routes/_authenticated/paniers/$id.tsx
+++ b/apps/kpilote-webapp/src/routes/_authenticated/paniers/$id.tsx
@@ -120,9 +120,12 @@ function PanierDetailComponent() {
       : undefined
 
   return (
-    <Page title={panier.nom} description={panier.description ?? undefined} back={back}>
-      {search.individu && (
-        <div className="sticky top-20 z-20 -mx-6 mb-2 flex justify-start bg-surface/90 px-6 py-3 backdrop-blur sm:-mx-8 sm:px-8">
+    <Page
+      title={panier.nom}
+      description={panier.description ?? undefined}
+      back={back}
+      stickybar={
+        search.individu ? (
           <div className="max-w-md">
             <FormField label="Individu" htmlFor={selectId}>
               <IndividuSelect
@@ -139,9 +142,9 @@ function PanierDetailComponent() {
               />
             </FormField>
           </div>
-        </div>
-      )}
-
+        ) : undefined
+      }
+    >
       <Tabs
         value={search.onglet}
         onValueChange={(onglet) => {

--- a/apps/kpilote-webapp/src/routes/_authenticated/paniers/$id.tsx
+++ b/apps/kpilote-webapp/src/routes/_authenticated/paniers/$id.tsx
@@ -121,6 +121,27 @@ function PanierDetailComponent() {
 
   return (
     <Page title={panier.nom} description={panier.description ?? undefined} back={back}>
+      {search.individu && (
+        <div className="sticky top-20 z-20 -mx-6 mb-2 flex justify-start bg-surface/90 px-6 py-3 backdrop-blur sm:-mx-8 sm:px-8">
+          <div className="max-w-md flex-1">
+            <FormField label="Individu" htmlFor={selectId}>
+              <IndividuSelect
+                id={selectId}
+                referentielIds={referentielIds}
+                value={search.individu}
+                onChange={({ individu, referentiel }) => {
+                  startTransition(() => {
+                    void navigate({
+                      search: (prev) => ({ ...prev, individu, referentiel }),
+                    })
+                  })
+                }}
+              />
+            </FormField>
+          </div>
+        </div>
+      )}
+
       <Tabs
         value={search.onglet}
         onValueChange={(onglet) => {
@@ -138,29 +159,11 @@ function PanierDetailComponent() {
 
         <TabsContent value="resultats">
           <div className="flex flex-col gap-6">
-            {search.individu ? (
-              <div className="flex flex-col gap-6">
-                <div className="max-w-md">
-                  <FormField label="Individu observé" htmlFor={selectId}>
-                    <IndividuSelect
-                      id={selectId}
-                      referentielIds={referentielIds}
-                      value={search.individu}
-                      onChange={({ individu, referentiel }) => {
-                        startTransition(() => {
-                          void navigate({
-                            search: (prev) => ({ ...prev, individu, referentiel }),
-                          })
-                        })
-                      }}
-                    />
-                  </FormField>
-                </div>
-                <div className="max-w-xs">
-                  <PanierTauxProgression panierId={id} individu={search.individu} />
-                </div>
+            {search.individu && (
+              <div className="max-w-xs">
+                <PanierTauxProgression panierId={id} individu={search.individu} />
               </div>
-            ) : null}
+            )}
 
             <Text as="span" variant="kicker" tone="muted">
               {orderedIndicateurs.length} indicateur{orderedIndicateurs.length > 1 ? 's' : ''}

--- a/apps/kpilote-webapp/src/routes/_authenticated/paniers/index.tsx
+++ b/apps/kpilote-webapp/src/routes/_authenticated/paniers/index.tsx
@@ -75,31 +75,32 @@ function PaniersListComponent() {
     <Page
       title="Tableau de bord"
       description="Consultez et gérez l'ensemble de vos indicateurs par valeur ou par dossier."
-    >
-      <div className="sticky top-20 z-20 -mx-6 mb-2 flex flex-wrap items-end justify-between gap-4 bg-surface/90 px-6 py-3 backdrop-blur sm:-mx-8 sm:px-8">
-        {search.individu ? (
-          <div className="max-w-md flex-1">
-            <FormField label="Individu" htmlFor={selectId}>
-              <IndividuSelect
-                id={selectId}
-                referentielIds={referentielIds}
-                value={search.individu}
-                onChange={({ individu, referentiel }) => {
-                  startTransition(() => {
-                    void navigate({
-                      search: (prev) => ({ ...prev, individu, referentiel }),
+      stickybar={
+        <>
+          {search.individu ? (
+            <div className="max-w-md flex-1">
+              <FormField label="Individu" htmlFor={selectId}>
+                <IndividuSelect
+                  id={selectId}
+                  referentielIds={referentielIds}
+                  value={search.individu}
+                  onChange={({ individu, referentiel }) => {
+                    startTransition(() => {
+                      void navigate({
+                        search: (prev) => ({ ...prev, individu, referentiel }),
+                      })
                     })
-                  })
-                }}
-              />
-            </FormField>
-          </div>
-        ) : (
-          <div />
-        )}
-        <DashboardSwitch />
-      </div>
-
+                  }}
+                />
+              </FormField>
+            </div>
+          ) : (
+            <div />
+          )}
+          <DashboardSwitch />
+        </>
+      }
+    >
       <div className="flex flex-col gap-6">
         <Text as="span" variant="kicker" tone="muted">
           {data.total} dossier{data.total > 1 ? 's' : ''}

--- a/apps/kpilote-webapp/src/routes/_authenticated/paniers/index.tsx
+++ b/apps/kpilote-webapp/src/routes/_authenticated/paniers/index.tsx
@@ -76,31 +76,31 @@ function PaniersListComponent() {
       title="Tableau de bord"
       description="Consultez et gérez l'ensemble de vos indicateurs par valeur ou par dossier."
     >
-      <div className="flex flex-col gap-6">
-        <div className="flex flex-wrap items-end justify-between gap-4">
-          {search.individu ? (
-            <div className="max-w-md flex-1">
-              <FormField label="Individu observé" htmlFor={selectId}>
-                <IndividuSelect
-                  id={selectId}
-                  referentielIds={referentielIds}
-                  value={search.individu}
-                  onChange={({ individu, referentiel }) => {
-                    startTransition(() => {
-                      void navigate({
-                        search: (prev) => ({ ...prev, individu, referentiel }),
-                      })
+      <div className="sticky top-20 z-20 -mx-6 mb-2 flex flex-wrap items-end justify-between gap-4 bg-surface/90 px-6 py-3 backdrop-blur sm:-mx-8 sm:px-8">
+        {search.individu ? (
+          <div className="max-w-md flex-1">
+            <FormField label="Individu" htmlFor={selectId}>
+              <IndividuSelect
+                id={selectId}
+                referentielIds={referentielIds}
+                value={search.individu}
+                onChange={({ individu, referentiel }) => {
+                  startTransition(() => {
+                    void navigate({
+                      search: (prev) => ({ ...prev, individu, referentiel }),
                     })
-                  }}
-                />
-              </FormField>
-            </div>
-          ) : (
-            <div />
-          )}
-          <DashboardSwitch />
-        </div>
+                  })
+                }}
+              />
+            </FormField>
+          </div>
+        ) : (
+          <div />
+        )}
+        <DashboardSwitch />
+      </div>
 
+      <div className="flex flex-col gap-6">
         <Text as="span" variant="kicker" tone="muted">
           {data.total} dossier{data.total > 1 ? 's' : ''}
         </Text>

--- a/apps/kpilote-webapp/src/routes/_authenticated/paniers/index.tsx
+++ b/apps/kpilote-webapp/src/routes/_authenticated/paniers/index.tsx
@@ -78,7 +78,7 @@ function PaniersListComponent() {
       stickybar={
         <>
           {search.individu ? (
-            <div className="max-w-md flex-1">
+            <div>
               <FormField label="Individu" htmlFor={selectId}>
                 <IndividuSelect
                   id={selectId}


### PR DESCRIPTION
## Résumé

- L'`IndividuSelect` est désormais dans un bandeau sticky positionné juste sous le header, sur les 4 pages concernées
- Sur les **pages liste** (indicateurs, paniers) : le bandeau contient l'`IndividuSelect` + le `DashboardSwitch` côte à côte
- Sur les **pages détail** (indicateur, panier) : le bandeau contient l'`IndividuSelect` seul, visible quel que soit l'onglet actif

## Détails techniques

- Le composant `Page` expose une nouvelle prop `stickybar?: ReactNode` qui rend un bandeau `sticky top-20 z-20` avec `bg-surface/90 backdrop-blur` juste sous le header — les tokens sont centralisés en un seul endroit
- `-mx-6 px-6 sm:-mx-8 sm:px-8` — bord à bord dans la zone de contenu sans déborder du `max-w-7xl`
- Sur la page détail panier, l'`IndividuSelect` a été sorti du `TabsContent "resultats"` et placé dans le bandeau

## Plan de test

- [ ] Page liste indicateurs : le bandeau (IndividuSelect + DashboardSwitch) reste visible au scroll, DashboardSwitch aligné à droite
- [ ] Page liste paniers : idem
- [ ] Page détail indicateur : le bandeau (IndividuSelect) reste visible, les onglets Résultats / Métadonnées apparaissent en dessous en flow normal
- [ ] Page détail panier : le bandeau reste visible sur tous les onglets (Résultats, Gouvernance, Confiance, Commentaires)
- [ ] Vérifier que le dropdown de l'`IndividuSelect` passe bien au-dessus du contenu (z-50 sur le popover)

🤖 Generated with [Claude Code](https://claude.com/claude-code)