### PR TITLE
feat(indicateur): drill-down par référentiel racine dans IndividuSelect

### DIFF
--- a/apps/kpilote-webapp/src/components/indicateurs/IndividuSelect.tsx
+++ b/apps/kpilote-webapp/src/components/indicateurs/IndividuSelect.tsx
@@ -5,7 +5,12 @@ import { Check, ChevronDown, ChevronLeft, ChevronRight, Search } from 'lucide-re
 import { useMemo, useState } from 'react'
 
 import { clsxm } from '@/lib/clsxm'
-import { buildOrderedNodes, groupNodesByRootReferentiel } from '@/lib/individus/hierarchy'
+import {
+  buildOrderedNodes,
+  groupNodesByRootReferentiel,
+  type IndividuNode,
+  type ReferentielGroup,
+} from '@/lib/individus/hierarchy'
 import { referentielIndividusQueryOptions, referentielQueryOptions } from '@/queries/referentiels'
 
 type IndividuSelectProps = {
@@ -22,9 +27,147 @@ const commandFilter = (itemValue: string, query: string) => {
   return haystack.includes(needle) ? 1 : 0
 }
 
+const listClassName =
+  'max-h-[min(20rem,var(--radix-popover-content-available-height))] overflow-y-auto p-1.5'
+const emptyClassName = 'px-3 py-6 text-center text-sm text-text-muted'
+const itemClassName = clsxm(
+  'flex cursor-pointer select-none items-center gap-2 rounded-md px-2.5 py-2 text-sm text-text outline-none',
+  'data-[selected=true]:bg-surface-tinted data-[selected=true]:text-primary',
+)
+
+function CommandSearchInput({
+  value,
+  onValueChange,
+  placeholder,
+}: {
+  value: string
+  onValueChange: (next: string) => void
+  placeholder: string
+}) {
+  return (
+    <div className="flex items-center gap-2 border-b border-border px-3">
+      <Search className="size-4 text-text-muted" />
+      <Command.Input
+        value={value}
+        onValueChange={onValueChange}
+        placeholder={placeholder}
+        className="h-10 w-full bg-transparent text-sm text-text outline-none placeholder:text-text-subtle"
+      />
+    </div>
+  )
+}
+
+// Étape 1 : choix du référentiel racine parmi la forêt.
+function RootReferentielsCommandStep({
+  groups,
+  onSelect,
+}: {
+  groups: ReadonlyArray<ReferentielGroup>
+  onSelect: (referentielId: string) => void
+}) {
+  const [search, setSearch] = useState('')
+  return (
+    <Command label="Choisir un référentiel" filter={commandFilter}>
+      <CommandSearchInput
+        value={search}
+        onValueChange={setSearch}
+        placeholder="Rechercher un référentiel…"
+      />
+      <Command.List className={listClassName}>
+        <Command.Empty className={emptyClassName}>Aucun référentiel trouvé.</Command.Empty>
+        {groups.map((group) => (
+          <Command.Item
+            key={group.referentiel.id}
+            value={group.referentiel.nom}
+            onSelect={() => onSelect(group.referentiel.id)}
+            className={itemClassName}
+          >
+            <span className="min-w-0 flex-1 truncate font-medium">{group.referentiel.nom}</span>
+            <span className="shrink-0 rounded-full bg-surface-tinted px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-text-muted">
+              {group.nodes.length}
+            </span>
+            <ChevronRight className="size-4 shrink-0 text-text-muted" />
+          </Command.Item>
+        ))}
+      </Command.List>
+    </Command>
+  )
+}
+
+// Étape 2 : choix d'un individu dans la hiérarchie complète du référentiel racine.
+function ReferentielSelectCommandStep({
+  referentielNom,
+  nodes,
+  value,
+  onBack,
+  onSelect,
+}: {
+  referentielNom: string
+  nodes: ReadonlyArray<IndividuNode>
+  value: string
+  onBack: (() => void) | null
+  onSelect: (next: { individu: string; referentiel: string }) => void
+}) {
+  const [search, setSearch] = useState('')
+  return (
+    <Command label="Rechercher un individu" filter={commandFilter}>
+      {onBack ? (
+        <button
+          type="button"
+          onClick={onBack}
+          className="flex w-full items-center gap-1.5 border-b border-border px-3 py-2 text-left text-xs font-semibold text-text-muted hover:text-text"
+        >
+          <ChevronLeft className="size-4 shrink-0" />
+          <span className="truncate">{referentielNom}</span>
+        </button>
+      ) : null}
+      <CommandSearchInput value={search} onValueChange={setSearch} placeholder="Rechercher…" />
+      <Command.List className={listClassName}>
+        <Command.Empty className={emptyClassName}>Aucun individu trouvé.</Command.Empty>
+        {nodes.map((node) => {
+          const isSelected = node.individu.id === value
+          const searchableValue = [node.individu.nom, node.individu.id, ...node.parentPath].join(
+            ' ',
+          )
+          return (
+            <Command.Item
+              key={node.individu.id}
+              value={searchableValue}
+              onSelect={() =>
+                onSelect({ individu: node.individu.id, referentiel: node.individu.referentiel })
+              }
+              className={clsxm(
+                itemClassName,
+                isSelected && 'bg-primary-tinted font-semibold text-primary',
+              )}
+              style={{ paddingLeft: `${0.625 + node.depth * 0.875}rem` }}
+            >
+              <Check
+                className={clsxm('size-4 shrink-0', isSelected ? 'opacity-100' : 'opacity-0')}
+              />
+              <span className="flex min-w-0 flex-1 flex-col">
+                <span className="flex items-baseline gap-2">
+                  <span className="truncate">{node.individu.nom}</span>
+                  <span className="shrink-0 font-mono text-[11px] font-normal text-text-subtle">
+                    {node.individu.id}
+                  </span>
+                </span>
+                {node.parentPath.length > 0 ? (
+                  <span className="truncate text-xs font-normal text-text-muted">
+                    {node.parentPath.join(' › ')}
+                  </span>
+                ) : null}
+              </span>
+            </Command.Item>
+          )
+        })}
+      </Command.List>
+    </Command>
+  )
+}
+
 export function IndividuSelect({ id, referentielIds, value, onChange }: IndividuSelectProps) {
   const [open, setOpen] = useState(false)
-  const [search, setSearch] = useState('')
   const [activeReferentielId, setActiveReferentielId] = useState<string | null>(null)
 
   const referentiels = useSuspenseQueries({
@@ -49,8 +192,6 @@ export function IndividuSelect({ id, referentielIds, value, onChange }: Individu
   const selected = nodes.find((node) => node.individu.id === value)
   const hasSingleRootReferentiel = groups.length === 1
   const activeGroup = groups.find((group) => group.referentiel.id === activeReferentielId)
-  const activeReferentiel = activeGroup?.referentiel
-  const activeNodes = activeGroup?.nodes ?? []
 
   // Étape d'ouverture : on ouvre directement sur le référentiel racine de l'arbre
   // de l'individu déjà sélectionné, ou sur l'unique référentiel racine ; sinon on
@@ -64,17 +205,12 @@ export function IndividuSelect({ id, referentielIds, value, onChange }: Individu
     return null
   }
 
-  const openReferentiel = (referentielId: string | null) => {
-    setActiveReferentielId(referentielId)
-    setSearch('')
-  }
-
   return (
     <PopoverPrimitive.Root
       open={open}
       onOpenChange={(next) => {
         setOpen(next)
-        if (next) openReferentiel(resolveInitialReferentiel())
+        if (next) setActiveReferentielId(resolveInitialReferentiel())
       }}
     >
       <PopoverPrimitive.Trigger
@@ -114,121 +250,19 @@ export function IndividuSelect({ id, referentielIds, value, onChange }: Individu
           sideOffset={6}
           className="z-50 w-[var(--radix-popover-trigger-width)] min-w-[32rem] overflow-hidden rounded-lg border border-border bg-surface shadow-[0_8px_24px_rgba(0,0,0,0.06)]"
         >
-          {activeReferentielId === null ? (
-            <Command key="referentiels" label="Choisir un référentiel" filter={commandFilter}>
-              <div className="flex items-center gap-2 border-b border-border px-3">
-                <Search className="size-4 text-text-muted" />
-                <Command.Input
-                  value={search}
-                  onValueChange={setSearch}
-                  placeholder="Rechercher un référentiel…"
-                  className="h-10 w-full bg-transparent text-sm text-text outline-none placeholder:text-text-subtle"
-                />
-              </div>
-              <Command.List className="max-h-[min(20rem,var(--radix-popover-content-available-height))] overflow-y-auto p-1.5">
-                <Command.Empty className="px-3 py-6 text-center text-sm text-text-muted">
-                  Aucun référentiel trouvé.
-                </Command.Empty>
-                {groups.map((group) => (
-                  <Command.Item
-                    key={group.referentiel.id}
-                    value={group.referentiel.nom}
-                    onSelect={() => openReferentiel(group.referentiel.id)}
-                    className={clsxm(
-                      'flex cursor-pointer select-none items-center gap-2 rounded-md px-2.5 py-2 text-sm text-text outline-none',
-                      'data-[selected=true]:bg-surface-tinted data-[selected=true]:text-primary',
-                    )}
-                  >
-                    <span className="min-w-0 flex-1 truncate font-medium">
-                      {group.referentiel.nom}
-                    </span>
-                    <span className="shrink-0 rounded-full bg-surface-tinted px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-text-muted">
-                      {group.nodes.length}
-                    </span>
-                    <ChevronRight className="size-4 shrink-0 text-text-muted" />
-                  </Command.Item>
-                ))}
-              </Command.List>
-            </Command>
+          {activeGroup ? (
+            <ReferentielSelectCommandStep
+              referentielNom={activeGroup.referentiel.nom}
+              nodes={activeGroup.nodes}
+              value={value}
+              onBack={hasSingleRootReferentiel ? null : () => setActiveReferentielId(null)}
+              onSelect={(next) => {
+                onChange(next)
+                setOpen(false)
+              }}
+            />
           ) : (
-            <Command
-              key={activeReferentielId}
-              label="Rechercher un individu"
-              filter={commandFilter}
-            >
-              {!hasSingleRootReferentiel ? (
-                <button
-                  type="button"
-                  onClick={() => openReferentiel(null)}
-                  className="flex w-full items-center gap-1.5 border-b border-border px-3 py-2 text-left text-xs font-semibold text-text-muted hover:text-text"
-                >
-                  <ChevronLeft className="size-4 shrink-0" />
-                  <span className="truncate">{activeReferentiel?.nom ?? 'Référentiels'}</span>
-                </button>
-              ) : null}
-              <div className="flex items-center gap-2 border-b border-border px-3">
-                <Search className="size-4 text-text-muted" />
-                <Command.Input
-                  value={search}
-                  onValueChange={setSearch}
-                  placeholder="Rechercher…"
-                  className="h-10 w-full bg-transparent text-sm text-text outline-none placeholder:text-text-subtle"
-                />
-              </div>
-              <Command.List className="max-h-[min(20rem,var(--radix-popover-content-available-height))] overflow-y-auto p-1.5">
-                <Command.Empty className="px-3 py-6 text-center text-sm text-text-muted">
-                  Aucun individu trouvé.
-                </Command.Empty>
-                {activeNodes.map((node) => {
-                  const isSelected = node.individu.id === value
-                  const searchableValue = [
-                    node.individu.nom,
-                    node.individu.id,
-                    ...node.parentPath,
-                  ].join(' ')
-                  return (
-                    <Command.Item
-                      key={node.individu.id}
-                      value={searchableValue}
-                      onSelect={() => {
-                        onChange({
-                          individu: node.individu.id,
-                          referentiel: node.individu.referentiel,
-                        })
-                        setOpen(false)
-                        setSearch('')
-                      }}
-                      className={clsxm(
-                        'flex cursor-pointer select-none items-center gap-2 rounded-md px-2.5 py-2 text-sm text-text outline-none',
-                        'data-[selected=true]:bg-surface-tinted data-[selected=true]:text-primary',
-                        isSelected && 'bg-primary-tinted font-semibold text-primary',
-                      )}
-                      style={{ paddingLeft: `${0.625 + node.depth * 0.875}rem` }}
-                    >
-                      <Check
-                        className={clsxm(
-                          'size-4 shrink-0',
-                          isSelected ? 'opacity-100' : 'opacity-0',
-                        )}
-                      />
-                      <span className="flex min-w-0 flex-1 flex-col">
-                        <span className="flex items-baseline gap-2">
-                          <span className="truncate">{node.individu.nom}</span>
-                          <span className="shrink-0 font-mono text-[11px] font-normal text-text-subtle">
-                            {node.individu.id}
-                          </span>
-                        </span>
-                        {node.parentPath.length > 0 ? (
-                          <span className="truncate text-xs font-normal text-text-muted">
-                            {node.parentPath.join(' › ')}
-                          </span>
-                        ) : null}
-                      </span>
-                    </Command.Item>
-                  )
-                })}
-              </Command.List>
-            </Command>
+            <RootReferentielsCommandStep groups={groups} onSelect={setActiveReferentielId} />
           )}
         </PopoverPrimitive.Content>
       </PopoverPrimitive.Portal>

--- a/apps/kpilote-webapp/src/components/indicateurs/IndividuSelect.tsx
+++ b/apps/kpilote-webapp/src/components/indicateurs/IndividuSelect.tsx
@@ -1,7 +1,7 @@
 import { Popover as PopoverPrimitive } from 'radix-ui'
 import { useSuspenseQueries } from '@tanstack/react-query'
 import { Command } from 'cmdk'
-import { Check, ChevronDown, Search } from 'lucide-react'
+import { Check, ChevronDown, ChevronLeft, ChevronRight, Search } from 'lucide-react'
 import { useMemo, useState } from 'react'
 
 import { clsxm } from '@/lib/clsxm'
@@ -15,9 +15,17 @@ type IndividuSelectProps = {
   onChange: (next: { individu: string; referentiel: string }) => void
 }
 
+const commandFilter = (itemValue: string, query: string) => {
+  const haystack = itemValue.toLowerCase()
+  const needle = query.trim().toLowerCase()
+  if (!needle) return 1
+  return haystack.includes(needle) ? 1 : 0
+}
+
 export function IndividuSelect({ id, referentielIds, value, onChange }: IndividuSelectProps) {
   const [open, setOpen] = useState(false)
   const [search, setSearch] = useState('')
+  const [activeReferentielId, setActiveReferentielId] = useState<string | null>(null)
 
   const referentiels = useSuspenseQueries({
     queries: referentielIds.map((refId) => referentielQueryOptions(refId)),
@@ -34,10 +42,42 @@ export function IndividuSelect({ id, referentielIds, value, onChange }: Individu
     return buildOrderedNodes(allIndividus, referentielsById)
   }, [referentiels, individusByReferentiel])
 
+  const countByReferentiel = useMemo(() => {
+    const counts = new Map<string, number>()
+    for (const node of nodes) {
+      counts.set(node.individu.referentiel, (counts.get(node.individu.referentiel) ?? 0) + 1)
+    }
+    return counts
+  }, [nodes])
+
   const selected = nodes.find((node) => node.individu.id === value)
+  const hasSingleReferentiel = referentiels.length === 1
+  const activeReferentiel = referentiels.find((r) => r.id === activeReferentielId)
+  const activeNodes = activeReferentielId
+    ? nodes.filter((node) => node.individu.referentiel === activeReferentielId)
+    : []
+
+  // Étape d'ouverture : on ouvre directement sur le référentiel de l'individu déjà
+  // sélectionné, ou sur l'unique référentiel disponible ; sinon on liste les référentiels.
+  const resolveInitialReferentiel = () => {
+    if (selected) return selected.individu.referentiel
+    if (hasSingleReferentiel) return referentiels[0]?.id ?? null
+    return null
+  }
+
+  const openReferentiel = (referentielId: string | null) => {
+    setActiveReferentielId(referentielId)
+    setSearch('')
+  }
 
   return (
-    <PopoverPrimitive.Root open={open} onOpenChange={setOpen}>
+    <PopoverPrimitive.Root
+      open={open}
+      onOpenChange={(next) => {
+        setOpen(next)
+        if (next) openReferentiel(resolveInitialReferentiel())
+      }}
+    >
       <PopoverPrimitive.Trigger
         id={id}
         className={clsxm(
@@ -75,79 +115,120 @@ export function IndividuSelect({ id, referentielIds, value, onChange }: Individu
           sideOffset={6}
           className="z-50 w-[var(--radix-popover-trigger-width)] min-w-[32rem] overflow-hidden rounded-lg border border-border bg-surface shadow-[0_8px_24px_rgba(0,0,0,0.06)]"
         >
-          <Command
-            label="Rechercher un individu"
-            filter={(itemValue, query) => {
-              const haystack = itemValue.toLowerCase()
-              const needle = query.trim().toLowerCase()
-              if (!needle) return 1
-              return haystack.includes(needle) ? 1 : 0
-            }}
-          >
-            <div className="flex items-center gap-2 border-b border-border px-3">
-              <Search className="size-4 text-text-muted" />
-              <Command.Input
-                value={search}
-                onValueChange={setSearch}
-                placeholder="Rechercher…"
-                className="h-10 w-full bg-transparent text-sm text-text outline-none placeholder:text-text-subtle"
-              />
-            </div>
-            <Command.List className="max-h-[min(20rem,var(--radix-popover-content-available-height))] overflow-y-auto p-1.5">
-              <Command.Empty className="px-3 py-6 text-center text-sm text-text-muted">
-                Aucun individu trouvé.
-              </Command.Empty>
-              {nodes.map((node) => {
-                const isSelected = node.individu.id === value
-                const searchableValue = [
-                  node.individu.nom,
-                  node.individu.id,
-                  ...node.parentPath,
-                  node.referentiel.nom,
-                ].join(' ')
-                return (
+          {activeReferentielId === null ? (
+            <Command key="referentiels" label="Choisir un référentiel" filter={commandFilter}>
+              <div className="flex items-center gap-2 border-b border-border px-3">
+                <Search className="size-4 text-text-muted" />
+                <Command.Input
+                  value={search}
+                  onValueChange={setSearch}
+                  placeholder="Rechercher un référentiel…"
+                  className="h-10 w-full bg-transparent text-sm text-text outline-none placeholder:text-text-subtle"
+                />
+              </div>
+              <Command.List className="max-h-[min(20rem,var(--radix-popover-content-available-height))] overflow-y-auto p-1.5">
+                <Command.Empty className="px-3 py-6 text-center text-sm text-text-muted">
+                  Aucun référentiel trouvé.
+                </Command.Empty>
+                {referentiels.map((referentiel) => (
                   <Command.Item
-                    key={node.individu.id}
-                    value={searchableValue}
-                    onSelect={() => {
-                      onChange({
-                        individu: node.individu.id,
-                        referentiel: node.individu.referentiel,
-                      })
-                      setOpen(false)
-                      setSearch('')
-                    }}
+                    key={referentiel.id}
+                    value={referentiel.nom}
+                    onSelect={() => openReferentiel(referentiel.id)}
                     className={clsxm(
                       'flex cursor-pointer select-none items-center gap-2 rounded-md px-2.5 py-2 text-sm text-text outline-none',
                       'data-[selected=true]:bg-surface-tinted data-[selected=true]:text-primary',
-                      isSelected && 'bg-primary-tinted font-semibold text-primary',
                     )}
-                    style={{ paddingLeft: `${0.625 + node.depth * 0.875}rem` }}
                   >
-                    <Check
-                      className={clsxm('size-4 shrink-0', isSelected ? 'opacity-100' : 'opacity-0')}
-                    />
-                    <span className="flex min-w-0 flex-1 flex-col">
-                      <span className="flex items-baseline gap-2">
-                        <span className="truncate">{node.individu.nom}</span>
-                        <span className="shrink-0 font-mono text-[11px] font-normal text-text-subtle">
-                          {node.individu.id}
-                        </span>
-                      </span>
-                      {node.parentPath.length > 0 ? (
-                        <span className="truncate text-xs font-normal text-text-muted">
-                          {node.parentPath.join(' › ')}
-                        </span>
-                      ) : null}
-                    </span>
+                    <span className="min-w-0 flex-1 truncate font-medium">{referentiel.nom}</span>
                     <span className="shrink-0 rounded-full bg-surface-tinted px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-text-muted">
-                      {node.referentiel.nom}
+                      {countByReferentiel.get(referentiel.id) ?? 0}
                     </span>
+                    <ChevronRight className="size-4 shrink-0 text-text-muted" />
                   </Command.Item>
-                )
-              })}
-            </Command.List>
-          </Command>
+                ))}
+              </Command.List>
+            </Command>
+          ) : (
+            <Command
+              key={activeReferentielId}
+              label="Rechercher un individu"
+              filter={commandFilter}
+            >
+              {!hasSingleReferentiel ? (
+                <button
+                  type="button"
+                  onClick={() => openReferentiel(null)}
+                  className="flex w-full items-center gap-1.5 border-b border-border px-3 py-2 text-left text-xs font-semibold text-text-muted hover:text-text"
+                >
+                  <ChevronLeft className="size-4 shrink-0" />
+                  <span className="truncate">{activeReferentiel?.nom ?? 'Référentiels'}</span>
+                </button>
+              ) : null}
+              <div className="flex items-center gap-2 border-b border-border px-3">
+                <Search className="size-4 text-text-muted" />
+                <Command.Input
+                  value={search}
+                  onValueChange={setSearch}
+                  placeholder="Rechercher…"
+                  className="h-10 w-full bg-transparent text-sm text-text outline-none placeholder:text-text-subtle"
+                />
+              </div>
+              <Command.List className="max-h-[min(20rem,var(--radix-popover-content-available-height))] overflow-y-auto p-1.5">
+                <Command.Empty className="px-3 py-6 text-center text-sm text-text-muted">
+                  Aucun individu trouvé.
+                </Command.Empty>
+                {activeNodes.map((node) => {
+                  const isSelected = node.individu.id === value
+                  const searchableValue = [
+                    node.individu.nom,
+                    node.individu.id,
+                    ...node.parentPath,
+                  ].join(' ')
+                  return (
+                    <Command.Item
+                      key={node.individu.id}
+                      value={searchableValue}
+                      onSelect={() => {
+                        onChange({
+                          individu: node.individu.id,
+                          referentiel: node.individu.referentiel,
+                        })
+                        setOpen(false)
+                        setSearch('')
+                      }}
+                      className={clsxm(
+                        'flex cursor-pointer select-none items-center gap-2 rounded-md px-2.5 py-2 text-sm text-text outline-none',
+                        'data-[selected=true]:bg-surface-tinted data-[selected=true]:text-primary',
+                        isSelected && 'bg-primary-tinted font-semibold text-primary',
+                      )}
+                      style={{ paddingLeft: `${0.625 + node.depth * 0.875}rem` }}
+                    >
+                      <Check
+                        className={clsxm(
+                          'size-4 shrink-0',
+                          isSelected ? 'opacity-100' : 'opacity-0',
+                        )}
+                      />
+                      <span className="flex min-w-0 flex-1 flex-col">
+                        <span className="flex items-baseline gap-2">
+                          <span className="truncate">{node.individu.nom}</span>
+                          <span className="shrink-0 font-mono text-[11px] font-normal text-text-subtle">
+                            {node.individu.id}
+                          </span>
+                        </span>
+                        {node.parentPath.length > 0 ? (
+                          <span className="truncate text-xs font-normal text-text-muted">
+                            {node.parentPath.join(' › ')}
+                          </span>
+                        ) : null}
+                      </span>
+                    </Command.Item>
+                  )
+                })}
+              </Command.List>
+            </Command>
+          )}
         </PopoverPrimitive.Content>
       </PopoverPrimitive.Portal>
     </PopoverPrimitive.Root>

--- a/apps/kpilote-webapp/src/components/indicateurs/IndividuSelect.tsx
+++ b/apps/kpilote-webapp/src/components/indicateurs/IndividuSelect.tsx
@@ -5,7 +5,7 @@ import { Check, ChevronDown, ChevronLeft, ChevronRight, Search } from 'lucide-re
 import { useMemo, useState } from 'react'
 
 import { clsxm } from '@/lib/clsxm'
-import { buildOrderedNodes } from '@/lib/individus/hierarchy'
+import { buildOrderedNodes, groupNodesByRootReferentiel } from '@/lib/individus/hierarchy'
 import { referentielIndividusQueryOptions, referentielQueryOptions } from '@/queries/referentiels'
 
 type IndividuSelectProps = {
@@ -42,26 +42,25 @@ export function IndividuSelect({ id, referentielIds, value, onChange }: Individu
     return buildOrderedNodes(allIndividus, referentielsById)
   }, [referentiels, individusByReferentiel])
 
-  const countByReferentiel = useMemo(() => {
-    const counts = new Map<string, number>()
-    for (const node of nodes) {
-      counts.set(node.individu.referentiel, (counts.get(node.individu.referentiel) ?? 0) + 1)
-    }
-    return counts
-  }, [nodes])
+  // Groupes par référentiel *racine* : chaque groupe porte tout le sous-arbre de
+  // sa racine, hiérarchie transverse comprise (ex. France → régions → départements).
+  const groups = useMemo(() => groupNodesByRootReferentiel(nodes), [nodes])
 
   const selected = nodes.find((node) => node.individu.id === value)
-  const hasSingleReferentiel = referentiels.length === 1
-  const activeReferentiel = referentiels.find((r) => r.id === activeReferentielId)
-  const activeNodes = activeReferentielId
-    ? nodes.filter((node) => node.individu.referentiel === activeReferentielId)
-    : []
+  const hasSingleRootReferentiel = groups.length === 1
+  const activeGroup = groups.find((group) => group.referentiel.id === activeReferentielId)
+  const activeReferentiel = activeGroup?.referentiel
+  const activeNodes = activeGroup?.nodes ?? []
 
-  // Étape d'ouverture : on ouvre directement sur le référentiel de l'individu déjà
-  // sélectionné, ou sur l'unique référentiel disponible ; sinon on liste les référentiels.
+  // Étape d'ouverture : on ouvre directement sur le référentiel racine de l'arbre
+  // de l'individu déjà sélectionné, ou sur l'unique référentiel racine ; sinon on
+  // liste les référentiels racines.
   const resolveInitialReferentiel = () => {
-    if (selected) return selected.individu.referentiel
-    if (hasSingleReferentiel) return referentiels[0]?.id ?? null
+    if (selected) {
+      const group = groups.find((g) => g.nodes.some((n) => n.individu.id === value))
+      if (group) return group.referentiel.id
+    }
+    if (hasSingleRootReferentiel) return groups[0]?.referentiel.id ?? null
     return null
   }
 
@@ -130,19 +129,21 @@ export function IndividuSelect({ id, referentielIds, value, onChange }: Individu
                 <Command.Empty className="px-3 py-6 text-center text-sm text-text-muted">
                   Aucun référentiel trouvé.
                 </Command.Empty>
-                {referentiels.map((referentiel) => (
+                {groups.map((group) => (
                   <Command.Item
-                    key={referentiel.id}
-                    value={referentiel.nom}
-                    onSelect={() => openReferentiel(referentiel.id)}
+                    key={group.referentiel.id}
+                    value={group.referentiel.nom}
+                    onSelect={() => openReferentiel(group.referentiel.id)}
                     className={clsxm(
                       'flex cursor-pointer select-none items-center gap-2 rounded-md px-2.5 py-2 text-sm text-text outline-none',
                       'data-[selected=true]:bg-surface-tinted data-[selected=true]:text-primary',
                     )}
                   >
-                    <span className="min-w-0 flex-1 truncate font-medium">{referentiel.nom}</span>
+                    <span className="min-w-0 flex-1 truncate font-medium">
+                      {group.referentiel.nom}
+                    </span>
                     <span className="shrink-0 rounded-full bg-surface-tinted px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-text-muted">
-                      {countByReferentiel.get(referentiel.id) ?? 0}
+                      {group.nodes.length}
                     </span>
                     <ChevronRight className="size-4 shrink-0 text-text-muted" />
                   </Command.Item>
@@ -155,7 +156,7 @@ export function IndividuSelect({ id, referentielIds, value, onChange }: Individu
               label="Rechercher un individu"
               filter={commandFilter}
             >
-              {!hasSingleReferentiel ? (
+              {!hasSingleRootReferentiel ? (
                 <button
                   type="button"
                   onClick={() => openReferentiel(null)}

--- a/apps/kpilote-webapp/src/lib/individus/hierarchy.test.ts
+++ b/apps/kpilote-webapp/src/lib/individus/hierarchy.test.ts
@@ -2,7 +2,7 @@ import { type IndividuApiModel } from '@pilote/kpilote-shared/individu'
 import { type ReferentielApiModel } from '@pilote/kpilote-shared/referentiel'
 import { describe, expect, it } from 'vitest'
 
-import { buildOrderedNodes, pickRoot } from './hierarchy'
+import { buildOrderedNodes, groupNodesByRootReferentiel, pickRoot } from './hierarchy'
 
 const referentiel = (id: string, nom: string): ReferentielApiModel => ({
   id,
@@ -121,5 +121,51 @@ describe('pickRoot', () => {
 
   it('renvoie null sur un arbre vide', () => {
     expect(pickRoot([])).toBeNull()
+  })
+})
+
+describe('groupNodesByRootReferentiel', () => {
+  it('rattache un sous-arbre transverse au référentiel de sa racine', () => {
+    const refNat = referentiel('REF-NAT', 'France (national)')
+    const refReg = referentiel('REF-REG', 'Régions')
+    const refDept = referentiel('REF-DEPT', 'Départements')
+    const refsById = new Map([
+      [refNat.id, refNat],
+      [refReg.id, refReg],
+      [refDept.id, refDept],
+    ])
+    const fr = individu('IND-FR', 'France', 'REF-NAT')
+    const idf = individu('IND-IDF', 'Île-de-France', 'REF-REG', ['IND-FR'])
+    const paris = individu('IND-PARIS', 'Paris', 'REF-DEPT', ['IND-IDF'])
+
+    const groups = groupNodesByRootReferentiel(buildOrderedNodes([fr, idf, paris], refsById))
+
+    // Un seul référentiel racine (REF-NAT), mais tout le sous-arbre y est rattaché.
+    expect(groups).toHaveLength(1)
+    expect(groups[0]!.referentiel.id).toBe('REF-NAT')
+    expect(groups[0]!.nodes.map((n) => n.individu.id)).toEqual(['IND-FR', 'IND-IDF', 'IND-PARIS'])
+  })
+
+  it('produit un groupe par référentiel racine, dans l’ordre de la forêt', () => {
+    const refA = referentiel('REF-A', 'Alpha')
+    const refB = referentiel('REF-B', 'Bravo')
+    const refsById = new Map([
+      [refA.id, refA],
+      [refB.id, refB],
+    ])
+    // Deux racines de référentiels distincts, chacune avec un enfant.
+    const a = individu('IND-A', 'Racine A', 'REF-A')
+    const aChild = individu('IND-A1', 'Enfant A', 'REF-A', ['IND-A'])
+    const b = individu('IND-B', 'Racine B', 'REF-B')
+
+    const groups = groupNodesByRootReferentiel(buildOrderedNodes([a, aChild, b], refsById))
+
+    expect(groups.map((g) => g.referentiel.id)).toEqual(['REF-A', 'REF-B'])
+    expect(groups[0]!.nodes.map((n) => n.individu.id)).toEqual(['IND-A', 'IND-A1'])
+    expect(groups[1]!.nodes.map((n) => n.individu.id)).toEqual(['IND-B'])
+  })
+
+  it('renvoie un tableau vide sans nœud', () => {
+    expect(groupNodesByRootReferentiel([])).toEqual([])
   })
 })

--- a/apps/kpilote-webapp/src/lib/individus/hierarchy.ts
+++ b/apps/kpilote-webapp/src/lib/individus/hierarchy.ts
@@ -39,3 +39,35 @@ export const buildOrderedNodes = (
 
 export const pickRoot = (nodes: ReadonlyArray<IndividuNode>): IndividuNode | null =>
   nodes.find((node) => node.depth === 0) ?? null
+
+export type ReferentielGroup = {
+  referentiel: ReferentielApiModel
+  nodes: IndividuNode[]
+}
+
+// Regroupe les nœuds ordonnés (issus de buildOrderedNodes, ordre DFS) par
+// référentiel *racine* : chaque arbre de la forêt est rattaché au référentiel de
+// son individu racine (depth 0). Les descendants rattachés à d'autres
+// référentiels (ex. régions/départements sous la France nationale) restent dans
+// le groupe de leur racine, ce qui préserve la hiérarchie complète en étape 2.
+export const groupNodesByRootReferentiel = (
+  nodes: ReadonlyArray<IndividuNode>,
+): ReferentielGroup[] => {
+  const groups: ReferentielGroup[] = []
+  const byReferentielId = new Map<string, ReferentielGroup>()
+  let current: ReferentielGroup | null = null
+  for (const node of nodes) {
+    if (node.depth === 0) {
+      current =
+        byReferentielId.get(node.referentiel.id) ??
+        (() => {
+          const created: ReferentielGroup = { referentiel: node.referentiel, nodes: [] }
+          byReferentielId.set(node.referentiel.id, created)
+          groups.push(created)
+          return created
+        })()
+    }
+    current?.nodes.push(node)
+  }
+  return groups
+}


### PR DESCRIPTION
## Contexte

Le sélecteur d'individu (`IndividuSelect`) aplatissait tous les individus de tous les référentiels dans une seule liste. On veut d'abord choisir un **référentiel racine**, puis l'individu dans sa hiérarchie.

Les individus forment **une hiérarchie transverse aux référentiels** (relations) : France (REF-NAT) → régions (REF-REG) → départements (REF-DEPT). « France (national) » est donc le seul référentiel *racine* (individu `NAT-FR` à `depth 0`) ; REF-REG / REF-DEPT sont des descendants. Le composant supporte plusieurs référentiels racines dès qu'il en existe.

## Changements

### `IndividuSelect.tsx` — drill-down 2 étapes
- **Étape 1** : liste des référentiels **racines** uniquement (badge = taille du sous-arbre complet). Sautée s'il n'y a qu'une seule racine.
- **Étape 2** : **toute la hiérarchie** rattachée à la racine choisie (France → régions → départements), avec bouton **‹ retour**.
- **Ouverture contextuelle** : si un individu est déjà sélectionné → ouverture directe sur le référentiel racine de son arbre.
- **Recherche scopée** à l'étape courante.

### `IndividuSelect.tsx` — découpage en sous-composants
- `RootReferentielsCommandStep` (étape 1) et `ReferentielSelectCommandStep` (étape 2), chacun **propriétaire de son propre état de recherche**. Le parent ne gère plus `search`/`setSearch` : le démontage/remontage entre les deux composants réinitialise la recherche naturellement (plus de reset manuel ni de `key`).
- Extraction de `CommandSearchInput` et des classes de liste/item partagées (anti-duplication).

### `hierarchy.ts` — helper pur `groupNodesByRootReferentiel` (+ tests)
Regroupe les nœuds ordonnés (DFS) par référentiel *racine*, chaque groupe portant tout son sous-arbre — y compris les descendants rattachés à d'autres référentiels. Sans ce regroupement, l'étape 2 n'afficherait que l'individu racine seul (ex. « France ») au lieu de toute sa hiérarchie. Le cas multi-racines est couvert par les tests.

## Vérifications

- `vitest` (hierarchy, 11 tests) ✅
- `tsc --noEmit` (webapp) ✅
- `eslint` + `prettier` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)