### PR TITLE
feat(kpilote-admin): écran Console API pour appels HTTP arbitraires

### DIFF
--- a/apps/kpilote-admin/package.json
+++ b/apps/kpilote-admin/package.json
@@ -14,6 +14,7 @@
     "dev": "portless kpilote-admin vite",
     "deploy:prepare": "bash deploy-prepare.sh",
     "routes:generate": "tsr generate",
+    "typecheck": "tsr generate && tsc --noEmit",
     "build": "rm -rf dist && tsr generate && tsc --noEmit && vite build && vite build -c vite.server.config.ts",
     "deploy:bundle": "bash deploy-bundle.sh",
     "start": "node dist/server/index.js",

--- a/apps/kpilote-admin/package.json
+++ b/apps/kpilote-admin/package.json
@@ -28,6 +28,7 @@
     "@codemirror/state": "^6.7.0",
     "@codemirror/view": "^6.43.4",
     "@hono/node-server": "^1.19.13",
+    "@hono/zod-validator": "^0.7.6",
     "@hookform/resolvers": "^5.4.0",
     "@pilote/kpilote-shared": "workspace:*",
     "@tanstack/react-query": "^5.62.7",

--- a/apps/kpilote-admin/package.json
+++ b/apps/kpilote-admin/package.json
@@ -11,7 +11,7 @@
     "node": "24.9.0"
   },
   "scripts": {
-    "dev": "portless run vite",
+    "dev": "portless kpilote-admin vite",
     "deploy:prepare": "bash deploy-prepare.sh",
     "routes:generate": "tsr generate",
     "build": "rm -rf dist && tsr generate && tsc --noEmit && vite build && vite build -c vite.server.config.ts",

--- a/apps/kpilote-admin/package.json
+++ b/apps/kpilote-admin/package.json
@@ -36,6 +36,7 @@
     "@tanstack/react-router-devtools": "^1.166.13",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "cmdk": "^1.1.1",
     "codemirror": "^6.0.2",
     "dotenv": "16.4.5",
     "hono": "^4.12.18",

--- a/apps/kpilote-admin/package.json
+++ b/apps/kpilote-admin/package.json
@@ -23,6 +23,10 @@
     "format:check": "prettier --check ."
   },
   "dependencies": {
+    "@codemirror/lang-json": "^6.0.2",
+    "@codemirror/lint": "^6.9.7",
+    "@codemirror/state": "^6.7.0",
+    "@codemirror/view": "^6.43.4",
     "@hono/node-server": "^1.19.13",
     "@hookform/resolvers": "^5.4.0",
     "@pilote/kpilote-shared": "workspace:*",
@@ -31,6 +35,7 @@
     "@tanstack/react-router-devtools": "^1.166.13",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "codemirror": "^6.0.2",
     "dotenv": "16.4.5",
     "hono": "^4.12.18",
     "hono-rate-limiter": "^0.5.3",

--- a/apps/kpilote-admin/src/api/console.ts
+++ b/apps/kpilote-admin/src/api/console.ts
@@ -1,0 +1,67 @@
+import ky from 'ky'
+
+export const HTTP_METHODS = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'] as const
+export type HttpMethod = (typeof HTTP_METHODS)[number]
+
+export type HeaderPair = { key: string; value: string }
+
+export type ConsoleRequest = {
+  method: HttpMethod
+  path: string
+  headers: HeaderPair[]
+  body: string
+}
+
+export type ConsoleResponse = {
+  status: number
+  headers: Record<string, string>
+  body: string
+  durationMs: number
+}
+
+const consoleClient = ky.create({
+  prefixUrl: new URL('/console/', location.origin).toString(),
+  credentials: 'include',
+  retry: 0,
+  throwHttpErrors: false,
+})
+
+// Normalise le path saisi (retire les `/` de tête) pour le préfixer à `proxy/`.
+const normalizePath = (path: string): string => path.replace(/^\/+/, '')
+
+const isBodyless = (method: HttpMethod): boolean => method === 'GET'
+
+export const sendConsoleRequest = async (request: ConsoleRequest): Promise<ConsoleResponse> => {
+  const headers = new Headers()
+  for (const { key, value } of request.headers) {
+    if (key.trim()) headers.set(key, value)
+  }
+  const bodyProvided = !isBodyless(request.method) && request.body.trim().length > 0
+  if (bodyProvided && !headers.has('Content-Type')) {
+    headers.set('Content-Type', 'application/json')
+  }
+
+  const start = performance.now()
+  const response = await consoleClient(`proxy/${normalizePath(request.path)}`, {
+    method: request.method,
+    headers,
+    ...(bodyProvided ? { body: request.body } : {}),
+  })
+  const text = await response.text()
+  const durationMs = Math.round(performance.now() - start)
+
+  const responseHeaders: Record<string, string> = {}
+  response.headers.forEach((value, key) => {
+    responseHeaders[key] = value
+  })
+
+  return { status: response.status, headers: responseHeaders, body: text, durationMs }
+}
+
+export const fetchConsoleMeta = async (): Promise<{ environment: string; baseUrl: string }> => {
+  return consoleClient.get('meta').json()
+}
+
+export const fetchOpenapiSpec = async (): Promise<unknown> => {
+  return consoleClient.get('openapi.json').json()
+}

--- a/apps/kpilote-admin/src/api/console.ts
+++ b/apps/kpilote-admin/src/api/console.ts
@@ -1,24 +1,31 @@
+import {
+  consoleMetaSchema,
+  consoleResponseSchema,
+  HTTP_METHODS,
+  type ConsoleMeta,
+  type ConsoleRequest,
+  type ConsoleResponse,
+  type HeaderPair,
+  type HttpMethod,
+} from '@pilote/kpilote-shared/console'
 import ky from 'ky'
 
-export const HTTP_METHODS = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'] as const
-export type HttpMethod = (typeof HTTP_METHODS)[number]
+// Le contrat (schémas + types) vit dans le package partagé : front et back
+// parlent la même enveloppe. On ré-exporte ici ce dont l'UI a besoin pour éviter
+// de propager l'import `@pilote/kpilote-shared/console` dans tous les composants.
+export { HTTP_METHODS }
+export type { ConsoleMeta, ConsoleRequest, ConsoleResponse, HeaderPair, HttpMethod }
 
-export type HeaderPair = { key: string; value: string }
-
-export type ConsoleRequest = {
-  method: HttpMethod
-  path: string
-  headers: HeaderPair[]
-  body: string
+// L'UI manipule une URL relative unique (`/indicateurs?limit=10`) ; l'enveloppe,
+// elle, sépare chemin et querystring. Ces deux helpers font le pont.
+export const splitUrl = (url: string): { path: string; query: string } => {
+  const index = url.indexOf('?')
+  if (index === -1) return { path: url, query: '' }
+  return { path: url.slice(0, index), query: url.slice(index + 1) }
 }
 
-export type ConsoleResponse = {
-  status: number
-  statusText: string
-  headers: Record<string, string>
-  body: string
-  durationMs: number
-}
+export const joinUrl = ({ path, query }: { path: string; query: string }): string =>
+  query ? `${path}?${query}` : path
 
 const consoleClient = ky.create({
   prefixUrl: new URL('/console/', location.origin).toString(),
@@ -32,25 +39,22 @@ const consoleClient = ky.create({
 // on peut poser des en-têtes que le `fetch` du navigateur interdirait). La réponse
 // est elle aussi une enveloppe : status/statusText/headers/body + timing serveur.
 export const sendConsoleRequest = async (request: ConsoleRequest): Promise<ConsoleResponse> => {
-  const bffResponse = await consoleClient.post('proxy', {
-    json: {
-      method: request.method,
-      path: request.path,
-      headers: request.headers.filter((header) => header.key.trim()),
-      body: request.body,
-    },
-  })
+  const payload: ConsoleRequest = {
+    ...request,
+    headers: request.headers.filter((header) => header.key.trim()),
+  }
+  // `throwHttpErrors: false` : ky ne lève pas sur les status HTTP, on inspecte
+  // `.ok` nous-mêmes (pas de try/catch nécessaire ici).
+  const bffResponse = await consoleClient.post('proxy', { json: payload })
   if (!bffResponse.ok) {
     const detail = await bffResponse.text()
     throw new Error(`Erreur proxy console (${bffResponse.status}) : ${detail}`)
   }
-  return bffResponse.json<ConsoleResponse>()
+  return consoleResponseSchema.parse(await bffResponse.json())
 }
 
-export const fetchConsoleMeta = async (): Promise<{ environment: string; baseUrl: string }> => {
-  return consoleClient.get('meta').json()
-}
+export const fetchConsoleMeta = async (): Promise<ConsoleMeta> =>
+  consoleMetaSchema.parse(await consoleClient.get('meta').json())
 
-export const fetchOpenapiSpec = async (): Promise<unknown> => {
-  return consoleClient.get('openapi.json').json()
-}
+export const fetchOpenapiSpec = async (): Promise<unknown> =>
+  consoleClient.get('openapi.json').json()

--- a/apps/kpilote-admin/src/api/console.ts
+++ b/apps/kpilote-admin/src/api/console.ts
@@ -14,6 +14,7 @@ export type ConsoleRequest = {
 
 export type ConsoleResponse = {
   status: number
+  statusText: string
   headers: Record<string, string>
   body: string
   durationMs: number
@@ -26,36 +27,24 @@ const consoleClient = ky.create({
   throwHttpErrors: false,
 })
 
-// Normalise le path saisi (retire les `/` de tête) pour le préfixer à `proxy/`.
-const normalizePath = (path: string): string => path.replace(/^\/+/, '')
-
-const isBodyless = (method: HttpMethod): boolean => method === 'GET'
-
+// La requête à exécuter est décrite dans une enveloppe JSON POSTée au BFF, qui
+// forge l'appel upstream côté serveur (le token n'est jamais exposé au client, et
+// on peut poser des en-têtes que le `fetch` du navigateur interdirait). La réponse
+// est elle aussi une enveloppe : status/statusText/headers/body + timing serveur.
 export const sendConsoleRequest = async (request: ConsoleRequest): Promise<ConsoleResponse> => {
-  const headers = new Headers()
-  for (const { key, value } of request.headers) {
-    if (key.trim()) headers.set(key, value)
-  }
-  const bodyProvided = !isBodyless(request.method) && request.body.trim().length > 0
-  if (bodyProvided && !headers.has('Content-Type')) {
-    headers.set('Content-Type', 'application/json')
-  }
-
-  const start = performance.now()
-  const response = await consoleClient(`proxy/${normalizePath(request.path)}`, {
-    method: request.method,
-    headers,
-    ...(bodyProvided ? { body: request.body } : {}),
+  const bffResponse = await consoleClient.post('proxy', {
+    json: {
+      method: request.method,
+      path: request.path,
+      headers: request.headers.filter((header) => header.key.trim()),
+      body: request.body,
+    },
   })
-  const text = await response.text()
-  const durationMs = Math.round(performance.now() - start)
-
-  const responseHeaders: Record<string, string> = {}
-  response.headers.forEach((value, key) => {
-    responseHeaders[key] = value
-  })
-
-  return { status: response.status, headers: responseHeaders, body: text, durationMs }
+  if (!bffResponse.ok) {
+    const detail = await bffResponse.text()
+    throw new Error(`Erreur proxy console (${bffResponse.status}) : ${detail}`)
+  }
+  return bffResponse.json<ConsoleResponse>()
 }
 
 export const fetchConsoleMeta = async (): Promise<{ environment: string; baseUrl: string }> => {

--- a/apps/kpilote-admin/src/components/console/CurlPreview.tsx
+++ b/apps/kpilote-admin/src/components/console/CurlPreview.tsx
@@ -1,0 +1,24 @@
+import { useFormContext, useWatch } from 'react-hook-form'
+
+import { CopyButton } from '@/components/ui/CopyButton'
+import type { ConsoleFormValues } from '@/lib/consoleForm'
+import { toCurl } from '@/lib/toCurl'
+
+// Aperçu de la commande curl équivalente, dérivé en direct des valeurs du form.
+export function CurlPreview({ baseUrl }: { baseUrl: string }) {
+  const { control } = useFormContext<ConsoleFormValues>()
+  const [method, path, headers, body] = useWatch({
+    control,
+    name: ['method', 'path', 'headers', 'body'],
+  })
+
+  const url = `${baseUrl}${path.startsWith('/') ? path : `/${path}`}`
+  const curl = toCurl({ method, url, headers, body })
+
+  return (
+    <div className="flex items-center gap-2 rounded-md border border-border bg-surface-muted px-3 py-2">
+      <code className="flex-1 overflow-auto whitespace-pre text-xs">{curl}</code>
+      <CopyButton value={curl} label="Copier la commande curl" />
+    </div>
+  )
+}

--- a/apps/kpilote-admin/src/components/console/EndpointPicker.tsx
+++ b/apps/kpilote-admin/src/components/console/EndpointPicker.tsx
@@ -1,95 +1,43 @@
 import { useQuery } from '@tanstack/react-query'
-import { Command } from 'cmdk'
-import { ChevronDown, Search } from 'lucide-react'
-import { Popover as PopoverPrimitive } from 'radix-ui'
-import { useState } from 'react'
 
+import { Picker } from '@/components/ui/Picker'
 import { clsxm } from '@/lib/clsxm'
 import type { OpenapiEndpoint } from '@/queries/console'
 import { openapiEndpointsQueryOptions } from '@/queries/console'
 
-// Filtre par sous-chaîne (méthode + path + résumé), prévisible plutôt que le
-// scoring fuzzy par défaut de cmdk.
-const commandFilter = (itemValue: string, query: string): number => {
-  const needle = query.trim().toLowerCase()
-  if (!needle) return 1
-  return itemValue.toLowerCase().includes(needle) ? 1 : 0
-}
-
 export function EndpointPicker({ onSelect }: { onSelect: (endpoint: OpenapiEndpoint) => void }) {
   const { data, isPending, isError } = useQuery(openapiEndpointsQueryOptions)
-  const [open, setOpen] = useState(false)
-  const endpoints = data ?? []
 
   return (
     <div className="flex flex-col gap-1">
-      <PopoverPrimitive.Root open={open} onOpenChange={setOpen}>
-        <PopoverPrimitive.Trigger
-          disabled={isPending || isError}
-          className={clsxm(
-            'flex w-full items-center gap-2 rounded-md border border-border px-3 py-2.5 text-left text-sm',
-            'hover:border-primary focus-visible:border-primary focus-visible:outline-none',
-            'data-[state=open]:border-primary disabled:cursor-not-allowed disabled:opacity-60',
-          )}
-        >
-          <Search className="size-4 shrink-0 text-text-muted" />
-          <span className="flex-1 truncate text-text-subtle">
-            {isPending ? 'Chargement des endpoints…' : 'Rechercher un endpoint (OpenAPI)…'}
-          </span>
-          <ChevronDown className="size-4 shrink-0 text-text-muted" />
-        </PopoverPrimitive.Trigger>
-
-        <PopoverPrimitive.Portal>
-          <PopoverPrimitive.Content
-            align="start"
-            sideOffset={6}
-            className="z-50 w-[var(--radix-popover-trigger-width)] overflow-hidden rounded-md border border-border bg-surface shadow-lg"
-          >
-            <Command label="Rechercher un endpoint" filter={commandFilter}>
-              <div className="flex items-center gap-2 border-b border-border px-3">
-                <Search className="size-4 shrink-0 text-text-muted" />
-                <Command.Input
-                  autoFocus
-                  placeholder="Rechercher un endpoint…"
-                  className="h-10 w-full bg-transparent text-sm outline-none placeholder:text-text-subtle"
-                />
-              </div>
-              <Command.List className="max-h-72 overflow-y-auto p-1.5">
-                <Command.Empty className="px-3 py-6 text-center text-sm text-text-muted">
-                  Aucun endpoint trouvé.
-                </Command.Empty>
-                {endpoints.map((endpoint) => (
-                  <Command.Item
-                    key={`${endpoint.method} ${endpoint.path}`}
-                    value={`${endpoint.method} ${endpoint.path} ${endpoint.summary}`}
-                    onSelect={() => {
-                      onSelect(endpoint)
-                      setOpen(false)
-                    }}
-                    className={clsxm(
-                      'flex cursor-pointer select-none items-center gap-3 rounded-md px-2.5 py-2 text-sm outline-none',
-                      'data-[selected=true]:bg-surface-tinted data-[selected=true]:text-primary',
-                    )}
-                  >
-                    <span
-                      className={clsxm(
-                        'w-14 shrink-0 text-xs font-bold',
-                        endpoint.method === 'GET' ? 'text-primary' : 'text-accent',
-                      )}
-                    >
-                      {endpoint.method}
-                    </span>
-                    <span className="font-mono text-xs">{endpoint.path}</span>
-                    {endpoint.summary ? (
-                      <span className="truncate text-xs text-text-muted">{endpoint.summary}</span>
-                    ) : null}
-                  </Command.Item>
-                ))}
-              </Command.List>
-            </Command>
-          </PopoverPrimitive.Content>
-        </PopoverPrimitive.Portal>
-      </PopoverPrimitive.Root>
+      <Picker
+        items={data ?? []}
+        onSelect={onSelect}
+        disabled={isPending || isError}
+        getKey={(endpoint) => `${endpoint.method} ${endpoint.path}`}
+        getSearchText={(endpoint) => `${endpoint.method} ${endpoint.path} ${endpoint.summary}`}
+        triggerLabel={
+          isPending ? 'Chargement des endpoints…' : 'Rechercher un endpoint (OpenAPI)…'
+        }
+        searchPlaceholder="Rechercher un endpoint…"
+        emptyLabel="Aucun endpoint trouvé."
+        renderItem={(endpoint) => (
+          <>
+            <span
+              className={clsxm(
+                'w-14 shrink-0 text-xs font-bold',
+                endpoint.method === 'GET' ? 'text-primary' : 'text-accent',
+              )}
+            >
+              {endpoint.method}
+            </span>
+            <span className="font-mono text-xs">{endpoint.path}</span>
+            {endpoint.summary ? (
+              <span className="truncate text-xs text-text-muted">{endpoint.summary}</span>
+            ) : null}
+          </>
+        )}
+      />
 
       {isError ? (
         <p className="text-xs text-text-muted">OpenAPI indisponible — saisie manuelle possible.</p>

--- a/apps/kpilote-admin/src/components/console/EndpointPicker.tsx
+++ b/apps/kpilote-admin/src/components/console/EndpointPicker.tsx
@@ -1,0 +1,70 @@
+import { useQuery } from '@tanstack/react-query'
+import { useState } from 'react'
+
+import { clsxm } from '@/lib/clsxm'
+import type { OpenapiEndpoint } from '@/queries/console'
+import { openapiEndpointsQueryOptions } from '@/queries/console'
+
+export function EndpointPicker({ onSelect }: { onSelect: (endpoint: OpenapiEndpoint) => void }) {
+  const { data, isPending, isError } = useQuery(openapiEndpointsQueryOptions)
+  const [search, setSearch] = useState('')
+  const [open, setOpen] = useState(false)
+
+  const endpoints = data ?? []
+  const filtered = search.trim()
+    ? endpoints.filter((endpoint) =>
+        `${endpoint.method} ${endpoint.path} ${endpoint.summary}`
+          .toLowerCase()
+          .includes(search.toLowerCase()),
+      )
+    : endpoints
+
+  return (
+    <div className="relative">
+      <input
+        value={search}
+        onChange={(event) => setSearch(event.target.value)}
+        onFocus={() => setOpen(true)}
+        onBlur={() => setTimeout(() => setOpen(false), 150)}
+        placeholder={isPending ? 'Chargement des endpoints…' : 'Rechercher un endpoint (OpenAPI)…'}
+        className="w-full rounded-md border border-border px-3 py-2.5 text-sm focus:border-primary focus:outline-none"
+      />
+      {isError ? (
+        <p className="mt-1 text-xs text-text-muted">
+          OpenAPI indisponible — saisie manuelle possible.
+        </p>
+      ) : null}
+      {open && filtered.length > 0 ? (
+        <ul className="absolute z-20 mt-1 max-h-72 w-full overflow-auto rounded-md border border-border bg-white shadow-lg">
+          {filtered.slice(0, 100).map((endpoint) => (
+            <li key={`${endpoint.method} ${endpoint.path}`}>
+              <button
+                type="button"
+                onMouseDown={(event) => {
+                  event.preventDefault()
+                  onSelect(endpoint)
+                  setSearch('')
+                  setOpen(false)
+                }}
+                className="flex w-full items-center gap-3 px-3 py-2 text-left text-sm hover:bg-surface-muted"
+              >
+                <span
+                  className={clsxm(
+                    'w-14 shrink-0 text-xs font-bold',
+                    endpoint.method === 'GET' ? 'text-primary' : 'text-accent',
+                  )}
+                >
+                  {endpoint.method}
+                </span>
+                <span className="font-mono text-xs">{endpoint.path}</span>
+                {endpoint.summary ? (
+                  <span className="truncate text-xs text-text-muted">{endpoint.summary}</span>
+                ) : null}
+              </button>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+    </div>
+  )
+}

--- a/apps/kpilote-admin/src/components/console/EndpointPicker.tsx
+++ b/apps/kpilote-admin/src/components/console/EndpointPicker.tsx
@@ -1,74 +1,98 @@
 import { useQuery } from '@tanstack/react-query'
+import { Command } from 'cmdk'
+import { ChevronDown, Search } from 'lucide-react'
+import { Popover as PopoverPrimitive } from 'radix-ui'
 import { useState } from 'react'
 
 import { clsxm } from '@/lib/clsxm'
 import type { OpenapiEndpoint } from '@/queries/console'
 import { openapiEndpointsQueryOptions } from '@/queries/console'
 
+// Filtre par sous-chaîne (méthode + path + résumé), prévisible plutôt que le
+// scoring fuzzy par défaut de cmdk.
+const commandFilter = (itemValue: string, query: string): number => {
+  const needle = query.trim().toLowerCase()
+  if (!needle) return 1
+  return itemValue.toLowerCase().includes(needle) ? 1 : 0
+}
+
 export function EndpointPicker({ onSelect }: { onSelect: (endpoint: OpenapiEndpoint) => void }) {
   const { data, isPending, isError } = useQuery(openapiEndpointsQueryOptions)
-  const [search, setSearch] = useState('')
   const [open, setOpen] = useState(false)
-
   const endpoints = data ?? []
-  const filtered = search.trim()
-    ? endpoints.filter((endpoint) =>
-        `${endpoint.method} ${endpoint.path} ${endpoint.summary}`
-          .toLowerCase()
-          .includes(search.toLowerCase()),
-      )
-    : endpoints
 
   return (
-    <div className="relative">
-      <input
-        value={search}
-        onChange={(event) => {
-          setSearch(event.target.value)
-          // Après une sélection, l'input garde le focus (onMouseDown+preventDefault)
-          // et la liste est fermée : rouvrir à la saisie pour permettre une 2e recherche.
-          setOpen(true)
-        }}
-        onFocus={() => setOpen(true)}
-        onBlur={() => setTimeout(() => setOpen(false), 150)}
-        placeholder={isPending ? 'Chargement des endpoints…' : 'Rechercher un endpoint (OpenAPI)…'}
-        className="w-full rounded-md border border-border px-3 py-2.5 text-sm focus:border-primary focus:outline-none"
-      />
+    <div className="flex flex-col gap-1">
+      <PopoverPrimitive.Root open={open} onOpenChange={setOpen}>
+        <PopoverPrimitive.Trigger
+          disabled={isPending || isError}
+          className={clsxm(
+            'flex w-full items-center gap-2 rounded-md border border-border px-3 py-2.5 text-left text-sm',
+            'hover:border-primary focus-visible:border-primary focus-visible:outline-none',
+            'data-[state=open]:border-primary disabled:cursor-not-allowed disabled:opacity-60',
+          )}
+        >
+          <Search className="size-4 shrink-0 text-text-muted" />
+          <span className="flex-1 truncate text-text-subtle">
+            {isPending ? 'Chargement des endpoints…' : 'Rechercher un endpoint (OpenAPI)…'}
+          </span>
+          <ChevronDown className="size-4 shrink-0 text-text-muted" />
+        </PopoverPrimitive.Trigger>
+
+        <PopoverPrimitive.Portal>
+          <PopoverPrimitive.Content
+            align="start"
+            sideOffset={6}
+            className="z-50 w-[var(--radix-popover-trigger-width)] overflow-hidden rounded-md border border-border bg-surface shadow-lg"
+          >
+            <Command label="Rechercher un endpoint" filter={commandFilter}>
+              <div className="flex items-center gap-2 border-b border-border px-3">
+                <Search className="size-4 shrink-0 text-text-muted" />
+                <Command.Input
+                  autoFocus
+                  placeholder="Rechercher un endpoint…"
+                  className="h-10 w-full bg-transparent text-sm outline-none placeholder:text-text-subtle"
+                />
+              </div>
+              <Command.List className="max-h-72 overflow-y-auto p-1.5">
+                <Command.Empty className="px-3 py-6 text-center text-sm text-text-muted">
+                  Aucun endpoint trouvé.
+                </Command.Empty>
+                {endpoints.map((endpoint) => (
+                  <Command.Item
+                    key={`${endpoint.method} ${endpoint.path}`}
+                    value={`${endpoint.method} ${endpoint.path} ${endpoint.summary}`}
+                    onSelect={() => {
+                      onSelect(endpoint)
+                      setOpen(false)
+                    }}
+                    className={clsxm(
+                      'flex cursor-pointer select-none items-center gap-3 rounded-md px-2.5 py-2 text-sm outline-none',
+                      'data-[selected=true]:bg-surface-tinted data-[selected=true]:text-primary',
+                    )}
+                  >
+                    <span
+                      className={clsxm(
+                        'w-14 shrink-0 text-xs font-bold',
+                        endpoint.method === 'GET' ? 'text-primary' : 'text-accent',
+                      )}
+                    >
+                      {endpoint.method}
+                    </span>
+                    <span className="font-mono text-xs">{endpoint.path}</span>
+                    {endpoint.summary ? (
+                      <span className="truncate text-xs text-text-muted">{endpoint.summary}</span>
+                    ) : null}
+                  </Command.Item>
+                ))}
+              </Command.List>
+            </Command>
+          </PopoverPrimitive.Content>
+        </PopoverPrimitive.Portal>
+      </PopoverPrimitive.Root>
+
       {isError ? (
-        <p className="mt-1 text-xs text-text-muted">
-          OpenAPI indisponible — saisie manuelle possible.
-        </p>
-      ) : null}
-      {open && filtered.length > 0 ? (
-        <ul className="absolute z-20 mt-1 max-h-72 w-full overflow-auto rounded-md border border-border bg-white shadow-lg">
-          {filtered.slice(0, 100).map((endpoint) => (
-            <li key={`${endpoint.method} ${endpoint.path}`}>
-              <button
-                type="button"
-                onMouseDown={(event) => {
-                  event.preventDefault()
-                  onSelect(endpoint)
-                  setSearch('')
-                  setOpen(false)
-                }}
-                className="flex w-full items-center gap-3 px-3 py-2 text-left text-sm hover:bg-surface-muted"
-              >
-                <span
-                  className={clsxm(
-                    'w-14 shrink-0 text-xs font-bold',
-                    endpoint.method === 'GET' ? 'text-primary' : 'text-accent',
-                  )}
-                >
-                  {endpoint.method}
-                </span>
-                <span className="font-mono text-xs">{endpoint.path}</span>
-                {endpoint.summary ? (
-                  <span className="truncate text-xs text-text-muted">{endpoint.summary}</span>
-                ) : null}
-              </button>
-            </li>
-          ))}
-        </ul>
+        <p className="text-xs text-text-muted">OpenAPI indisponible — saisie manuelle possible.</p>
       ) : null}
     </div>
   )

--- a/apps/kpilote-admin/src/components/console/EndpointPicker.tsx
+++ b/apps/kpilote-admin/src/components/console/EndpointPicker.tsx
@@ -23,7 +23,12 @@ export function EndpointPicker({ onSelect }: { onSelect: (endpoint: OpenapiEndpo
     <div className="relative">
       <input
         value={search}
-        onChange={(event) => setSearch(event.target.value)}
+        onChange={(event) => {
+          setSearch(event.target.value)
+          // Après une sélection, l'input garde le focus (onMouseDown+preventDefault)
+          // et la liste est fermée : rouvrir à la saisie pour permettre une 2e recherche.
+          setOpen(true)
+        }}
         onFocus={() => setOpen(true)}
         onBlur={() => setTimeout(() => setOpen(false), 150)}
         placeholder={isPending ? 'Chargement des endpoints…' : 'Rechercher un endpoint (OpenAPI)…'}

--- a/apps/kpilote-admin/src/components/console/HeadersEditor.tsx
+++ b/apps/kpilote-admin/src/components/console/HeadersEditor.tsx
@@ -1,0 +1,57 @@
+import { Plus, Trash2 } from 'lucide-react'
+
+import type { HeaderPair } from '@/api/console'
+import { Button } from '@/components/ui/Button'
+
+export function HeadersEditor({
+  headers,
+  onChange,
+}: {
+  headers: HeaderPair[]
+  onChange: (headers: HeaderPair[]) => void
+}) {
+  const update = (index: number, patch: Partial<HeaderPair>) => {
+    onChange(headers.map((header, i) => (i === index ? { ...header, ...patch } : header)))
+  }
+  const remove = (index: number) => onChange(headers.filter((_, i) => i !== index))
+  const add = () => onChange([...headers, { key: '', value: '' }])
+
+  return (
+    <div className="flex flex-col gap-2">
+      <p className="text-xs text-text-muted">
+        L'en-tête <code>Authorization</code> est injecté côté serveur — inutile de l'ajouter ici.
+      </p>
+      {headers.map((header, index) => (
+        <div key={index} className="flex items-center gap-2">
+          <input
+            aria-label="Nom de l'en-tête"
+            value={header.key}
+            onChange={(event) => update(index, { key: event.target.value })}
+            placeholder="Content-Type"
+            className="w-1/3 rounded-md border border-border px-3 py-2 text-sm focus:border-primary focus:outline-none"
+          />
+          <input
+            aria-label="Valeur de l'en-tête"
+            value={header.value}
+            onChange={(event) => update(index, { value: event.target.value })}
+            placeholder="application/json"
+            className="flex-1 rounded-md border border-border px-3 py-2 text-sm focus:border-primary focus:outline-none"
+          />
+          <button
+            type="button"
+            onClick={() => remove(index)}
+            aria-label="Supprimer l'en-tête"
+            className="text-text-muted hover:text-accent"
+          >
+            <Trash2 className="size-4" />
+          </button>
+        </div>
+      ))}
+      <div>
+        <Button type="button" variant="tertiary" size="sm" onClick={add}>
+          <Plus className="size-4" /> Ajouter un en-tête
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/apps/kpilote-admin/src/components/console/HistoryList.tsx
+++ b/apps/kpilote-admin/src/components/console/HistoryList.tsx
@@ -1,0 +1,53 @@
+import { clsxm } from '@/lib/clsxm'
+import type { HistoryEntry } from '@/lib/consoleHistory'
+
+export function HistoryList({
+  entries,
+  onRestore,
+  onClear,
+}: {
+  entries: HistoryEntry[]
+  onRestore: (entry: HistoryEntry) => void
+  onClear: () => void
+}) {
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center justify-between">
+        <h2 className="text-xs font-semibold uppercase tracking-wide text-text-muted">
+          Historique
+        </h2>
+        {entries.length > 0 ? (
+          <button type="button" onClick={onClear} className="text-xs text-primary">
+            Vider
+          </button>
+        ) : null}
+      </div>
+      {entries.length === 0 ? (
+        <p className="text-xs text-text-muted">Aucun appel récent.</p>
+      ) : (
+        <ul className="flex flex-col gap-1">
+          {entries.map((entry) => (
+            <li key={entry.id}>
+              <button
+                type="button"
+                onClick={() => onRestore(entry)}
+                className="flex w-full items-center gap-2 rounded-md border border-border px-2 py-1.5 text-left text-xs hover:bg-surface-muted"
+              >
+                <span
+                  className={clsxm(
+                    'w-12 shrink-0 font-bold',
+                    entry.method === 'GET' ? 'text-primary' : 'text-accent',
+                  )}
+                >
+                  {entry.method}
+                </span>
+                <span className="flex-1 truncate font-mono">{entry.path}</span>
+                <span className="text-text-muted">{entry.status || '—'}</span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/apps/kpilote-admin/src/components/console/RequestForm.tsx
+++ b/apps/kpilote-admin/src/components/console/RequestForm.tsx
@@ -1,0 +1,144 @@
+import { HTTP_METHODS, type HttpMethod } from '@pilote/kpilote-shared/console'
+import { useState } from 'react'
+import { Controller, useFormContext, useWatch } from 'react-hook-form'
+
+import { EndpointPicker } from '@/components/console/EndpointPicker'
+import { HeadersEditor } from '@/components/console/HeadersEditor'
+import { Button } from '@/components/ui/Button'
+import { FieldSelect } from '@/components/ui/FieldSelect'
+import { formatJson, JsonEditor } from '@/components/ui/JsonEditor'
+import { TabNav } from '@/components/ui/TabNav'
+import type { ConsoleFormValues } from '@/lib/consoleForm'
+
+const MUTATING: ReadonlySet<HttpMethod> = new Set<HttpMethod>(['POST', 'PUT', 'PATCH', 'DELETE'])
+
+export function RequestForm({
+  baseUrl,
+  isProd,
+  locked,
+  unlock,
+  isPending,
+}: {
+  baseUrl: string
+  isProd: boolean
+  locked: boolean
+  unlock: () => void
+  isPending: boolean
+}) {
+  const { control, register, setValue, getValues } = useFormContext<ConsoleFormValues>()
+  const method = useWatch({ control, name: 'method' })
+  const [tab, setTab] = useState<'body' | 'headers'>('body')
+
+  // GET est bodyless : on masque l'onglet Body et on force l'affichage des en-têtes.
+  const bodyless = method === 'GET'
+  const activeTab = bodyless ? 'headers' : tab
+  const blockedByProd = isProd && locked && MUTATING.has(method)
+
+  return (
+    <div className="flex flex-col gap-4">
+      <EndpointPicker
+        onSelect={(endpoint) => {
+          setValue('method', endpoint.method)
+          setValue('path', endpoint.path)
+          if (endpoint.bodyExample) {
+            setValue('body', endpoint.bodyExample)
+            setTab('body')
+          }
+        }}
+      />
+
+      <div className="flex items-end gap-2">
+        <Controller
+          control={control}
+          name="method"
+          render={({ field }) => (
+            <FieldSelect
+              label="Méthode"
+              hideLabel
+              value={field.value}
+              onChange={(event) => field.onChange(event.target.value)}
+              className="w-32"
+            >
+              {HTTP_METHODS.map((httpMethod) => (
+                <option key={httpMethod} value={httpMethod}>
+                  {httpMethod}
+                </option>
+              ))}
+            </FieldSelect>
+          )}
+        />
+        <div className="flex flex-1 items-center rounded-md border border-border">
+          <span className="max-w-[45%] truncate px-2 py-2.5 text-xs text-text-muted">
+            {baseUrl}
+          </span>
+          <input
+            aria-label="Chemin de la requête"
+            placeholder="/indicateurs?limit=10"
+            className="flex-1 rounded-r-md px-2 py-2.5 text-sm focus:outline-none"
+            {...register('path')}
+          />
+        </div>
+        <Button type="submit" disabled={isPending || blockedByProd}>
+          Envoyer
+        </Button>
+      </div>
+
+      {blockedByProd ? (
+        <div className="flex items-center justify-between rounded-md border border-accent/40 bg-accent/5 px-3 py-2 text-xs">
+          <span>Mutation sur la prod verrouillée.</span>
+          <button type="button" onClick={unlock} className="font-semibold text-accent">
+            Déverrouiller
+          </button>
+        </div>
+      ) : null}
+
+      <div>
+        <TabNav
+          tabs={
+            bodyless
+              ? [{ key: 'headers', label: 'En-têtes' }]
+              : [
+                  { key: 'body', label: 'Body' },
+                  { key: 'headers', label: 'En-têtes' },
+                ]
+          }
+          active={activeTab}
+          onChange={(key) => setTab(key as 'body' | 'headers')}
+        />
+        {activeTab === 'body' ? (
+          <div className="flex flex-col gap-2">
+            <div className="flex justify-end">
+              <Button
+                type="button"
+                variant="tertiary"
+                size="sm"
+                onClick={() => setValue('body', formatJson(getValues('body')))}
+              >
+                Formater
+              </Button>
+            </div>
+            <Controller
+              control={control}
+              name="body"
+              render={({ field }) => (
+                <JsonEditor
+                  value={field.value}
+                  onChange={field.onChange}
+                  ariaLabel="Corps de la requête"
+                />
+              )}
+            />
+          </div>
+        ) : (
+          <Controller
+            control={control}
+            name="headers"
+            render={({ field }) => (
+              <HeadersEditor headers={field.value} onChange={field.onChange} />
+            )}
+          />
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/kpilote-admin/src/components/console/ResponsePanel.tsx
+++ b/apps/kpilote-admin/src/components/console/ResponsePanel.tsx
@@ -1,0 +1,58 @@
+import { useState } from 'react'
+
+import type { ConsoleResponse } from '@/api/console'
+import { formatJson, JsonEditor } from '@/components/ui/JsonEditor'
+import { clsxm } from '@/lib/clsxm'
+
+const statusTone = (status: number): string => {
+  if (status >= 200 && status < 300) return 'bg-primary text-primary-foreground'
+  if (status >= 400) return 'bg-accent text-white'
+  return 'border border-border text-text-muted'
+}
+
+export function ResponsePanel({
+  response,
+  pending,
+  error,
+}: {
+  response: ConsoleResponse | null
+  pending: boolean
+  error: string | null
+}) {
+  const [showHeaders, setShowHeaders] = useState(false)
+
+  if (pending) return <p className="text-sm text-text-muted">Appel en cours…</p>
+  if (error) return <p className="text-sm text-accent">{error}</p>
+  if (!response) return <p className="text-sm text-text-muted">Aucune réponse pour l'instant.</p>
+
+  const contentType = response.headers['content-type'] ?? ''
+  const body = contentType.includes('json') ? formatJson(response.body) : response.body
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-center gap-3 text-sm">
+        <span
+          className={clsxm('rounded-full px-3 py-1 text-xs font-bold', statusTone(response.status))}
+        >
+          {response.status}
+        </span>
+        <span className="text-text-muted">{response.durationMs} ms</span>
+        <button
+          type="button"
+          onClick={() => setShowHeaders((value) => !value)}
+          className="text-xs text-primary"
+        >
+          {showHeaders ? 'Masquer' : 'Afficher'} les en-têtes
+        </button>
+      </div>
+      {showHeaders ? (
+        <pre className="overflow-auto rounded-md border border-border bg-surface-muted p-3 text-xs">
+          {Object.entries(response.headers)
+            .map(([key, value]) => `${key}: ${value}`)
+            .join('\n')}
+        </pre>
+      ) : null}
+      <JsonEditor value={body} readOnly ariaLabel="Corps de la réponse" />
+    </div>
+  )
+}

--- a/apps/kpilote-admin/src/components/console/ResponsePanel.tsx
+++ b/apps/kpilote-admin/src/components/console/ResponsePanel.tsx
@@ -37,6 +37,9 @@ export function ResponsePanel({
         >
           {response.status}
         </span>
+        {response.statusText ? (
+          <span className="text-text-muted">{response.statusText}</span>
+        ) : null}
         <span className="text-text-muted">{response.durationMs} ms</span>
         <button
           type="button"

--- a/apps/kpilote-admin/src/components/console/ResponsePanel.tsx
+++ b/apps/kpilote-admin/src/components/console/ResponsePanel.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 
 import type { ConsoleResponse } from '@/api/console'
+import { CopyButton } from '@/components/ui/CopyButton'
 import { formatJson, JsonEditor } from '@/components/ui/JsonEditor'
 import { clsxm } from '@/lib/clsxm'
 
@@ -44,6 +45,10 @@ export function ResponsePanel({
         >
           {showHeaders ? 'Masquer' : 'Afficher'} les en-têtes
         </button>
+        <div className="ml-auto flex items-center gap-1 text-xs text-primary">
+          <CopyButton value={body} label="Copier le corps de la réponse" />
+          Copier
+        </div>
       </div>
       {showHeaders ? (
         <pre className="overflow-auto rounded-md border border-border bg-surface-muted p-3 text-xs">

--- a/apps/kpilote-admin/src/components/ui/JsonEditor.tsx
+++ b/apps/kpilote-admin/src/components/ui/JsonEditor.tsx
@@ -1,0 +1,97 @@
+import { json, jsonParseLinter } from '@codemirror/lang-json'
+import { lintGutter, linter } from '@codemirror/lint'
+import { EditorState } from '@codemirror/state'
+import { EditorView, keymap } from '@codemirror/view'
+import { basicSetup } from 'codemirror'
+import { useEffect, useRef } from 'react'
+
+import { clsxm } from '@/lib/clsxm'
+
+export const formatJson = (raw: string): string => {
+  const trimmed = raw.trim()
+  if (!trimmed) return raw
+  try {
+    return JSON.stringify(JSON.parse(trimmed), null, 2)
+  } catch {
+    return raw
+  }
+}
+
+export function JsonEditor({
+  value,
+  onChange,
+  readOnly = false,
+  minHeight = 200,
+  ariaLabel = 'Éditeur JSON',
+}: {
+  value: string
+  onChange?: (value: string) => void
+  readOnly?: boolean
+  minHeight?: number
+  ariaLabel?: string
+}) {
+  const hostRef = useRef<HTMLDivElement | null>(null)
+  const viewRef = useRef<EditorView | null>(null)
+  // On garde `onChange` dans une ref pour éviter de recréer l'éditeur à chaque render.
+  const onChangeRef = useRef(onChange)
+  useEffect(() => {
+    onChangeRef.current = onChange
+  }, [onChange])
+
+  useEffect(() => {
+    if (!hostRef.current) return
+    const view = new EditorView({
+      parent: hostRef.current,
+      state: EditorState.create({
+        doc: value,
+        extensions: [
+          basicSetup,
+          json(),
+          linter(jsonParseLinter()),
+          lintGutter(),
+          keymap.of([]),
+          EditorView.lineWrapping,
+          EditorState.readOnly.of(readOnly),
+          EditorView.editable.of(!readOnly),
+          EditorView.theme({
+            '&': { fontSize: '13px', minHeight: `${minHeight}px` },
+            '.cm-scroller': { fontFamily: 'ui-monospace, monospace' },
+            '&.cm-focused': { outline: 'none' },
+          }),
+          EditorView.updateListener.of((update) => {
+            if (update.docChanged) onChangeRef.current?.(update.state.doc.toString())
+          }),
+        ],
+      }),
+    })
+    viewRef.current = view
+    return () => {
+      view.destroy()
+      viewRef.current = null
+    }
+    // Recréation uniquement si le mode read-only ou la hauteur change.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [readOnly, minHeight])
+
+  // Synchronise la valeur externe (ex. picker qui pré-remplit) sans casser le curseur.
+  useEffect(() => {
+    const view = viewRef.current
+    if (!view) return
+    const current = view.state.doc.toString()
+    if (current !== value) {
+      view.dispatch({ changes: { from: 0, to: current.length, insert: value } })
+    }
+  }, [value])
+
+  return (
+    <div
+      ref={hostRef}
+      role="textbox"
+      aria-label={ariaLabel}
+      className={clsxm(
+        'overflow-hidden rounded-md border border-border',
+        readOnly && 'bg-surface-muted',
+      )}
+    />
+  )
+}

--- a/apps/kpilote-admin/src/components/ui/JsonEditor.tsx
+++ b/apps/kpilote-admin/src/components/ui/JsonEditor.tsx
@@ -3,7 +3,7 @@ import { lintGutter, linter } from '@codemirror/lint'
 import { EditorState } from '@codemirror/state'
 import { EditorView, keymap } from '@codemirror/view'
 import { basicSetup } from 'codemirror'
-import { useEffect, useRef } from 'react'
+import { useCallback, useEffect, useRef } from 'react'
 
 import { clsxm } from '@/lib/clsxm'
 
@@ -30,48 +30,56 @@ export function JsonEditor({
   minHeight?: number
   ariaLabel?: string
 }) {
-  const hostRef = useRef<HTMLDivElement | null>(null)
   const viewRef = useRef<EditorView | null>(null)
-  // On garde `onChange` dans une ref pour éviter de recréer l'éditeur à chaque render.
+  // On garde `onChange`/`value` dans des refs pour éviter de recréer l'éditeur à
+  // chaque render. `value` sert au doc initial d'un (re)mount ; un éventuel décalage
+  // d'un render est corrigé par l'effet de synchronisation ci-dessous.
   const onChangeRef = useRef(onChange)
+  const valueRef = useRef(value)
   useEffect(() => {
     onChangeRef.current = onChange
-  }, [onChange])
+    valueRef.current = value
+  }, [onChange, value])
 
-  useEffect(() => {
-    if (!hostRef.current) return
-    const view = new EditorView({
-      parent: hostRef.current,
-      state: EditorState.create({
-        doc: value,
-        extensions: [
-          basicSetup,
-          json(),
-          linter(jsonParseLinter()),
-          lintGutter(),
-          keymap.of([]),
-          EditorView.lineWrapping,
-          EditorState.readOnly.of(readOnly),
-          EditorView.editable.of(!readOnly),
-          EditorView.theme({
-            '&': { fontSize: '13px', minHeight: `${minHeight}px` },
-            '.cm-scroller': { fontFamily: 'ui-monospace, monospace' },
-            '&.cm-focused': { outline: 'none' },
-          }),
-          EditorView.updateListener.of((update) => {
-            if (update.docChanged) onChangeRef.current?.(update.state.doc.toString())
-          }),
-        ],
-      }),
-    })
-    viewRef.current = view
-    return () => {
-      view.destroy()
-      viewRef.current = null
-    }
-    // Recréation uniquement si le mode read-only ou la hauteur change.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [readOnly, minHeight])
+  // Callback ref (React 19) : React (re)appelle cette fonction quand son identité
+  // change — donc quand `readOnly`/`minHeight` changent — et exécute le cleanup
+  // retourné au démontage. Plus besoin de hostRef, d'un useEffect de création ni
+  // d'eslint-disable : le cycle de vie de l'éditeur suit celui du nœud.
+  const mountEditor = useCallback(
+    (host: HTMLDivElement | null) => {
+      if (!host) return
+      const view = new EditorView({
+        parent: host,
+        state: EditorState.create({
+          doc: valueRef.current,
+          extensions: [
+            basicSetup,
+            json(),
+            linter(jsonParseLinter()),
+            lintGutter(),
+            keymap.of([]),
+            EditorView.lineWrapping,
+            EditorState.readOnly.of(readOnly),
+            EditorView.editable.of(!readOnly),
+            EditorView.theme({
+              '&': { fontSize: '13px', minHeight: `${minHeight}px` },
+              '.cm-scroller': { fontFamily: 'ui-monospace, monospace' },
+              '&.cm-focused': { outline: 'none' },
+            }),
+            EditorView.updateListener.of((update) => {
+              if (update.docChanged) onChangeRef.current?.(update.state.doc.toString())
+            }),
+          ],
+        }),
+      })
+      viewRef.current = view
+      return () => {
+        view.destroy()
+        viewRef.current = null
+      }
+    },
+    [readOnly, minHeight],
+  )
 
   // Synchronise la valeur externe (ex. picker qui pré-remplit) sans casser le curseur.
   useEffect(() => {
@@ -85,7 +93,7 @@ export function JsonEditor({
 
   return (
     <div
-      ref={hostRef}
+      ref={mountEditor}
       role="textbox"
       aria-label={ariaLabel}
       className={clsxm(

--- a/apps/kpilote-admin/src/components/ui/Picker.tsx
+++ b/apps/kpilote-admin/src/components/ui/Picker.tsx
@@ -1,0 +1,97 @@
+import { Command } from 'cmdk'
+import { ChevronDown, Search } from 'lucide-react'
+import { Popover as PopoverPrimitive } from 'radix-ui'
+import type { ReactNode } from 'react'
+import { useState } from 'react'
+
+import { clsxm } from '@/lib/clsxm'
+
+// Filtre par sous-chaîne, prévisible plutôt que le scoring fuzzy par défaut de cmdk.
+const commandFilter = (itemValue: string, query: string): number => {
+  const needle = query.trim().toLowerCase()
+  if (!needle) return 1
+  return itemValue.toLowerCase().includes(needle) ? 1 : 0
+}
+
+type PickerProps<T> = {
+  items: T[]
+  onSelect: (item: T) => void
+  getKey: (item: T) => string
+  getSearchText: (item: T) => string
+  renderItem: (item: T) => ReactNode
+  triggerLabel: ReactNode
+  searchPlaceholder?: string
+  emptyLabel?: string
+  disabled?: boolean
+}
+
+export function Picker<T>({
+  items,
+  onSelect,
+  getKey,
+  getSearchText,
+  renderItem,
+  triggerLabel,
+  searchPlaceholder = 'Rechercher…',
+  emptyLabel = 'Aucun résultat.',
+  disabled = false,
+}: PickerProps<T>) {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <PopoverPrimitive.Root open={open} onOpenChange={setOpen}>
+      <PopoverPrimitive.Trigger
+        disabled={disabled}
+        className={clsxm(
+          'flex w-full items-center gap-2 rounded-md border border-border px-3 py-2.5 text-left text-sm',
+          'hover:border-primary focus-visible:border-primary focus-visible:outline-none',
+          'data-[state=open]:border-primary disabled:cursor-not-allowed disabled:opacity-60',
+        )}
+      >
+        <Search className="size-4 shrink-0 text-text-muted" />
+        <span className="flex-1 truncate text-text-subtle">{triggerLabel}</span>
+        <ChevronDown className="size-4 shrink-0 text-text-muted" />
+      </PopoverPrimitive.Trigger>
+
+      <PopoverPrimitive.Portal>
+        <PopoverPrimitive.Content
+          align="start"
+          sideOffset={6}
+          className="z-50 w-[var(--radix-popover-trigger-width)] overflow-hidden rounded-md border border-border bg-surface shadow-lg"
+        >
+          <Command filter={commandFilter}>
+            <div className="flex items-center gap-2 border-b border-border px-3">
+              <Search className="size-4 shrink-0 text-text-muted" />
+              <Command.Input
+                autoFocus
+                placeholder={searchPlaceholder}
+                className="h-10 w-full bg-transparent text-sm outline-none placeholder:text-text-subtle"
+              />
+            </div>
+            <Command.List className="max-h-72 overflow-y-auto p-1.5">
+              <Command.Empty className="px-3 py-6 text-center text-sm text-text-muted">
+                {emptyLabel}
+              </Command.Empty>
+              {items.map((item) => (
+                <Command.Item
+                  key={getKey(item)}
+                  value={getSearchText(item)}
+                  onSelect={() => {
+                    onSelect(item)
+                    setOpen(false)
+                  }}
+                  className={clsxm(
+                    'flex cursor-pointer select-none items-center gap-3 rounded-md px-2.5 py-2 text-sm outline-none',
+                    'data-[selected=true]:bg-surface-tinted data-[selected=true]:text-primary',
+                  )}
+                >
+                  {renderItem(item)}
+                </Command.Item>
+              ))}
+            </Command.List>
+          </Command>
+        </PopoverPrimitive.Content>
+      </PopoverPrimitive.Portal>
+    </PopoverPrimitive.Root>
+  )
+}

--- a/apps/kpilote-admin/src/lib/consoleForm.ts
+++ b/apps/kpilote-admin/src/lib/consoleForm.ts
@@ -1,0 +1,39 @@
+import {
+  consoleHeaderPairSchema,
+  httpMethodSchema,
+  type ConsoleRequest,
+} from '@pilote/kpilote-shared/console'
+import { z } from 'zod'
+
+import { joinUrl, splitUrl } from '@/api/console'
+import type { HistoryEntry } from '@/lib/consoleHistory'
+
+// Modèle du formulaire : l'UI manipule une URL relative unique (`path`, qui peut
+// contenir la querystring). L'enveloppe wire, elle, sépare chemin et query — la
+// conversion se fait au submit (toConsoleRequest) et à la restauration (valuesFromHistory).
+export const consoleFormSchema = z.object({
+  method: httpMethodSchema,
+  path: z.string(),
+  headers: z.array(consoleHeaderPairSchema),
+  body: z.string(),
+})
+export type ConsoleFormValues = z.infer<typeof consoleFormSchema>
+
+export const emptyConsoleForm: ConsoleFormValues = {
+  method: 'GET',
+  path: '',
+  headers: [],
+  body: '',
+}
+
+export const toConsoleRequest = (values: ConsoleFormValues): ConsoleRequest => {
+  const { path, query } = splitUrl(values.path)
+  return { method: values.method, path, query, headers: values.headers, body: values.body }
+}
+
+export const valuesFromHistory = (entry: HistoryEntry): ConsoleFormValues => ({
+  method: entry.request.method,
+  path: joinUrl({ path: entry.request.path, query: entry.request.query }),
+  headers: entry.request.headers,
+  body: entry.request.body,
+})

--- a/apps/kpilote-admin/src/lib/consoleHistory.ts
+++ b/apps/kpilote-admin/src/lib/consoleHistory.ts
@@ -1,24 +1,30 @@
-import type { ConsoleRequest, HttpMethod } from '@/api/console'
+import { consoleRequestSchema, httpMethodSchema } from '@pilote/kpilote-shared/console'
+import { z } from 'zod'
 
 const STORAGE_KEY = 'kpiloteadmin_console_history'
 const MAX_ENTRIES = 20
 
-export type HistoryEntry = {
-  id: string
-  method: HttpMethod
-  path: string
-  status: number
-  ts: number
-  request: ConsoleRequest
-}
+const historyEntrySchema = z.object({
+  id: z.string(),
+  method: httpMethodSchema,
+  path: z.string(),
+  status: z.number(),
+  ts: z.number(),
+  request: consoleRequestSchema,
+})
+export type HistoryEntry = z.infer<typeof historyEntrySchema>
+
+const historySchema = z.array(historyEntrySchema)
 
 export const loadHistory = (): HistoryEntry[] => {
   if (typeof localStorage === 'undefined') return []
+  const raw = localStorage.getItem(STORAGE_KEY)
+  if (!raw) return []
   try {
-    const raw = localStorage.getItem(STORAGE_KEY)
-    if (!raw) return []
-    const parsed: unknown = JSON.parse(raw)
-    return Array.isArray(parsed) ? (parsed as HistoryEntry[]) : []
+    // Sortie type-safe du localStorage : tout ce qui ne matche pas le schéma
+    // (ancienne version, données corrompues) est ignoré silencieusement.
+    const parsed = historySchema.safeParse(JSON.parse(raw))
+    return parsed.success ? parsed.data : []
   } catch {
     return []
   }

--- a/apps/kpilote-admin/src/lib/consoleHistory.ts
+++ b/apps/kpilote-admin/src/lib/consoleHistory.ts
@@ -1,0 +1,43 @@
+import type { ConsoleRequest, HttpMethod } from '@/api/console'
+
+const STORAGE_KEY = 'kpiloteadmin_console_history'
+const MAX_ENTRIES = 20
+
+export type HistoryEntry = {
+  id: string
+  method: HttpMethod
+  path: string
+  status: number
+  ts: number
+  request: ConsoleRequest
+}
+
+export const loadHistory = (): HistoryEntry[] => {
+  if (typeof localStorage === 'undefined') return []
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (!raw) return []
+    const parsed: unknown = JSON.parse(raw)
+    return Array.isArray(parsed) ? (parsed as HistoryEntry[]) : []
+  } catch {
+    return []
+  }
+}
+
+export const pushHistory = (entry: HistoryEntry): HistoryEntry[] => {
+  const next = [entry, ...loadHistory()].slice(0, MAX_ENTRIES)
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(next))
+  } catch {
+    // best-effort : quota plein / stockage indisponible
+  }
+  return next
+}
+
+export const clearHistory = (): void => {
+  try {
+    localStorage.removeItem(STORAGE_KEY)
+  } catch {
+    // best-effort
+  }
+}

--- a/apps/kpilote-admin/src/lib/toCurl.ts
+++ b/apps/kpilote-admin/src/lib/toCurl.ts
@@ -1,0 +1,32 @@
+import type { HeaderPair, HttpMethod } from '@/api/console'
+
+// Échappement shell d'une valeur entre quotes simples : ' → '\''
+const shellQuote = (value: string): string => `'${value.replace(/'/g, `'\\''`)}'`
+
+const BODYLESS: ReadonlySet<HttpMethod> = new Set<HttpMethod>(['GET'])
+
+// Construit une commande curl multi-lignes. Le token n'est jamais inclus : on
+// émet un placeholder `$API_KEY` que l'utilisateur remplacera.
+export const toCurl = ({
+  method,
+  url,
+  headers,
+  body,
+}: {
+  method: HttpMethod
+  url: string
+  headers: HeaderPair[]
+  body: string
+}): string => {
+  const lines = [`curl -X ${method} ${shellQuote(url)}`]
+  lines.push(`  -H ${shellQuote('Authorization: Bearer $API_KEY')}`)
+  for (const { key, value } of headers) {
+    if (!key.trim()) continue
+    lines.push(`  -H ${shellQuote(`${key}: ${value}`)}`)
+  }
+  const trimmedBody = body.trim()
+  if (!BODYLESS.has(method) && trimmedBody) {
+    lines.push(`  --data ${shellQuote(trimmedBody)}`)
+  }
+  return lines.join(' \\\n')
+}

--- a/apps/kpilote-admin/src/queries/console.ts
+++ b/apps/kpilote-admin/src/queries/console.ts
@@ -9,25 +9,53 @@ export type OpenapiEndpoint = {
   bodyExample: string
 }
 
-const METHOD_SET = new Set<string>(HTTP_METHODS)
+// Sous-ensemble de la spec OpenAPI que l'on exploite. On type l'entrée une seule
+// fois à la frontière (`spec as OpenapiSpec`) plutôt que de caster à chaque accès.
+type OpenapiSchema = {
+  $ref?: string
+  example?: unknown
+  enum?: unknown[]
+  type?: string
+  properties?: Record<string, OpenapiSchema>
+  items?: OpenapiSchema
+}
+type OpenapiOperation = {
+  summary?: string
+  requestBody?: { content?: Record<string, { schema?: OpenapiSchema }> }
+}
+type OpenapiSpec = {
+  paths?: Record<string, Record<string, OpenapiOperation>>
+  components?: { schemas?: Record<string, OpenapiSchema> }
+}
 
-// Génère un exemple JSON minimal depuis un schéma OpenAPI (profondeur limitée).
-const exampleFromSchema = (schema: unknown, depth = 0): unknown => {
-  if (depth > 4 || typeof schema !== 'object' || schema === null) return null
-  const node = schema as Record<string, unknown>
-  if ('example' in node) return node.example
-  if (Array.isArray(node.enum) && node.enum.length > 0) return node.enum[0]
-  switch (node.type) {
+const METHOD_SET = new Set<string>(HTTP_METHODS)
+const REF_PREFIX = '#/components/schemas/'
+
+// Génère un exemple JSON minimal depuis un schéma OpenAPI. Les `$ref` (que
+// @hono/zod-openapi émet pour les bodies enregistrés en composants) sont résolus
+// contre `components.schemas`. La profondeur est bornée (refs cycliques, imbrication).
+const exampleFromSchema = (
+  schema: OpenapiSchema | undefined,
+  schemas: Record<string, OpenapiSchema>,
+  depth = 0,
+): unknown => {
+  if (depth > 6 || !schema) return null
+  if (schema.$ref) {
+    const name = schema.$ref.startsWith(REF_PREFIX) ? schema.$ref.slice(REF_PREFIX.length) : ''
+    return exampleFromSchema(schemas[name], schemas, depth + 1)
+  }
+  if ('example' in schema) return schema.example
+  if (Array.isArray(schema.enum) && schema.enum.length > 0) return schema.enum[0]
+  switch (schema.type) {
     case 'object': {
-      const properties = (node.properties as Record<string, unknown>) ?? {}
       const result: Record<string, unknown> = {}
-      for (const [key, value] of Object.entries(properties)) {
-        result[key] = exampleFromSchema(value, depth + 1)
+      for (const [key, value] of Object.entries(schema.properties ?? {})) {
+        result[key] = exampleFromSchema(value, schemas, depth + 1)
       }
       return result
     }
     case 'array':
-      return [exampleFromSchema(node.items, depth + 1)]
+      return [exampleFromSchema(schema.items, schemas, depth + 1)]
     case 'string':
       return ''
     case 'number':
@@ -40,31 +68,33 @@ const exampleFromSchema = (schema: unknown, depth = 0): unknown => {
   }
 }
 
-const bodyExampleFor = (operation: Record<string, unknown>): string => {
-  const requestBody = operation.requestBody as Record<string, unknown> | undefined
-  const content = requestBody?.content as Record<string, unknown> | undefined
-  const jsonContent = content?.['application/json'] as Record<string, unknown> | undefined
-  if (!jsonContent?.schema) return ''
-  const example = exampleFromSchema(jsonContent.schema)
+const bodyExampleFor = (
+  operation: OpenapiOperation,
+  schemas: Record<string, OpenapiSchema>,
+): string => {
+  const schema = operation.requestBody?.content?.['application/json']?.schema
+  if (!schema) return ''
+  const example = exampleFromSchema(schema, schemas)
   if (example === null || example === undefined) return ''
   return JSON.stringify(example, null, 2)
 }
 
 const parseEndpoints = (spec: unknown): OpenapiEndpoint[] => {
-  const paths = (spec as { paths?: Record<string, unknown> })?.paths
+  const typed = spec as OpenapiSpec
+  const paths = typed.paths
   if (!paths) return []
+  const schemas = typed.components?.schemas ?? {}
   const endpoints: OpenapiEndpoint[] = []
   for (const [path, pathItem] of Object.entries(paths)) {
-    if (typeof pathItem !== 'object' || pathItem === null) continue
-    for (const [rawMethod, operation] of Object.entries(pathItem as Record<string, unknown>)) {
+    for (const [rawMethod, operation] of Object.entries(pathItem)) {
       const method = rawMethod.toUpperCase()
-      if (!METHOD_SET.has(method) || typeof operation !== 'object' || operation === null) continue
-      const op = operation as Record<string, unknown>
+      // Le filtre méthode écarte de fait les clés non-opérations (parameters, $ref…).
+      if (!METHOD_SET.has(method)) continue
       endpoints.push({
         method: method as HttpMethod,
         path,
-        summary: typeof op.summary === 'string' ? op.summary : '',
-        bodyExample: bodyExampleFor(op),
+        summary: operation.summary ?? '',
+        bodyExample: bodyExampleFor(operation, schemas),
       })
     }
   }

--- a/apps/kpilote-admin/src/queries/console.ts
+++ b/apps/kpilote-admin/src/queries/console.ts
@@ -1,0 +1,84 @@
+import { queryOptions } from '@tanstack/react-query'
+
+import { fetchConsoleMeta, fetchOpenapiSpec, HTTP_METHODS, type HttpMethod } from '@/api/console'
+
+export type OpenapiEndpoint = {
+  method: HttpMethod
+  path: string
+  summary: string
+  bodyExample: string
+}
+
+const METHOD_SET = new Set<string>(HTTP_METHODS)
+
+// Génère un exemple JSON minimal depuis un schéma OpenAPI (profondeur limitée).
+const exampleFromSchema = (schema: unknown, depth = 0): unknown => {
+  if (depth > 4 || typeof schema !== 'object' || schema === null) return null
+  const node = schema as Record<string, unknown>
+  if ('example' in node) return node.example
+  if (Array.isArray(node.enum) && node.enum.length > 0) return node.enum[0]
+  switch (node.type) {
+    case 'object': {
+      const properties = (node.properties as Record<string, unknown>) ?? {}
+      const result: Record<string, unknown> = {}
+      for (const [key, value] of Object.entries(properties)) {
+        result[key] = exampleFromSchema(value, depth + 1)
+      }
+      return result
+    }
+    case 'array':
+      return [exampleFromSchema(node.items, depth + 1)]
+    case 'string':
+      return ''
+    case 'number':
+    case 'integer':
+      return 0
+    case 'boolean':
+      return false
+    default:
+      return null
+  }
+}
+
+const bodyExampleFor = (operation: Record<string, unknown>): string => {
+  const requestBody = operation.requestBody as Record<string, unknown> | undefined
+  const content = requestBody?.content as Record<string, unknown> | undefined
+  const jsonContent = content?.['application/json'] as Record<string, unknown> | undefined
+  if (!jsonContent?.schema) return ''
+  const example = exampleFromSchema(jsonContent.schema)
+  if (example === null || example === undefined) return ''
+  return JSON.stringify(example, null, 2)
+}
+
+const parseEndpoints = (spec: unknown): OpenapiEndpoint[] => {
+  const paths = (spec as { paths?: Record<string, unknown> })?.paths
+  if (!paths) return []
+  const endpoints: OpenapiEndpoint[] = []
+  for (const [path, pathItem] of Object.entries(paths)) {
+    if (typeof pathItem !== 'object' || pathItem === null) continue
+    for (const [rawMethod, operation] of Object.entries(pathItem as Record<string, unknown>)) {
+      const method = rawMethod.toUpperCase()
+      if (!METHOD_SET.has(method) || typeof operation !== 'object' || operation === null) continue
+      const op = operation as Record<string, unknown>
+      endpoints.push({
+        method: method as HttpMethod,
+        path,
+        summary: typeof op.summary === 'string' ? op.summary : '',
+        bodyExample: bodyExampleFor(op),
+      })
+    }
+  }
+  return endpoints.sort((a, b) => a.path.localeCompare(b.path) || a.method.localeCompare(b.method))
+}
+
+export const consoleMetaQueryOptions = queryOptions({
+  queryKey: ['console', 'meta'],
+  queryFn: fetchConsoleMeta,
+  staleTime: 60 * 60 * 1000,
+})
+
+export const openapiEndpointsQueryOptions = queryOptions({
+  queryKey: ['console', 'openapi'],
+  queryFn: async () => parseEndpoints(await fetchOpenapiSpec()),
+  staleTime: 60 * 60 * 1000,
+})

--- a/apps/kpilote-admin/src/routes/_authed/console.tsx
+++ b/apps/kpilote-admin/src/routes/_authed/console.tsx
@@ -49,7 +49,7 @@ function ConsoleComponent() {
   const activeTab = bodyless ? 'headers' : tab
 
   const baseUrl = (meta?.baseUrl ?? '').replace(/\/+$/, '')
-  const fullUrl = `${baseUrl}/${path}`
+  const fullUrl = `${baseUrl}${path.startsWith('/') ? path : `/${path}`}`
   const blockedByProd = isProd && locked && MUTATING.has(method)
 
   // Ramène la réponse dans le viewport dès qu'un résultat (ou une erreur) arrive.
@@ -100,7 +100,7 @@ function ConsoleComponent() {
           <EndpointPicker
             onSelect={(endpoint) => {
               setMethod(endpoint.method)
-              setPath(endpoint.path.replace(/^\/+/, ''))
+              setPath(endpoint.path)
               if (endpoint.bodyExample) {
                 setBody(endpoint.bodyExample)
                 setTab('body')
@@ -124,13 +124,13 @@ function ConsoleComponent() {
             </FieldSelect>
             <div className="flex flex-1 items-center rounded-md border border-border">
               <span className="max-w-[45%] truncate px-2 py-2.5 text-xs text-text-muted">
-                {baseUrl}/
+                {baseUrl}
               </span>
               <input
                 aria-label="Chemin de la requête"
                 value={path}
-                onChange={(event) => setPath(event.target.value.replace(/^\/+/, ''))}
-                placeholder="indicateurs?limit=10"
+                onChange={(event) => setPath(event.target.value)}
+                placeholder="/indicateurs?limit=10"
                 className="flex-1 rounded-r-md px-2 py-2.5 text-sm focus:outline-none"
               />
             </div>
@@ -185,7 +185,7 @@ function ConsoleComponent() {
             <CopyButton value={curl} label="Copier la commande curl" />
           </div>
 
-          <div ref={responseRef} className="scroll-mt-4 rounded-md border border-border p-4">
+          <div ref={responseRef} className="scroll-mt-24 rounded-md border border-border p-4">
             <ResponsePanel response={response} pending={pending} error={error} />
           </div>
         </div>

--- a/apps/kpilote-admin/src/routes/_authed/console.tsx
+++ b/apps/kpilote-admin/src/routes/_authed/console.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query'
 import { createFileRoute } from '@tanstack/react-router'
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 import {
   HTTP_METHODS,
@@ -42,10 +42,22 @@ function ConsoleComponent() {
   const [pending, setPending] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [history, setHistory] = useState<HistoryEntry[]>(() => loadHistory())
+  const responseRef = useRef<HTMLDivElement>(null)
 
-  const baseUrl = (meta?.baseUrl ?? '').replace(/\/$/, '')
-  const fullUrl = `${baseUrl}/${path.replace(/^\/+/, '')}`
+  // GET est bodyless : on masque l'onglet Body et on force l'affichage des en-têtes.
+  const bodyless = method === 'GET'
+  const activeTab = bodyless ? 'headers' : tab
+
+  const baseUrl = (meta?.baseUrl ?? '').replace(/\/+$/, '')
+  const fullUrl = `${baseUrl}/${path}`
   const blockedByProd = isProd && locked && MUTATING.has(method)
+
+  // Ramène la réponse dans le viewport dès qu'un résultat (ou une erreur) arrive.
+  useEffect(() => {
+    if (response || error) {
+      responseRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+    }
+  }, [response, error])
 
   const curl = toCurl({ method, url: fullUrl, headers, body })
 
@@ -88,7 +100,7 @@ function ConsoleComponent() {
           <EndpointPicker
             onSelect={(endpoint) => {
               setMethod(endpoint.method)
-              setPath(endpoint.path)
+              setPath(endpoint.path.replace(/^\/+/, ''))
               if (endpoint.bodyExample) {
                 setBody(endpoint.bodyExample)
                 setTab('body')
@@ -138,14 +150,18 @@ function ConsoleComponent() {
 
           <div>
             <TabNav
-              tabs={[
-                { key: 'body', label: 'Body' },
-                { key: 'headers', label: 'En-têtes' },
-              ]}
-              active={tab}
+              tabs={
+                bodyless
+                  ? [{ key: 'headers', label: 'En-têtes' }]
+                  : [
+                      { key: 'body', label: 'Body' },
+                      { key: 'headers', label: 'En-têtes' },
+                    ]
+              }
+              active={activeTab}
               onChange={(key) => setTab(key as 'body' | 'headers')}
             />
-            {tab === 'body' ? (
+            {activeTab === 'body' ? (
               <div className="flex flex-col gap-2">
                 <div className="flex justify-end">
                   <Button
@@ -169,7 +185,7 @@ function ConsoleComponent() {
             <CopyButton value={curl} label="Copier la commande curl" />
           </div>
 
-          <div className="rounded-md border border-border p-4">
+          <div ref={responseRef} className="scroll-mt-4 rounded-md border border-border p-4">
             <ResponsePanel response={response} pending={pending} error={error} />
           </div>
         </div>

--- a/apps/kpilote-admin/src/routes/_authed/console.tsx
+++ b/apps/kpilote-admin/src/routes/_authed/console.tsx
@@ -1,199 +1,125 @@
-import { useQuery } from '@tanstack/react-query'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useMutation, useQuery } from '@tanstack/react-query'
 import { createFileRoute } from '@tanstack/react-router'
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useState } from 'react'
+import { FormProvider, useForm } from 'react-hook-form'
 
-import {
-  HTTP_METHODS,
-  sendConsoleRequest,
-  type ConsoleResponse,
-  type HeaderPair,
-  type HttpMethod,
-} from '@/api/console'
-import { EndpointPicker } from '@/components/console/EndpointPicker'
-import { HeadersEditor } from '@/components/console/HeadersEditor'
+import { sendConsoleRequest, type ConsoleResponse } from '@/api/console'
+import { CurlPreview } from '@/components/console/CurlPreview'
 import { HistoryList } from '@/components/console/HistoryList'
+import { RequestForm } from '@/components/console/RequestForm'
 import { ResponsePanel } from '@/components/console/ResponsePanel'
 import { PageHeading } from '@/components/PageHeading'
-import { Button } from '@/components/ui/Button'
-import { CopyButton } from '@/components/ui/CopyButton'
-import { FieldSelect } from '@/components/ui/FieldSelect'
-import { formatJson, JsonEditor } from '@/components/ui/JsonEditor'
-import { TabNav } from '@/components/ui/TabNav'
+import {
+  consoleFormSchema,
+  emptyConsoleForm,
+  toConsoleRequest,
+  valuesFromHistory,
+  type ConsoleFormValues,
+} from '@/lib/consoleForm'
 import { clearHistory, loadHistory, pushHistory, type HistoryEntry } from '@/lib/consoleHistory'
-import { toCurl } from '@/lib/toCurl'
 import { useProdEditUnlock } from '@/lib/useProdEditUnlock'
 import { consoleMetaQueryOptions } from '@/queries/console'
 
 export const Route = createFileRoute('/_authed/console')({ component: ConsoleComponent })
 
-const MUTATING: ReadonlySet<HttpMethod> = new Set<HttpMethod>(['POST', 'PUT', 'PATCH', 'DELETE'])
+// Section réponse isolée : sa `key` (submittedAt) change à chaque envoi, ce qui
+// la remonte et redéclenche la callback ref → scroll vers le résultat.
+function ResponseSection({
+  response,
+  pending,
+  error,
+}: {
+  response: ConsoleResponse | null
+  pending: boolean
+  error: string | null
+}) {
+  const scrollIntoView = useCallback((node: HTMLDivElement | null) => {
+    node?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+  }, [])
+  return (
+    <div ref={scrollIntoView} className="scroll-mt-24 rounded-md border border-border p-4">
+      <ResponsePanel response={response} pending={pending} error={error} />
+    </div>
+  )
+}
 
 function ConsoleComponent() {
   const { data: meta } = useQuery(consoleMetaQueryOptions)
   const { isProd, locked, unlock } = useProdEditUnlock()
-
-  const [method, setMethod] = useState<HttpMethod>('GET')
-  const [path, setPath] = useState('')
-  const [headers, setHeaders] = useState<HeaderPair[]>([])
-  const [body, setBody] = useState('')
-  const [tab, setTab] = useState<'body' | 'headers'>('body')
-
-  const [response, setResponse] = useState<ConsoleResponse | null>(null)
-  const [pending, setPending] = useState(false)
-  const [error, setError] = useState<string | null>(null)
   const [history, setHistory] = useState<HistoryEntry[]>(() => loadHistory())
-  const responseRef = useRef<HTMLDivElement>(null)
+  // Incrémenté à chaque résultat/erreur : sert de `key` à la section réponse pour
+  // la remonter (et redéclencher le scroll) quand le RÉSULTAT arrive, pas au submit.
+  const [resultKey, setResultKey] = useState(0)
 
-  // GET est bodyless : on masque l'onglet Body et on force l'affichage des en-têtes.
-  const bodyless = method === 'GET'
-  const activeTab = bodyless ? 'headers' : tab
+  const form = useForm<ConsoleFormValues>({
+    resolver: zodResolver(consoleFormSchema),
+    defaultValues: emptyConsoleForm,
+  })
 
-  const baseUrl = (meta?.baseUrl ?? '').replace(/\/+$/, '')
-  const fullUrl = `${baseUrl}${path.startsWith('/') ? path : `/${path}`}`
-  const blockedByProd = isProd && locked && MUTATING.has(method)
-
-  // Ramène la réponse dans le viewport dès qu'un résultat (ou une erreur) arrive.
-  useEffect(() => {
-    if (response || error) {
-      responseRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' })
-    }
-  }, [response, error])
-
-  const curl = toCurl({ method, url: fullUrl, headers, body })
-
-  const send = async () => {
-    setPending(true)
-    setError(null)
-    try {
-      const request = { method, path, headers, body }
-      const result = await sendConsoleRequest(request)
-      setResponse(result)
+  const mutation = useMutation({
+    mutationFn: (values: ConsoleFormValues) => sendConsoleRequest(toConsoleRequest(values)),
+    onSuccess: (result, values) => {
       const entry: HistoryEntry = {
         id: crypto.randomUUID(),
-        method,
-        path,
+        method: values.method,
+        path: values.path,
         status: result.status,
         ts: Date.now(),
-        request,
+        request: toConsoleRequest(values),
       }
       setHistory(pushHistory(entry))
-    } catch (caught) {
-      setError(caught instanceof Error ? caught.message : 'Échec de l’appel')
-    } finally {
-      setPending(false)
-    }
-  }
+      setResultKey((key) => key + 1)
+    },
+    onError: () => setResultKey((key) => key + 1),
+  })
 
-  const restore = (entry: HistoryEntry) => {
-    setMethod(entry.request.method)
-    setPath(entry.request.path)
-    setHeaders(entry.request.headers)
-    setBody(entry.request.body)
-  }
+  const baseUrl = (meta?.baseUrl ?? '').replace(/\/+$/, '')
+  const errorMessage = mutation.isError
+    ? mutation.error instanceof Error
+      ? mutation.error.message
+      : 'Échec de l’appel'
+    : null
 
   return (
     <div className="mx-auto flex max-w-7xl flex-col gap-6">
       <PageHeading title="Console API" subtitle={`Environnement : ${meta?.environment ?? '…'}`} />
 
       <div className="grid grid-cols-1 gap-6 lg:grid-cols-[1fr_260px]">
-        <div className="flex flex-col gap-4">
-          <EndpointPicker
-            onSelect={(endpoint) => {
-              setMethod(endpoint.method)
-              setPath(endpoint.path)
-              if (endpoint.bodyExample) {
-                setBody(endpoint.bodyExample)
-                setTab('body')
-              }
-            }}
-          />
-
-          <div className="flex items-end gap-2">
-            <FieldSelect
-              label="Méthode"
-              hideLabel
-              value={method}
-              onChange={(event) => setMethod(event.target.value as HttpMethod)}
-              className="w-32"
-            >
-              {HTTP_METHODS.map((httpMethod) => (
-                <option key={httpMethod} value={httpMethod}>
-                  {httpMethod}
-                </option>
-              ))}
-            </FieldSelect>
-            <div className="flex flex-1 items-center rounded-md border border-border">
-              <span className="max-w-[45%] truncate px-2 py-2.5 text-xs text-text-muted">
-                {baseUrl}
-              </span>
-              <input
-                aria-label="Chemin de la requête"
-                value={path}
-                onChange={(event) => setPath(event.target.value)}
-                placeholder="/indicateurs?limit=10"
-                className="flex-1 rounded-r-md px-2 py-2.5 text-sm focus:outline-none"
-              />
-            </div>
-            <Button type="button" onClick={() => void send()} disabled={pending || blockedByProd}>
-              Envoyer
-            </Button>
-          </div>
-
-          {blockedByProd ? (
-            <div className="flex items-center justify-between rounded-md border border-accent/40 bg-accent/5 px-3 py-2 text-xs">
-              <span>Mutation sur la prod verrouillée.</span>
-              <button type="button" onClick={unlock} className="font-semibold text-accent">
-                Déverrouiller
-              </button>
-            </div>
-          ) : null}
-
-          <div>
-            <TabNav
-              tabs={
-                bodyless
-                  ? [{ key: 'headers', label: 'En-têtes' }]
-                  : [
-                      { key: 'body', label: 'Body' },
-                      { key: 'headers', label: 'En-têtes' },
-                    ]
-              }
-              active={activeTab}
-              onChange={(key) => setTab(key as 'body' | 'headers')}
+        <FormProvider {...form}>
+          <form
+            className="flex flex-col gap-4"
+            onSubmit={(event) => void form.handleSubmit((values) => mutation.mutate(values))(event)}
+          >
+            <RequestForm
+              baseUrl={baseUrl}
+              isProd={isProd}
+              locked={locked}
+              unlock={unlock}
+              isPending={mutation.isPending}
             />
-            {activeTab === 'body' ? (
-              <div className="flex flex-col gap-2">
-                <div className="flex justify-end">
-                  <Button
-                    type="button"
-                    variant="tertiary"
-                    size="sm"
-                    onClick={() => setBody((value) => formatJson(value))}
-                  >
-                    Formater
-                  </Button>
-                </div>
-                <JsonEditor value={body} onChange={setBody} ariaLabel="Corps de la requête" />
+
+            <CurlPreview baseUrl={baseUrl} />
+
+            {mutation.submittedAt === 0 ? (
+              <div className="scroll-mt-24 rounded-md border border-border p-4">
+                <ResponsePanel response={null} pending={false} error={null} />
               </div>
             ) : (
-              <HeadersEditor headers={headers} onChange={setHeaders} />
+              <ResponseSection
+                key={resultKey}
+                response={mutation.data ?? null}
+                pending={mutation.isPending}
+                error={errorMessage}
+              />
             )}
-          </div>
-
-          <div className="flex items-center gap-2 rounded-md border border-border bg-surface-muted px-3 py-2">
-            <code className="flex-1 overflow-auto whitespace-pre text-xs">{curl}</code>
-            <CopyButton value={curl} label="Copier la commande curl" />
-          </div>
-
-          <div ref={responseRef} className="scroll-mt-24 rounded-md border border-border p-4">
-            <ResponsePanel response={response} pending={pending} error={error} />
-          </div>
-        </div>
+          </form>
+        </FormProvider>
 
         <aside className="rounded-md border border-border p-3">
           <HistoryList
             entries={history}
-            onRestore={restore}
+            onRestore={(entry) => form.reset(valuesFromHistory(entry))}
             onClear={() => {
               clearHistory()
               setHistory([])

--- a/apps/kpilote-admin/src/routes/_authed/console.tsx
+++ b/apps/kpilote-admin/src/routes/_authed/console.tsx
@@ -1,0 +1,190 @@
+import { useQuery } from '@tanstack/react-query'
+import { createFileRoute } from '@tanstack/react-router'
+import { useState } from 'react'
+
+import {
+  HTTP_METHODS,
+  sendConsoleRequest,
+  type ConsoleResponse,
+  type HeaderPair,
+  type HttpMethod,
+} from '@/api/console'
+import { EndpointPicker } from '@/components/console/EndpointPicker'
+import { HeadersEditor } from '@/components/console/HeadersEditor'
+import { HistoryList } from '@/components/console/HistoryList'
+import { ResponsePanel } from '@/components/console/ResponsePanel'
+import { PageHeading } from '@/components/PageHeading'
+import { Button } from '@/components/ui/Button'
+import { CopyButton } from '@/components/ui/CopyButton'
+import { FieldSelect } from '@/components/ui/FieldSelect'
+import { formatJson, JsonEditor } from '@/components/ui/JsonEditor'
+import { TabNav } from '@/components/ui/TabNav'
+import { clearHistory, loadHistory, pushHistory, type HistoryEntry } from '@/lib/consoleHistory'
+import { toCurl } from '@/lib/toCurl'
+import { useProdEditUnlock } from '@/lib/useProdEditUnlock'
+import { consoleMetaQueryOptions } from '@/queries/console'
+
+export const Route = createFileRoute('/_authed/console')({ component: ConsoleComponent })
+
+const MUTATING: ReadonlySet<HttpMethod> = new Set<HttpMethod>(['POST', 'PUT', 'PATCH', 'DELETE'])
+
+function ConsoleComponent() {
+  const { data: meta } = useQuery(consoleMetaQueryOptions)
+  const { isProd, locked, unlock } = useProdEditUnlock()
+
+  const [method, setMethod] = useState<HttpMethod>('GET')
+  const [path, setPath] = useState('')
+  const [headers, setHeaders] = useState<HeaderPair[]>([])
+  const [body, setBody] = useState('')
+  const [tab, setTab] = useState<'body' | 'headers'>('body')
+
+  const [response, setResponse] = useState<ConsoleResponse | null>(null)
+  const [pending, setPending] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [history, setHistory] = useState<HistoryEntry[]>(() => loadHistory())
+
+  const baseUrl = (meta?.baseUrl ?? '').replace(/\/$/, '')
+  const fullUrl = `${baseUrl}/${path.replace(/^\/+/, '')}`
+  const blockedByProd = isProd && locked && MUTATING.has(method)
+
+  const curl = toCurl({ method, url: fullUrl, headers, body })
+
+  const send = async () => {
+    setPending(true)
+    setError(null)
+    try {
+      const request = { method, path, headers, body }
+      const result = await sendConsoleRequest(request)
+      setResponse(result)
+      const entry: HistoryEntry = {
+        id: crypto.randomUUID(),
+        method,
+        path,
+        status: result.status,
+        ts: Date.now(),
+        request,
+      }
+      setHistory(pushHistory(entry))
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : 'Échec de l’appel')
+    } finally {
+      setPending(false)
+    }
+  }
+
+  const restore = (entry: HistoryEntry) => {
+    setMethod(entry.request.method)
+    setPath(entry.request.path)
+    setHeaders(entry.request.headers)
+    setBody(entry.request.body)
+  }
+
+  return (
+    <div className="mx-auto flex max-w-7xl flex-col gap-6">
+      <PageHeading title="Console API" subtitle={`Environnement : ${meta?.environment ?? '…'}`} />
+
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-[1fr_260px]">
+        <div className="flex flex-col gap-4">
+          <EndpointPicker
+            onSelect={(endpoint) => {
+              setMethod(endpoint.method)
+              setPath(endpoint.path)
+              if (endpoint.bodyExample) {
+                setBody(endpoint.bodyExample)
+                setTab('body')
+              }
+            }}
+          />
+
+          <div className="flex items-end gap-2">
+            <FieldSelect
+              label="Méthode"
+              hideLabel
+              value={method}
+              onChange={(event) => setMethod(event.target.value as HttpMethod)}
+              className="w-32"
+            >
+              {HTTP_METHODS.map((httpMethod) => (
+                <option key={httpMethod} value={httpMethod}>
+                  {httpMethod}
+                </option>
+              ))}
+            </FieldSelect>
+            <div className="flex flex-1 items-center rounded-md border border-border">
+              <span className="max-w-[45%] truncate px-2 py-2.5 text-xs text-text-muted">
+                {baseUrl}/
+              </span>
+              <input
+                aria-label="Chemin de la requête"
+                value={path}
+                onChange={(event) => setPath(event.target.value.replace(/^\/+/, ''))}
+                placeholder="indicateurs?limit=10"
+                className="flex-1 rounded-r-md px-2 py-2.5 text-sm focus:outline-none"
+              />
+            </div>
+            <Button type="button" onClick={() => void send()} disabled={pending || blockedByProd}>
+              Envoyer
+            </Button>
+          </div>
+
+          {blockedByProd ? (
+            <div className="flex items-center justify-between rounded-md border border-accent/40 bg-accent/5 px-3 py-2 text-xs">
+              <span>Mutation sur la prod verrouillée.</span>
+              <button type="button" onClick={unlock} className="font-semibold text-accent">
+                Déverrouiller
+              </button>
+            </div>
+          ) : null}
+
+          <div>
+            <TabNav
+              tabs={[
+                { key: 'body', label: 'Body' },
+                { key: 'headers', label: 'En-têtes' },
+              ]}
+              active={tab}
+              onChange={(key) => setTab(key as 'body' | 'headers')}
+            />
+            {tab === 'body' ? (
+              <div className="flex flex-col gap-2">
+                <div className="flex justify-end">
+                  <Button
+                    type="button"
+                    variant="tertiary"
+                    size="sm"
+                    onClick={() => setBody((value) => formatJson(value))}
+                  >
+                    Formater
+                  </Button>
+                </div>
+                <JsonEditor value={body} onChange={setBody} ariaLabel="Corps de la requête" />
+              </div>
+            ) : (
+              <HeadersEditor headers={headers} onChange={setHeaders} />
+            )}
+          </div>
+
+          <div className="flex items-center gap-2 rounded-md border border-border bg-surface-muted px-3 py-2">
+            <code className="flex-1 overflow-auto whitespace-pre text-xs">{curl}</code>
+            <CopyButton value={curl} label="Copier la commande curl" />
+          </div>
+
+          <div className="rounded-md border border-border p-4">
+            <ResponsePanel response={response} pending={pending} error={error} />
+          </div>
+        </div>
+
+        <aside className="rounded-md border border-border p-3">
+          <HistoryList
+            entries={history}
+            onRestore={restore}
+            onClear={() => {
+              clearHistory()
+              setHistory([])
+            }}
+          />
+        </aside>
+      </div>
+    </div>
+  )
+}

--- a/apps/kpilote-admin/src/routes/_authed/fonctionnalites.tsx
+++ b/apps/kpilote-admin/src/routes/_authed/fonctionnalites.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
-import { BarChart3, FolderTree, KeyRound, Users } from 'lucide-react'
+import { BarChart3, FolderTree, KeyRound, Terminal, Users } from 'lucide-react'
 
 import { BarCard } from '@/components/ui/BarCard'
 import { FadeIn } from '@/components/ui/FadeIn'
@@ -44,6 +44,14 @@ function FeaturesComponent() {
             title="Gérer les utilisateurs"
             description="Créer, lister et modifier les utilisateurs OIDC pré-provisionnés (réservé aux clés ADMIN)."
             onClick={() => void navigate({ to: '/utilisateurs' })}
+          />
+        </FadeIn>
+        <FadeIn delayMs={300}>
+          <BarCard
+            icon={Terminal}
+            title="Console API"
+            description="Effectuer des appels HTTP arbitraires vers l'API, avec export curl."
+            onClick={() => void navigate({ to: '/console' })}
           />
         </FadeIn>
       </div>

--- a/apps/kpilote-admin/src/server/api/router.ts
+++ b/apps/kpilote-admin/src/server/api/router.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono'
 
-import { mbApiUrlFor } from '@/server/environments'
+import { kpiloteApiUrlFor } from '@/server/environments'
 import { readSession } from '@/server/session'
 
 // Ressources relayables (lecture + upsert indicateurs/référentiels/individus).
@@ -31,7 +31,7 @@ apiRouter.all('/*', async (context) => {
     return context.json({ error: 'forbidden' }, 403)
   }
 
-  const base = new URL(mbApiUrlFor(session.environment))
+  const base = new URL(kpiloteApiUrlFor(session.environment))
   const basePath = base.pathname.replace(/\/$/, '')
   const url = new URL(`${basePath}/${subPath}`, base)
   url.search = new URL(context.req.url).search

--- a/apps/kpilote-admin/src/server/app.ts
+++ b/apps/kpilote-admin/src/server/app.ts
@@ -3,6 +3,7 @@ import { secureHeaders } from 'hono/secure-headers'
 
 import { apiRouter } from '@/server/api/router'
 import { authRouter } from '@/server/auth/router'
+import { consoleRouter } from '@/server/console/router'
 
 export const app = new Hono()
 
@@ -31,3 +32,4 @@ app.use(
 app.get('/healthz', (context) => context.text('ok\n'))
 app.route('/auth', authRouter)
 app.route('/api', apiRouter)
+app.route('/console', consoleRouter)

--- a/apps/kpilote-admin/src/server/console/router.ts
+++ b/apps/kpilote-admin/src/server/console/router.ts
@@ -1,10 +1,14 @@
+import { zValidator } from '@hono/zod-validator'
+import { consoleRequestSchema, type ConsoleResponse } from '@pilote/kpilote-shared/console'
 import { Hono } from 'hono'
-import { z } from 'zod'
+import ky from 'ky'
 
-import { mbApiUrlFor } from '@/server/environments'
-import { readSession } from '@/server/session'
+import { kpiloteApiUrlFor } from '@/server/environments'
+import { requireSession } from '@/server/session'
 
-// Rejette toute tentative de traversal / d'URL absolue AVANT la normalisation.
+// Rejette toute tentative de traversal / d'URL absolue AVANT la construction de
+// l'URL cible. Le `path` de l'enveloppe est un chemin pur (la querystring voyage
+// à part), donc aucun `?`/`&` légitime à préserver ici.
 const isSuspicious = (subPath: string): boolean =>
   subPath.includes('..') ||
   subPath.includes('//') ||
@@ -13,64 +17,43 @@ const isSuspicious = (subPath: string): boolean =>
   /%2e/i.test(subPath) ||
   /%2f/i.test(subPath)
 
-// Enveloppe décrivant la requête à forger côté serveur. La méthode et le path
-// voyagent comme des données (pas dans l'URL du BFF), ce qui permet de poser des
-// en-têtes que le `fetch` du navigateur interdirait (Host, Referer…).
-const envelopeSchema = z.object({
-  method: z.enum(['GET', 'POST', 'PUT', 'PATCH', 'DELETE']),
-  path: z.string(),
-  headers: z.array(z.object({ key: z.string(), value: z.string() })).default([]),
-  body: z.string().default(''),
-})
-
 export const consoleRouter = new Hono()
 
 consoleRouter.get('/meta', async (context) => {
-  const session = await readSession(context)
-  if (!session) return context.json({ error: 'unauthorized' }, 401)
+  const session = await requireSession(context)
   return context.json({
     environment: session.environment,
-    baseUrl: mbApiUrlFor(session.environment),
+    baseUrl: kpiloteApiUrlFor(session.environment),
   })
 })
 
 consoleRouter.get('/openapi.json', async (context) => {
-  const session = await readSession(context)
-  if (!session) return context.json({ error: 'unauthorized' }, 401)
-
-  const base = mbApiUrlFor(session.environment).replace(/\/$/, '')
-  const upstream = await fetch(`${base}/openapi.json`, {
-    headers: { Authorization: `Bearer ${session.apiKey}` },
-  })
+  const session = await requireSession(context)
+  // La spec OpenAPI de l'API est publique : pas besoin du token pour la lire.
+  const base = kpiloteApiUrlFor(session.environment).replace(/\/$/, '')
+  const upstream = await ky.get(`${base}/openapi.json`, { throwHttpErrors: false })
   const headers = new Headers({ 'Cache-Control': 'no-store' })
   const contentType = upstream.headers.get('content-type')
   if (contentType) headers.set('content-type', contentType)
   return new Response(upstream.body, { status: upstream.status, headers })
 })
 
-consoleRouter.post('/proxy', async (context) => {
-  const session = await readSession(context)
-  if (!session) return context.json({ error: 'unauthorized' }, 401)
+consoleRouter.post('/proxy', zValidator('json', consoleRequestSchema), async (context) => {
+  const session = await requireSession(context)
+  const { method, path, query, headers: headerPairs, body } = context.req.valid('json')
 
-  const raw: unknown = await context.req.json().catch(() => null)
-  const parsed = envelopeSchema.safeParse(raw)
-  if (!parsed.success) return context.json({ error: 'invalid_request' }, 400)
-  const { method, path, headers: headerPairs, body } = parsed.data
-
-  const queryIndex = path.indexOf('?')
-  const rawPath = queryIndex === -1 ? path : path.slice(0, queryIndex)
-  const search = queryIndex === -1 ? '' : path.slice(queryIndex + 1)
-  const subPath = rawPath.replace(/^\/+/, '')
+  const subPath = path.replace(/^\/+/, '')
   if (isSuspicious(subPath)) return context.json({ error: 'forbidden' }, 403)
 
-  const base = new URL(mbApiUrlFor(session.environment))
+  const base = new URL(kpiloteApiUrlFor(session.environment))
   const basePath = base.pathname.replace(/\/$/, '')
   const url = new URL(`${basePath}/${subPath}`, base)
-  if (search) url.search = search
+  if (query) url.search = query
 
-  // Défense en profondeur : après normalisation, on doit toujours être sur
-  // l'origine de l'environnement sélectionné. Pas d'allowlist de ressources :
-  // les appels arbitraires sont le but, mais bornés à cette origine.
+  // Défense en profondeur : le path est déjà sanitizé (isSuspicious) et la query
+  // ne peut pas changer d'origine, mais comme il n'y a aucune allowlist ici (les
+  // appels arbitraires sont le but), on garde ce filet pour ne jamais relayer le
+  // token vers une autre origine que l'environnement sélectionné.
   if (url.origin !== base.origin) return context.json({ error: 'forbidden' }, 403)
 
   const forwarded = new Headers()
@@ -86,9 +69,11 @@ consoleRouter.post('/proxy', async (context) => {
   forwarded.set('Authorization', `Bearer ${session.apiKey}`)
 
   const start = performance.now()
-  const upstream = await fetch(url, {
+  const upstream = await ky(url, {
     method,
     headers: forwarded,
+    throwHttpErrors: false,
+    retry: 0,
     ...(isBodyless ? {} : { body }),
   })
   const responseBody = await upstream.text()
@@ -102,11 +87,12 @@ consoleRouter.post('/proxy', async (context) => {
   // Le BFF répond toujours 200 : le vrai status de l'API vit dans l'enveloppe.
   // Le timing est mesuré ici (latence réelle de l'appel upstream, hors hop BFF).
   context.header('Cache-Control', 'no-store')
-  return context.json({
+  const payload: ConsoleResponse = {
     status: upstream.status,
     statusText: upstream.statusText,
     headers: responseHeaders,
     durationMs,
     body: responseBody,
-  })
+  }
+  return context.json(payload)
 })

--- a/apps/kpilote-admin/src/server/console/router.ts
+++ b/apps/kpilote-admin/src/server/console/router.ts
@@ -1,20 +1,27 @@
 import { Hono } from 'hono'
+import { z } from 'zod'
 
 import { mbApiUrlFor } from '@/server/environments'
 import { readSession } from '@/server/session'
 
-// En-têtes que le client a le droit de transmettre à l'API cible. `Authorization`
-// est volontairement EXCLU : il est injecté côté serveur et ne doit jamais être
-// pilotable par le navigateur.
-const FORWARDABLE_HEADERS = new Set(['content-type', 'accept', 'x-request-id'])
-
 // Rejette toute tentative de traversal / d'URL absolue AVANT la normalisation.
 const isSuspicious = (subPath: string): boolean =>
   subPath.includes('..') ||
+  subPath.includes('//') ||
   subPath.includes('\\') ||
   subPath.startsWith('/') ||
   /%2e/i.test(subPath) ||
   /%2f/i.test(subPath)
+
+// Enveloppe décrivant la requête à forger côté serveur. La méthode et le path
+// voyagent comme des données (pas dans l'URL du BFF), ce qui permet de poser des
+// en-têtes que le `fetch` du navigateur interdirait (Host, Referer…).
+const envelopeSchema = z.object({
+  method: z.enum(['GET', 'POST', 'PUT', 'PATCH', 'DELETE']),
+  path: z.string(),
+  headers: z.array(z.object({ key: z.string(), value: z.string() })).default([]),
+  body: z.string().default(''),
+})
 
 export const consoleRouter = new Hono()
 
@@ -41,38 +48,65 @@ consoleRouter.get('/openapi.json', async (context) => {
   return new Response(upstream.body, { status: upstream.status, headers })
 })
 
-consoleRouter.all('/proxy/*', async (context) => {
+consoleRouter.post('/proxy', async (context) => {
   const session = await readSession(context)
   if (!session) return context.json({ error: 'unauthorized' }, 401)
 
-  const subPath = context.req.path.replace(/^\/console\/proxy\//, '')
+  const raw: unknown = await context.req.json().catch(() => null)
+  const parsed = envelopeSchema.safeParse(raw)
+  if (!parsed.success) return context.json({ error: 'invalid_request' }, 400)
+  const { method, path, headers: headerPairs, body } = parsed.data
+
+  const queryIndex = path.indexOf('?')
+  const rawPath = queryIndex === -1 ? path : path.slice(0, queryIndex)
+  const search = queryIndex === -1 ? '' : path.slice(queryIndex + 1)
+  const subPath = rawPath.replace(/^\/+/, '')
   if (isSuspicious(subPath)) return context.json({ error: 'forbidden' }, 403)
 
   const base = new URL(mbApiUrlFor(session.environment))
   const basePath = base.pathname.replace(/\/$/, '')
   const url = new URL(`${basePath}/${subPath}`, base)
-  url.search = new URL(context.req.url).search
+  if (search) url.search = search
 
   // Défense en profondeur : après normalisation, on doit toujours être sur
   // l'origine de l'environnement sélectionné. Pas d'allowlist de ressources :
   // les appels arbitraires sont le but, mais bornés à cette origine.
   if (url.origin !== base.origin) return context.json({ error: 'forbidden' }, 403)
 
-  const forwarded = new Headers({ Authorization: `Bearer ${session.apiKey}` })
-  context.req.raw.headers.forEach((value, key) => {
-    if (FORWARDABLE_HEADERS.has(key.toLowerCase())) forwarded.set(key, value)
+  const forwarded = new Headers()
+  for (const { key, value } of headerPairs) {
+    if (key.trim()) forwarded.set(key, value)
+  }
+  const isBodyless = method === 'GET'
+  if (!isBodyless && body && !forwarded.has('content-type')) {
+    forwarded.set('content-type', 'application/json')
+  }
+  // Toujours en dernier : le token est injecté serveur et prime sur toute valeur
+  // fournie par le client (qui ne doit jamais piloter l'Authorization).
+  forwarded.set('Authorization', `Bearer ${session.apiKey}`)
+
+  const start = performance.now()
+  const upstream = await fetch(url, {
+    method,
+    headers: forwarded,
+    ...(isBodyless ? {} : { body }),
+  })
+  const responseBody = await upstream.text()
+  const durationMs = Math.round(performance.now() - start)
+
+  const responseHeaders: Record<string, string> = {}
+  upstream.headers.forEach((value, key) => {
+    responseHeaders[key] = value
   })
 
-  const isBodyless = context.req.method === 'GET' || context.req.method === 'HEAD'
-  const init: RequestInit = {
-    method: context.req.method,
-    headers: forwarded,
-    ...(isBodyless ? {} : { body: await context.req.text() }),
-  }
-
-  const upstream = await fetch(url, init)
-  const headers = new Headers({ 'Cache-Control': 'no-store' })
-  const contentType = upstream.headers.get('content-type')
-  if (contentType) headers.set('content-type', contentType)
-  return new Response(upstream.body, { status: upstream.status, headers })
+  // Le BFF répond toujours 200 : le vrai status de l'API vit dans l'enveloppe.
+  // Le timing est mesuré ici (latence réelle de l'appel upstream, hors hop BFF).
+  context.header('Cache-Control', 'no-store')
+  return context.json({
+    status: upstream.status,
+    statusText: upstream.statusText,
+    headers: responseHeaders,
+    durationMs,
+    body: responseBody,
+  })
 })

--- a/apps/kpilote-admin/src/server/console/router.ts
+++ b/apps/kpilote-admin/src/server/console/router.ts
@@ -1,0 +1,78 @@
+import { Hono } from 'hono'
+
+import { mbApiUrlFor } from '@/server/environments'
+import { readSession } from '@/server/session'
+
+// En-têtes que le client a le droit de transmettre à l'API cible. `Authorization`
+// est volontairement EXCLU : il est injecté côté serveur et ne doit jamais être
+// pilotable par le navigateur.
+const FORWARDABLE_HEADERS = new Set(['content-type', 'accept', 'x-request-id'])
+
+// Rejette toute tentative de traversal / d'URL absolue AVANT la normalisation.
+const isSuspicious = (subPath: string): boolean =>
+  subPath.includes('..') ||
+  subPath.includes('\\') ||
+  subPath.startsWith('/') ||
+  /%2e/i.test(subPath) ||
+  /%2f/i.test(subPath)
+
+export const consoleRouter = new Hono()
+
+consoleRouter.get('/meta', async (context) => {
+  const session = await readSession(context)
+  if (!session) return context.json({ error: 'unauthorized' }, 401)
+  return context.json({
+    environment: session.environment,
+    baseUrl: mbApiUrlFor(session.environment),
+  })
+})
+
+consoleRouter.get('/openapi.json', async (context) => {
+  const session = await readSession(context)
+  if (!session) return context.json({ error: 'unauthorized' }, 401)
+
+  const base = mbApiUrlFor(session.environment).replace(/\/$/, '')
+  const upstream = await fetch(`${base}/openapi.json`, {
+    headers: { Authorization: `Bearer ${session.apiKey}` },
+  })
+  const headers = new Headers({ 'Cache-Control': 'no-store' })
+  const contentType = upstream.headers.get('content-type')
+  if (contentType) headers.set('content-type', contentType)
+  return new Response(upstream.body, { status: upstream.status, headers })
+})
+
+consoleRouter.all('/proxy/*', async (context) => {
+  const session = await readSession(context)
+  if (!session) return context.json({ error: 'unauthorized' }, 401)
+
+  const subPath = context.req.path.replace(/^\/console\/proxy\//, '')
+  if (isSuspicious(subPath)) return context.json({ error: 'forbidden' }, 403)
+
+  const base = new URL(mbApiUrlFor(session.environment))
+  const basePath = base.pathname.replace(/\/$/, '')
+  const url = new URL(`${basePath}/${subPath}`, base)
+  url.search = new URL(context.req.url).search
+
+  // Défense en profondeur : après normalisation, on doit toujours être sur
+  // l'origine de l'environnement sélectionné. Pas d'allowlist de ressources :
+  // les appels arbitraires sont le but, mais bornés à cette origine.
+  if (url.origin !== base.origin) return context.json({ error: 'forbidden' }, 403)
+
+  const forwarded = new Headers({ Authorization: `Bearer ${session.apiKey}` })
+  context.req.raw.headers.forEach((value, key) => {
+    if (FORWARDABLE_HEADERS.has(key.toLowerCase())) forwarded.set(key, value)
+  })
+
+  const isBodyless = context.req.method === 'GET' || context.req.method === 'HEAD'
+  const init: RequestInit = {
+    method: context.req.method,
+    headers: forwarded,
+    ...(isBodyless ? {} : { body: await context.req.text() }),
+  }
+
+  const upstream = await fetch(url, init)
+  const headers = new Headers({ 'Cache-Control': 'no-store' })
+  const contentType = upstream.headers.get('content-type')
+  if (contentType) headers.set('content-type', contentType)
+  return new Response(upstream.body, { status: upstream.status, headers })
+})

--- a/apps/kpilote-admin/src/server/environments.ts
+++ b/apps/kpilote-admin/src/server/environments.ts
@@ -12,4 +12,5 @@ const URL_BY_ENVIRONMENT: Record<Environment, string> = {
   prod: serverEnv.API_BASE_URL_PROD,
 }
 
-export const mbApiUrlFor = (environment: Environment): string => URL_BY_ENVIRONMENT[environment]
+export const kpiloteApiUrlFor = (environment: Environment): string =>
+  URL_BY_ENVIRONMENT[environment]

--- a/apps/kpilote-admin/src/server/mbApi.ts
+++ b/apps/kpilote-admin/src/server/mbApi.ts
@@ -1,7 +1,7 @@
 import ky, { HTTPError } from 'ky'
 
 import type { Environment } from '@/server/environments'
-import { mbApiUrlFor } from '@/server/environments'
+import { kpiloteApiUrlFor } from '@/server/environments'
 
 export type WhoamiResult = { kind: 'user' | 'apiKey'; label: string }
 
@@ -11,7 +11,7 @@ export const fetchWhoami = async (
 ): Promise<WhoamiResult | null> => {
   try {
     const json = await ky
-      .get(`${mbApiUrlFor(environment)}/auth/whoami`, {
+      .get(`${kpiloteApiUrlFor(environment)}/auth/whoami`, {
         headers: { Authorization: `Bearer ${apiKey}` },
         retry: 0,
         timeout: 5000,

--- a/apps/kpilote-admin/src/server/session.ts
+++ b/apps/kpilote-admin/src/server/session.ts
@@ -1,5 +1,6 @@
 import type { Context } from 'hono'
 import { deleteCookie, getCookie, setCookie } from 'hono/cookie'
+import { HTTPException } from 'hono/http-exception'
 import { sealData, unsealData } from 'iron-session'
 
 import { serverEnv } from '@/server/env'
@@ -44,6 +45,14 @@ export const readSession = async (context: Context): Promise<AdminSession | null
 
 export const clearSession = (context: Context) => {
   deleteCookie(context, SESSION_COOKIE, { path: '/' })
+}
+
+// Garde de session : renvoie la session ou court-circuite le handler avec une 401
+// générique. Évite de répéter le `if (!session) return 401` dans chaque route.
+export const requireSession = async (context: Context): Promise<AdminSession> => {
+  const session = await readSession(context)
+  if (!session) throw new HTTPException(401, { message: 'unauthorized' })
+  return session
 }
 
 // Coffre des clés validées, par environnement. Cookie chiffré httpOnly : la clé

--- a/apps/kpilote-admin/vite.config.ts
+++ b/apps/kpilote-admin/vite.config.ts
@@ -19,7 +19,7 @@ export default defineConfig({
         /^\/@.+$/,
         /.*\.(ts|tsx|js|jsx|css|svg|png|jpg|jpeg|gif|webp|woff2?)($|\?)/,
         /^\/(public|assets|static|src|node_modules)\/.+/,
-        /^\/(?!auth(\/|$)|healthz(\/|$)|api(\/|$)).*/,
+        /^\/(?!auth(\/|$)|healthz(\/|$)|api(\/|$)|console(\/|$)).*/,
       ],
     }),
   ],

--- a/apps/kpilote-admin/vite.config.ts
+++ b/apps/kpilote-admin/vite.config.ts
@@ -19,7 +19,9 @@ export default defineConfig({
         /^\/@.+$/,
         /.*\.(ts|tsx|js|jsx|css|svg|png|jpg|jpeg|gif|webp|woff2?)($|\?)/,
         /^\/(public|assets|static|src|node_modules)\/.+/,
-        /^\/(?!auth(\/|$)|healthz(\/|$)|api(\/|$)|console(\/|$)).*/,
+        // `console\/.` : on forwarde `/console/<sous-chemin>` (meta, openapi, proxy)
+        // vers Hono, mais pas le `/console` nu qui est une route SPA (sinon F5 → 404).
+        /^\/(?!auth(\/|$)|healthz(\/|$)|api(\/|$)|console\/.).*/,
       ],
     }),
   ],

--- a/apps/kpilote-api/package.json
+++ b/apps/kpilote-api/package.json
@@ -11,7 +11,7 @@
     "node": "24.9.0"
   },
   "scripts": {
-    "dev": "portless run vite",
+    "dev": "portless kpilote-api.modernisation vite",
     "deploy:prepare": "bash deploy-prepare.sh",
     "build": "prisma migrate deploy && prisma generate --sql && prisma db seed && vite build",
     "deploy:bundle": "bash deploy-bundle.sh",

--- a/apps/kpilote-webapp/package.json
+++ b/apps/kpilote-webapp/package.json
@@ -11,7 +11,7 @@
     "node": "24.9.0"
   },
   "scripts": {
-    "dev": "portless run vite",
+    "dev": "portless kpilote.modernisation vite",
     "deploy:prepare": "bash deploy-prepare.sh",
     "routes:generate": "tsr generate",
     "build": "rm -rf dist && tsr generate && tsc --noEmit && vite build && vite build -c vite.server.config.ts",

--- a/packages/kpilote-shared/package.json
+++ b/packages/kpilote-shared/package.json
@@ -24,6 +24,10 @@
       "types": "./src/commentaire.ts",
       "default": "./src/commentaire.ts"
     },
+    "./console": {
+      "types": "./src/console.ts",
+      "default": "./src/console.ts"
+    },
     "./niveauConfiance": {
       "types": "./src/niveauConfiance.ts",
       "default": "./src/niveauConfiance.ts"

--- a/packages/kpilote-shared/src/console.ts
+++ b/packages/kpilote-shared/src/console.ts
@@ -1,0 +1,44 @@
+import { z } from 'zod'
+
+// Contrat de la Console API admin, partagé front/back pour un appel type-safe.
+// L'enveloppe décrit la requête à forger côté serveur : la méthode et le path
+// voyagent comme des données (pas dans l'URL du BFF), ce qui permet de poser des
+// en-têtes que le `fetch` du navigateur interdirait (Host, Referer…). Le token
+// n'est jamais exposé au client : il est injecté serveur.
+
+export const HTTP_METHODS = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'] as const
+export const httpMethodSchema = z.enum(HTTP_METHODS)
+export type HttpMethod = z.infer<typeof httpMethodSchema>
+
+export const consoleHeaderPairSchema = z.object({
+  key: z.string(),
+  value: z.string(),
+})
+export type HeaderPair = z.infer<typeof consoleHeaderPairSchema>
+
+// `path` = chemin pur (sans querystring) ; `query` = querystring brute (sans `?`).
+// Les deux sont séparés à la source pour éviter tout re-parsing bricolé côté
+// serveur : le path est sanitizé tel quel, la query est posée via `url.search`.
+export const consoleRequestSchema = z.object({
+  method: httpMethodSchema,
+  path: z.string(),
+  query: z.string().default(''),
+  headers: z.array(consoleHeaderPairSchema).default([]),
+  body: z.string().default(''),
+})
+export type ConsoleRequest = z.infer<typeof consoleRequestSchema>
+
+export const consoleResponseSchema = z.object({
+  status: z.number(),
+  statusText: z.string(),
+  headers: z.record(z.string(), z.string()),
+  durationMs: z.number(),
+  body: z.string(),
+})
+export type ConsoleResponse = z.infer<typeof consoleResponseSchema>
+
+export const consoleMetaSchema = z.object({
+  environment: z.string(),
+  baseUrl: z.string(),
+})
+export type ConsoleMeta = z.infer<typeof consoleMetaSchema>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,18 @@ importers:
 
   apps/kpilote-admin:
     dependencies:
+      '@codemirror/lang-json':
+        specifier: ^6.0.2
+        version: 6.0.2
+      '@codemirror/lint':
+        specifier: ^6.9.7
+        version: 6.9.7
+      '@codemirror/state':
+        specifier: ^6.7.0
+        version: 6.7.0
+      '@codemirror/view':
+        specifier: ^6.43.4
+        version: 6.43.4
       '@hono/node-server':
         specifier: '>=1.19.13'
         version: 1.19.14(hono@4.12.19)
@@ -45,6 +57,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      codemirror:
+        specifier: ^6.0.2
+        version: 6.0.2
       dotenv:
         specifier: 16.4.5
         version: 16.4.5
@@ -1142,6 +1157,30 @@ packages:
   '@chevrotain/types@11.1.2':
     resolution: {integrity: sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==}
 
+  '@codemirror/autocomplete@6.20.3':
+    resolution: {integrity: sha512-tlosUqb+3BbxCxZdu4tKeRghPFC+QM7q4X5YhKV2eCmPG+1r2F3f4AaSz5sCrFqUtX4Jh20VFTKecl16MgiV9g==}
+
+  '@codemirror/commands@6.10.4':
+    resolution: {integrity: sha512-Ryk9y9T0FFVF0cUGhAknveAyUOl/A1qReTFi+qPKtOh2Z9F4AUBz3XOrYD4ZEgZirdugVzHvd/2/Wcwy5OliTg==}
+
+  '@codemirror/lang-json@6.0.2':
+    resolution: {integrity: sha512-x2OtO+AvwEHrEwR0FyyPtfDUiloG3rnVTSZV1W8UteaLL8/MajQd8DpvUb2YVzC+/T18aSDv0H9mu+xw0EStoQ==}
+
+  '@codemirror/language@6.12.4':
+    resolution: {integrity: sha512-1q4PaT+o6PbgpkJt4Q8Fv5XJxTy4FUZ4MWETtyiDw3J0Pyr9E2vqcKL+k9wcvjNTIsauxvE7OfmWj3FRPHQ76A==}
+
+  '@codemirror/lint@6.9.7':
+    resolution: {integrity: sha512-28/+iWLYxKxsvGYhSYL7zaCZqLz5+FFFDq9tVsvGv9kv8RY4fFAchJ5WX9M3YrrRlTIsECjsXPqeNgnSmNP2dg==}
+
+  '@codemirror/search@6.7.1':
+    resolution: {integrity: sha512-uMe5UO6PamJtSHrXhhHOzSX3ReWtiJrva6GnPMwSOrZtiExb5X5eExhr2OUZQVvdxPsKpY3Ro2mFbQadpPWmHA==}
+
+  '@codemirror/state@6.7.0':
+    resolution: {integrity: sha512-Zbl9NyscLMZkfXPQnNAIIAFftidrA1UbcJEIMp24C0Bukc2I5T8wJS0wsXYsnDOqCFJUeJ1BITGNs5CqPDSmSg==}
+
+  '@codemirror/view@6.43.4':
+    resolution: {integrity: sha512-YImu23iyKfncJzT7sRy+rEqEhSc8RhOHqDxwy4WzXRKJwYm6iwf/9OJk5ctCAdZ6yi2ZqaGEvmf55fSVqMDrgg==}
+
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
@@ -2050,6 +2089,21 @@ packages:
 
   '@kurkle/color@0.3.4':
     resolution: {integrity: sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==}
+
+  '@lezer/common@1.5.2':
+    resolution: {integrity: sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==}
+
+  '@lezer/highlight@1.2.3':
+    resolution: {integrity: sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==}
+
+  '@lezer/json@1.0.3':
+    resolution: {integrity: sha512-BP9KzdF9Y35PDpv04r0VeSTKDeox5vVr3efE7eBbx3r4s3oNLfunchejZhjArmeieBH+nVOpgIiBJpEAv8ilqQ==}
+
+  '@lezer/lr@1.4.10':
+    resolution: {integrity: sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==}
+
+  '@marijn/find-cluster-break@1.0.3':
+    resolution: {integrity: sha512-FY+MKLBoTsLNJF/eLWaOsXGdz6uh3Iu1axjPf6TUq92IYumcTcXWHoS747JARLkcdlJ/Waiaxc5wQfFO8jC6NA==}
 
   '@mdx-js/mdx@3.1.1':
     resolution: {integrity: sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==}
@@ -5008,6 +5062,9 @@ packages:
 
   code-block-writer@13.0.3:
     resolution: {integrity: sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==}
+
+  codemirror@6.0.2:
+    resolution: {integrity: sha512-VhydHotNW5w1UGK0Qj96BwSk/Zqbp9WbnyK2W/eVMv4QyF41INRGpjUhFJY7/uDNuudSc33a/PKr4iDqRduvHw==}
 
   codepage@1.15.0:
     resolution: {integrity: sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==}
@@ -8763,6 +8820,9 @@ packages:
   strnum@2.2.3:
     resolution: {integrity: sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==}
 
+  style-mod@4.1.3:
+    resolution: {integrity: sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==}
+
   style-to-js@1.1.21:
     resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
 
@@ -9900,6 +9960,57 @@ snapshots:
 
   '@chevrotain/types@11.1.2': {}
 
+  '@codemirror/autocomplete@6.20.3':
+    dependencies:
+      '@codemirror/language': 6.12.4
+      '@codemirror/state': 6.7.0
+      '@codemirror/view': 6.43.4
+      '@lezer/common': 1.5.2
+
+  '@codemirror/commands@6.10.4':
+    dependencies:
+      '@codemirror/language': 6.12.4
+      '@codemirror/state': 6.7.0
+      '@codemirror/view': 6.43.4
+      '@lezer/common': 1.5.2
+
+  '@codemirror/lang-json@6.0.2':
+    dependencies:
+      '@codemirror/language': 6.12.4
+      '@lezer/json': 1.0.3
+
+  '@codemirror/language@6.12.4':
+    dependencies:
+      '@codemirror/state': 6.7.0
+      '@codemirror/view': 6.43.4
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+      style-mod: 4.1.3
+
+  '@codemirror/lint@6.9.7':
+    dependencies:
+      '@codemirror/state': 6.7.0
+      '@codemirror/view': 6.43.4
+      crelt: 1.0.6
+
+  '@codemirror/search@6.7.1':
+    dependencies:
+      '@codemirror/state': 6.7.0
+      '@codemirror/view': 6.43.4
+      crelt: 1.0.6
+
+  '@codemirror/state@6.7.0':
+    dependencies:
+      '@marijn/find-cluster-break': 1.0.3
+
+  '@codemirror/view@6.43.4':
+    dependencies:
+      '@codemirror/state': 6.7.0
+      crelt: 1.0.6
+      style-mod: 4.1.3
+      w3c-keyname: 2.2.8
+
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
@@ -10656,6 +10767,24 @@ snapshots:
       url-template: 3.1.1
 
   '@kurkle/color@0.3.4': {}
+
+  '@lezer/common@1.5.2': {}
+
+  '@lezer/highlight@1.2.3':
+    dependencies:
+      '@lezer/common': 1.5.2
+
+  '@lezer/json@1.0.3':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/lr@1.4.10':
+    dependencies:
+      '@lezer/common': 1.5.2
+
+  '@marijn/find-cluster-break@1.0.3': {}
 
   '@mdx-js/mdx@3.1.1':
     dependencies:
@@ -14020,6 +14149,16 @@ snapshots:
       - '@types/react-dom'
 
   code-block-writer@13.0.3: {}
+
+  codemirror@6.0.2:
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/commands': 6.10.4
+      '@codemirror/language': 6.12.4
+      '@codemirror/lint': 6.9.7
+      '@codemirror/search': 6.7.1
+      '@codemirror/state': 6.7.0
+      '@codemirror/view': 6.43.4
 
   codepage@1.15.0: {}
 
@@ -18729,6 +18868,8 @@ snapshots:
   strip-json-comments@5.0.3: {}
 
   strnum@2.2.3: {}
+
+  style-mod@4.1.3: {}
 
   style-to-js@1.1.21:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,6 +36,9 @@ importers:
       '@hono/node-server':
         specifier: '>=1.19.13'
         version: 1.19.14(hono@4.12.19)
+      '@hono/zod-validator':
+        specifier: ^0.7.6
+        version: 0.7.6(hono@4.12.19)(zod@4.3.6)
       '@hookform/resolvers':
         specifier: ^5.4.0
         version: 5.4.0(react-hook-form@7.79.0(react@19.2.5))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      cmdk:
+        specifier: ^1.1.1
+        version: 1.1.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       codemirror:
         specifier: ^6.0.2
         version: 6.0.2


### PR DESCRIPTION
## Contexte

Ajoute un écran **Console API** dans `kpilote-admin` : un mini-client HTTP intégré pour faire des appels arbitraires vers `kpilote-api`, déjà authentifié sur l'environnement de la session (local / dev / prod). Pratique pour le debug et le support.

## Fonctionnement

- **Proxy BFF `/console/*`** : le navigateur ne connaît jamais le token. Il POST une **enveloppe** `{ method, path, headers, body }` sur `/console/proxy` ; le serveur forge l'appel upstream, injecte `Authorization` côté serveur (prime toujours sur toute valeur cliente) et borne l'appel à l'origine de l'environnement sélectionné (revalidation `origin`, anti-traversal).
- **Réponse enveloppée** : `{ status, statusText, headers, durationMs, body }`, le **timing est mesuré côté serveur** (latence réelle de l'API).
- **Picker OpenAPI hybride** : `/console/openapi.json` alimente une recherche d'endpoints qui pré-remplit method + path + exemple de body ; l'URL/method restent librement éditables (appels hors-spec possibles).
- **Éditeur JSON CodeMirror 6** : pretty-format, fold des brackets, lint. Onglet Body masqué en GET.
- **Éditeur de headers** custom (l'`Authorization` reste injecté serveur).
- **Panneau réponse** : status + statusText + timing, headers repliables, body foldé, bouton copier, scroll auto à l'arrivée.
- **Historique** des N derniers appels (localStorage), restaurables.
- **Export curl** avec placeholder `$API_KEY` (jamais le vrai secret), URL pointée sur l'env réel.
- **Garde-fou prod** : les mutations (POST/PUT/PATCH/DELETE) sur prod sont bloquées tant que le déverrouillage prod n'est pas fait (réutilise `useProdEditUnlock`).

## Sécurité

- Token injecté serveur, jamais exposé au navigateur ; curl avec placeholder.
- Proxy borné à l'origine de l'env sélectionné, `Authorization` non surchargeable par le client.
- Gating par rôle délégué à l'API (401/403 remontés proprement) — page ouverte à toute session authentifiée, cohérent avec le reste de l'admin.

## Notes

- L'accès à `/console` est ouvert à toute session authentifiée (le gating fin vit dans l'API).
- Le proxy lit la réponse en texte : parfait pour du JSON, une réponse binaire serait abîmée (hors périmètre debug).
- Pas de tests unitaires : `kpilote-admin` n'a pas de harnais de test ; vérification par `tsc --noEmit` + eslint + prettier + build.

## Vérification

- `pnpm --filter @pilote/kpilote-admin run lint` ✅
- `pnpm --filter @pilote/kpilote-admin run build` ✅
- Test manuel : F5 sur `/console`, GET, POST avec body, affichage status/timing, export curl, garde-fou prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
