### PR TITLE
feat(home): rediriger vers /indicateurs si l'utilisateur est connecté

### DIFF
--- a/apps/kpilote-webapp/src/routes/index.tsx
+++ b/apps/kpilote-webapp/src/routes/index.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute, Link } from '@tanstack/react-router'
+import { createFileRoute, Link, redirect } from '@tanstack/react-router'
 import { ArrowRight, BarChart3, ShoppingBasket } from 'lucide-react'
 import type { ReactNode } from 'react'
 
@@ -7,6 +7,11 @@ import { Section } from '@/components/ui/Section'
 import { Heading, Text } from '@/components/ui/Typography'
 
 export const Route = createFileRoute('/')({
+  beforeLoad: ({ context }) => {
+    if (context.auth.isAuthenticated) {
+      throw redirect({ to: '/indicateurs', search: {} })
+    }
+  },
   component: HomeComponent,
 })
 

--- a/apps/kpilote-webapp/src/tests/routing.test.tsx
+++ b/apps/kpilote-webapp/src/tests/routing.test.tsx
@@ -64,6 +64,13 @@ describe('routing', () => {
     })
   })
 
+  it("redirige vers /indicateurs si l'utilisateur est authentifié et accède à /", async () => {
+    renderAt('/', stubAuth({ userId: 'sub-1', prenom: 'Admin', nom: 'DITP' }))
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { level: 1, name: 'Tableau de bord' })).toBeInTheDocument()
+    })
+  })
+
   it('ne rend pas /indicateurs sans être authentifié (le beforeLoad bloque le rendu)', async () => {
     renderAt('/indicateurs', stubAuth(null))
     await new Promise((resolve) => setTimeout(resolve, 50))


### PR DESCRIPTION
## Contexte

La page d'accueil (`/`) est une landing destinée aux visiteurs non connectés. Un utilisateur déjà authentifié n'a pas de raison de la voir.

## Changements

- Ajout d'un `beforeLoad` sur la route `/` qui redirige vers `/indicateurs` si `auth.isAuthenticated` est `true`
- La landing reste accessible normalement pour les visiteurs non connectés