### PR TITLE
feat(admin): rediriger vers /fonctionnalites si une session est active

### DIFF
--- a/apps/kpilote-admin/src/routes/cle.$environment.tsx
+++ b/apps/kpilote-admin/src/routes/cle.$environment.tsx
@@ -11,8 +11,9 @@ const isEnvironment = (value: string): value is Environment =>
   value === 'local' || value === 'dev' || value === 'prod'
 
 export const Route = createFileRoute('/cle/$environment')({
-  beforeLoad: ({ params }) => {
+  beforeLoad: ({ params, context }) => {
     if (!isEnvironment(params.environment)) throw redirect({ to: '/' })
+    if (context.session.current) throw redirect({ to: '/fonctionnalites' })
   },
   component: KeyComponent,
 })

--- a/apps/kpilote-admin/src/routes/index.tsx
+++ b/apps/kpilote-admin/src/routes/index.tsx
@@ -1,11 +1,16 @@
-import { createFileRoute, useNavigate } from '@tanstack/react-router'
+import { createFileRoute, redirect, useNavigate } from '@tanstack/react-router'
 import { FlaskConical, Laptop, Siren } from 'lucide-react'
 
 import { BarCard } from '@/components/ui/BarCard'
 import { FadeIn } from '@/components/ui/FadeIn'
 import type { Environment } from '@/session'
 
-export const Route = createFileRoute('/')({ component: LandingComponent })
+export const Route = createFileRoute('/')({
+  beforeLoad: ({ context }) => {
+    if (context.session.current) throw redirect({ to: '/fonctionnalites' })
+  },
+  component: LandingComponent,
+})
 
 function LandingComponent() {
   const navigate = useNavigate()


### PR DESCRIPTION
## Contexte

Sur kpilote-admin, un utilisateur avec une session active (clé API valide, cookie 8h) voyait quand même le picker d'environnement et l'écran de saisie de clé à chaque visite.

## Changements

- `beforeLoad` sur `/` : redirige vers `/fonctionnalites` si `session.current` est non nul
- `beforeLoad` sur `/cle/$environment` : même logique, en plus de la validation d'env existante

Le bouton "Changer d'environnement" dans le header passe par `session.logout()` avant de revenir sur `/`, donc le flow de changement d'env reste intact.