### PR TITLE
feature(PIL-1657): nav primaire DSFR + titres bleu marianne

### DIFF
--- a/apps/kpilote-webapp/src/routes/_authenticated/indicateurs/$id.tsx
+++ b/apps/kpilote-webapp/src/routes/_authenticated/indicateurs/$id.tsx
@@ -148,26 +148,7 @@ function IndicateurDetailComponent() {
   const referentielNom = indicateur.referentiels.find((c) => c.id === referentielId)?.nom ?? null
 
   return (
-    <Page
-      title={indicateur.nom}
-      back={back}
-      actions={actionsFiche}
-      stickybar={
-        <div className="max-w-md">
-          <FieldIndividuSelect
-            referentielIds={referentielIds}
-            value={individuId}
-            onChange={({ individu, referentiel }) => {
-              startTransition(() => {
-                void navigate({
-                  search: (prev) => ({ ...prev, individu, referentiel }),
-                })
-              })
-            }}
-          />
-        </div>
-      }
-    >
+    <Page title={indicateur.nom} back={back} actions={actionsFiche}>
       <Tabs
         value={search.onglet}
         onValueChange={(onglet) => {
@@ -178,21 +159,38 @@ function IndicateurDetailComponent() {
       >
         <TabsList>
           <TabsTrigger value="resultats">Résultats</TabsTrigger>
-          <TabsTrigger value="metadonnees">Métadonnées</TabsTrigger>
+          <TabsTrigger value="metadonnees">Informations sur l'indicateur</TabsTrigger>
         </TabsList>
 
         <TabsContent value="resultats">
-          <IndicateurResultatsTab
-            indicateurId={id}
-            individuId={individuId}
-            referentielId={referentielId}
-            unite={indicateur.unite}
-            referentielNom={referentielNom}
-            sousOnglet={search.sousOnglet}
-            onSousOngletChange={(sousOnglet) => {
-              void navigate({ search: (prev) => ({ ...prev, sousOnglet }) })
-            }}
-          />
+          <div className="flex flex-col gap-8">
+            {/* Sélecteur d'individu propre à l'onglet Résultats : positionné sous la
+                navigation primaire et masqué sur l'onglet Informations. */}
+            <div className="max-w-md">
+              <FieldIndividuSelect
+                referentielIds={referentielIds}
+                value={individuId}
+                onChange={({ individu, referentiel }) => {
+                  startTransition(() => {
+                    void navigate({
+                      search: (prev) => ({ ...prev, individu, referentiel }),
+                    })
+                  })
+                }}
+              />
+            </div>
+            <IndicateurResultatsTab
+              indicateurId={id}
+              individuId={individuId}
+              referentielId={referentielId}
+              unite={indicateur.unite}
+              referentielNom={referentielNom}
+              sousOnglet={search.sousOnglet}
+              onSousOngletChange={(sousOnglet) => {
+                void navigate({ search: (prev) => ({ ...prev, sousOnglet }) })
+              }}
+            />
+          </div>
         </TabsContent>
 
         <TabsContent value="metadonnees">

--- a/apps/kpilote-webapp/src/routes/_authenticated/paniers/$id.tsx
+++ b/apps/kpilote-webapp/src/routes/_authenticated/paniers/$id.tsx
@@ -118,28 +118,7 @@ function PanierDetailComponent() {
       : undefined
 
   return (
-    <Page
-      title={panier.nom}
-      description={panier.description ?? undefined}
-      back={back}
-      stickybar={
-        search.individu ? (
-          <div className="max-w-md">
-            <FieldIndividuSelect
-              referentielIds={referentielIds}
-              value={search.individu}
-              onChange={({ individu, referentiel }) => {
-                startTransition(() => {
-                  void navigate({
-                    search: (prev) => ({ ...prev, individu, referentiel }),
-                  })
-                })
-              }}
-            />
-          </div>
-        ) : undefined
-      }
-    >
+    <Page title={panier.nom} description={panier.description ?? undefined} back={back}>
       <Tabs
         value={search.onglet}
         onValueChange={(onglet) => {
@@ -158,9 +137,26 @@ function PanierDetailComponent() {
         <TabsContent value="resultats">
           <div className="flex flex-col gap-6">
             {search.individu && (
-              <div className="max-w-xs">
-                <PanierTauxProgression panierId={id} individu={search.individu} />
-              </div>
+              <>
+                {/* Sélecteur d'individu propre à l'onglet Résultats : positionné sous
+                    la navigation primaire et masqué sur les autres onglets. */}
+                <div className="max-w-md">
+                  <FieldIndividuSelect
+                    referentielIds={referentielIds}
+                    value={search.individu}
+                    onChange={({ individu, referentiel }) => {
+                      startTransition(() => {
+                        void navigate({
+                          search: (prev) => ({ ...prev, individu, referentiel }),
+                        })
+                      })
+                    }}
+                  />
+                </div>
+                <div className="max-w-xs">
+                  <PanierTauxProgression panierId={id} individu={search.individu} />
+                </div>
+              </>
             )}
 
             <Text as="span" variant="kicker" tone="muted">

--- a/packages/kpilote-ui/src/Page.tsx
+++ b/packages/kpilote-ui/src/Page.tsx
@@ -5,6 +5,7 @@ import { Heading, Text } from './Typography'
 type PageProps = {
   kicker?: ReactNode
   title: ReactNode
+  titleTone?: 'neutral' | 'primary'
   description?: ReactNode
   back?: ReactNode
   actions?: ReactNode
@@ -15,6 +16,7 @@ type PageProps = {
 export function Page({
   kicker,
   title,
+  titleTone = 'primary',
   description,
   back,
   actions,
@@ -31,7 +33,7 @@ export function Page({
               {kicker}
             </Text>
           )}
-          <Heading as="h1" size="display-lg" className="text-balance">
+          <Heading as="h1" size="display-lg" tone={titleTone} className="text-balance">
             {title}
           </Heading>
           {description && (

--- a/packages/kpilote-ui/src/Tabs.tsx
+++ b/packages/kpilote-ui/src/Tabs.tsx
@@ -8,7 +8,7 @@ export const Tabs = TabsPrimitive.Root
 export function TabsList({ className, ...props }: ComponentProps<typeof TabsPrimitive.List>) {
   return (
     <TabsPrimitive.List
-      className={clsxm('flex gap-1 border-b border-border', className)}
+      className={clsxm('relative z-10 flex flex-wrap items-end gap-1', className)}
       {...props}
     />
   )
@@ -18,10 +18,16 @@ export function TabsTrigger({ className, ...props }: ComponentProps<typeof TabsP
   return (
     <TabsPrimitive.Trigger
       className={clsxm(
-        '-mb-px inline-flex items-center border-b-2 border-transparent px-4 py-3 text-sm font-medium text-text-muted transition-colors',
-        'hover:text-text',
-        'focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary focus-visible:rounded-sm',
-        'data-[state=active]:border-primary data-[state=active]:text-primary data-[state=active]:font-semibold',
+        // Onglet DSFR : bouton « dossier » bordé, coins hauts arrondis. Le -mb-px
+        // fait chevaucher la bordure du panneau pour connecter l'onglet actif.
+        '-mb-px inline-flex items-center gap-2 whitespace-nowrap rounded-t-md px-4 py-2.5 text-base font-bold transition-colors',
+        'border border-border border-t-2 border-t-transparent',
+        'focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary',
+        // Inactif : fond bleu clair (bleu France « low »), texte foncé.
+        'bg-primary-tinted text-text hover:bg-primary/10',
+        // Actif : fond de la surface, texte + trait haut bleu marianne, bordure
+        // basse masquée pour se fondre dans le panneau de contenu.
+        'data-[state=active]:border-t-primary data-[state=active]:border-b-surface data-[state=active]:bg-surface data-[state=active]:text-primary',
         className,
       )}
       {...props}
@@ -32,7 +38,10 @@ export function TabsTrigger({ className, ...props }: ComponentProps<typeof TabsP
 export function TabsContent({ className, ...props }: ComponentProps<typeof TabsPrimitive.Content>) {
   return (
     <TabsPrimitive.Content
-      className={clsxm('pt-8 focus-visible:outline-none', className)}
+      className={clsxm(
+        'rounded-b-md border border-border bg-surface p-6 focus-visible:outline-none',
+        className,
+      )}
       {...props}
     />
   )


### PR DESCRIPTION
## PIL-1657 — [Indicateur & Paniers] Navigation primaire → intégrer les maquettes

Rapproche les pages **Indicateur** et **Panier** des maquettes, en s'appuyant sur le composant partagé `@pilote/kpilote-ui`.

### Changements

- **Onglets au design DSFR** (`packages/kpilote-ui/src/Tabs.tsx`) — restylage du composant `Tabs` partagé selon le [composant Onglet du DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/onglet) :
  - onglet inactif sur fond bleu clair (`primary-tinted`) + texte foncé
  - onglet actif sur fond blanc + texte bleu marianne + liseré 2px bleu marianne en haut, connecté au panneau de contenu bordé
  - s'applique à la nav primaire (indicateur + panier) **et** aux sous-onglets Résultats
- **Titre de page en bleu marianne par défaut** (`packages/kpilote-ui/src/Page.tsx`) — via le composant de typographie `Heading` ; nouvelle prop `titleTone` (défaut `primary`, opt-out possible). Homogène sur les fiches **et** le Tableau de bord.
- **Renommage** de l'onglet « Métadonnées » → **« Informations sur l'indicateur »** (page indicateur).
- **Sélecteur d'individu** déplacé de la stickybar vers l'intérieur de l'onglet **Résultats** (indicateur + panier) → positionné sous la navigation primaire et visible **uniquement** sur Résultats.

### Portée

| Fichier | Objet |
|---|---|
| `packages/kpilote-ui/src/Tabs.tsx` | onglets DSFR |
| `packages/kpilote-ui/src/Page.tsx` | titre bleu marianne par défaut |
| `apps/kpilote-webapp/.../indicateurs/$id.tsx` | renommage onglet + sélecteur individu |
| `apps/kpilote-webapp/.../paniers/$id.tsx` | sélecteur individu |

### Vérifications

- `pnpm -F @pilote/kpilote-webapp lint` : eslint + `tsc --noEmit` + prettier ✅
- Testé en local (webapp) : rendu des onglets, titres et sélecteur conformes.