### PR TITLE
refactor(PIL-1658): couleurs & typo de la valeur d'avancement (maquettes)

### DIFF
--- a/apps/kpilote-webapp/src/components/indicateurs/IndicateurProgression.tsx
+++ b/apps/kpilote-webapp/src/components/indicateurs/IndicateurProgression.tsx
@@ -25,6 +25,7 @@ export function IndicateurProgression({
       </div>
       <ProgressBar
         value={taux}
+        tone="neutral"
         label={`Progression vers l'objectif : ${formatNumberFr(taux)} %`}
         className="mt-2"
       />

--- a/apps/kpilote-webapp/src/components/indicateurs/IndicateurSynthesePanel.tsx
+++ b/apps/kpilote-webapp/src/components/indicateurs/IndicateurSynthesePanel.tsx
@@ -74,25 +74,23 @@ export function IndicateurSynthesePanel({
             </Text>
             {derniere ? (
               <>
-                <div className="mt-3 flex flex-wrap items-end gap-3">
-                  <Heading as="p" size="display-lg">
-                    {formatNumberFr(derniere.valeur)}
-                    {unite?.abbreviation && (
-                      <span className="ml-[0.06em] text-[0.46em] font-bold text-text-muted">
-                        {unite.abbreviation}
-                      </span>
-                    )}
-                  </Heading>
-                  {variation !== null && variation !== 0 && (
-                    <Pill tone={variation > 0 ? 'success' : 'warning'} className="mb-2">
-                      {variation > 0 ? '↑' : '↓'} {formatVariationFr(variation)} ·{' '}
-                      {variation > 0 ? 'en hausse' : 'en baisse'}
-                    </Pill>
+                <Heading as="p" size="display-lg" className="mt-3 text-blue-cumulus">
+                  {formatNumberFr(derniere.valeur)}
+                  {unite?.abbreviation && (
+                    <span className="ml-[0.06em] text-[0.46em] font-bold text-blue-cumulus">
+                      {unite.abbreviation}
+                    </span>
                   )}
-                </div>
+                </Heading>
                 <Text variant="caption" tone="subtle" className="mt-2">
                   au {formatDateFr(derniere.date)}
                 </Text>
+                {variation !== null && variation !== 0 && (
+                  <Pill tone={variation > 0 ? 'success' : 'warning'} className="mt-3 w-fit">
+                    {variation > 0 ? '↑' : '↓'} {variation > 0 ? 'EN HAUSSE' : 'EN BAISSE'} :{' '}
+                    {formatVariationFr(variation)}
+                  </Pill>
+                )}
               </>
             ) : (
               <Heading as="p" size="display-lg" tone="muted" className="mt-3">
@@ -103,7 +101,7 @@ export function IndicateurSynthesePanel({
             {precedente && (
               <Text variant="body" tone="muted" className="mt-3">
                 Valeur précédente :{' '}
-                <span className="font-semibold text-text">
+                <span className="font-semibold text-primary">
                   {formatNumberAvecUniteFr(precedente.valeur, unite)}
                 </span>{' '}
                 ({formatDateFr(precedente.date)})
@@ -132,19 +130,19 @@ export function IndicateurSynthesePanel({
           </Text>
           <ul className="mt-3 flex flex-col gap-0.5">
             <ComparaisonRow
-              dotClassName="bg-success"
+              valueClassName="text-success-425"
               label="Valeur maximale observée"
               value={stats.max}
               unite={unite}
             />
             <ComparaisonRow
-              dotClassName="bg-text-subtle"
+              valueClassName="text-blue-425"
               label="Valeur médiane observée"
               value={stats.mediane}
               unite={unite}
             />
             <ComparaisonRow
-              dotClassName="bg-red-marianne"
+              valueClassName="text-warning-425"
               label="Valeur minimale observée"
               value={stats.min}
               unite={unite}
@@ -156,7 +154,7 @@ export function IndicateurSynthesePanel({
               <Text variant="body" tone="muted">
                 Écart à la médiane
               </Text>
-              <Pill tone={ecartMediane > 0 ? 'success' : ecartMediane < 0 ? 'warning' : 'neutral'}>
+              <Pill tone={ecartMediane > 0 ? 'success' : ecartMediane < 0 ? 'warning' : 'info'}>
                 {formatVariationAvecUniteFr(ecartMediane, unite)} ·{' '}
                 {ecartMediane > 0 ? 'en avance' : ecartMediane < 0 ? 'en retard' : 'à la médiane'}
               </Pill>
@@ -169,23 +167,25 @@ export function IndicateurSynthesePanel({
 }
 
 function ComparaisonRow({
-  dotClassName,
+  valueClassName,
   label,
   value,
   unite,
 }: {
-  dotClassName: string
+  valueClassName: string
   label: string
   value: number | null
   unite: UniteIndicateurApiModel | null
 }) {
   return (
     <li className="flex items-baseline justify-between gap-3 py-1.5">
-      <span className="flex items-center gap-2.5 text-sm text-text-muted">
-        <span className={clsxm('size-2 rounded-full', dotClassName)} aria-hidden />
-        {label}
-      </span>
-      <span className="whitespace-nowrap text-base font-bold tabular-nums text-text">
+      <span className="text-sm text-text-muted">{label}</span>
+      <span
+        className={clsxm(
+          'whitespace-nowrap text-base font-bold tabular-nums',
+          value === null ? 'text-text-subtle' : valueClassName,
+        )}
+      >
         {value === null ? (
           '—'
         ) : (

--- a/packages/kpilote-ui/src/Pill.tsx
+++ b/packages/kpilote-ui/src/Pill.tsx
@@ -2,11 +2,12 @@ import { type ReactNode } from 'react'
 
 import { clsxm } from './clsxm'
 
-type PillTone = 'success' | 'warning' | 'neutral'
+type PillTone = 'success' | 'warning' | 'info' | 'neutral'
 
 const pillToneClasses: Record<PillTone, string> = {
-  success: 'bg-success-tinted text-success',
-  warning: 'bg-warning-tinted text-warning',
+  success: 'bg-success-tinted text-success-425',
+  warning: 'bg-warning-tinted text-warning-425',
+  info: 'bg-primary-tinted text-blue-425',
   neutral: 'bg-surface-muted text-text-muted',
 }
 

--- a/packages/kpilote-ui/src/ProgressBar.tsx
+++ b/packages/kpilote-ui/src/ProgressBar.tsx
@@ -2,13 +2,27 @@ import { Progress } from 'radix-ui'
 
 import { clsxm } from './clsxm'
 
+type ProgressTone = 'primary' | 'neutral'
+
+const trackToneClasses: Record<ProgressTone, string> = {
+  primary: 'bg-primary/20',
+  neutral: 'bg-text-muted/20',
+}
+
+const barToneClasses: Record<ProgressTone, string> = {
+  primary: 'bg-primary',
+  neutral: 'bg-text-muted',
+}
+
 export function ProgressBar({
   value,
   label,
+  tone = 'primary',
   className,
 }: {
   value: number
   label: string
+  tone?: ProgressTone
   className?: string
 }) {
   const clamped = Math.min(100, Math.max(0, value))
@@ -17,10 +31,13 @@ export function ProgressBar({
       value={clamped}
       max={100}
       aria-label={label}
-      className={clsxm('h-2 overflow-hidden rounded-full bg-primary/20', className)}
+      className={clsxm('h-2 overflow-hidden rounded-full', trackToneClasses[tone], className)}
     >
       <Progress.Indicator
-        className="h-full rounded-full bg-primary transition-transform duration-300"
+        className={clsxm(
+          'h-full rounded-full transition-transform duration-300',
+          barToneClasses[tone],
+        )}
         style={{ transform: `translateX(-${100 - clamped}%)` }}
       />
     </Progress.Root>

--- a/packages/kpilote-ui/theme.css
+++ b/packages/kpilote-ui/theme.css
@@ -33,6 +33,8 @@
   --color-primary-hover: #1212a8;
   --color-primary-foreground: #ffffff;
   --color-primary-tinted: #ececfe;
+  --color-blue-425: #0a76f6;
+  --color-blue-cumulus: #3558a2;
 
   /* Action secondary — outline bleu République */
   --color-secondary: #ffffff;
@@ -55,8 +57,10 @@
   /* Statuts (sémantique DSFR) */
   --color-success: #18753c;
   --color-success-tinted: #e3fbe9;
+  --color-success-425: #27a658;
   --color-warning: #b34000;
   --color-warning-tinted: #fff4e6;
+  --color-warning-425: #fc5d00;
   --color-error: #ce0500;
   --color-error-tinted: #fff4f3;
 


### PR DESCRIPTION
## PIL-1658 — [Indicateur] Valeur d'avancement : intégrer maquettes

Rapproche le **panneau de synthèse** de l'indicateur (`IndicateurSynthesePanel`) des maquettes, en s'appuyant sur les tokens DSFR du thème partagé.

### Changements

- **Valeur d'avancement** + unité → `blue-cumulus` (#3558a2) ; **valeur précédente** → bleu marianne ; **objectif** → gris (`text-muted`).
- **Badge « en hausse / en baisse »** déplacé sur sa propre ligne, **au-dessus de « Valeur précédente »** (justification à gauche conservée).
- **Données de comparaison** : puces retirées (absentes des maquettes), couleurs reportées sur **les valeurs** — max = vert `success-425`, médiane = bleu `blue-425`, min = orange `warning-425`.
- **Badges** (en hausse/baisse, écart à la médiane) recolorés sur la **palette vive** des maquettes : `success` (vert), `warning` (orange-rouge), `info` (bleu, cas « à la médiane »).
- **Barre de progression** de l'indicateur en **gris** (nouvelle prop `tone` sur `ProgressBar` ; barre du panier inchangée).

### Tokens & composants partagés

- Ajout au `theme.css` : `--color-success-425` (#27a658), `--color-warning-425` (#fc5d00), `--color-blue-425` (#0a76f6), `--color-blue-cumulus` (#3558a2) — tous issus de la palette DSFR.
- `Pill` : tons `success` / `warning` / `info` alignés sur les teintes vives (ton `error` retiré, non utilisé).
- `ProgressBar` : prop `tone` (`primary` par défaut | `neutral`).

### Portée

| Fichier | Objet |
|---|---|
| `packages/kpilote-ui/theme.css` | tokens couleur DSFR |
| `packages/kpilote-ui/src/Pill.tsx` | tons vifs success/warning/info |
| `packages/kpilote-ui/src/ProgressBar.tsx` | prop `tone` (barre grise) |
| `apps/kpilote-webapp/.../IndicateurSynthesePanel.tsx` | couleurs/typo VA, badges, comparaison |
| `apps/kpilote-webapp/.../IndicateurProgression.tsx` | objectif gris, barre grise |

### Notes

- Coloration des badges **par signe** (hausse=vert / baisse=orange) et non par favorabilité réelle : l'API ne renvoie pas de champ « sens » de l'indicateur.
- Tailles de police laissées sur l'échelle existante ; ce sont surtout les **couleurs** qui ont été intégrées.

### Vérifications

- `pnpm -F @pilote/kpilote-webapp lint` : eslint + `tsc --noEmit` + prettier ✅
- Testé en local (webapp).