### PR TITLE
feature: header épuré & titres de carte en blue-cumulus

### DIFF
--- a/apps/kpilote-webapp/src/components/HeaderNav.tsx
+++ b/apps/kpilote-webapp/src/components/HeaderNav.tsx
@@ -1,6 +1,6 @@
-import { Link, useLocation, useNavigate, useSearch } from '@tanstack/react-router'
+import { useNavigate } from '@tanstack/react-router'
 import { Search } from 'lucide-react'
-import { Suspense, useState, type ReactNode } from 'react'
+import { Suspense, useState } from 'react'
 
 import { CommandPalette } from '@/components/command-palette/CommandPalette'
 import { RaccourciKbd } from '@/components/command-palette/RaccourciKbd'
@@ -9,9 +9,9 @@ import { Button } from '@pilote/kpilote-ui/Button'
 import type { Auth } from '@/auth'
 
 /**
- * Barre de navigation du header : recherche (⌘K / Ctrl+K), lien tableau de bord
- * et menu utilisateur. Regroupe toute la logique liée à la command palette et à
- * l'état d'authentification, pour garder le layout racine (`__root`) minimal.
+ * Barre de navigation du header : recherche (⌘K / Ctrl+K) et menu utilisateur.
+ * Regroupe toute la logique liée à la command palette et à l'état
+ * d'authentification, pour garder le layout racine (`__root`) minimal.
  */
 export function HeaderNav({ auth }: { auth: Auth }) {
   const navigate = useNavigate()
@@ -25,15 +25,13 @@ export function HeaderNav({ auth }: { auth: Auth }) {
             type="button"
             onClick={() => setPaletteOpen(true)}
             aria-label="Ouvrir la recherche"
-            className="flex items-center gap-2 rounded-md border border-border bg-surface px-2 py-1.5 text-sm text-text-subtle transition-colors hover:border-border-strong hover:text-text sm:px-3"
+            className="flex items-center gap-2 rounded-md border border-border bg-surface px-2 py-1.5 text-sm text-text-subtle transition-colors hover:border-border-strong hover:text-text sm:min-w-96 sm:px-3"
           >
-            <Search className="size-4" />
-            <span className="hidden sm:inline">Rechercher…</span>
-            <RaccourciKbd className="ml-4 hidden sm:inline-block" />
+            <Search className="size-4 shrink-0" />
+            <span className="hidden sm:inline">Rechercher un indicateur, un dossier, …</span>
+            <RaccourciKbd className="ml-auto hidden sm:inline-block" />
           </button>
         ) : null}
-
-        <NavLink>Tableau de bord</NavLink>
 
         <div className="mx-2 hidden h-6 w-px bg-border sm:block" />
 
@@ -57,21 +55,5 @@ export function HeaderNav({ auth }: { auth: Auth }) {
         </Suspense>
       ) : null}
     </>
-  )
-}
-
-function NavLink({ children }: { children: ReactNode }) {
-  const search = useSearch({ strict: false })
-  const { pathname } = useLocation()
-  const isActive = pathname.startsWith('/indicateurs') || pathname.startsWith('/paniers')
-  return (
-    <Link
-      to="/indicateurs"
-      search={{ individu: search.individu, referentiel: search.referentiel }}
-      data-status={isActive ? 'active' : undefined}
-      className="rounded-md px-3 py-2 text-sm font-medium text-text-muted transition-colors hover:bg-surface-tinted hover:text-primary data-[status=active]:bg-primary-tinted data-[status=active]:text-primary"
-    >
-      {children}
-    </Link>
   )
 }

--- a/apps/kpilote-webapp/src/components/indicateurs/IndicateurAvancement.tsx
+++ b/apps/kpilote-webapp/src/components/indicateurs/IndicateurAvancement.tsx
@@ -2,7 +2,7 @@ import { type UniteIndicateurApiModel } from '@pilote/kpilote-shared/indicateur'
 import { useSuspenseQueries } from '@tanstack/react-query'
 
 import { IndicateurProgression } from '@/components/indicateurs/IndicateurProgression'
-import { formatMonthYearNumericFr, formatNumberAvecUniteFr } from '@/lib/format'
+import { formatNumberAvecUniteFr } from '@/lib/format'
 import { dernierValeurIndividuQueryOptions } from '@/queries/dernieresValeurs'
 import { tauxProgressionIndividuQueryOptions } from '@/queries/tauxProgression'
 
@@ -42,7 +42,6 @@ export function IndicateurAvancement({
       <span className="text-2xl font-bold leading-none text-primary">
         {formatNumberAvecUniteFr(data.valeur, unite)}
       </span>
-      <span className="text-xs text-text-muted">au {formatMonthYearNumericFr(data.date)}</span>
       {tauxData?.tauxProgression != null && (
         <div className="mt-auto pt-4">
           <IndicateurProgression

--- a/apps/kpilote-webapp/src/components/indicateurs/IndicateurSynthesePanel.tsx
+++ b/apps/kpilote-webapp/src/components/indicateurs/IndicateurSynthesePanel.tsx
@@ -74,7 +74,7 @@ export function IndicateurSynthesePanel({
             </Text>
             {derniere ? (
               <>
-                <Heading as="p" size="display-lg" className="mt-3 text-blue-cumulus">
+                <Heading as="p" size="display-sm" className="mt-3 text-blue-cumulus">
                   {formatNumberFr(derniere.valeur)}
                   {unite?.abbreviation && (
                     <span className="ml-[0.06em] text-[0.46em] font-bold text-blue-cumulus">
@@ -93,7 +93,7 @@ export function IndicateurSynthesePanel({
                 )}
               </>
             ) : (
-              <Heading as="p" size="display-lg" tone="muted" className="mt-3">
+              <Heading as="p" size="display-sm" tone="muted" className="mt-3">
                 —
               </Heading>
             )}

--- a/apps/kpilote-webapp/src/components/paniers/PanierCard.tsx
+++ b/apps/kpilote-webapp/src/components/paniers/PanierCard.tsx
@@ -21,7 +21,6 @@ export function PanierCard({
   return (
     <EntityCard
       asChild
-      kicker={panier.id}
       title={panier.nom}
       body={
         context ? (

--- a/apps/kpilote-webapp/src/routes/__root.tsx
+++ b/apps/kpilote-webapp/src/routes/__root.tsx
@@ -20,7 +20,7 @@ function RootComponent() {
 
   return (
     <div className="flex min-h-screen flex-col bg-background text-text">
-      <header className="sticky top-0 z-30 border-b border-border bg-surface/90 backdrop-blur">
+      <header className="sticky top-0 z-30 border-b border-border bg-surface/90 shadow-raised backdrop-blur">
         <div className="mx-auto flex max-w-7xl items-center justify-between gap-8 px-6 py-3 sm:px-10">
           <Link
             to="/"

--- a/packages/kpilote-ui/src/EntityCard.tsx
+++ b/packages/kpilote-ui/src/EntityCard.tsx
@@ -41,7 +41,11 @@ export function EntityCard({
           {kicker}
         </Text>
       )}
-      <Heading as="h3" size="md" className="text-text transition-colors group-hover:text-primary">
+      <Heading
+        as="h3"
+        size="md"
+        className="text-blue-cumulus transition-colors group-hover:text-primary"
+      >
         {title}
       </Heading>
       <SlotPrimitive.Slottable>{children}</SlotPrimitive.Slottable>

--- a/packages/kpilote-ui/src/EntityCard.tsx
+++ b/packages/kpilote-ui/src/EntityCard.tsx
@@ -18,7 +18,7 @@ type EntityCardProps = Omit<ComponentProps<'div'>, 'title'> & {
 
 const styles = [
   'group relative flex h-full flex-col gap-3 overflow-hidden rounded-xl bg-surface py-5 pl-6 pr-5',
-  'border border-border transition-all duration-150',
+  'border border-text-subtle transition-all duration-150',
   'hover:border-primary hover:bg-surface-tinted hover:-translate-y-0.5',
   'focus-within:border-primary focus-within:bg-surface-tinted',
 ].join(' ')

--- a/packages/kpilote-ui/theme.css
+++ b/packages/kpilote-ui/theme.css
@@ -23,6 +23,8 @@
   --color-border: #ececec;
   --color-border-strong: #e0e0e0;
 
+  --shadow-raised: 0 1px 3px rgba(0, 0, 18, 0.16);
+
   /* Texte */
   --color-text: #161616;
   --color-text-muted: #666666;


### PR DESCRIPTION
## Ajustements UI (hors ticket)

Série de retouches d'interface sur la webapp kpilote.

### Header
- **Suppression du bouton « Tableau de bord »** (et du composant `NavLink` + imports orphelins).
- **Barre de recherche ⌘K élargie** : largeur mini (`sm:min-w-96`), placeholder complet **« Rechercher un indicateur, un dossier, … »**, raccourci ⌘K poussé à droite (`ml-auto`).
- **Ombre portée DSFR** sur le header : token `--shadow-raised` (`0 1px 3px rgba(0,0,18,0.16)`, le `raised-shadow` du DSFR) appliqué via `shadow-raised`.

### Cartes
- **Titre des cartes** (`EntityCard`, donc **indicateurs ET dossiers**) en **blue-cumulus** (`#3558a2`), au survol → bleu marianne.
- **Border des cartes** renforcé : `#ececec` (border) → **`#929292`** (text-subtle) pour un contour plus visible.
- **Tuile indicateur** (`IndicateurAvancement`) : suppression de la date **« au … »** sous la valeur.
- **Carte dossier** (`PanierCard`) : retrait de l'**identifiant** (`PAN-…`) en tête de carte.

### Fiche indicateur
- **Valeur d'avancement** réduite de `display-lg` (56px) à **`display-sm` (32px)**.

### Portée

| Fichier | Objet |
|---|---|
| `apps/kpilote-webapp/.../HeaderNav.tsx` | header épuré + recherche élargie |
| `apps/kpilote-webapp/src/routes/__root.tsx` | ombre portée sur le header |
| `packages/kpilote-ui/theme.css` | token `--shadow-raised` |
| `packages/kpilote-ui/src/EntityCard.tsx` | titre blue-cumulus + border #929292 |
| `apps/kpilote-webapp/.../IndicateurAvancement.tsx` | retrait « au … » |
| `apps/kpilote-webapp/.../PanierCard.tsx` | retrait identifiant |
| `apps/kpilote-webapp/.../IndicateurSynthesePanel.tsx` | valeur d'avancement en 32px |

### Vérifications
- `pnpm -F @pilote/kpilote-webapp lint` : eslint + `tsc --noEmit` + prettier ✅
- Testé en local (webapp).