### PR TITLE
feat(ssl): renouvellement automatique des certificats SSL Sectigo (certbot HTTP-01)

### DIFF
--- a/.github/workflows/README-renouvellement-ssl.md
+++ b/.github/workflows/README-renouvellement-ssl.md
@@ -1,0 +1,61 @@
+# Renouvellement certificats SSL (Sectigo / ACME HTTP-01)
+
+Workflow : `.github/workflows/renouvellement-ssl.yml`.
+
+Émet/renouvelle les certificats Sectigo pour les domaines des apps `pilote-ppg`
+(webapp) et `pilote-ppg-auth` (keycloak), puis les pousse sur Scalingo.
+
+## Déclenchement
+
+- **Automatique** : cron le 1er du mois à 03h UTC.
+- **Manuel** : onglet Actions → *Renouvellement certificats SSL* → *Run workflow*,
+  choisir la cible (`tous` / `prod` / `preprod` / `dev`).
+
+## Configuration requise
+
+### Repository secrets (Settings → Secrets and variables → Actions)
+- `SECTIGO_ACME_EAB_KID` — ID EAB Sectigo.
+- `SECTIGO_ACME_EAB_HMAC_KEY` — clé HMAC EAB Sectigo.
+- `ACME_EMAIL` — email du compte ACME.
+- `SCALINGO_API_TOKEN` — token API Scalingo (commun à tous les envs).
+
+### Environments GitHub (Settings → Environments : `prod`, `preprod`, `dev`)
+Variables :
+- `WEBAPP_DOMAIN`, `WEBAPP_SCALINGO_APP` (requis)
+- `AUTH_DOMAIN`, `AUTH_SCALINGO_APP` (optionnels — si absents, le job `auth` de
+  l'env est ignoré proprement)
+
+Secret :
+- `ACME_UPLOAD_API_KEY` — clé Bearer de la route de challenge de cet env.
+
+> Ne pas mettre de *required reviewers* sur ces environments, sinon le cron se
+> bloque en attente d'approbation.
+
+## Fonctionnement
+
+certbot (`--manual`) émet le certificat. Le hook `scripts/acme/auth-hook.sh`
+dépose la `keyAuthorization` via la route de push de l'app (Bearer) et attend
+qu'elle soit servie sur `/.well-known/acme-challenge/<token>` ; la CA la vérifie ;
+`scripts/acme/cleanup-hook.sh` la supprime. Le certificat est ensuite poussé sur
+le domaine Scalingo (`PATCH tlscert/tlskey`).
+
+Les routes de challenge diffèrent selon l'app (gérées automatiquement par le
+workflow via `ACME_PUSH_PATH` / `ACME_DELETE_STYLE`) :
+
+| App | Push (POST) | Cleanup (DELETE) |
+|---|---|---|
+| webapp (`pilote-ppg`) | `/api/admin/acme-challenge` | `/api/admin/acme-challenge?token=…` |
+| auth (`pilote-ppg-auth`) | `/api/acme/challenge` | `/api/acme/challenge/<token>` |
+
+## Limitation connue
+
+Le store des challenges est **en mémoire par dyno**. Si une app web tourne sur
+plus d'un dyno, la CA peut interroger un dyno qui n'a pas le token. Ce workflow
+suppose des apps à **1 dyno web** pendant le renouvellement, ou tolère les retries
+ACME.
+
+## Tests locaux des hooks
+
+```bash
+bash scripts/acme/__tests__/hooks.test.sh
+```

--- a/.github/workflows/renouvellement-ssl.yml
+++ b/.github/workflows/renouvellement-ssl.yml
@@ -1,0 +1,185 @@
+name: Renouvellement certificats SSL
+
+on:
+  workflow_dispatch:
+    inputs:
+      cible:
+        description: "Environnement à renouveler"
+        type: choice
+        required: true
+        default: tous
+        options:
+          - tous
+          - prod
+          - preprod
+          - dev
+  schedule:
+    # Le 1er du mois à 03h00 UTC
+    - cron: "0 3 1 * *"
+
+jobs:
+  renouveler:
+    name: "Renouveler ${{ matrix.environnement }} / ${{ matrix.application }}"
+    runs-on: ubuntu-latest
+    # Sur workflow_dispatch avec une cible précise, on ne garde que l'env visé.
+    # Sur schedule (inputs.cible vide) ou cible=tous, on garde tout.
+    if: >-
+      github.event_name == 'schedule' ||
+      github.event.inputs.cible == 'tous' ||
+      github.event.inputs.cible == matrix.environnement
+    environment: ${{ matrix.environnement }}
+    strategy:
+      fail-fast: false
+      matrix:
+        environnement: [prod, preprod, dev]
+        application: [webapp, auth]
+    env:
+      ACME_DIRECTORY_URL: https://acme.sectigo.com/v2/OV
+      SCALINGO_API_BASE: https://api.osc-secnum-fr1.scalingo.com
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Résoudre la cible (domaine, app, routes de challenge)
+        id: cible
+        env:
+          WEBAPP_DOMAIN: ${{ vars.WEBAPP_DOMAIN }}
+          WEBAPP_SCALINGO_APP: ${{ vars.WEBAPP_SCALINGO_APP }}
+          AUTH_DOMAIN: ${{ vars.AUTH_DOMAIN }}
+          AUTH_SCALINGO_APP: ${{ vars.AUTH_SCALINGO_APP }}
+        run: |
+          if [ "${{ matrix.application }}" = "webapp" ]; then
+            DOMAINE="$WEBAPP_DOMAIN"
+            SCALINGO_APP="$WEBAPP_SCALINGO_APP"
+            PUSH_PATH="/api/admin/acme-challenge"
+            DELETE_STYLE="query"
+          else
+            DOMAINE="$AUTH_DOMAIN"
+            SCALINGO_APP="$AUTH_SCALINGO_APP"
+            PUSH_PATH="/api/acme/challenge"
+            DELETE_STYLE="path"
+          fi
+
+          if [ -z "$DOMAINE" ] || [ -z "$SCALINGO_APP" ]; then
+            echo "Aucune config pour ${{ matrix.environnement }}/${{ matrix.application }} — job ignoré."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+          echo "domaine=$DOMAINE" >> "$GITHUB_OUTPUT"
+          echo "scalingo_app=$SCALINGO_APP" >> "$GITHUB_OUTPUT"
+          echo "push_path=$PUSH_PATH" >> "$GITHUB_OUTPUT"
+          echo "delete_style=$DELETE_STYLE" >> "$GITHUB_OUTPUT"
+
+      - name: Installer certbot
+        if: steps.cible.outputs.skip == 'false'
+        run: |
+          python3 -m venv "$HOME/.certbot-venv"
+          "$HOME/.certbot-venv/bin/pip" install --quiet --upgrade pip
+          "$HOME/.certbot-venv/bin/pip" install --quiet 'certbot==3.1.0'
+          "$HOME/.certbot-venv/bin/certbot" --version
+
+      - name: Émettre le certificat (HTTP-01 via hooks)
+        if: steps.cible.outputs.skip == 'false'
+        env:
+          # Lus par les hooks scripts/acme/*.sh
+          ACME_PUSH_PATH: ${{ steps.cible.outputs.push_path }}
+          ACME_DELETE_STYLE: ${{ steps.cible.outputs.delete_style }}
+          ACME_UPLOAD_API_KEY: ${{ secrets.ACME_UPLOAD_API_KEY }}
+        run: |
+          "$HOME/.certbot-venv/bin/certbot" certonly \
+            --manual --preferred-challenges http \
+            --server "$ACME_DIRECTORY_URL" \
+            --eab-kid "${{ secrets.SECTIGO_ACME_EAB_KID }}" \
+            --eab-hmac-key "${{ secrets.SECTIGO_ACME_EAB_HMAC_KEY }}" \
+            --email "${{ secrets.ACME_EMAIL }}" \
+            --agree-tos --no-eff-email \
+            --key-type rsa2048 \
+            --domain "${{ steps.cible.outputs.domaine }}" \
+            --config-dir "$GITHUB_WORKSPACE/.certbot/config" \
+            --work-dir "$GITHUB_WORKSPACE/.certbot/work" \
+            --logs-dir "$GITHUB_WORKSPACE/.certbot/logs" \
+            --manual-auth-hook "$GITHUB_WORKSPACE/scripts/acme/auth-hook.sh" \
+            --manual-cleanup-hook "$GITHUB_WORKSPACE/scripts/acme/cleanup-hook.sh" \
+            --non-interactive
+
+      - name: Vérifier le certificat émis
+        if: steps.cible.outputs.skip == 'false'
+        run: |
+          DOMAIN="${{ steps.cible.outputs.domaine }}"
+          LIVE="$GITHUB_WORKSPACE/.certbot/config/live/$DOMAIN"
+          BUNDLE="$LIVE/fullchain.pem"
+          KEY="$LIVE/privkey.pem"
+
+          echo "=== Fichiers ==="
+          ls -la "$LIVE"
+
+          NB_CERTS=$(grep -c "BEGIN CERTIFICATE" "$BUNDLE")
+          echo "Bundle : $NB_CERTS certificat(s) (attendu >= 2)"
+          if [ "$NB_CERTS" -lt 2 ]; then
+            echo "::warning::Chaîne incomplète (< 2 certificats) — origin strict pourrait échouer"
+          fi
+
+          echo "=== Subject / Issuer / Validity ==="
+          openssl x509 -in "$BUNDLE" -noout -subject -issuer -dates
+
+          echo "=== Cohérence clé/certificat ==="
+          CERT_PUBKEY=$(openssl x509 -in "$BUNDLE" -noout -pubkey | openssl sha256 | awk '{print $2}')
+          KEY_PUBKEY=$(openssl pkey -in "$KEY" -pubout | openssl sha256 | awk '{print $2}')
+          if [ "$CERT_PUBKEY" != "$KEY_PUBKEY" ]; then
+            echo "::error::La clé privée ne correspond pas au certificat"
+            exit 1
+          fi
+          echo "Cohérence clé/certificat OK"
+
+      - name: Échanger le token Scalingo contre un JWT
+        id: scalingo-auth
+        if: steps.cible.outputs.skip == 'false'
+        env:
+          SCALINGO_API_TOKEN: ${{ secrets.SCALINGO_API_TOKEN }}
+        run: |
+          JWT=$(curl -sSf -X POST https://auth.scalingo.com/v1/tokens/exchange \
+            -u ":$SCALINGO_API_TOKEN" | jq -r .token)
+          if [ -z "$JWT" ] || [ "$JWT" = "null" ]; then
+            echo "Échec de l'échange du token Scalingo (.token absent)"
+            exit 1
+          fi
+          echo "::add-mask::$JWT"
+          echo "jwt=$JWT" >> "$GITHUB_OUTPUT"
+
+      - name: Trouver l'ID du domaine Scalingo
+        id: scalingo-domain
+        if: steps.cible.outputs.skip == 'false'
+        run: |
+          DOMAIN_ID=$(curl -sSf \
+            -H "Authorization: Bearer ${{ steps.scalingo-auth.outputs.jwt }}" \
+            "${SCALINGO_API_BASE}/v1/apps/${{ steps.cible.outputs.scalingo_app }}/domains" \
+            | jq -r --arg name "${{ steps.cible.outputs.domaine }}" \
+              '.domains[] | select(.name == $name) | .id')
+          if [ -z "$DOMAIN_ID" ] || [ "$DOMAIN_ID" = "null" ]; then
+            echo "Domaine ${{ steps.cible.outputs.domaine }} introuvable sur ${{ steps.cible.outputs.scalingo_app }}"
+            exit 1
+          fi
+          echo "domain_id=$DOMAIN_ID" >> "$GITHUB_OUTPUT"
+
+      - name: Pousser le certificat sur Scalingo
+        if: steps.cible.outputs.skip == 'false'
+        run: |
+          DOMAIN="${{ steps.cible.outputs.domaine }}"
+          LIVE="$GITHUB_WORKSPACE/.certbot/config/live/$DOMAIN"
+          CERT=$(cat "$LIVE/fullchain.pem")
+          KEY=$(cat "$LIVE/privkey.pem")
+          RESP=$(mktemp)
+          HTTP_CODE=$(jq -n --arg cert "$CERT" --arg key "$KEY" \
+            '{domain: {tlscert: $cert, tlskey: $key}}' \
+            | curl -sS -X PATCH -o "$RESP" -w "%{http_code}" \
+              -H "Authorization: Bearer ${{ steps.scalingo-auth.outputs.jwt }}" \
+              -H "Content-Type: application/json" \
+              --data-binary @- \
+              "${SCALINGO_API_BASE}/v1/apps/${{ steps.cible.outputs.scalingo_app }}/domains/${{ steps.scalingo-domain.outputs.domain_id }}")
+          echo "HTTP $HTTP_CODE"
+          cat "$RESP"; echo ""
+          if [ "$HTTP_CODE" -lt 200 ] || [ "$HTTP_CODE" -ge 300 ]; then
+            exit 1
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ docs/superpowers/*
 !docs/superpowers/specs/
 docs/superpowers/specs/*
 !docs/superpowers/specs/2026-06-23-commentaires-niveau-confiance-design.md
+!docs/superpowers/specs/2026-07-17-renouvellement-ssl-acme-design.md
 
 # superpowers visual companion (mockups)
 .superpowers/

--- a/docs/superpowers/specs/2026-07-17-renouvellement-ssl-acme-design.md
+++ b/docs/superpowers/specs/2026-07-17-renouvellement-ssl-acme-design.md
@@ -1,0 +1,201 @@
+# Renouvellement automatique des certificats SSL (Sectigo / ACME HTTP-01)
+
+## Contexte
+
+Les domaines publics de la plateforme sont servis par des apps Scalingo. Le TLS
+est terminé côté Scalingo (le certificat est poussé sur le domaine via l'API
+Scalingo). Il faut automatiser l'émission/renouvellement de ces certificats via
+l'autorité ACME de Sectigo.
+
+Deux apps portent des domaines publics et savent répondre au challenge ACME
+**HTTP-01** grâce à un mécanisme de _challenge push_ déjà implémenté :
+
+| App | Sert le challenge | Push (POST) | Cleanup (DELETE) |
+|---|---|---|---|
+| **pilote-ppg** (Next.js) | `GET /.well-known/acme-challenge/:token` (rewrite Next → `/api/acme-challenge/:token`) | `POST /api/admin/acme-challenge` body `{token, keyAuthorization}` | `DELETE /api/admin/acme-challenge?token=…` |
+| **pilote-ppg-auth** (Keycloak, via `acme-proxy` Hono) | `GET /.well-known/acme-challenge/:token` (store mémoire) | `POST /api/acme/challenge` body `{token, keyAuthorization}` | `DELETE /api/acme/challenge/:token` |
+
+Dans les deux cas :
+- la route de push est protégée par un header `Authorization: Bearer <ACME_UPLOAD_API_KEY>` ;
+- le challenge est stocké **en mémoire** dans le dyno et servi sur le chemin `/.well-known/acme-challenge/:token` public.
+
+Le mécanisme attend explicitement un client ACME de type **certbot** (cf. commentaire
+`apps/pilote-ppg-auth/scripts/start.sh`) : le client émet le certificat, dépose la
+`keyAuthorization` via la route de push, la CA la lit sur le domaine public, puis le
+client nettoie.
+
+## Objectif
+
+Un workflow GitHub Actions qui, sur planification mensuelle et sur déclenchement
+manuel, émet/renouvelle les certificats Sectigo pour les domaines des apps
+`pilote-ppg` (webapp) et `pilote-ppg-auth` (keycloak), sur les environnements
+`prod`, `preprod`, `dev`, puis pousse chaque certificat sur le domaine Scalingo
+correspondant.
+
+## Choix de conception
+
+### Client ACME : certbot (pas lego)
+
+Le modèle de référence (autre projet) utilisait `lego` en **DNS-01 Cloudflare**.
+Ici on est en **HTTP-01 « push »** : le client doit déposer le challenge dans une
+API distante (la route de push de l'app), pas sur un webroot local ni via DNS.
+
+`lego` en HTTP-01 ne sait faire que `standalone` / `webroot` / `memcached` / `s3` —
+aucun mécanisme pour pousser vers une API custom distante. `certbot --manual` avec
+`--manual-auth-hook` / `--manual-cleanup-hook` correspond exactement au besoin (et
+au commentaire du code) : le hook d'auth POST le challenge, le hook de cleanup le
+DELETE.
+
+### Matrice via GitHub Environments
+
+La matrice est le produit cartésien `environnement ∈ {prod, preprod, dev}` ×
+`application ∈ {webapp, auth}` → 6 jobs (`fail-fast: false`).
+
+Chaque job déclare `environment: ${{ matrix.environnement }}`, ce qui donne accès
+aux **variables** et **secrets** scopés à cet Environment GitHub. Les valeurs
+concrètes (domaine, nom d'app Scalingo) ne sont donc **pas** hardcodées dans le
+workflow — elles vivent dans les `vars` de chaque Environment, cohérent avec le
+reste de la conf déjà en base/plateforme.
+
+### Région Scalingo
+
+`osc-secnum-fr1` (comme les autres workflows du repo), base API
+`https://api.osc-secnum-fr1.scalingo.com`. **Pas** `osc-fr1`.
+
+## Configuration attendue (côté GitHub, hors code)
+
+### Repository secrets (communs à tous les envs)
+- `SECTIGO_ACME_EAB_KID` — l'ID EAB reçu de Sectigo.
+- `SECTIGO_ACME_EAB_HMAC_KEY` — la clé HMAC EAB reçue de Sectigo.
+- `ACME_EMAIL` — email du compte ACME.
+- `SCALINGO_API_TOKEN` — token API Scalingo (identique pour tous les envs).
+
+### Par Environment (`prod`, `preprod`, `dev`)
+- **Variables** (`vars`, non sensibles) :
+  - `WEBAPP_DOMAIN`, `WEBAPP_SCALINGO_APP` (requis)
+  - `AUTH_DOMAIN`, `AUTH_SCALINGO_APP` (**optionnels** : si absents sur un env, le
+    job `auth` de cet env se termine en _skipped_ propre)
+- **Secret** :
+  - `ACME_UPLOAD_API_KEY` — clé Bearer de la route de push de cet env (celle lue
+    par `configuration().acme.uploadApiKey` côté pilote-ppg et `ACME_UPLOAD_API_KEY`
+    côté acme-proxy).
+
+### Non secret, dans le workflow
+- `ACME_DIRECTORY_URL = https://acme.sectigo.com/v2/OV`.
+
+### Protection rules
+Les 3 environments n'ont **pas** de required reviewers, sinon le cron mensuel se
+bloquerait en attente d'approbation manuelle à chaque exécution.
+
+## Architecture du workflow
+
+Fichier : `.github/workflows/renouvellement-ssl.yml`.
+
+### Déclencheurs
+- `schedule` : cron mensuel (1er du mois, ~03h UTC).
+- `workflow_dispatch` avec un input `cible` : `tous` (défaut) / `prod` / `preprod` / `dev`.
+
+### Filtrage de la matrice
+Un job s'exécute si l'input `cible == tous` (ou déclenchement par cron) ou si
+`cible == matrix.environnement`. Implémenté via une condition `if:` au niveau du
+job (le job est marqué skipped sinon, sans échouer la run).
+
+### Étapes d'un job
+
+1. **Checkout** (pour disposer des scripts de hook versionnés).
+
+2. **Résoudre la cible** : selon `matrix.application`, dériver dans l'env du step :
+   - `DOMAINE` ← `vars.WEBAPP_DOMAIN` ou `vars.AUTH_DOMAIN`
+   - `SCALINGO_APP` ← `vars.WEBAPP_SCALINGO_APP` ou `vars.AUTH_SCALINGO_APP`
+   - `ACME_PUSH_PATH` ← `/api/admin/acme-challenge` (webapp) ou `/api/acme/challenge` (auth)
+   - `ACME_DELETE_STYLE` ← `query` (webapp, `?token=`) ou `path` (auth, `/:token`)
+   - Si `DOMAINE` est vide (env sans cette app) → le job se termine proprement en
+     _skipped_ (log explicite, pas d'échec).
+
+3. **Installer certbot** (version épinglée, via `pip` dans un venv ou `apt`).
+
+4. **Émettre le certificat** :
+   ```
+   certbot certonly \
+     --manual --preferred-challenges http \
+     --server "$ACME_DIRECTORY_URL" \
+     --eab-kid "$SECTIGO_ACME_EAB_KID" --eab-hmac-key "$SECTIGO_ACME_EAB_HMAC_KEY" \
+     --email "$ACME_EMAIL" --agree-tos --no-eff-email \
+     --key-type rsa2048 \
+     --domain "$DOMAINE" \
+     --config-dir "$GITHUB_WORKSPACE/.certbot/config" \
+     --work-dir  "$GITHUB_WORKSPACE/.certbot/work" \
+     --logs-dir  "$GITHUB_WORKSPACE/.certbot/logs" \
+     --manual-auth-hook    "$GITHUB_WORKSPACE/scripts/acme/auth-hook.sh" \
+     --manual-cleanup-hook "$GITHUB_WORKSPACE/scripts/acme/cleanup-hook.sh" \
+     --non-interactive
+   ```
+   Le certificat émis se trouve dans `.certbot/config/live/$DOMAINE/{fullchain,privkey}.pem`.
+
+5. **Vérifier le certificat émis** (repris du modèle) : nombre de certs dans le
+   bundle (≥ 2 = leaf + intermédiaire(s)), subject/issuer/dates, cohérence
+   clé privée ↔ certificat (comparaison des pubkeys). Échec dur si mismatch.
+
+6. **Pousser sur Scalingo** :
+   - échange `SCALINGO_API_TOKEN` → JWT (`POST https://auth.scalingo.com/v1/tokens/exchange`) ;
+   - `GET /v1/apps/$SCALINGO_APP/domains` → trouver l'`id` du domaine `$DOMAINE` ;
+   - `PATCH /v1/apps/$SCALINGO_APP/domains/$ID` avec `{domain:{tlscert, tlskey}}` ;
+   - vérifier le code HTTP 2xx, logguer la réponse.
+
+### Scripts de hook (versionnés)
+
+`scripts/acme/auth-hook.sh` :
+- lit `$CERTBOT_DOMAIN`, `$CERTBOT_TOKEN`, `$CERTBOT_VALIDATION` (fournis par certbot) ;
+- lit `$ACME_PUSH_PATH`, `$ACME_UPLOAD_API_KEY` depuis l'env du job ;
+- `POST https://$CERTBOT_DOMAIN$ACME_PUSH_PATH` avec `Authorization: Bearer …`,
+  body JSON `{token, keyAuthorization}` (`keyAuthorization = $CERTBOT_VALIDATION`) ;
+- **poll** `GET https://$CERTBOT_DOMAIN/.well-known/acme-challenge/$CERTBOT_TOKEN`
+  jusqu'à recevoir la `keyAuthorization` attendue (timeout borné), pour garantir
+  que le challenge est servi avant que la CA ne vérifie ;
+- échec dur si le POST échoue ou si le poll expire.
+
+`scripts/acme/cleanup-hook.sh` :
+- selon `$ACME_DELETE_STYLE` : `DELETE …$ACME_PUSH_PATH?token=$CERTBOT_TOKEN`
+  (query) ou `DELETE …$ACME_PUSH_PATH/$CERTBOT_TOKEN` (path), avec le Bearer ;
+- best-effort : loggue mais n'échoue pas la run si le cleanup rate (le store est
+  en mémoire, le challenge disparaîtra au prochain redéploiement de toute façon).
+
+Ces scripts sont versionnés (testables, lisibles) plutôt qu'en heredoc inline.
+
+## Gestion des erreurs
+
+- `fail-fast: false` : l'échec d'un couple (env, app) n'annule pas les autres.
+- `auth-hook` : échec dur si le challenge ne peut pas être déposé/servi → certbot
+  reporte l'échec, le job est rouge pour ce couple uniquement.
+- `cleanup-hook` : best-effort, n'échoue jamais le job.
+- Push Scalingo : échec dur si code HTTP non-2xx.
+- Vérification cert : échec dur si mismatch clé/cert.
+
+## Points de vigilance / limitations connues
+
+- **Store en mémoire non partagé entre dynos** : si une app web tourne sur > 1 dyno,
+  la CA peut interroger un dyno qui n'a pas le token (le poll de l'auth-hook ne
+  couvre pas ce cas car le load-balancer peut router la CA vers un autre dyno).
+  **Hypothèse** : renouvellement sur des apps à **1 dyno web**, ou tolérance aux
+  retries ACME. À documenter dans le README du workflow.
+- **Sectigo OV + EAB** : l'organisation doit être pré-validée côté Sectigo ; l'EAB
+  pré-autorise le compte ACME. La validation de domaine reste automatisée par HTTP-01.
+- **App `auth` optionnelle** : `AUTH_DOMAIN` / `AUTH_SCALINGO_APP` peuvent être
+  absents sur n'importe quel env (Keycloak pas déployé séparément, etc.). Dans ce
+  cas le job `auth` de cet env se termine en _skipped_ propre (étape 2), sans job
+  rouge. Seul le couple `webapp` est garanti présent.
+
+## Testabilité
+
+- Scripts de hook : testables en isolation (mock du serveur de push via un petit
+  serveur local ou variables d'env, vérification du body POST et de la logique de
+  poll/cleanup selon `ACME_DELETE_STYLE`).
+- Workflow : validable via `act` ou un déclenchement `workflow_dispatch` ciblé sur
+  `dev` d'abord, avant d'activer le cron.
+
+## Hors scope
+
+- Émission de certs pour des domaines non fronted par une route de challenge ACME
+  (nécessiterait d'ajouter le mécanisme de push sur l'app concernée).
+- Bascule DNS-01.
+- Monitoring/alerting de l'expiration (pourrait faire l'objet d'une US dédiée).

--- a/scripts/acme/__tests__/hooks.test.sh
+++ b/scripts/acme/__tests__/hooks.test.sh
@@ -10,18 +10,25 @@ ECHECS=0
 demarrer_mock() {
   MOCK_LOG="$(mktemp)"
   export MOCK_LOG
-  # Lance le mock, récupère le port sur sa première ligne stdout.
-  exec 3< <(node "$ICI/mock-challenge-server.mjs")
+  PORT_FILE="$(mktemp)"
+  # Lance le mock en background ; MOCK_PID est bien le pid de node.
+  node "$ICI/mock-challenge-server.mjs" > "$PORT_FILE" &
   MOCK_PID=$!
-  read -r ligne_port <&3
+  # Attend la ligne "PORT=<port>" écrite par le mock une fois à l'écoute.
+  ligne_port=""
+  for _ in $(seq 1 50); do
+    ligne_port="$(cat "$PORT_FILE")"
+    [ -n "$ligne_port" ] && break
+    sleep 0.1
+  done
   MOCK_PORT="${ligne_port#PORT=}"
   BASE_URL="http://127.0.0.1:$MOCK_PORT"
 }
 
 arreter_mock() {
   kill "$MOCK_PID" 2>/dev/null || true
-  exec 3<&- 2>/dev/null || true
-  rm -f "$MOCK_LOG"
+  wait "$MOCK_PID" 2>/dev/null || true
+  rm -f "$MOCK_LOG" "$PORT_FILE"
 }
 
 assert_contient() {
@@ -60,6 +67,35 @@ assert_contient "POST reçu sur la bonne route" '"method":"POST".*"path":"/api/a
 assert_contient "Bearer transmis" '"authorization":"Bearer secret-key"' "$MOCK_LOG"
 assert_contient "body contient token+keyAuthorization" 'keyauth-abc' "$MOCK_LOG"
 assert_contient "poll GET well-known" '"method":"GET".*"/.well-known/acme-challenge/tok123"' "$MOCK_LOG"
+arreter_mock
+
+echo ""
+echo "== cleanup-hook : style query (webapp) =="
+demarrer_mock
+CERTBOT_DOMAIN=exemple.test \
+CERTBOT_TOKEN=tok123 \
+ACME_PUSH_PATH=/api/admin/acme-challenge \
+ACME_UPLOAD_API_KEY=secret-key \
+ACME_DELETE_STYLE=query \
+ACME_BASE_URL="$BASE_URL" \
+  bash "$ACME_DIR/cleanup-hook.sh"
+assert_code "cleanup-hook (query) exit 0" 0 "$?"
+assert_contient "DELETE avec ?token=" '"method":"DELETE".*"search":"?token=tok123"' "$MOCK_LOG"
+assert_contient "Bearer transmis au cleanup" '"authorization":"Bearer secret-key"' "$MOCK_LOG"
+arreter_mock
+
+echo ""
+echo "== cleanup-hook : style path (auth) =="
+demarrer_mock
+CERTBOT_DOMAIN=exemple.test \
+CERTBOT_TOKEN=tok999 \
+ACME_PUSH_PATH=/api/acme/challenge \
+ACME_UPLOAD_API_KEY=secret-key \
+ACME_DELETE_STYLE=path \
+ACME_BASE_URL="$BASE_URL" \
+  bash "$ACME_DIR/cleanup-hook.sh"
+assert_code "cleanup-hook (path) exit 0" 0 "$?"
+assert_contient "DELETE sur /:token" '"method":"DELETE".*"path":"/api/acme/challenge/tok999"' "$MOCK_LOG"
 arreter_mock
 
 echo ""

--- a/scripts/acme/__tests__/hooks.test.sh
+++ b/scripts/acme/__tests__/hooks.test.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Tests des hooks ACME : lance le mock server node, exécute les hooks contre lui,
+# vérifie les requêtes journalisées. Aucune dépendance hors node + curl.
+set -uo pipefail
+
+ICI="$(cd "$(dirname "$0")" && pwd)"
+ACME_DIR="$(dirname "$ICI")"
+ECHECS=0
+
+demarrer_mock() {
+  MOCK_LOG="$(mktemp)"
+  export MOCK_LOG
+  # Lance le mock, récupère le port sur sa première ligne stdout.
+  exec 3< <(node "$ICI/mock-challenge-server.mjs")
+  MOCK_PID=$!
+  read -r ligne_port <&3
+  MOCK_PORT="${ligne_port#PORT=}"
+  BASE_URL="http://127.0.0.1:$MOCK_PORT"
+}
+
+arreter_mock() {
+  kill "$MOCK_PID" 2>/dev/null || true
+  exec 3<&- 2>/dev/null || true
+  rm -f "$MOCK_LOG"
+}
+
+assert_contient() {
+  # $1 = description, $2 = motif grep, $3 = fichier
+  if grep -q "$2" "$3"; then
+    echo "  ok   $1"
+  else
+    echo "  FAIL $1 (motif '$2' absent)"
+    ECHECS=$((ECHECS + 1))
+  fi
+}
+
+assert_code() {
+  # $1 = description, $2 = code attendu, $3 = code obtenu
+  if [ "$2" = "$3" ]; then
+    echo "  ok   $1"
+  else
+    echo "  FAIL $1 (attendu $2, obtenu $3)"
+    ECHECS=$((ECHECS + 1))
+  fi
+}
+
+echo "== auth-hook : dépose puis voit le challenge servi =="
+demarrer_mock
+CERTBOT_DOMAIN=exemple.test \
+CERTBOT_TOKEN=tok123 \
+CERTBOT_VALIDATION=keyauth-abc \
+ACME_PUSH_PATH=/api/admin/acme-challenge \
+ACME_UPLOAD_API_KEY=secret-key \
+ACME_BASE_URL="$BASE_URL" \
+ACME_POLL_INTERVAL=1 ACME_POLL_TIMEOUT=10 \
+  bash "$ACME_DIR/auth-hook.sh"
+code=$?
+assert_code "auth-hook exit 0" 0 "$code"
+assert_contient "POST reçu sur la bonne route" '"method":"POST".*"path":"/api/admin/acme-challenge"' "$MOCK_LOG"
+assert_contient "Bearer transmis" '"authorization":"Bearer secret-key"' "$MOCK_LOG"
+assert_contient "body contient token+keyAuthorization" 'keyauth-abc' "$MOCK_LOG"
+assert_contient "poll GET well-known" '"method":"GET".*"/.well-known/acme-challenge/tok123"' "$MOCK_LOG"
+arreter_mock
+
+echo ""
+if [ "$ECHECS" -eq 0 ]; then
+  echo "TOUS LES TESTS PASSENT"
+  exit 0
+else
+  echo "$ECHECS test(s) en échec"
+  exit 1
+fi

--- a/scripts/acme/__tests__/mock-challenge-server.mjs
+++ b/scripts/acme/__tests__/mock-challenge-server.mjs
@@ -1,0 +1,64 @@
+// Mock du serveur de challenge ACME (webapp/auth) pour tester les hooks bash.
+// - POST <n'importe quel path>  : stocke {token -> keyAuthorization}, 201
+// - GET /.well-known/acme-challenge/:token : renvoie la keyAuthorization, 200/404
+// - DELETE <path>?token= ou <path>/:token  : supprime, 204
+// Journalise chaque requête (méthode, url, auth, body) en JSON-line dans $MOCK_LOG.
+// Imprime "PORT=<port>" sur stdout une fois à l'écoute.
+import { createServer } from "node:http";
+import { appendFileSync } from "node:fs";
+
+const store = new Map();
+const logFile = process.env.MOCK_LOG;
+
+const log = (entry) => {
+  if (logFile) appendFileSync(logFile, JSON.stringify(entry) + "\n");
+};
+
+const server = createServer((req, res) => {
+  const url = new URL(req.url, "http://localhost");
+  const chunks = [];
+  req.on("data", (c) => chunks.push(c));
+  req.on("end", () => {
+    const body = Buffer.concat(chunks).toString();
+    log({
+      method: req.method,
+      path: url.pathname,
+      search: url.search,
+      authorization: req.headers["authorization"] ?? null,
+      body,
+    });
+
+    // Sert le challenge
+    const wellKnown = "/.well-known/acme-challenge/";
+    if (req.method === "GET" && url.pathname.startsWith(wellKnown)) {
+      const token = url.pathname.slice(wellKnown.length);
+      const value = store.get(token);
+      if (value === undefined) {
+        res.writeHead(404).end("Not found");
+        return;
+      }
+      res.writeHead(200, { "Content-Type": "text/plain" }).end(value);
+      return;
+    }
+
+    if (req.method === "POST") {
+      const { token, keyAuthorization } = JSON.parse(body || "{}");
+      store.set(token, keyAuthorization);
+      res.writeHead(201, { "Content-Type": "application/json" }).end('{"stored":true}');
+      return;
+    }
+
+    if (req.method === "DELETE") {
+      const token = url.searchParams.get("token") ?? url.pathname.split("/").pop();
+      store.delete(token);
+      res.writeHead(204).end();
+      return;
+    }
+
+    res.writeHead(405).end();
+  });
+});
+
+server.listen(0, "127.0.0.1", () => {
+  process.stdout.write(`PORT=${server.address().port}\n`);
+});

--- a/scripts/acme/auth-hook.sh
+++ b/scripts/acme/auth-hook.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# --manual-auth-hook de certbot.
+# Dépose la keyAuthorization du challenge HTTP-01 sur la route de push de l'app
+# (protégée par Bearer), puis attend que le challenge soit effectivement servi
+# sur /.well-known/acme-challenge/<token> avant de rendre la main à certbot
+# (sinon la CA pourrait vérifier avant que le dyno n'ait le token en mémoire).
+set -euo pipefail
+
+# Variables fournies par certbot.
+: "${CERTBOT_DOMAIN:?CERTBOT_DOMAIN manquant}"
+: "${CERTBOT_TOKEN:?CERTBOT_TOKEN manquant}"
+: "${CERTBOT_VALIDATION:?CERTBOT_VALIDATION manquant}"
+# Variables fournies par le workflow.
+: "${ACME_PUSH_PATH:?ACME_PUSH_PATH manquant}"
+: "${ACME_UPLOAD_API_KEY:?ACME_UPLOAD_API_KEY manquant}"
+
+BASE_URL="${ACME_BASE_URL:-https://$CERTBOT_DOMAIN}"
+POLL_TIMEOUT="${ACME_POLL_TIMEOUT:-60}"
+POLL_INTERVAL="${ACME_POLL_INTERVAL:-2}"
+
+reponse="$(mktemp)"
+trap 'rm -f "$reponse"' EXIT
+
+# 1. Dépose le challenge.
+corps="$(printf '{"token":"%s","keyAuthorization":"%s"}' "$CERTBOT_TOKEN" "$CERTBOT_VALIDATION")"
+code="$(curl -sS -o "$reponse" -w '%{http_code}' -X POST \
+  -H "Authorization: Bearer $ACME_UPLOAD_API_KEY" \
+  -H "Content-Type: application/json" \
+  --data "$corps" \
+  "$BASE_URL$ACME_PUSH_PATH")"
+
+if [ "$code" -lt 200 ] || [ "$code" -ge 300 ]; then
+  echo "[auth-hook] échec du POST du challenge (HTTP $code)"
+  cat "$reponse"
+  exit 1
+fi
+echo "[auth-hook] challenge déposé pour $CERTBOT_DOMAIN (token $CERTBOT_TOKEN)"
+
+# 2. Attend que le challenge soit servi publiquement.
+url_challenge="$BASE_URL/.well-known/acme-challenge/$CERTBOT_TOKEN"
+echeance=$(( $(date +%s) + POLL_TIMEOUT ))
+while true; do
+  servi="$(curl -sS "$url_challenge" 2>/dev/null || true)"
+  if [ "$servi" = "$CERTBOT_VALIDATION" ]; then
+    echo "[auth-hook] challenge servi sur $url_challenge"
+    exit 0
+  fi
+  if [ "$(date +%s)" -ge "$echeance" ]; then
+    echo "[auth-hook] timeout : challenge non servi après ${POLL_TIMEOUT}s sur $url_challenge"
+    exit 1
+  fi
+  sleep "$POLL_INTERVAL"
+done

--- a/scripts/acme/cleanup-hook.sh
+++ b/scripts/acme/cleanup-hook.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# --manual-cleanup-hook de certbot.
+# Supprime le challenge déposé. Best-effort : on ne fait jamais échouer la run
+# ici (le store est en mémoire et disparaîtra de toute façon au prochain
+# redéploiement du dyno). Le chemin de suppression diffère selon l'app :
+#   - webapp (query) : DELETE <path>?token=<token>
+#   - auth   (path)  : DELETE <path>/<token>
+set -uo pipefail
+
+: "${CERTBOT_DOMAIN:?CERTBOT_DOMAIN manquant}"
+: "${CERTBOT_TOKEN:?CERTBOT_TOKEN manquant}"
+: "${ACME_PUSH_PATH:?ACME_PUSH_PATH manquant}"
+: "${ACME_UPLOAD_API_KEY:?ACME_UPLOAD_API_KEY manquant}"
+
+BASE_URL="${ACME_BASE_URL:-https://$CERTBOT_DOMAIN}"
+STYLE="${ACME_DELETE_STYLE:-query}"
+
+if [ "$STYLE" = "path" ]; then
+  url="$BASE_URL$ACME_PUSH_PATH/$CERTBOT_TOKEN"
+else
+  url="$BASE_URL$ACME_PUSH_PATH?token=$CERTBOT_TOKEN"
+fi
+
+code="$(curl -sS -o /dev/null -w '%{http_code}' -X DELETE \
+  -H "Authorization: Bearer $ACME_UPLOAD_API_KEY" \
+  "$url" || echo "000")"
+echo "[cleanup-hook] DELETE $url -> HTTP $code"
+
+# Best-effort : succès quel que soit le résultat.
+exit 0


### PR DESCRIPTION
## Objectif

Automatiser l'émission/renouvellement des certificats Sectigo (ACME **HTTP-01**) pour les domaines des apps `pilote-ppg` (webapp) et `pilote-ppg-auth` (keycloak) sur `prod`/`preprod`/`dev`, puis les pousser sur Scalingo.

## Contexte / choix de conception

Le modèle de référence (autre projet) utilisait `lego` + **DNS-01**. Ici on est en **HTTP-01 « push »** : les deux apps exposent déjà une route de challenge (protégée par Bearer `ACME_UPLOAD_API_KEY`) qui stocke la `keyAuthorization` en mémoire et la sert sur `/.well-known/acme-challenge/<token>`. `lego` ne sait pas pousser vers une API distante en HTTP-01 → on utilise **certbot `--manual`** avec des hooks, ce qui colle au code existant (cf. commentaire de `start.sh`).

## Contenu

- `scripts/acme/auth-hook.sh` — `--manual-auth-hook` : POST le challenge sur la route de l'app + poll jusqu'à ce qu'il soit servi.
- `scripts/acme/cleanup-hook.sh` — `--manual-cleanup-hook` : DELETE best-effort (styles `query` webapp / `path` auth).
- `scripts/acme/__tests__/` — mock server node + harnais de test bash des hooks (aucune nouvelle dépendance).
- `.github/workflows/renouvellement-ssl.yml` — cron mensuel + `workflow_dispatch`, matrice `{prod,preprod,dev} × {webapp,auth}` (`fail-fast: false`), certbot EAB Sectigo, vérif du cert, push Scalingo (région `osc-secnum-fr1`).
- `.github/workflows/README-renouvellement-ssl.md` — doc de configuration (secrets/vars).

## Configuration requise (côté GitHub, hors code)

- **Repository secrets** : `SECTIGO_ACME_EAB_KID`, `SECTIGO_ACME_EAB_HMAC_KEY`, `ACME_EMAIL`, `SCALINGO_API_TOKEN`.
- **Environments** `prod`/`preprod`/`dev` :
  - Variables : `WEBAPP_DOMAIN`, `WEBAPP_SCALINGO_APP`, `AUTH_DOMAIN`/`AUTH_SCALINGO_APP` (optionnels → job `auth` ignoré si absents).
  - Secret : `ACME_UPLOAD_API_KEY`.
- Pas de *required reviewers* sur ces environments (sinon le cron se bloque).

## Limitation connue

Store des challenges **en mémoire par dyno** : suppose des apps à 1 dyno web pendant le renouvellement, ou tolère les retries ACME.

## Tests

```bash
bash scripts/acme/__tests__/hooks.test.sh
```
→ auth-hook (dépôt + poll) et cleanup-hook (query + path) au vert.

La vraie validation du workflow se fera via un `workflow_dispatch` ciblé sur `dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)