### PR TITLE
fix(ssl): corrige le workflow SSL (matrix hors if job-level, défaut dev)

### DIFF
--- a/.github/workflows/README-renouvellement-ssl.md
+++ b/.github/workflows/README-renouvellement-ssl.md
@@ -9,7 +9,7 @@ Workflow : `.github/workflows/renouvellement-ssl.yml`.
 
 - **Automatique** : cron le 1er du mois à 03h UTC.
 - **Manuel** : onglet Actions → *Renouvellement certificats SSL* → *Run workflow*,
-  choisir la cible (`tous` / `prod` / `preprod` / `dev`).
+  choisir la cible parmi `tous` / `prod` / `preprod` / `dev` (défaut : `dev`).
 
 ## Configuration requise
 

--- a/.github/workflows/renouvellement-ssl.yml
+++ b/.github/workflows/renouvellement-ssl.yml
@@ -7,7 +7,7 @@ on:
         description: "Environnement à renouveler"
         type: choice
         required: true
-        default: tous
+        default: dev
         options:
           - tous
           - prod
@@ -21,12 +21,6 @@ jobs:
   renouveler:
     name: "Renouveler ${{ matrix.environnement }} / ${{ matrix.application }}"
     runs-on: ubuntu-latest
-    # Sur workflow_dispatch avec une cible précise, on ne garde que l'env visé.
-    # Sur schedule (inputs.cible vide) ou cible=tous, on garde tout.
-    if: >-
-      github.event_name == 'schedule' ||
-      github.event.inputs.cible == 'tous' ||
-      github.event.inputs.cible == matrix.environnement
     environment: ${{ matrix.environnement }}
     strategy:
       fail-fast: false
@@ -48,6 +42,16 @@ jobs:
           AUTH_DOMAIN: ${{ vars.AUTH_DOMAIN }}
           AUTH_SCALINGO_APP: ${{ vars.AUTH_SCALINGO_APP }}
         run: |
+          # Le contexte `matrix` n'est pas accessible dans un `if:` de job, donc
+          # on filtre ici : sur workflow_dispatch avec une cible précise, on ignore
+          # les environnements non visés. Sur schedule, inputs.cible est vide → tout tourne.
+          CIBLE="${{ github.event.inputs.cible }}"
+          if [ -n "$CIBLE" ] && [ "$CIBLE" != "tous" ] && [ "$CIBLE" != "${{ matrix.environnement }}" ]; then
+            echo "Cible '$CIBLE' != ${{ matrix.environnement }} — job ignoré."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           if [ "${{ matrix.application }}" = "webapp" ]; then
             DOMAINE="$WEBAPP_DOMAIN"
             SCALINGO_APP="$WEBAPP_SCALINGO_APP"

--- a/.github/workflows/renouvellement-ssl.yml
+++ b/.github/workflows/renouvellement-ssl.yml
@@ -81,7 +81,10 @@ jobs:
         run: |
           python3 -m venv "$HOME/.certbot-venv"
           "$HOME/.certbot-venv/bin/pip" install --quiet --upgrade pip
-          "$HOME/.certbot-venv/bin/pip" install --quiet 'certbot==3.1.0'
+          # pyopenssl<25 : pyOpenSSL 25.x supprime crypto.X509Req, encore référencé
+          # par la josepy embarquée avec certbot 3.1.0 (AttributeError au démarrage).
+          # 24.x est la version testée pour cette certbot.
+          "$HOME/.certbot-venv/bin/pip" install --quiet 'certbot==3.1.0' 'pyopenssl<25'
           "$HOME/.certbot-venv/bin/certbot" --version
 
       - name: Émettre le certificat (HTTP-01 via hooks)

--- a/.github/workflows/renouvellement-ssl.yml
+++ b/.github/workflows/renouvellement-ssl.yml
@@ -102,7 +102,7 @@ jobs:
             --eab-hmac-key "${{ secrets.SECTIGO_ACME_EAB_HMAC_KEY }}" \
             --email "${{ secrets.ACME_EMAIL }}" \
             --agree-tos --no-eff-email \
-            --key-type rsa2048 \
+            --key-type rsa --rsa-key-size 2048 \
             --domain "${{ steps.cible.outputs.domaine }}" \
             --config-dir "$GITHUB_WORKSPACE/.certbot/config" \
             --work-dir "$GITHUB_WORKSPACE/.certbot/work" \

--- a/.github/workflows/test-acme-store.yml
+++ b/.github/workflows/test-acme-store.yml
@@ -1,0 +1,105 @@
+name: Test store ACME HTTP-01
+
+# Workflow de diagnostic : valide le round-trip du challenge HTTP-01 contre les
+# apps réelles (webapp / auth), SANS passer par Sectigo. Rejoue exactement ce que
+# certbot déclenche via les hooks : dépôt du challenge (auth-hook) → attente qu'il
+# soit servi sur /.well-known/acme-challenge/<token> → suppression (cleanup-hook)
+# → vérification du 404. Utilise un token/keyAuthorization bidon.
+# À lancer manuellement. Peut être supprimé une fois le store validé.
+
+on:
+  workflow_dispatch:
+    inputs:
+      cible:
+        description: "Environnement à tester"
+        type: choice
+        required: true
+        default: dev
+        options:
+          - tous
+          - prod
+          - preprod
+          - dev
+
+jobs:
+  test-store:
+    name: "Test store ${{ matrix.environnement }} / ${{ matrix.application }}"
+    runs-on: ubuntu-latest
+    environment: ${{ matrix.environnement }}
+    strategy:
+      fail-fast: false
+      matrix:
+        environnement: [prod, preprod, dev]
+        application: [webapp, auth]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Résoudre la cible (domaine, routes de challenge)
+        id: cible
+        env:
+          WEBAPP_DOMAIN: ${{ vars.WEBAPP_DOMAIN }}
+          AUTH_DOMAIN: ${{ vars.AUTH_DOMAIN }}
+        run: |
+          CIBLE="${{ github.event.inputs.cible }}"
+          if [ -n "$CIBLE" ] && [ "$CIBLE" != "tous" ] && [ "$CIBLE" != "${{ matrix.environnement }}" ]; then
+            echo "Cible '$CIBLE' != ${{ matrix.environnement }} — job ignoré."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "${{ matrix.application }}" = "webapp" ]; then
+            DOMAINE="$WEBAPP_DOMAIN"
+            PUSH_PATH="/api/admin/acme-challenge"
+            DELETE_STYLE="query"
+          else
+            DOMAINE="$AUTH_DOMAIN"
+            PUSH_PATH="/api/acme/challenge"
+            DELETE_STYLE="path"
+          fi
+
+          if [ -z "$DOMAINE" ]; then
+            echo "Aucun domaine pour ${{ matrix.environnement }}/${{ matrix.application }} — job ignoré."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+          echo "domaine=$DOMAINE" >> "$GITHUB_OUTPUT"
+          echo "push_path=$PUSH_PATH" >> "$GITHUB_OUTPUT"
+          echo "delete_style=$DELETE_STYLE" >> "$GITHUB_OUTPUT"
+
+      - name: Round-trip du challenge (dépôt → servi → suppression → 404)
+        if: steps.cible.outputs.skip == 'false'
+        env:
+          # Lus par les hooks scripts/acme/*.sh
+          CERTBOT_DOMAIN: ${{ steps.cible.outputs.domaine }}
+          ACME_PUSH_PATH: ${{ steps.cible.outputs.push_path }}
+          ACME_DELETE_STYLE: ${{ steps.cible.outputs.delete_style }}
+          ACME_UPLOAD_API_KEY: ${{ secrets.ACME_UPLOAD_API_KEY }}
+          ACME_POLL_TIMEOUT: "30"
+          ACME_POLL_INTERVAL: "2"
+        run: |
+          set -euo pipefail
+
+          # Token/keyAuthorization bidon (le token respecte le regex [A-Za-z0-9_-]+
+          # exigé par la route webapp).
+          export CERTBOT_TOKEN="smoketest-${GITHUB_RUN_ID}-${{ matrix.application }}"
+          export CERTBOT_VALIDATION="smoketest-validation-${GITHUB_RUN_ID}"
+
+          echo "== Dépôt + attente que le challenge soit servi =="
+          bash "$GITHUB_WORKSPACE/scripts/acme/auth-hook.sh"
+
+          echo "== Suppression du challenge =="
+          bash "$GITHUB_WORKSPACE/scripts/acme/cleanup-hook.sh"
+
+          echo "== Vérification : le challenge n'est plus servi (404 attendu) =="
+          url="https://$CERTBOT_DOMAIN/.well-known/acme-challenge/$CERTBOT_TOKEN"
+          code="$(curl -sS -o /dev/null -w '%{http_code}' "$url")"
+          echo "GET $url -> HTTP $code"
+          if [ "$code" != "404" ]; then
+            echo "::error::Après suppression, le challenge est toujours servi (HTTP $code au lieu de 404)"
+            exit 1
+          fi
+
+          echo "Round-trip OK pour $CERTBOT_DOMAIN"


### PR DESCRIPTION
Corrige les premières erreurs du workflow de renouvellement SSL mergé sur `dev`.

## Corrections

- **`Unrecognized named-value: 'matrix'`** : le contexte `matrix` n'est pas accessible dans un `if:` de job. Le filtrage par `cible` est déplacé dans le step *Résoudre la cible*, via le mécanisme `skip` déjà en place (sur `schedule`, `inputs.cible` est vide → tout tourne ; sur dispatch, on ignore les env non visés).
- **Défaut du `workflow_dispatch`** passé de `tous` à **`dev`** (le choix reste possible parmi `tous`/`prod`/`preprod`/`dev`).

Les autres usages de `matrix.` (`name:`, `environment:`, steps) restent valides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)