### PR TITLE
feature: progressions en gris, valeur tuile blue-cumulus, border allégé

### DIFF
--- a/apps/kpilote-webapp/src/components/indicateurs/IndicateurAvancement.tsx
+++ b/apps/kpilote-webapp/src/components/indicateurs/IndicateurAvancement.tsx
@@ -39,7 +39,7 @@ export function IndicateurAvancement({
   }
   return (
     <div className="flex flex-1 flex-col gap-1">
-      <span className="text-2xl font-bold leading-none text-primary">
+      <span className="text-2xl font-bold leading-none text-blue-cumulus">
         {formatNumberAvecUniteFr(data.valeur, unite)}
       </span>
       {tauxData?.tauxProgression != null && (

--- a/apps/kpilote-webapp/src/components/indicateurs/IndicateurProgression.tsx
+++ b/apps/kpilote-webapp/src/components/indicateurs/IndicateurProgression.tsx
@@ -18,10 +18,12 @@ export function IndicateurProgression({
   return (
     <div>
       <div className="flex items-baseline justify-between">
-        <Text variant="kicker" tone="subtle" as="p">
+        <Text variant="kicker" tone="muted" as="p">
           Progression
         </Text>
-        <span className="text-sm font-bold tabular-nums text-text">{formatNumberFr(taux)} %</span>
+        <span className="text-sm font-bold tabular-nums text-text-muted">
+          {formatNumberFr(taux)} %
+        </span>
       </div>
       <ProgressBar
         value={taux}
@@ -29,13 +31,17 @@ export function IndicateurProgression({
         label={`Progression vers l'objectif : ${formatNumberFr(taux)} %`}
         className="mt-2"
       />
-      <Text variant="caption" tone="subtle" className="mt-2 text-right">
-        Objectif :{' '}
-        <span className="font-semibold text-text-muted">
-          {formatNumberAvecUniteFr(valeurCible, unite)}
-        </span>{' '}
-        · au {formatDateFr(dateCible)}
-      </Text>
+      <div className="mt-2 text-right">
+        <Text variant="caption" tone="muted">
+          Objectif :{' '}
+          <span className="font-semibold text-text-muted">
+            {formatNumberAvecUniteFr(valeurCible, unite)}
+          </span>
+        </Text>
+        <Text variant="caption" tone="muted">
+          {formatDateFr(dateCible)}
+        </Text>
+      </div>
     </div>
   )
 }

--- a/apps/kpilote-webapp/src/components/paniers/PanierAvancement.tsx
+++ b/apps/kpilote-webapp/src/components/paniers/PanierAvancement.tsx
@@ -32,15 +32,16 @@ export function PanierAvancement({
   return (
     <div>
       <div className="flex items-baseline justify-between">
-        <Text variant="kicker" tone="subtle" as="p">
+        <Text variant="kicker" tone="muted" as="p">
           Progression
         </Text>
-        <span className="text-sm font-bold tabular-nums text-text">
+        <span className="text-sm font-bold tabular-nums text-text-muted">
           {formatNumberFr(data.tauxProgression)} %
         </span>
       </div>
       <ProgressBar
         value={data.tauxProgression}
+        tone="neutral"
         label={`Progression du panier : ${formatNumberFr(data.tauxProgression)} %`}
         className="mt-2"
       />

--- a/packages/kpilote-ui/src/EntityCard.tsx
+++ b/packages/kpilote-ui/src/EntityCard.tsx
@@ -18,7 +18,7 @@ type EntityCardProps = Omit<ComponentProps<'div'>, 'title'> & {
 
 const styles = [
   'group relative flex h-full flex-col gap-3 overflow-hidden rounded-xl bg-surface py-5 pl-6 pr-5',
-  'border border-text-subtle transition-all duration-150',
+  'border border-border-strong transition-all duration-150',
   'hover:border-primary hover:bg-surface-tinted hover:-translate-y-0.5',
   'focus-within:border-primary focus-within:bg-surface-tinted',
 ].join(' ')


### PR DESCRIPTION
## Ajustements UI (hors ticket)

Retouches de cohérence visuelle sur les tuiles et les blocs de progression.

### Progression (tuiles indicateur & dossier)
- **Uniformisation en gris `#666`** (`text-muted`) : libellé « Progression », taux `%` et **barre de progression** (`tone="neutral"`).
- Concerne `IndicateurProgression` **et** `PanierAvancement` (la barre du dossier était restée bleue).

### Objectif (sous la barre)
- Suppression du **« au »** ; la **date passe sur une ligne en dessous** de l'objectif.

### Valeur d'avancement (tuile indicateur)
- Passée en **blue-cumulus** (`#3558a2`), cohérente avec la fiche indicateur.

### Border des tuiles
- Allégé de `#929292` (`text-subtle`) à **`#e0e0e0`** (`border-strong`, ≈ le `border-default` du DSFR).

### Portée

| Fichier | Objet |
|---|---|
| `apps/kpilote-webapp/.../IndicateurProgression.tsx` | progression grise + date objectif en dessous |
| `apps/kpilote-webapp/.../IndicateurAvancement.tsx` | valeur tuile en blue-cumulus |
| `apps/kpilote-webapp/.../PanierAvancement.tsx` | progression dossier grise |
| `packages/kpilote-ui/src/EntityCard.tsx` | border tuile #e0e0e0 |

### Vérifications
- `pnpm -F @pilote/kpilote-webapp lint` : eslint + `tsc --noEmit` + prettier ✅
- Testé en local (webapp).