### PR TITLE
feature: retouches UI listing, onglets, fiche indicateur & niveau de confiance

### DIFF
--- a/apps/kpilote-webapp/src/components/commentaires/LigneHistorique.tsx
+++ b/apps/kpilote-webapp/src/components/commentaires/LigneHistorique.tsx
@@ -6,7 +6,6 @@ import { ContenuRepliable } from '@/components/commentaires/ContenuRepliable'
 import { libelleAuteur } from '@/components/commentaires/libelleAuteur'
 import {
   iconeMeteoIndice,
-  meteoLabelIndice,
   niveauConfianceFromIndice,
 } from '@/components/commentaires/niveauConfianceAffichage'
 import { Text } from '@pilote/kpilote-ui/Typography'
@@ -38,17 +37,14 @@ function NiveauConfianceInline({ commentaireId }: { commentaireId: string }) {
   const { data: niveau } = useSuspenseQuery(niveauPourCommentaireQueryOptions(commentaireId))
   if (!niveau) return null
   return (
-    <span
-      title={niveauConfianceFromIndice(niveau.indice).label}
-      className="inline-flex items-center gap-1.5 text-sm font-semibold leading-none text-text"
-    >
+    <span className="inline-flex items-center gap-1.5 text-sm font-normal leading-none text-text">
       <img
         src={iconeMeteoIndice(niveau.indice)}
         alt=""
         aria-hidden
         className="h-5 w-auto shrink-0"
       />
-      {meteoLabelIndice(niveau.indice)}
+      {niveauConfianceFromIndice(niveau.indice).label}
     </span>
   )
 }

--- a/apps/kpilote-webapp/src/components/commentaires/NiveauConfianceTag.tsx
+++ b/apps/kpilote-webapp/src/components/commentaires/NiveauConfianceTag.tsx
@@ -2,18 +2,15 @@ import { type IndiceConfiance } from '@pilote/kpilote-shared/niveauConfiance'
 
 import {
   iconeMeteoIndice,
-  meteoLabelIndice,
   niveauConfianceFromIndice,
 } from '@/components/commentaires/niveauConfianceAffichage'
 
 export function NiveauConfianceTag({ indice }: { indice: IndiceConfiance }) {
+  const { label } = niveauConfianceFromIndice(indice)
   return (
-    <span
-      title={niveauConfianceFromIndice(indice).label}
-      className="inline-flex items-center gap-2 rounded-xl border border-border px-4 py-2 text-sm font-semibold leading-none text-text"
-    >
+    <span className="inline-flex items-center gap-2 rounded-xl border border-border px-4 py-2 text-sm font-normal leading-none text-text">
       <img src={iconeMeteoIndice(indice)} alt="" aria-hidden className="h-6 w-auto shrink-0" />
-      {meteoLabelIndice(indice)}
+      {label}
     </span>
   )
 }

--- a/apps/kpilote-webapp/src/components/commentaires/SelecteurNiveauConfiance.tsx
+++ b/apps/kpilote-webapp/src/components/commentaires/SelecteurNiveauConfiance.tsx
@@ -3,7 +3,6 @@ import { type IndiceConfiance } from '@pilote/kpilote-shared/niveauConfiance'
 import {
   NIVEAUX_CONFIANCE,
   iconeMeteoIndice,
-  meteoLabelIndice,
 } from '@/components/commentaires/niveauConfianceAffichage'
 import { clsxm } from '@/lib/clsxm'
 
@@ -26,10 +25,9 @@ export function SelecteurNiveauConfiance({
             type="button"
             disabled={disabled}
             aria-pressed={actif}
-            title={label}
             onClick={() => onChange(indice)}
             className={clsxm(
-              'inline-flex items-center gap-2 rounded-xl border px-4 py-2.5 text-sm font-semibold leading-none transition-colors',
+              'inline-flex items-center gap-2 rounded-xl border px-4 py-2.5 text-sm font-normal leading-none transition-colors',
               'disabled:cursor-not-allowed disabled:opacity-60',
               actif
                 ? 'border-primary bg-primary-tinted text-primary'
@@ -42,7 +40,7 @@ export function SelecteurNiveauConfiance({
               aria-hidden
               className="h-6 w-auto shrink-0"
             />
-            {meteoLabelIndice(indice)}
+            {label}
           </button>
         )
       })}

--- a/apps/kpilote-webapp/src/components/commentaires/niveauConfianceAffichage.ts
+++ b/apps/kpilote-webapp/src/components/commentaires/niveauConfianceAffichage.ts
@@ -61,15 +61,6 @@ const ICONE_METEO_PAR_INDICE: Record<IndiceConfiance, string> = {
 
 export const iconeMeteoIndice = (indice: IndiceConfiance): string => ICONE_METEO_PAR_INDICE[indice]
 
-const METEO_LABEL_PAR_INDICE: Record<IndiceConfiance, string> = {
-  OBJECTIF_COMPROMIS: 'Orage',
-  APPUIS_NECESSAIRE: 'Nuage',
-  OBJECTIF_ATTEIGNABLE: 'Couvert',
-  OBJECTIF_SECURISE: 'Soleil',
-}
-
-export const meteoLabelIndice = (indice: IndiceConfiance): string => METEO_LABEL_PAR_INDICE[indice]
-
 // Ordre d'affichage du sélecteur, du plus dégradé au plus serein.
 const ORDRE_SELECTEUR: readonly IndiceConfiance[] = [
   'OBJECTIF_COMPROMIS',

--- a/apps/kpilote-webapp/src/components/indicateurs/IndicateurSynthesePanel.tsx
+++ b/apps/kpilote-webapp/src/components/indicateurs/IndicateurSynthesePanel.tsx
@@ -6,7 +6,7 @@ import { Pill } from '@pilote/kpilote-ui/Pill'
 import { Heading, Text } from '@pilote/kpilote-ui/Typography'
 import { clsxm } from '@/lib/clsxm'
 import {
-  formatDateFr,
+  formatMonthYearNumericFr,
   formatNumberAvecUniteFr,
   formatNumberFr,
   formatVariationAvecUniteFr,
@@ -76,14 +76,10 @@ export function IndicateurSynthesePanel({
               <>
                 <Heading as="p" size="display-sm" className="mt-3 text-blue-cumulus">
                   {formatNumberFr(derniere.valeur)}
-                  {unite?.abbreviation && (
-                    <span className="ml-[0.06em] text-[0.46em] font-bold text-blue-cumulus">
-                      {unite.abbreviation}
-                    </span>
-                  )}
+                  {unite?.abbreviation && <span className="ml-2">{unite.abbreviation}</span>}
                 </Heading>
-                <Text variant="caption" tone="subtle" className="mt-2">
-                  au {formatDateFr(derniere.date)}
+                <Text variant="body" tone="subtle" className="mt-2">
+                  {formatMonthYearNumericFr(derniere.date)}
                 </Text>
                 {variation !== null && variation !== 0 && (
                   <Pill tone={variation > 0 ? 'success' : 'warning'} className="mt-3 w-fit">
@@ -104,7 +100,7 @@ export function IndicateurSynthesePanel({
                 <span className="font-semibold text-primary">
                   {formatNumberAvecUniteFr(precedente.valeur, unite)}
                 </span>{' '}
-                ({formatDateFr(precedente.date)})
+                ({formatMonthYearNumericFr(precedente.date)})
               </Text>
             )}
           </div>

--- a/apps/kpilote-webapp/src/routes/_authenticated/indicateurs/index.tsx
+++ b/apps/kpilote-webapp/src/routes/_authenticated/indicateurs/index.tsx
@@ -13,7 +13,6 @@ import { FieldIndividuSelect } from '@/components/indicateurs/FieldIndividuSelec
 import { CardGrid } from '@pilote/kpilote-ui/CardGrid'
 import { EmptyState } from '@pilote/kpilote-ui/EmptyState'
 import { Page } from '@pilote/kpilote-ui/Page'
-import { SearchField } from '@pilote/kpilote-ui/SearchField'
 import { Text } from '@pilote/kpilote-ui/Typography'
 import { ensureIndividuReferentielPair } from '@/lib/individus/pair'
 import { DEFAULT_PAGE_SIZE_OPTIONS, Pagination } from '@pilote/kpilote-ui/Pagination'
@@ -21,7 +20,6 @@ import { indicateursQueryOptions, loadIndicateurs } from '@/queries/indicateurs'
 import { allReferentielsQueryOptions, loadAllReferentielIds } from '@/queries/referentiels'
 
 const indicateursSearchSchema = z.object({
-  recherche: z.string().optional(),
   cursor: z.string().optional(),
   pageSize: z.coerce.number().int().min(1).max(100).optional(),
   individu: individuPublicIdSchema.optional(),
@@ -89,26 +87,12 @@ function IndicateursListComponent() {
       }
     >
       <div className="flex flex-col gap-6">
-        <div className="flex flex-wrap items-center justify-between gap-4">
-          <Text as="span" variant="kicker" tone="muted">
-            {data.total} indicateur{data.total > 1 ? 's' : ''}
-          </Text>
-          <SearchField
-            label="Rechercher un indicateur par nom"
-            placeholder="Rechercher un indicateur…"
-            value={search.recherche ?? ''}
-            onChange={(value) => {
-              const recherche = value || undefined
-              void navigate({ search: (prev) => ({ ...prev, recherche, cursor: undefined }) })
-            }}
-          />
-        </div>
+        <Text as="span" variant="kicker" tone="muted">
+          {data.total} indicateur{data.total > 1 ? 's' : ''}
+        </Text>
 
         {data.items.length === 0 ? (
-          <EmptyState
-            title="Aucun indicateur ne correspond"
-            description="Essayez d'élargir votre recherche ou de réinitialiser les filtres."
-          />
+          <EmptyState title="Aucun indicateur disponible." />
         ) : (
           <CardGrid>
             {data.items.map((indicateur) => (

--- a/packages/kpilote-ui/src/Tabs.tsx
+++ b/packages/kpilote-ui/src/Tabs.tsx
@@ -18,9 +18,9 @@ export function TabsTrigger({ className, ...props }: ComponentProps<typeof TabsP
   return (
     <TabsPrimitive.Trigger
       className={clsxm(
-        // Onglet DSFR : bouton « dossier » bordé, coins hauts arrondis. Le -mb-px
-        // fait chevaucher la bordure du panneau pour connecter l'onglet actif.
-        '-mb-px inline-flex items-center gap-2 whitespace-nowrap rounded-t-md px-4 py-2.5 text-base font-bold transition-colors',
+        // Onglet DSFR : bouton « dossier » bordé. Le -mb-px fait chevaucher la
+        // bordure du panneau pour connecter l'onglet actif.
+        '-mb-px inline-flex items-center gap-2 whitespace-nowrap px-4 py-2.5 text-base font-bold transition-colors',
         'border border-border border-t-2 border-t-transparent',
         'focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary',
         // Inactif : fond bleu clair (bleu France « low »), texte foncé.
@@ -39,7 +39,7 @@ export function TabsContent({ className, ...props }: ComponentProps<typeof TabsP
   return (
     <TabsPrimitive.Content
       className={clsxm(
-        'rounded-b-md border border-border bg-surface p-6 focus-visible:outline-none',
+        'border border-border bg-surface p-6 focus-visible:outline-none',
         className,
       )}
       {...props}

--- a/packages/kpilote-ui/theme.css
+++ b/packages/kpilote-ui/theme.css
@@ -140,7 +140,6 @@
     background-color: var(--color-background);
     color: var(--color-text);
     font-feature-settings: 'cv11', 'ss01';
-    font-weight: 700;
   }
 
   ::selection {


### PR DESCRIPTION
## Retouches UI (hors ticket)

### Listing indicateur
- **Suppression de la barre de recherche** et de tout son fonctionnement : champ `SearchField`, paramètre d'URL `recherche`, ajustement de l'`EmptyState`. (La recherche globale ⌘K du header reste inchangée.)

### Onglets (`Tabs`)
- **Suppression du border-radius** (`rounded-t-md` / `rounded-b-md`) → coins droits, sur la nav primaire et les sous-onglets.

### Fiche indicateur (`IndicateurSynthesePanel`)
- **Unité** de la valeur d'avancement à la **même taille** que le chiffre (+ espacement `ml-2`).
- **« au »** retiré de la date.
- **Date** de la valeur d'avancement à la même taille que la « valeur précédente ».
- **Dates** (avancement + valeur précédente) passées en **MM/AAAA** (au lieu de JJ/MM/AAAA).

### Niveau de confiance (commentaires)
- Retour aux **libellés métier** (« Objectifs sécurisés / atteignables / Appuis nécessaires / Objectifs compromis ») à la place des noms météo — **l'icône météo est conservée**.
- Texte **non gras** (`font-normal`) sur le sélecteur, le tag de lecture et l'historique.
- Nettoyage du helper `meteoLabelIndice` devenu inutile.

### Typographie
- **Retrait du `font-weight: 700` par défaut** sur `body` (le poids revient à la valeur normale 400).

### Vérifications
- `pnpm -F @pilote/kpilote-webapp lint` : eslint + `tsc --noEmit` + prettier ✅
- Testé en local (webapp).