### PR TITLE
feature: retours UI fiche indicateur/dossier (libellés, gras, unités)

### DIFF
--- a/apps/kpilote-webapp/src/components/indicateurs/IndicateurResultatsTab.tsx
+++ b/apps/kpilote-webapp/src/components/indicateurs/IndicateurResultatsTab.tsx
@@ -41,13 +41,13 @@ export function IndicateurResultatsTab({
       <Tabs value={sousOnglet} onValueChange={(valeur) => onSousOngletChange(valeur as SousOnglet)}>
         <TabsList>
           <TabsTrigger value="confiance" className="text-xs">
-            Niveau de confiance
+            Niveaux de confiance
           </TabsTrigger>
           <TabsTrigger value="evolution" className="text-xs">
             Evolution et répartition
           </TabsTrigger>
           <TabsTrigger value="commentaire" className="text-xs">
-            Commentaire
+            Commentaires
           </TabsTrigger>
         </TabsList>
 

--- a/apps/kpilote-webapp/src/components/indicateurs/IndicateurSynthesePanel.tsx
+++ b/apps/kpilote-webapp/src/components/indicateurs/IndicateurSynthesePanel.tsx
@@ -96,7 +96,7 @@ export function IndicateurSynthesePanel({
 
             {precedente && (
               <Text variant="body" tone="muted" className="mt-3">
-                Valeur précédente :{' '}
+                <span className="font-bold">Valeur précédente :</span>{' '}
                 <span className="font-semibold text-primary">
                   {formatNumberAvecUniteFr(precedente.valeur, unite)}
                 </span>{' '}
@@ -147,7 +147,7 @@ export function IndicateurSynthesePanel({
 
           {ecartMediane !== null && (
             <div className="mt-3 flex items-center justify-between gap-3 border-t border-border pt-3">
-              <Text variant="body" tone="muted">
+              <Text variant="body" tone="muted" className="font-bold">
                 Écart à la médiane
               </Text>
               <Pill tone={ecartMediane > 0 ? 'success' : ecartMediane < 0 ? 'warning' : 'info'}>
@@ -175,7 +175,7 @@ function ComparaisonRow({
 }) {
   return (
     <li className="flex items-baseline justify-between gap-3 py-1.5">
-      <span className="text-sm text-text-muted">{label}</span>
+      <span className="text-sm font-bold text-text-muted">{label}</span>
       <span
         className={clsxm(
           'whitespace-nowrap text-base font-bold tabular-nums',
@@ -188,9 +188,7 @@ function ComparaisonRow({
           <>
             {formatNumberFr(value)}
             {unite?.abbreviation && (
-              <span className="ml-0.5 text-xs font-medium text-text-subtle">
-                {unite.abbreviation}
-              </span>
+              <span className="ml-1 font-medium text-text-subtle">{unite.abbreviation}</span>
             )}
           </>
         )}

--- a/apps/kpilote-webapp/src/routes/_authenticated/indicateurs/$id.tsx
+++ b/apps/kpilote-webapp/src/routes/_authenticated/indicateurs/$id.tsx
@@ -121,7 +121,7 @@ function IndicateurDetailComponent() {
         to="/indicateurs"
         search={{ individu: search.individu, referentiel: search.referentiel }}
       >
-        Retour à la liste
+        Tableau de bord
       </Link>
     </BackLink>
   )

--- a/apps/kpilote-webapp/src/routes/_authenticated/paniers/$id.tsx
+++ b/apps/kpilote-webapp/src/routes/_authenticated/paniers/$id.tsx
@@ -107,7 +107,7 @@ function PanierDetailComponent() {
   const back = (
     <BackLink asChild>
       <Link to="/paniers" search={{ individu: search.individu, referentiel: search.referentiel }}>
-        Retour aux paniers
+        Tableau de bord
       </Link>
     </BackLink>
   )
@@ -130,7 +130,7 @@ function PanierDetailComponent() {
         <TabsList>
           <TabsTrigger value="resultats">Résultats</TabsTrigger>
           <TabsTrigger value="gouvernance">Gouvernance</TabsTrigger>
-          <TabsTrigger value="confiance">Niveau de confiance</TabsTrigger>
+          <TabsTrigger value="confiance">Niveaux de confiance</TabsTrigger>
           <TabsTrigger value="commentaires">Commentaires</TabsTrigger>
         </TabsList>
 


### PR DESCRIPTION
## Retours UI (hors ticket)

### Libellés
- Sous-onglets de l'indicateur : **« Niveau de confiance » → « Niveaux de confiance »**, **« Commentaire » → « Commentaires »**.
- Page dossier : onglet **« Niveau de confiance » → « Niveaux de confiance »**.
- Boutons de retour (indicateur **et** dossier) : « Retour à la liste / aux paniers » → **« Tableau de bord »**.

### Fiche indicateur (`IndicateurSynthesePanel`)
- **Unités** des données de comparaison (min / max / médiane) à la **même taille que les valeurs** (avec un petit espace), couleur grise conservée.
- **Labels en gras** : « Valeur maximale/médiane/minimale observée », « Écart à la médiane » et « Valeur précédente : ».

### Portée

| Fichier | Objet |
|---|---|
| `.../indicateurs/IndicateurResultatsTab.tsx` | libellés sous-onglets |
| `.../indicateurs/IndicateurSynthesePanel.tsx` | unités + labels en gras |
| `.../indicateurs/$id.tsx` | bouton retour → Tableau de bord |
| `.../paniers/$id.tsx` | bouton retour + onglet « Niveaux de confiance » |

### Vérifications
- `pnpm -F @pilote/kpilote-webapp lint` : eslint + `tsc --noEmit` + prettier ✅
- Testé en local (webapp).