### PR TITLE
feature(PIL-1676): dernières retouches UI + pages légales & footer

### DIFF
--- a/apps/kpilote-admin/src/components/AdminHeader.tsx
+++ b/apps/kpilote-admin/src/components/AdminHeader.tsx
@@ -22,9 +22,7 @@ export function AdminHeader({
           <Marianne />
           <span className="hidden w-px bg-border sm:block" aria-hidden />
           <span className="hidden flex-col justify-center gap-0.5 sm:flex">
-            <span className="text-xl font-bold uppercase leading-none tracking-tight">
-              Pilote MB
-            </span>
+            <span className="text-xl font-bold uppercase leading-none tracking-tight">KPilote</span>
             <span className="text-sm text-text-muted">Console d'administration</span>
           </span>
         </Link>

--- a/apps/kpilote-webapp/.gitignore
+++ b/apps/kpilote-webapp/.gitignore
@@ -5,3 +5,4 @@ coverage/
 .env
 .env.local
 src/routeTree.gen.ts
+.tanstack/

--- a/apps/kpilote-webapp/src/components/ContacterEquipe.tsx
+++ b/apps/kpilote-webapp/src/components/ContacterEquipe.tsx
@@ -1,0 +1,13 @@
+import { Mail } from 'lucide-react'
+
+export function ContacterEquipe() {
+  return (
+    <a
+      href="mailto:pilote.ditp@modernisation.gouv.fr"
+      className="hidden items-center gap-2 rounded-md px-3 py-2 text-sm font-medium text-primary transition-colors hover:bg-surface-tinted sm:inline-flex"
+    >
+      <Mail className="size-4" />
+      Contacter l'équipe KPILOTE
+    </a>
+  )
+}

--- a/apps/kpilote-webapp/src/components/ContacterEquipe.tsx
+++ b/apps/kpilote-webapp/src/components/ContacterEquipe.tsx
@@ -4,9 +4,9 @@ export function ContacterEquipe() {
   return (
     <a
       href="mailto:pilote.ditp@modernisation.gouv.fr"
-      className="hidden items-center gap-2 rounded-md px-3 py-2 text-sm font-medium text-primary transition-colors hover:bg-surface-tinted sm:inline-flex"
+      className="hidden items-center gap-2 rounded-md px-3 py-2 text-sm font-semibold text-primary transition-colors hover:bg-surface-tinted sm:inline-flex"
     >
-      <Mail className="size-4" />
+      <Mail className="size-5" />
       Contacter l'équipe KPILOTE
     </a>
   )

--- a/apps/kpilote-webapp/src/components/HeaderNav.tsx
+++ b/apps/kpilote-webapp/src/components/HeaderNav.tsx
@@ -1,8 +1,9 @@
 import { useNavigate } from '@tanstack/react-router'
-import { Mail, Search } from 'lucide-react'
+import { Search } from 'lucide-react'
 import { Suspense, useState } from 'react'
 
 import { CommandPalette } from '@/components/command-palette/CommandPalette'
+import { ContacterEquipe } from '@/components/ContacterEquipe'
 import { RaccourciKbd } from '@/components/command-palette/RaccourciKbd'
 import { UserMenu } from '@/components/UserMenu'
 import { Button } from '@pilote/kpilote-ui/Button'
@@ -35,13 +36,7 @@ export function HeaderNav({ auth }: { auth: Auth }) {
 
         <div className="mx-2 hidden h-6 w-px bg-border sm:block" />
 
-        <a
-          href="mailto:pilote.ditp@modernisation.gouv.fr"
-          className="hidden items-center gap-2 rounded-md px-3 py-2 text-sm font-medium text-primary transition-colors hover:bg-surface-tinted sm:inline-flex"
-        >
-          <Mail className="size-4" />
-          Contacter l'équipe PILOTE
-        </a>
+        <ContacterEquipe />
 
         {auth.isAuthenticated && auth.user ? (
           <UserMenu

--- a/apps/kpilote-webapp/src/components/HeaderNav.tsx
+++ b/apps/kpilote-webapp/src/components/HeaderNav.tsx
@@ -36,7 +36,7 @@ export function HeaderNav({ auth }: { auth: Auth }) {
 
         <div className="mx-2 hidden h-6 w-px bg-border sm:block" />
 
-        <div className="flex flex-col items-start gap-1">
+        <div className="flex flex-col items-start">
           <ContacterEquipe />
 
           {auth.isAuthenticated && auth.user ? (

--- a/apps/kpilote-webapp/src/components/HeaderNav.tsx
+++ b/apps/kpilote-webapp/src/components/HeaderNav.tsx
@@ -1,5 +1,5 @@
 import { useNavigate } from '@tanstack/react-router'
-import { Search } from 'lucide-react'
+import { Mail, Search } from 'lucide-react'
 import { Suspense, useState } from 'react'
 
 import { CommandPalette } from '@/components/command-palette/CommandPalette'
@@ -34,6 +34,14 @@ export function HeaderNav({ auth }: { auth: Auth }) {
         ) : null}
 
         <div className="mx-2 hidden h-6 w-px bg-border sm:block" />
+
+        <a
+          href="mailto:pilote.ditp@modernisation.gouv.fr"
+          className="hidden items-center gap-2 rounded-md px-3 py-2 text-sm font-medium text-primary transition-colors hover:bg-surface-tinted sm:inline-flex"
+        >
+          <Mail className="size-4" />
+          Contacter l'équipe PILOTE
+        </a>
 
         {auth.isAuthenticated && auth.user ? (
           <UserMenu

--- a/apps/kpilote-webapp/src/components/HeaderNav.tsx
+++ b/apps/kpilote-webapp/src/components/HeaderNav.tsx
@@ -36,20 +36,22 @@ export function HeaderNav({ auth }: { auth: Auth }) {
 
         <div className="mx-2 hidden h-6 w-px bg-border sm:block" />
 
-        <ContacterEquipe />
+        <div className="flex flex-col items-start gap-1">
+          <ContacterEquipe />
 
-        {auth.isAuthenticated && auth.user ? (
-          <UserMenu
-            user={auth.user}
-            onLogout={() => {
-              void auth.logout()
-            }}
-          />
-        ) : (
-          <Button size="sm" type="button" onClick={() => void navigate({ to: '/login' })}>
-            Se connecter
-          </Button>
-        )}
+          {auth.isAuthenticated && auth.user ? (
+            <UserMenu
+              user={auth.user}
+              onLogout={() => {
+                void auth.logout()
+              }}
+            />
+          ) : (
+            <Button size="sm" type="button" onClick={() => void navigate({ to: '/login' })}>
+              Se connecter
+            </Button>
+          )}
+        </div>
       </nav>
 
       {auth.isAuthenticated ? (

--- a/apps/kpilote-webapp/src/components/indicateurs/IndicateurAvancement.tsx
+++ b/apps/kpilote-webapp/src/components/indicateurs/IndicateurAvancement.tsx
@@ -2,7 +2,7 @@ import { type UniteIndicateurApiModel } from '@pilote/kpilote-shared/indicateur'
 import { useSuspenseQueries } from '@tanstack/react-query'
 
 import { IndicateurProgression } from '@/components/indicateurs/IndicateurProgression'
-import { formatNumberAvecUniteFr } from '@/lib/format'
+import { formatMonthYearNumericFr, formatNumberAvecUniteFr } from '@/lib/format'
 import { dernierValeurIndividuQueryOptions } from '@/queries/dernieresValeurs'
 import { tauxProgressionIndividuQueryOptions } from '@/queries/tauxProgression'
 
@@ -42,6 +42,7 @@ export function IndicateurAvancement({
       <span className="text-2xl font-bold leading-none text-blue-cumulus">
         {formatNumberAvecUniteFr(data.valeur, unite)}
       </span>
+      <span className="text-xs text-text-muted">{formatMonthYearNumericFr(data.date)}</span>
       {tauxData?.tauxProgression != null && (
         <div className="mt-auto pt-4">
           <IndicateurProgression

--- a/apps/kpilote-webapp/src/components/indicateurs/IndicateurProgression.tsx
+++ b/apps/kpilote-webapp/src/components/indicateurs/IndicateurProgression.tsx
@@ -2,7 +2,7 @@ import { type UniteIndicateurApiModel } from '@pilote/kpilote-shared/indicateur'
 
 import { ProgressBar } from '@pilote/kpilote-ui/ProgressBar'
 import { Text } from '@pilote/kpilote-ui/Typography'
-import { formatDateFr, formatNumberAvecUniteFr, formatNumberFr } from '@/lib/format'
+import { formatMonthYearNumericFr, formatNumberAvecUniteFr, formatNumberFr } from '@/lib/format'
 
 export function IndicateurProgression({
   taux,
@@ -39,7 +39,7 @@ export function IndicateurProgression({
           </span>
         </Text>
         <Text variant="caption" tone="muted">
-          {formatDateFr(dateCible)}
+          {formatMonthYearNumericFr(dateCible)}
         </Text>
       </div>
     </div>

--- a/apps/kpilote-webapp/src/components/indicateurs/IndicateurSynthesePanel.tsx
+++ b/apps/kpilote-webapp/src/components/indicateurs/IndicateurSynthesePanel.tsx
@@ -82,7 +82,7 @@ export function IndicateurSynthesePanel({
                   {formatMonthYearNumericFr(derniere.date)}
                 </Text>
                 {variation !== null && variation !== 0 && (
-                  <Pill tone={variation > 0 ? 'success' : 'warning'} className="mt-3 w-fit">
+                  <Pill tone={variation > 0 ? 'success' : 'warning'} className="mt-3 w-fit text-sm">
                     {variation > 0 ? '↑' : '↓'} {variation > 0 ? 'EN HAUSSE' : 'EN BAISSE'} :{' '}
                     {formatVariationFr(variation)}
                   </Pill>

--- a/apps/kpilote-webapp/src/routes/__root.tsx
+++ b/apps/kpilote-webapp/src/routes/__root.tsx
@@ -43,31 +43,40 @@ function RootComponent() {
         </div>
       </header>
 
-      <main className="mx-auto flex w-full max-w-7xl flex-1 flex-col px-6 py-6 sm:px-8 sm:py-10">
+      <main className="mx-auto flex w-full max-w-7xl flex-1 flex-col px-6 py-6 sm:px-10 sm:py-10">
         <Outlet />
       </main>
 
-      <footer className="border-t border-border bg-surface-tinted">
-        <div className="mx-auto flex max-w-7xl flex-col gap-6 px-6 py-10 sm:px-10">
-          <div className="max-w-2xl space-y-3">
-            <p className="text-sm font-bold uppercase tracking-tight text-text">
-              République Française
-            </p>
-            <p className="text-sm leading-relaxed text-text-muted">
-              KPILOTE est le dispositif de suivi des politiques prioritaires du gouvernement. Il
-              permet d'évaluer les résultats des politiques publiques dans les territoires.
-            </p>
+      <footer className="border-t-2 border-primary bg-surface">
+        <div className="mx-auto max-w-7xl px-6 py-10 sm:px-10">
+          <div className="flex flex-col gap-8 pb-8 sm:flex-row sm:gap-12">
+            <Marianne className="shrink-0 text-base" />
+            <div className="max-w-2xl">
+              <p className="text-sm leading-relaxed text-text-muted">
+                KPILOTE est le dispositif de suivi des politiques prioritaires du gouvernement. Il
+                permet d'évaluer les résultats des politiques publiques dans les territoires.
+              </p>
+            </div>
           </div>
-          <div className="flex flex-wrap gap-x-6 gap-y-2 border-t border-border pt-6 text-sm text-text-muted">
-            <Link to="/accessibilite" className="transition-colors hover:text-primary">
-              Accessibilité : non conforme
-            </Link>
-            <Link to="/mentions-legales" className="transition-colors hover:text-primary">
-              Mentions légales
-            </Link>
-            <Link to="/donnees-personnelles" className="transition-colors hover:text-primary">
-              Données personnelles et cookies
-            </Link>
+
+          <div className="border-t border-border pt-6">
+            <ul className="flex flex-wrap gap-x-6 gap-y-2 text-xs text-text-muted">
+              <li>
+                <Link to="/accessibilite" className="transition-colors hover:text-primary">
+                  Accessibilité : non conforme
+                </Link>
+              </li>
+              <li>
+                <Link to="/mentions-legales" className="transition-colors hover:text-primary">
+                  Mentions légales
+                </Link>
+              </li>
+              <li>
+                <Link to="/donnees-personnelles" className="transition-colors hover:text-primary">
+                  Données personnelles et cookies
+                </Link>
+              </li>
+            </ul>
           </div>
         </div>
       </footer>

--- a/apps/kpilote-webapp/src/routes/__root.tsx
+++ b/apps/kpilote-webapp/src/routes/__root.tsx
@@ -25,13 +25,13 @@ function RootComponent() {
           <Link
             to="/"
             className="flex items-stretch gap-5 transition-opacity hover:opacity-80"
-            aria-label="Accueil Pilote"
+            aria-label="Accueil KPilote"
           >
             <Marianne />
             <span className="hidden w-px bg-border sm:block" aria-hidden />
             <span className="hidden flex-col justify-center gap-0.5 sm:flex">
               <span className="text-xl font-bold uppercase leading-none tracking-tight text-text">
-                Pilote
+                KPilote
               </span>
               <span className="text-sm font-normal text-text-muted">
                 Piloter l'action publique par les résultats
@@ -54,7 +54,7 @@ function RootComponent() {
               République Française
             </p>
             <p className="text-sm leading-relaxed text-text-muted">
-              PILOTE est le dispositif de suivi des politiques prioritaires du gouvernement. Il
+              KPILOTE est le dispositif de suivi des politiques prioritaires du gouvernement. Il
               permet d'évaluer les résultats des politiques publiques dans les territoires.
             </p>
           </div>

--- a/apps/kpilote-webapp/src/routes/__root.tsx
+++ b/apps/kpilote-webapp/src/routes/__root.tsx
@@ -50,11 +50,12 @@ function RootComponent() {
       <footer className="border-t-2 border-primary bg-surface">
         <div className="mx-auto max-w-7xl px-6 py-10 sm:px-10">
           <div className="flex flex-col gap-8 pb-8 sm:flex-row sm:gap-12">
-            <Marianne className="shrink-0 text-base" />
+            <Marianne className="shrink-0" />
             <div className="max-w-2xl">
               <p className="text-sm leading-relaxed text-text-muted">
-                KPILOTE est le dispositif de suivi des politiques prioritaires du gouvernement. Il
-                permet d'évaluer les résultats des politiques publiques dans les territoires.
+                À DÉFINIR — Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod
+                tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis
+                nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
               </p>
             </div>
           </div>

--- a/apps/kpilote-webapp/src/routes/__root.tsx
+++ b/apps/kpilote-webapp/src/routes/__root.tsx
@@ -48,12 +48,26 @@ function RootComponent() {
       </main>
 
       <footer className="border-t border-border bg-surface-tinted">
-        <div className="mx-auto flex max-w-7xl flex-col gap-4 px-6 py-8 text-xs text-text-muted sm:flex-row sm:items-center sm:justify-between sm:px-10">
-          <span>Pilote — République Française</span>
-          <div className="flex flex-wrap gap-x-5 gap-y-2">
-            <span>Accessibilité</span>
-            <span>Mentions légales</span>
-            <span>Données personnelles</span>
+        <div className="mx-auto flex max-w-7xl flex-col gap-6 px-6 py-10 sm:px-10">
+          <div className="max-w-2xl space-y-3">
+            <p className="text-sm font-bold uppercase tracking-tight text-text">
+              République Française
+            </p>
+            <p className="text-sm leading-relaxed text-text-muted">
+              PILOTE est le dispositif de suivi des politiques prioritaires du gouvernement. Il
+              permet d'évaluer les résultats des politiques publiques dans les territoires.
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-x-6 gap-y-2 border-t border-border pt-6 text-sm text-text-muted">
+            <Link to="/accessibilite" className="transition-colors hover:text-primary">
+              Accessibilité : non conforme
+            </Link>
+            <Link to="/mentions-legales" className="transition-colors hover:text-primary">
+              Mentions légales
+            </Link>
+            <Link to="/donnees-personnelles" className="transition-colors hover:text-primary">
+              Données personnelles et cookies
+            </Link>
           </div>
         </div>
       </footer>

--- a/apps/kpilote-webapp/src/routes/accessibilite.tsx
+++ b/apps/kpilote-webapp/src/routes/accessibilite.tsx
@@ -1,0 +1,116 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import { Heading, Text } from '@pilote/kpilote-ui/Typography'
+
+export const Route = createFileRoute('/accessibilite')({
+  component: AccessibilitePage,
+})
+
+function AccessibilitePage() {
+  return (
+    <div className="mx-auto max-w-3xl space-y-8">
+      <Heading as="h1" size="display-md" tone="primary">
+        Accessibilité
+      </Heading>
+
+      <section className="space-y-3">
+        <Heading as="h2" size="lg">
+          Déclaration d'accessibilité
+        </Heading>
+        <Text>
+          La Direction interministérielle de la transformation publique s'engage à rendre son
+          service accessible, conformément à l'article 47 de la loi n° 2005-102 du 11 février 2005.
+        </Text>
+        <Text>
+          À cette fin, nous mettons en œuvre la stratégie et les actions suivantes :
+          <br />
+          <a
+            href="https://www.modernisation.gouv.fr/files/2022-10/schema-pluriannuel-2022-2025-ditp.pdf"
+            target="_blank"
+            rel="noreferrer"
+            className="text-primary underline"
+          >
+            https://www.modernisation.gouv.fr/files/2022-10/schema-pluriannuel-2022-2025-ditp.pdf
+          </a>
+        </Text>
+        <Text>
+          Cette déclaration d'accessibilité s'applique à PILOTE (pilote.ditp@modernisation.gouv.fr).
+        </Text>
+      </section>
+
+      <section className="space-y-3">
+        <Heading as="h2" size="lg">
+          Etat de conformité
+        </Heading>
+        <Text>PILOTE est non conforme avec le RGAA. Le site n'a pas encore été audité.</Text>
+      </section>
+
+      <section className="space-y-3">
+        <Heading as="h2" size="lg">
+          Amélioration et contact
+        </Heading>
+        <Text>
+          Si vous n'arrivez pas à accéder à un contenu ou à un service, vous pouvez contacter
+          l'équipe de PILOTE pour être orienté vers une alternative accessible ou obtenir le contenu
+          sous une autre forme.
+        </Text>
+        <ul className="list-disc space-y-1 pl-5">
+          <Text as="li">E-mail: pilote.ditp@modernisation.gouv.fr</Text>
+          <Text as="li">Adresse : DITP, 20 avenue de Ségur, 75007 Paris France</Text>
+        </ul>
+        <Text>Nous essayons de répondre dans les 5 jours ouvrés suivant la demande.</Text>
+      </section>
+
+      <section className="space-y-3">
+        <Heading as="h2" size="lg">
+          Voie de recours
+        </Heading>
+        <Text>
+          Cette procédure est à utiliser dans le cas suivant : vous avez signalé au responsable du
+          site internet un défaut d'accessibilité qui vous empêche d'accéder à un contenu ou à un
+          des services du portail et vous n'avez pas obtenu de réponse satisfaisante.
+        </Text>
+        <Text>Vous pouvez :</Text>
+        <ul className="list-disc space-y-1 pl-5">
+          <Text as="li">
+            Écrire un message au{' '}
+            <a
+              href="https://formulaire.defenseurdesdroits.fr/formulaire_saisine/"
+              target="_blank"
+              rel="noreferrer"
+              className="text-primary underline"
+            >
+              Défenseur des droits
+            </a>
+          </Text>
+          <Text as="li">
+            Contacter{' '}
+            <a
+              href="https://www.defenseurdesdroits.fr/carte-des-delegues"
+              target="_blank"
+              rel="noreferrer"
+              className="text-primary underline"
+            >
+              le délégué du Défenseur des droits dans votre région
+            </a>
+          </Text>
+          <Text as="li">
+            Envoyer un courrier par la poste (gratuit, ne pas mettre de timbre) : Défenseur des
+            droits Libre réponse 71120 75342 Paris CEDEX 07
+          </Text>
+        </ul>
+        <Text>
+          Cette déclaration d'accessibilité a été créé le 28 juillet 2023 grâce au{' '}
+          <a
+            href="https://betagouv.github.io/a11y-generateur-declaration/#create"
+            target="_blank"
+            rel="noreferrer"
+            className="text-primary underline"
+          >
+            Générateur de Déclaration d'Accessibilité de BetaGouv.
+          </a>
+        </Text>
+      </section>
+    </div>
+  )
+}

--- a/apps/kpilote-webapp/src/routes/accessibilite.tsx
+++ b/apps/kpilote-webapp/src/routes/accessibilite.tsx
@@ -8,7 +8,7 @@ export const Route = createFileRoute('/accessibilite')({
 
 function AccessibilitePage() {
   return (
-    <div className="mx-auto max-w-3xl space-y-8">
+    <div className="space-y-8">
       <Heading as="h1" size="display-md" tone="primary">
         Accessibilité
       </Heading>

--- a/apps/kpilote-webapp/src/routes/accessibilite.tsx
+++ b/apps/kpilote-webapp/src/routes/accessibilite.tsx
@@ -34,7 +34,8 @@ function AccessibilitePage() {
           </a>
         </Text>
         <Text>
-          Cette déclaration d'accessibilité s'applique à PILOTE (pilote.ditp@modernisation.gouv.fr).
+          Cette déclaration d'accessibilité s'applique à KPILOTE
+          (pilote.ditp@modernisation.gouv.fr).
         </Text>
       </section>
 
@@ -42,7 +43,7 @@ function AccessibilitePage() {
         <Heading as="h2" size="lg">
           Etat de conformité
         </Heading>
-        <Text>PILOTE est non conforme avec le RGAA. Le site n'a pas encore été audité.</Text>
+        <Text>KPILOTE est non conforme avec le RGAA. Le site n'a pas encore été audité.</Text>
       </section>
 
       <section className="space-y-3">
@@ -51,8 +52,8 @@ function AccessibilitePage() {
         </Heading>
         <Text>
           Si vous n'arrivez pas à accéder à un contenu ou à un service, vous pouvez contacter
-          l'équipe de PILOTE pour être orienté vers une alternative accessible ou obtenir le contenu
-          sous une autre forme.
+          l'équipe de KPILOTE pour être orienté vers une alternative accessible ou obtenir le
+          contenu sous une autre forme.
         </Text>
         <ul className="list-disc space-y-1 pl-5">
           <Text as="li">E-mail: pilote.ditp@modernisation.gouv.fr</Text>

--- a/apps/kpilote-webapp/src/routes/donnees-personnelles.tsx
+++ b/apps/kpilote-webapp/src/routes/donnees-personnelles.tsx
@@ -8,7 +8,7 @@ export const Route = createFileRoute('/donnees-personnelles')({
 
 function DonneesPersonnellesPage() {
   return (
-    <div className="mx-auto max-w-3xl space-y-8 px-4 py-8">
+    <div className="space-y-8">
       <Heading as="h1" size="display-md" tone="primary">
         Données personnelles et cookies
       </Heading>

--- a/apps/kpilote-webapp/src/routes/donnees-personnelles.tsx
+++ b/apps/kpilote-webapp/src/routes/donnees-personnelles.tsx
@@ -20,7 +20,7 @@ function DonneesPersonnellesPage() {
         <Text>
           La Direction interministérielle de la transformation publique (mission Pilotage), située
           au 20 avenue de Ségur, 75007 Paris, est responsable du traitement des données personnelles
-          pour le site PILOTE et ses fonctionnalités, y compris le chatbot expérimental.
+          pour le site KPILOTE et ses fonctionnalités, y compris le chatbot expérimental.
         </Text>
         <Text>
           Pour toute question relative à la protection des données, vous pouvez contacter :
@@ -73,7 +73,7 @@ function DonneesPersonnellesPage() {
 
         <div className="space-y-3">
           <Heading as="h3" size="md">
-            Cookies utilisés sur PILOTE
+            Cookies utilisés sur KPILOTE
           </Heading>
           <Text>Deux types de cookies sont déposés :</Text>
 
@@ -127,7 +127,7 @@ function DonneesPersonnellesPage() {
 
         <div className="space-y-3">
           <Heading as="h3" size="md">
-            Traitement des données via le site PILOTE
+            Traitement des données via le site KPILOTE
           </Heading>
           <Text>
             Conformément au RGPD et à la loi &quot;Informatique et Libertés&quot; du 6 janvier 1978
@@ -171,7 +171,7 @@ function DonneesPersonnellesPage() {
 
         <div className="space-y-3">
           <Heading as="h3" size="md">
-            Dans le cadre de l&apos;expérimentation Assistant IA PILOTE
+            Dans le cadre de l&apos;expérimentation Assistant IA KPILOTE
           </Heading>
 
           <Heading as="h4" size="sm" tone="primary">

--- a/apps/kpilote-webapp/src/routes/donnees-personnelles.tsx
+++ b/apps/kpilote-webapp/src/routes/donnees-personnelles.tsx
@@ -1,0 +1,353 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import { Heading, Text } from '@pilote/kpilote-ui/Typography'
+
+export const Route = createFileRoute('/donnees-personnelles')({
+  component: DonneesPersonnellesPage,
+})
+
+function DonneesPersonnellesPage() {
+  return (
+    <div className="mx-auto max-w-3xl space-y-8 px-4 py-8">
+      <Heading as="h1" size="display-md" tone="primary">
+        Données personnelles et cookies
+      </Heading>
+
+      <section className="space-y-3">
+        <Heading as="h2" size="lg">
+          Responsable de traitement
+        </Heading>
+        <Text>
+          La Direction interministérielle de la transformation publique (mission Pilotage), située
+          au 20 avenue de Ségur, 75007 Paris, est responsable du traitement des données personnelles
+          pour le site PILOTE et ses fonctionnalités, y compris le chatbot expérimental.
+        </Text>
+        <Text>
+          Pour toute question relative à la protection des données, vous pouvez contacter :
+        </Text>
+        <ul className="list-disc space-y-1 pl-5">
+          <Text as="li">
+            Par email :{' '}
+            <a
+              href="mailto:contactrgpd.ditp@modernisation.gouv.fr"
+              className="text-primary underline"
+            >
+              contactrgpd.ditp@modernisation.gouv.fr
+            </a>
+          </Text>
+          <Text as="li">
+            Par voie postale : Direction interministérielle de la transformation publique TSA 70732
+            75334 Paris Cedex 07
+          </Text>
+        </ul>
+      </section>
+
+      <section className="space-y-3">
+        <Heading as="h2" size="lg">
+          Cookies
+        </Heading>
+
+        <div className="space-y-3">
+          <Heading as="h3" size="md">
+            Informations sur les cookies
+          </Heading>
+          <Text>
+            Lors de la consultation de notre site{' '}
+            <a
+              href="https://pilote.modernisation.gouv.fr"
+              target="_blank"
+              rel="noreferrer"
+              className="text-primary underline"
+            >
+              https://pilote.modernisation.gouv.fr
+            </a>
+            , des cookies sont déposés sur votre ordinateur, mobile ou tablette.
+          </Text>
+          <Text>
+            <span className="font-semibold">Définition d&apos;un cookie :</span> Un cookie est un
+            fichier texte déposé sur votre terminal lors de la visite d&apos;un site. Il permet de
+            collecter des informations relatives à votre navigation et de vous proposer des services
+            adaptés.
+          </Text>
+        </div>
+
+        <div className="space-y-3">
+          <Heading as="h3" size="md">
+            Cookies utilisés sur PILOTE
+          </Heading>
+          <Text>Deux types de cookies sont déposés :</Text>
+
+          <div className="rounded-lg border border-border bg-surface-tinted p-4">
+            <Text as="div" className="space-y-2">
+              <span className="block font-semibold text-primary">Cookies techniques :</span>
+              <ul className="list-disc space-y-1 pl-5">
+                <li>
+                  Permettent de personnaliser votre utilisation du site (ex. : afficher des cartes
+                  ou des réformes spécifiques selon votre profil).
+                </li>
+                <li>
+                  Assurent le bon fonctionnement du chatbot expérimental (ex. : conservation des
+                  préférences d&apos;affichage).
+                </li>
+              </ul>
+            </Text>
+          </div>
+
+          <div className="rounded-lg border border-border bg-surface-tinted p-4">
+            <Text as="div" className="space-y-2">
+              <span className="block font-semibold text-primary">
+                Cookies de mesure d&apos;audience :
+              </span>
+              <ul className="list-disc space-y-1 pl-5">
+                <li>
+                  Utilisés pour analyser la fréquentation du site (pages consultées, durée de
+                  visite, etc.).
+                </li>
+                <li>
+                  Outil utilisé : <span className="font-semibold">Matomo</span>, configuré pour être
+                  conforme à la recommandation &quot;Cookies&quot; de la CNIL (anonymisation des
+                  adresses IP).
+                </li>
+              </ul>
+              <span className="block">
+                <span className="font-semibold">Désactivation du suivi statistique :</span> Si vous
+                ne souhaitez pas être inclus dans les statistiques, activez la fonction &quot;Ne pas
+                me pister&quot; (Do Not Track) dans votre navigateur. Matomo respectera ce
+                paramètre.
+              </span>
+            </Text>
+          </div>
+        </div>
+      </section>
+
+      <section className="space-y-3">
+        <Heading as="h2" size="lg">
+          Données personnelles
+        </Heading>
+
+        <div className="space-y-3">
+          <Heading as="h3" size="md">
+            Traitement des données via le site PILOTE
+          </Heading>
+          <Text>
+            Conformément au RGPD et à la loi &quot;Informatique et Libertés&quot; du 6 janvier 1978
+            modifiée, vous disposez des droits suivants :
+          </Text>
+          <ul className="list-disc space-y-1 pl-5">
+            <Text as="li">
+              <span className="font-semibold">Droit d&apos;accès</span> (article 15 du RGPD) :
+              Demander une copie des données vous concernant.
+            </Text>
+            <Text as="li">
+              <span className="font-semibold">Droit de rectification</span> (article 16 du RGPD) :
+              Corriger des données inexactes.
+            </Text>
+            <Text as="li">
+              <span className="font-semibold">Droit à la limitation du traitement</span> (article 18
+              du RGPD) : Suspendre temporairement l&apos;utilisation de vos données.
+            </Text>
+            <Text as="li">
+              <span className="font-semibold">Droit à l&apos;effacement</span> (article 17 du RGPD)
+              : Sous réserve des obligations légales de conservation.
+            </Text>
+            <Text as="li">
+              <span className="font-semibold">Droit d&apos;opposition</span> (article 21 du RGPD) :
+              Pour des motifs légitimes, sauf si le traitement est obligatoire pour une mission de
+              service public.
+            </Text>
+          </ul>
+          <Text>Pour exercer ces droits, envoyez votre demande :</Text>
+          <ul className="list-disc space-y-1 pl-5">
+            <Text as="li">
+              Par email :{' '}
+              <a href="mailto:pilote.ditp@modernisation.gouv.fr" className="text-primary underline">
+                pilote.ditp@modernisation.gouv.fr
+              </a>
+            </Text>
+            <Text as="li">Par voie postale (adresse ci-dessus).</Text>
+          </ul>
+          <Text>En cas de difficulté non résolue, vous pouvez saisir la CNIL.</Text>
+        </div>
+
+        <div className="space-y-3">
+          <Heading as="h3" size="md">
+            Dans le cadre de l&apos;expérimentation Assistant IA PILOTE
+          </Heading>
+
+          <Heading as="h4" size="sm" tone="primary">
+            Finalités :
+          </Heading>
+          <Text>Le chatbot est une expérimentation visant à :</Text>
+          <ul className="list-disc space-y-1 pl-5">
+            <Text as="li">
+              Faciliter l&apos;exploitation du tableau de bord par les agents, en leur permettant
+              d&apos;interroger les données de manière intuitive, en utilisant des fonctionnalités
+              d&apos;intelligence artificielle (modèles de langage).
+            </Text>
+            <Text as="li">
+              Optimiser l&apos;utilisation des indicateurs pour améliorer les résultats de
+              l&apos;action publique.
+            </Text>
+            <Text as="li">
+              Recueillir des retours utilisateurs uniquement sur la qualité des réponses du chatbot
+              (ex. : pertinence, complétude, exactitude), afin d&apos;ajuster son fonctionnement
+              technique.
+            </Text>
+          </ul>
+
+          <Heading as="h4" size="sm" tone="primary">
+            Données collectées :
+          </Heading>
+          <ul className="list-disc space-y-1 pl-5">
+            <Text as="li">
+              Prompts (questions posées au chatbot, ex. : &quot;Quels sont les indicateurs clés pour
+              le programme X ?&quot;).
+            </Text>
+            <Text as="li">Réponses générées par l&apos;IA.</Text>
+            <Text as="li">
+              Feedbacks (👍/👎, catégories de problèmes : hallucination, réponse incomplète, hors
+              sujet, problème technique, autre).
+            </Text>
+            <Text as="li">
+              Commentaires libres (facultatifs, strictement limités à l&apos;évaluation des
+              réponses).
+            </Text>
+            <Text as="li">Logs d&apos;utilisation (horodatage, identifiants pseudonymisés).</Text>
+          </ul>
+
+          <Text>
+            <span className="font-semibold">Base légale :</span> Le traitement repose sur
+            l&apos;article 6.1.e du RGPD (mission d&apos;intérêt public), car il contribue à
+            améliorer l&apos;efficacité des outils d&apos;analyse des politiques publiques.
+          </Text>
+
+          <div className="rounded-lg border border-border bg-surface-tinted p-4">
+            <Text as="div" className="space-y-2">
+              <span className="block font-semibold text-primary">
+                Pseudonymisation et réidentification
+              </span>
+              <span className="block">
+                Vos données sont <span className="font-semibold">pseudonymisées par défaut</span> :
+                vos interactions ne sont pas directement associées à votre identité.
+              </span>
+              <span className="block">
+                Une réidentification est possible{' '}
+                <span className="font-semibold">
+                  uniquement en cas de besoin de support technique
+                </span>{' '}
+                (ex. : résolution d&apos;un bug, demande explicite de votre part), et uniquement par
+                des personnes habilitées.
+              </span>
+              <span className="block italic">
+                Exemple de cas de réidentification : &quot;Si vous signalez une erreur critique dans
+                une réponse du chatbot, notre équipe support pourra temporairement accéder à vos
+                données pour reproduire et corriger le problème.&quot;
+              </span>
+            </Text>
+          </div>
+
+          <Heading as="h4" size="sm" tone="primary">
+            Durées de conservation
+          </Heading>
+          <ul className="list-disc space-y-1 pl-5">
+            <Text as="li">
+              Prompts, réponses et retours utilisateurs : Conservés pendant la durée de
+              l&apos;expérimentation (1 an), puis supprimés.
+            </Text>
+            <Text as="li">
+              Données nominatives (en cas de réidentification) : Supprimées dès la résolution du
+              support (maximum 3 mois).
+            </Text>
+          </ul>
+        </div>
+
+        <div className="space-y-3">
+          <Heading as="h3" size="md">
+            Vos droits et recommandations
+          </Heading>
+
+          <Heading as="h4" size="sm" tone="primary">
+            Droits RGPD :
+          </Heading>
+          <ul className="list-disc space-y-1 pl-5">
+            <Text as="li">
+              Vous pouvez accéder, rectifier ou supprimer vos données (sous réserve des obligations
+              légales).
+            </Text>
+            <Text as="li">Vous pouvez refuser de fournir un feedback ou un commentaire libre.</Text>
+            <Text as="li">
+              Pour les commentaires libres, vous pouvez autoriser ou refuser d&apos;être
+              recontacté(e) pour approfondir votre retour.
+            </Text>
+          </ul>
+
+          <Heading as="h4" size="sm" tone="primary">
+            Recommandations :
+          </Heading>
+          <ul className="list-disc space-y-1 pl-5">
+            <Text as="li">
+              Évitez de saisir des données personnelles (noms, numéros de dossier, etc.) dans les
+              prompts ou commentaires.
+            </Text>
+            <Text as="li">
+              Signalez les réponses inappropriées (ex. : erreurs factuelles, hallucinations) via le
+              bouton &quot;Signaler un problème&quot; intégré au chatbot.
+            </Text>
+          </ul>
+        </div>
+
+        <div className="space-y-3">
+          <Heading as="h3" size="md">
+            Exercice de vos droits
+          </Heading>
+          <Text>
+            Pour toute question ou demande relative à vos données traitées via le chatbot, contactez
+            :
+          </Text>
+          <ul className="list-disc space-y-1 pl-5">
+            <Text as="li">
+              Par email :{' '}
+              <a href="mailto:pilote.ditp@modernisation.gouv.fr" className="text-primary underline">
+                pilote.ditp@modernisation.gouv.fr
+              </a>
+            </Text>
+            <Text as="li">Par voie postale (adresse ci-dessus).</Text>
+          </ul>
+        </div>
+
+        <div className="space-y-3">
+          <Heading as="h3" size="md">
+            Pour toute information complémentaire
+          </Heading>
+          <Text>
+            Pour des demandes plus largement liées à l&apos;application du RGPD, vous pouvez
+            contacter :
+          </Text>
+          <ul className="list-disc space-y-1 pl-5">
+            <Text as="li">
+              Par email :{' '}
+              <a
+                href="mailto:contactrgpd.ditp@modernisation.gouv.fr"
+                className="text-primary underline"
+              >
+                contactrgpd.ditp@modernisation.gouv.fr
+              </a>
+            </Text>
+          </ul>
+          <Text>
+            En cas de difficulté non résolue, vous pouvez contacter la{' '}
+            <a
+              href="https://www.cnil.fr"
+              target="_blank"
+              rel="noreferrer"
+              className="text-primary underline"
+            >
+              CNIL
+            </a>
+            .
+          </Text>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/apps/kpilote-webapp/src/routes/mentions-legales.tsx
+++ b/apps/kpilote-webapp/src/routes/mentions-legales.tsx
@@ -8,7 +8,7 @@ export const Route = createFileRoute('/mentions-legales')({
 
 function MentionsLegalesPage() {
   return (
-    <div className="mx-auto max-w-3xl space-y-8">
+    <div className="space-y-8">
       <Heading as="h1" size="display-md" tone="primary">
         Mentions légales
       </Heading>

--- a/apps/kpilote-webapp/src/routes/mentions-legales.tsx
+++ b/apps/kpilote-webapp/src/routes/mentions-legales.tsx
@@ -1,0 +1,80 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import { Heading, Text } from '@pilote/kpilote-ui/Typography'
+
+export const Route = createFileRoute('/mentions-legales')({
+  component: MentionsLegalesPage,
+})
+
+function MentionsLegalesPage() {
+  return (
+    <div className="mx-auto max-w-3xl space-y-8">
+      <Heading as="h1" size="display-md" tone="primary">
+        Mentions légales
+      </Heading>
+
+      <section className="space-y-3">
+        <Heading as="h2" size="lg">
+          Éditeur
+        </Heading>
+        <Text>
+          Ce site est édité par la Direction Interministérielle de la Transformation Publique.
+        </Text>
+        <ul>
+          <Text as="li">20 avenue de Ségur</Text>
+          <Text as="li">75334 Paris Cedex 07</Text>
+          <Text as="li">France</Text>
+        </ul>
+        <Text>
+          <a
+            href="https://www.modernisation.gouv.fr"
+            className="text-primary underline"
+            target="_blank"
+            rel="noreferrer"
+          >
+            https://www.modernisation.gouv.fr
+          </a>
+        </Text>
+      </section>
+
+      <section className="space-y-3">
+        <Heading as="h2" size="lg">
+          Direction de la publication
+        </Heading>
+        <Text>
+          Ce site est édité par la Direction Interministérielle de la Transformation Publique.
+        </Text>
+      </section>
+
+      <section className="space-y-3">
+        <Heading as="h2" size="lg">
+          Responsable éditoriale
+        </Heading>
+        <Text>Cécile Le Guen</Text>
+      </section>
+
+      <section className="space-y-3">
+        <Heading as="h2" size="lg">
+          Hébergement
+        </Heading>
+        <ul>
+          <Text as="li">Scalingo SAS</Text>
+          <Text as="li">3 place de Haguenau</Text>
+          <Text as="li">67000 Strasbourg</Text>
+          <Text as="li">France</Text>
+        </ul>
+        <Text>SIRET 80866548300018</Text>
+        <Text>
+          <a
+            href="https://scalingo.com/fr"
+            className="text-primary underline"
+            target="_blank"
+            rel="noreferrer"
+          >
+            https://scalingo.com/fr
+          </a>
+        </Text>
+      </section>
+    </div>
+  )
+}

--- a/packages/kpilote-ui/src/EntityCard.tsx
+++ b/packages/kpilote-ui/src/EntityCard.tsx
@@ -18,7 +18,7 @@ type EntityCardProps = Omit<ComponentProps<'div'>, 'title'> & {
 
 const styles = [
   'group relative flex h-full flex-col gap-3 overflow-hidden rounded-xl bg-surface py-5 pl-6 pr-5',
-  'border border-border-strong transition-all duration-150',
+  'border border-border transition-all duration-150',
   'hover:border-primary hover:bg-surface-tinted hover:-translate-y-0.5',
   'focus-within:border-primary focus-within:bg-surface-tinted',
 ].join(' ')

--- a/packages/kpilote-ui/theme.css
+++ b/packages/kpilote-ui/theme.css
@@ -19,8 +19,8 @@
   --color-surface-muted: #f6f6f6;
 
   /* Borders */
-  --color-border: #ececec;
-  --color-border-strong: #e0e0e0;
+  --color-border: #e0e0e0;
+  --color-border-strong: #cecece;
 
   --shadow-raised: 0 1px 3px rgba(0, 0, 18, 0.16);
 


### PR DESCRIPTION
## PIL-1676 — [MEP] Dernières retouches

### Retouches UI (`107eb557a`)
- **Borders unifiées** : `--color-border` → `#e0e0e0` (partout via `border-border`), `border-strong` → `#cecece`.
- **Tuile indicateur** : date de valeur d'avancement réaffichée sous la valeur, en **MM/AAAA** (sans « au »).
- **Date d'objectif** en **MM/AAAA**.
- **Fiche indicateur** : badge en hausse/baisse à la taille de la valeur précédente.
- **Header** : lien **« Contacter l'équipe »** (`mailto`) avant « Mon espace ».

### Pages légales + footer (`c1505d96b`)
- 3 **pages publiques** portées depuis `pilote-ppg` (Tailwind/kpilote-ui) : **/mentions-legales**, **/accessibilite**, **/donnees-personnelles**.
- **Footer** façon PILOTE : brand + description + liens cliquables.

### Renommage PILOTE → KPILOTE + extraction (`f2f086ed9`)
- Textes user-facing **« PILOTE » → « KPILOTE »** (footer, bouton contact, pages accessibilité & données personnelles).
- **Brand / aria-label / header admin → « KPilote »** (webapp + admin).
- Verbe « Piloter » et identifiants techniques (`@pilote/*`, email, clés) **non touchés**.
- Extraction du bouton contact dans un composant **`ContacterEquipe`**.

### Hors périmètre / notes
- **Cartes départements & régions** (`[TIME BOX]`) : reporté.
- Font bold global : rien à faire. Gris 625→425 : on garde `#e0e0e0`.
- Pages légales = **première proposition** (à faire relire par le métier/juridique).

### Vérifications
- Lint webapp **et** admin : eslint + `tsc --noEmit` + prettier ✅