### PR TITLE
feat: sélecteur d'individu par ensemble de référentiels (PIL-1677)

### DIFF
--- a/apps/kpilote-api/src/referentiel/queries/listReferentiels.test.ts
+++ b/apps/kpilote-api/src/referentiel/queries/listReferentiels.test.ts
@@ -4,7 +4,14 @@ import { encodeCursor } from '@/framework/persistence/paginate'
 import { listReferentiels } from '@/referentiel/queries/listReferentiels'
 import { fixtures } from '@/test/fixtures'
 import { integrationTest } from '@/test/integrationTest'
-import { testIndividuId, testReferentielId, testWidgetId } from '@/test/randomIds'
+import {
+  testIndicateurId,
+  testIndividuId,
+  testPanierId,
+  testReferentielId,
+  testWidgetId,
+} from '@/test/randomIds'
+import { runAsPrincipal } from '@/test/runAsPrincipal'
 
 describe.concurrent('listReferentiels', () => {
   it(
@@ -159,6 +166,74 @@ describe.concurrent('listReferentiels', () => {
       expect(value.items.map((r) => r.id)).toEqual([ref1, ref2, ref3, ref4, ref5])
       expect(value.pagination).toEqual({ cursor: encodeCursor(created[4]!.id), hasMore: true })
       expect(value.total).toBe(6)
+    }),
+  )
+
+  it(
+    'scope=me ne renvoie que les référentiels reliés à un indicateur lisible',
+    integrationTest(async () => {
+      const refAvec = testReferentielId()
+      const refSans = testReferentielId()
+      await fixtures.indicateurReferentiel({
+        indicateur: { publicId: testIndicateurId(), visibilite: 'PUBLIC' },
+        referentiel: { publicId: refAvec, nom: 'Avec' },
+      })
+      await fixtures.referentiel({ publicId: refSans, nom: 'Sans' })
+
+      const apiKey = await fixtures.apiKey()
+      const result = await runAsPrincipal(apiKey.id, () => listReferentiels({ scope: 'me' }))
+
+      const ids = result._unsafeUnwrap().items.map((r) => r.id)
+      expect(ids).toContain(refAvec)
+      expect(ids).not.toContain(refSans)
+    }),
+  )
+
+  it(
+    "scope=me exclut les référentiels dont l'indicateur n'est pas lisible par le principal",
+    integrationTest(async () => {
+      const refPrive = testReferentielId()
+      await fixtures.indicateurReferentiel({
+        indicateur: { publicId: testIndicateurId(), visibilite: 'PRIVE' },
+        referentiel: { publicId: refPrive, nom: 'Privé' },
+      })
+
+      const apiKey = await fixtures.apiKey()
+      const result = await runAsPrincipal(apiKey.id, () => listReferentiels({ scope: 'me' }))
+
+      expect(result._unsafeUnwrap().items.map((r) => r.id)).not.toContain(refPrive)
+    }),
+  )
+
+  it(
+    'scope=panier renvoie les référentiels des indicateurs du panier',
+    integrationTest(async () => {
+      const refDuPanier = testReferentielId()
+      const refHorsPanier = testReferentielId()
+      const indicateurPublicId = testIndicateurId()
+      const panierPublicId = testPanierId()
+      await fixtures.indicateurReferentiel({
+        indicateur: { publicId: indicateurPublicId, visibilite: 'PUBLIC' },
+        referentiel: { publicId: refDuPanier, nom: 'Dans le panier' },
+      })
+      await fixtures.indicateurReferentiel({
+        indicateur: { publicId: testIndicateurId(), visibilite: 'PUBLIC' },
+        referentiel: { publicId: refHorsPanier, nom: 'Hors panier' },
+      })
+      await fixtures.panier({
+        publicId: panierPublicId,
+        visibilite: 'PUBLIC',
+        indicateurs: [{ publicId: indicateurPublicId }],
+      })
+
+      const apiKey = await fixtures.apiKey()
+      const result = await runAsPrincipal(apiKey.id, () =>
+        listReferentiels({ scope: `panier:${panierPublicId}` }),
+      )
+
+      const ids = result._unsafeUnwrap().items.map((r) => r.id)
+      expect(ids).toContain(refDuPanier)
+      expect(ids).not.toContain(refHorsPanier)
     }),
   )
 })

--- a/apps/kpilote-api/src/referentiel/queries/listReferentiels.ts
+++ b/apps/kpilote-api/src/referentiel/queries/listReferentiels.ts
@@ -4,16 +4,41 @@ import {
 } from '@pilote/kpilote-shared/referentiel'
 import { ResultAsync } from 'neverthrow'
 
+import { isAdminPrincipal, requireCurrentPrincipalId } from '@/framework/auth/userContext'
 import { db } from '@/framework/persistence/dbStore'
 import { buildPaginationArgs, toPaginatedResponse } from '@/framework/persistence/paginate'
+import { type Prisma } from '@/generated/prisma/client'
+import { withIndicateurReadPermission } from '@/indicateur/permissions'
 import { toReferentielApiModel } from '@/referentiel/utils'
+
+const PANIER_SCOPE_PREFIX = 'panier:'
+
+// Restreint aux référentiels reliés à ≥1 indicateur pertinent selon le scope :
+// `me` = indicateurs lisibles par le principal, `panier:<publicId>` = indicateurs
+// du panier (toujours filtrés par lisibilité). Le concept d'« ensemble » n'est pas
+// matérialisé : la hiérarchie est reconstruite côté front via les individus.
+const buildScopeFilter = (
+  scope: ListReferentielsQuery['scope'],
+): Prisma.ReferentielWhereInput => {
+  if (!scope) return {}
+  const principalId = requireCurrentPrincipalId()
+  const isAdmin = isAdminPrincipal()
+  const base: Prisma.IndicateurWhereInput = scope.startsWith(PANIER_SCOPE_PREFIX)
+    ? { paniers: { some: { panier: { publicId: scope.slice(PANIER_SCOPE_PREFIX.length) } } } }
+    : {}
+  const indicateurWhere = withIndicateurReadPermission(base, principalId, { isAdmin })
+  return { indicateurs: { some: { indicateur: indicateurWhere } } }
+}
 
 export const listReferentiels = (
   params: ListReferentielsQuery,
 ): ResultAsync<ReferentielListApiModel, never> => {
-  const where = params.recherche
-    ? { nom: { contains: params.recherche, mode: 'insensitive' as const } }
-    : {}
+  const where: Prisma.ReferentielWhereInput = {
+    ...(params.recherche
+      ? { nom: { contains: params.recherche, mode: 'insensitive' as const } }
+      : {}),
+    ...buildScopeFilter(params.scope),
+  }
 
   const fetchPage = db().referentiel.findMany({
     where,

--- a/apps/kpilote-api/src/referentiel/routes.test.ts
+++ b/apps/kpilote-api/src/referentiel/routes.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+
+import { referentielRoutes } from '@/referentiel/routes'
+import { buildTestApp } from '@/test/buildTestApp'
+import { fixtures } from '@/test/fixtures'
+import { integrationTest } from '@/test/integrationTest'
+import { testIndicateurId } from '@/test/randomIds'
+
+const buildApp = () => buildTestApp(referentielRoutes)
+
+const RAW_KEY = 'pilote_live_referentiels_scope_me_key_ok'
+
+describe.concurrent('GET /referentiels', () => {
+  it(
+    // Régression : le handler doit transmettre `scope` à la query. Un test
+    // unitaire sur listReferentiels() ne couvre ni ce câblage ni la validation
+    // de la réponse OpenAPI (d'où des publicId au format attendu ici).
+    'scope=me ne renvoie que les référentiels reliés à un indicateur lisible',
+    integrationTest(async () => {
+      await fixtures.indicateurReferentiel({
+        indicateur: { publicId: testIndicateurId(), visibilite: 'PUBLIC' },
+        referentiel: { publicId: 'REF-SCOPEA', nom: 'Avec indicateur' },
+      })
+      await fixtures.referentiel({ publicId: 'REF-SCOPEB', nom: 'Sans indicateur' })
+      await fixtures.apiKey({ rawKey: RAW_KEY })
+
+      const response = await buildApp().request('/referentiels?scope=me', {
+        headers: { Authorization: `Bearer ${RAW_KEY}` },
+      })
+
+      expect(response.status).toBe(200)
+      const body = (await response.json()) as { items: Array<{ id: string }> }
+      const ids = body.items.map((r) => r.id)
+      expect(ids).toContain('REF-SCOPEA')
+      expect(ids).not.toContain('REF-SCOPEB')
+    }),
+  )
+})

--- a/apps/kpilote-api/src/referentiel/routes.ts
+++ b/apps/kpilote-api/src/referentiel/routes.ts
@@ -37,7 +37,7 @@ const getReferentielsRoute = createRoute({
   tags: ['Referentiel'],
   summary: 'Lister les référentiels',
   description:
-    'Retourne la liste paginée des référentiels avec un filtre de recherche par nom. La pagination est cursor-based : passez `cursor` (renvoyé dans la réponse précédente) pour obtenir la page suivante. Chaque item inclut `nombreIndividus` (population du référentiel).',
+    'Retourne la liste paginée des référentiels avec un filtre de recherche par nom. La pagination est cursor-based : passez `cursor` (renvoyé dans la réponse précédente) pour obtenir la page suivante. Chaque item inclut `nombreIndividus` (population du référentiel). Paramètre optionnel `scope` (`me` ou `panier:<publicId>`) pour ne renvoyer que les référentiels reliés à au moins un indicateur pertinent (respectivement lisible par l’utilisateur, ou appartenant au panier).',
   middleware: [requireAuthentication],
   request: { query: listReferentielsQuerySchema },
   responses: {

--- a/apps/kpilote-api/src/referentiel/routes.ts
+++ b/apps/kpilote-api/src/referentiel/routes.ts
@@ -127,9 +127,9 @@ const getIndividusForReferentielRoute = createRoute({
 export const referentielRoutes = createOpenApiHono()
 
 referentielRoutes.openapi(getReferentielsRoute, async (context) => {
-  const { recherche, cursor, pageSize } = context.req.valid('query')
+  const { recherche, cursor, pageSize, scope } = context.req.valid('query')
 
-  return listReferentiels({ recherche, cursor, pageSize }).match(
+  return listReferentiels({ recherche, cursor, pageSize, scope }).match(
     (data) =>
       jsonResponseOk({
         context,

--- a/apps/kpilote-webapp/src/api/referentiels.ts
+++ b/apps/kpilote-webapp/src/api/referentiels.ts
@@ -12,7 +12,7 @@ import {
 import { apiClient } from '@/api/client'
 
 export const fetchReferentiels = async (
-  params: { cursor?: string } = {},
+  params: { cursor?: string; scope?: string } = {},
 ): Promise<ReferentielListApiModel> => {
   const json = await apiClient.get('referentiels', { searchParams: params }).json()
   return referentielListApiModelSchema.parse(json)

--- a/apps/kpilote-webapp/src/components/DashboardSwitch.tsx
+++ b/apps/kpilote-webapp/src/components/DashboardSwitch.tsx
@@ -21,9 +21,17 @@ export function DashboardSwitch() {
       aria-label="Basculer entre indicateurs et dossiers"
       value={vue}
       onValueChange={(prochaineVue) => {
+        // On transporte les deux modèles de sélection : `/indicateurs` lit
+        // `individus` (sélection par ensemble) et strippe le reste ; `/paniers`
+        // (liste, ancien modèle) lit `individu`/`referentiel`. Chaque face ignore
+        // ce qu'elle ne connaît pas.
         void navigate({
           to: ROUTE_BY_VUE[prochaineVue],
-          search: { individu: search.individu, referentiel: search.referentiel },
+          search: {
+            individus: search.individus,
+            individu: search.individu,
+            referentiel: search.referentiel,
+          },
         })
       }}
       options={[

--- a/apps/kpilote-webapp/src/components/indicateurs/EnsembleIndividuSelect.tsx
+++ b/apps/kpilote-webapp/src/components/indicateurs/EnsembleIndividuSelect.tsx
@@ -1,0 +1,74 @@
+import { Popover as PopoverPrimitive } from 'radix-ui'
+import { ChevronDown } from 'lucide-react'
+import { useState } from 'react'
+
+import { clsxm } from '@/lib/clsxm'
+import { type ReferentielGroup } from '@/lib/individus/hierarchy'
+
+import { ReferentielSelectCommandStep } from './IndividuSelect'
+
+type EnsembleIndividuSelectProps = {
+  id?: string
+  group: ReferentielGroup
+  value: string
+  onChange: (next: { individu: string; referentiel: string }) => void
+}
+
+// Sélecteur d'individu scopé à un seul ensemble (référentiel racine + son
+// sous-arbre). Contrairement à IndividuSelect, pas d'étape « choisir le
+// référentiel racine » : la page affiche une rangée de ces sélecteurs, un par
+// ensemble pertinent.
+export function EnsembleIndividuSelect({
+  id,
+  group,
+  value,
+  onChange,
+}: EnsembleIndividuSelectProps) {
+  const [open, setOpen] = useState(false)
+  const selected = group.nodes.find((n) => n.individu.id === value)
+
+  return (
+    <PopoverPrimitive.Root open={open} onOpenChange={setOpen}>
+      <PopoverPrimitive.Trigger
+        id={id}
+        className={clsxm(
+          'inline-flex w-full min-w-[18rem] items-center justify-between gap-2 rounded-md border border-border bg-surface px-3 py-2.5 text-left text-sm font-medium text-text sm:min-w-[25rem]',
+          'hover:border-border-strong',
+          'focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary',
+          'data-[state=open]:border-primary',
+        )}
+      >
+        <span className="flex min-w-0 flex-col">
+          <span className="truncate text-xs font-normal text-text-muted">
+            {group.referentiel.nom}
+          </span>
+          {selected ? (
+            <span className="truncate">{selected.individu.nom}</span>
+          ) : (
+            <span className="text-text-subtle">Sélectionner un individu…</span>
+          )}
+        </span>
+        <ChevronDown className="size-4 shrink-0 text-text-muted" />
+      </PopoverPrimitive.Trigger>
+
+      <PopoverPrimitive.Portal>
+        <PopoverPrimitive.Content
+          align="start"
+          sideOffset={6}
+          className="z-50 w-[var(--radix-popover-trigger-width)] min-w-[32rem] overflow-hidden rounded-lg border border-border bg-surface shadow-[0_8px_24px_rgba(0,0,0,0.06)]"
+        >
+          <ReferentielSelectCommandStep
+            referentielNom={group.referentiel.nom}
+            nodes={group.nodes}
+            value={value}
+            onBack={null}
+            onSelect={(next) => {
+              onChange(next)
+              setOpen(false)
+            }}
+          />
+        </PopoverPrimitive.Content>
+      </PopoverPrimitive.Portal>
+    </PopoverPrimitive.Root>
+  )
+}

--- a/apps/kpilote-webapp/src/components/indicateurs/EnsembleIndividuSelect.tsx
+++ b/apps/kpilote-webapp/src/components/indicateurs/EnsembleIndividuSelect.tsx
@@ -32,7 +32,7 @@ export function EnsembleIndividuSelect({
       <PopoverPrimitive.Trigger
         id={id}
         className={clsxm(
-          'inline-flex w-full min-w-[18rem] items-center justify-between gap-2 rounded-md border border-border bg-surface px-3 py-2.5 text-left text-sm font-medium text-text sm:min-w-[25rem]',
+          'inline-flex min-w-[16rem] items-center justify-between gap-2 rounded-md border border-border bg-surface px-3 py-2.5 text-left text-sm font-medium text-text',
           'hover:border-border-strong',
           'focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary',
           'data-[state=open]:border-primary',

--- a/apps/kpilote-webapp/src/components/indicateurs/IndicateurCard.tsx
+++ b/apps/kpilote-webapp/src/components/indicateurs/IndicateurCard.tsx
@@ -9,8 +9,11 @@ import {
 import { EntityCard } from '@pilote/kpilote-ui/EntityCard'
 
 export type IndicateurCardContext = {
+  // Individu résolu pour cet indicateur (publicId) — sert à l'affichage de l'avancement.
   individu: string
-  referentiel: string
+  // Sélection complète par ensemble (search `individus`), propagée telle quelle
+  // au détail : la page détail y résout l'individu de son propre ensemble.
+  individus?: string | undefined
 }
 
 export function IndicateurCard({
@@ -36,7 +39,11 @@ export function IndicateurCard({
         ) : undefined
       }
     >
-      <Link to="/indicateurs/$id" params={{ id: indicateur.id }} search={context ?? {}} />
+      <Link
+        to="/indicateurs/$id"
+        params={{ id: indicateur.id }}
+        search={context ? { individus: context.individus } : {}}
+      />
     </EntityCard>
   )
 }

--- a/apps/kpilote-webapp/src/components/indicateurs/IndividuSelect.tsx
+++ b/apps/kpilote-webapp/src/components/indicateurs/IndividuSelect.tsx
@@ -95,7 +95,7 @@ function RootReferentielsCommandStep({
 }
 
 // Étape 2 : choix d'un individu dans la hiérarchie complète du référentiel racine.
-function ReferentielSelectCommandStep({
+export function ReferentielSelectCommandStep({
   referentielNom,
   nodes,
   value,

--- a/apps/kpilote-webapp/src/components/indicateurs/IndividusSelectorBar.tsx
+++ b/apps/kpilote-webapp/src/components/indicateurs/IndividusSelectorBar.tsx
@@ -1,0 +1,33 @@
+import { pickRoot, type ReferentielGroup } from '@/lib/individus/hierarchy'
+
+import { EnsembleIndividuSelect } from './EnsembleIndividuSelect'
+
+type IndividusSelectorBarProps = {
+  groups: ReadonlyArray<ReferentielGroup>
+  selected: ReadonlyMap<string, string>
+  onSelect: (rootReferentielId: string, individuId: string) => void
+}
+
+// Rangée de sélecteurs : un par ensemble de référentiels pertinent. Quand l'URL
+// ne porte pas de choix pour un ensemble, on affiche le défaut (niveau le plus
+// haut, premier de la liste) via pickRoot.
+export function IndividusSelectorBar({ groups, selected, onSelect }: IndividusSelectorBarProps) {
+  if (groups.length === 0) return null
+
+  return (
+    <div className="flex flex-wrap items-end gap-3">
+      {groups.map((group) => {
+        const rootId = group.referentiel.id
+        const value = selected.get(rootId) ?? pickRoot(group.nodes)?.individu.id ?? ''
+        return (
+          <EnsembleIndividuSelect
+            key={rootId}
+            group={group}
+            value={value}
+            onChange={({ individu }) => onSelect(rootId, individu)}
+          />
+        )
+      })}
+    </div>
+  )
+}

--- a/apps/kpilote-webapp/src/components/paniers/PanierCard.tsx
+++ b/apps/kpilote-webapp/src/components/paniers/PanierCard.tsx
@@ -36,7 +36,7 @@ export function PanierCard({
         </>
       }
     >
-      <Link to="/paniers/$id" params={{ id: panier.id }} search={context ?? {}} />
+      <Link to="/paniers/$id" params={{ id: panier.id }} search={{}} />
     </EntityCard>
   )
 }

--- a/apps/kpilote-webapp/src/lib/individus/hierarchy.test.ts
+++ b/apps/kpilote-webapp/src/lib/individus/hierarchy.test.ts
@@ -2,7 +2,13 @@ import { type IndividuApiModel } from '@pilote/kpilote-shared/individu'
 import { type ReferentielApiModel } from '@pilote/kpilote-shared/referentiel'
 import { describe, expect, it } from 'vitest'
 
-import { buildOrderedNodes, groupNodesByRootReferentiel, pickRoot } from './hierarchy'
+import {
+  buildOrderedNodes,
+  filterGroupsForReferentiels,
+  groupNodesByRootReferentiel,
+  pickRoot,
+  resolveIndividuForIndicateur,
+} from './hierarchy'
 
 const referentiel = (id: string, nom: string): ReferentielApiModel => ({
   id,
@@ -167,5 +173,93 @@ describe('groupNodesByRootReferentiel', () => {
 
   it('renvoie un tableau vide sans nœud', () => {
     expect(groupNodesByRootReferentiel([])).toEqual([])
+  })
+})
+
+// Forêt de référence : un ensemble France (NAT > REG > DEPT) et un ensemble Bassins.
+const buildReferenceGroups = () => {
+  const refNat = referentiel('REF-NAT', 'France (national)')
+  const refReg = referentiel('REF-REG', 'Régions')
+  const refDept = referentiel('REF-DEPT', 'Départements')
+  const refBv = referentiel('REF-BV', 'Bassins versants')
+  const refsById = new Map([
+    [refNat.id, refNat],
+    [refReg.id, refReg],
+    [refDept.id, refDept],
+    [refBv.id, refBv],
+  ])
+  const fr = individu('IND-FR', 'France', 'REF-NAT')
+  const idf = individu('IND-IDF', 'Île-de-France', 'REF-REG', ['IND-FR'])
+  const paris = individu('IND-PARIS', 'Paris', 'REF-DEPT', ['IND-IDF'])
+  const bv = individu('IND-BV1', 'Rhône', 'REF-BV')
+  return groupNodesByRootReferentiel(buildOrderedNodes([fr, idf, paris, bv], refsById))
+}
+
+describe('filterGroupsForReferentiels', () => {
+  it("ne garde que les groupes dont l'arbre intersecte les référentiels voulus", () => {
+    const groups = buildReferenceGroups()
+
+    const kept = filterGroupsForReferentiels(groups, ['REF-DEPT'])
+
+    expect(kept.map((g) => g.referentiel.id)).toEqual(['REF-NAT'])
+  })
+
+  it('renvoie tous les groupes concernés et exclut les autres', () => {
+    const groups = buildReferenceGroups()
+
+    const kept = filterGroupsForReferentiels(groups, ['REF-REG', 'REF-BV'])
+
+    expect(kept.map((g) => g.referentiel.id)).toEqual(['REF-NAT', 'REF-BV'])
+  })
+})
+
+describe('resolveIndividuForIndicateur', () => {
+  it("renvoie l'individu sélectionné quand son référentiel est associé à l'indicateur", () => {
+    const groups = buildReferenceGroups()
+
+    const res = resolveIndividuForIndicateur({
+      indicateurReferentielIds: ['REF-DEPT'],
+      selectedByRoot: new Map([['REF-NAT', 'IND-PARIS']]),
+      groups,
+    })
+
+    expect(res?.individu.id).toBe('IND-PARIS')
+  })
+
+  it('ignore un individu dont le référentiel n’est pas associé et retombe sur le défaut applicable', () => {
+    const groups = buildReferenceGroups()
+
+    // Indicateur région-only, mais un département est sélectionné → ignoré au profit de la région.
+    const res = resolveIndividuForIndicateur({
+      indicateurReferentielIds: ['REF-REG'],
+      selectedByRoot: new Map([['REF-NAT', 'IND-PARIS']]),
+      groups,
+    })
+
+    expect(res?.individu.id).toBe('IND-IDF')
+  })
+
+  it('utilise le premier nœud applicable en l’absence de sélection', () => {
+    const groups = buildReferenceGroups()
+
+    const res = resolveIndividuForIndicateur({
+      indicateurReferentielIds: ['REF-BV'],
+      selectedByRoot: new Map(),
+      groups,
+    })
+
+    expect(res?.individu.id).toBe('IND-BV1')
+  })
+
+  it('renvoie null si aucun ensemble ne correspond', () => {
+    const groups = buildReferenceGroups()
+
+    const res = resolveIndividuForIndicateur({
+      indicateurReferentielIds: ['REF-INCONNU'],
+      selectedByRoot: new Map(),
+      groups,
+    })
+
+    expect(res).toBeNull()
   })
 })

--- a/apps/kpilote-webapp/src/lib/individus/hierarchy.ts
+++ b/apps/kpilote-webapp/src/lib/individus/hierarchy.ts
@@ -71,3 +71,39 @@ export const groupNodesByRootReferentiel = (
   }
   return groups
 }
+
+// Ne conserve que les ensembles (groupes par référentiel racine) dont l'arbre
+// contient au moins un des référentiels voulus — typiquement ceux pertinents
+// pour la page (indicateurs accessibles / du panier / de l'indicateur consulté).
+export const filterGroupsForReferentiels = (
+  groups: ReadonlyArray<ReferentielGroup>,
+  referentielPublicIds: ReadonlyArray<string>,
+): ReferentielGroup[] => {
+  const wanted = new Set(referentielPublicIds)
+  return groups.filter((group) => group.nodes.some((n) => wanted.has(n.referentiel.id)))
+}
+
+// Résout l'individu à observer pour une carte indicateur, à partir de la
+// sélection par ensemble (référentiel racine → individu). On ignore un individu
+// sélectionné dont le référentiel n'est pas associé à l'indicateur et on retombe
+// alors sur le premier individu applicable de l'ensemble (défaut).
+export const resolveIndividuForIndicateur = ({
+  indicateurReferentielIds,
+  selectedByRoot,
+  groups,
+}: {
+  indicateurReferentielIds: ReadonlyArray<string>
+  selectedByRoot: ReadonlyMap<string, string>
+  groups: ReadonlyArray<ReferentielGroup>
+}): IndividuNode | null => {
+  const wanted = new Set(indicateurReferentielIds)
+  const group = groups.find((g) => g.nodes.some((n) => wanted.has(n.referentiel.id)))
+  if (!group) return null
+
+  const selectedIndividuId = selectedByRoot.get(group.referentiel.id)
+  if (selectedIndividuId) {
+    const selected = group.nodes.find((n) => n.individu.id === selectedIndividuId)
+    if (selected && wanted.has(selected.referentiel.id)) return selected
+  }
+  return group.nodes.find((n) => wanted.has(n.referentiel.id)) ?? null
+}

--- a/apps/kpilote-webapp/src/lib/individus/selection.test.ts
+++ b/apps/kpilote-webapp/src/lib/individus/selection.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+
+import { parseIndividusParam, serializeIndividusParam } from './selection'
+
+describe('parseIndividusParam', () => {
+  it('parse les paires référentiel racine → individu', () => {
+    const map = parseIndividusParam('REF-FR:DEPT-84,REF-BV:BV-12')
+
+    expect(map.get('REF-FR')).toBe('DEPT-84')
+    expect(map.get('REF-BV')).toBe('BV-12')
+    expect(map.size).toBe(2)
+  })
+
+  it('renvoie une map vide sans valeur', () => {
+    expect(parseIndividusParam(undefined).size).toBe(0)
+    expect(parseIndividusParam('').size).toBe(0)
+  })
+
+  it('ignore les entrées malformées', () => {
+    const map = parseIndividusParam('bidon,REF-FR:DEPT-84,:,REF-X:')
+
+    expect([...map.entries()]).toEqual([['REF-FR', 'DEPT-84']])
+  })
+})
+
+describe('serializeIndividusParam', () => {
+  it('sérialise une map non vide', () => {
+    const map = new Map([
+      ['REF-FR', 'DEPT-84'],
+      ['REF-BV', 'BV-12'],
+    ])
+
+    expect(serializeIndividusParam(map)).toBe('REF-FR:DEPT-84,REF-BV:BV-12')
+  })
+
+  it('renvoie undefined pour une map vide', () => {
+    expect(serializeIndividusParam(new Map())).toBeUndefined()
+  })
+
+  it('fait un aller-retour stable avec parseIndividusParam', () => {
+    const map = new Map([['REF-FR', 'DEPT-84']])
+
+    expect(parseIndividusParam(serializeIndividusParam(map))).toEqual(map)
+  })
+})

--- a/apps/kpilote-webapp/src/lib/individus/selection.ts
+++ b/apps/kpilote-webapp/src/lib/individus/selection.ts
@@ -1,0 +1,21 @@
+// Sérialisation de la sélection d'individu par ensemble dans l'URL.
+// Format : `REF-FR:DEPT-84,REF-BV:BV-12` — clé = référentiel racine (publicId),
+// valeur = individu (publicId). Source de vérité partageable, transportée d'une
+// page à l'autre pour persister le choix.
+
+export const parseIndividusParam = (raw?: string): Map<string, string> => {
+  const map = new Map<string, string>()
+  if (!raw) return map
+  for (const pair of raw.split(',')) {
+    const [root, individu] = pair.split(':')
+    if (root && individu) map.set(root, individu)
+  }
+  return map
+}
+
+export const serializeIndividusParam = (
+  map: ReadonlyMap<string, string>,
+): string | undefined => {
+  if (map.size === 0) return undefined
+  return [...map.entries()].map(([root, individu]) => `${root}:${individu}`).join(',')
+}

--- a/apps/kpilote-webapp/src/queries/referentiels.ts
+++ b/apps/kpilote-webapp/src/queries/referentiels.ts
@@ -32,6 +32,18 @@ export const allReferentielsQueryOptions = queryOptions({
   staleTime: DEFAULT_STALE_TIME,
 })
 
+// Référentiels pertinents pour la page selon le scope (`me` = indicateurs
+// lisibles par l'utilisateur, `panier:<publicId>` = indicateurs du panier).
+export const pertinentReferentielsQueryOptions = (scope: string) =>
+  queryOptions({
+    queryKey: ['referentiels', 'pertinents', scope],
+    queryFn: () =>
+      fetchAllPaginatedItems((cursor) =>
+        fetchReferentiels({ scope, ...(cursor ? { cursor } : {}) }),
+      ),
+    staleTime: DEFAULT_STALE_TIME,
+  })
+
 export const loadAllReferentielIds = async ({
   queryClient,
 }: {

--- a/apps/kpilote-webapp/src/routes/_authenticated/indicateurs/$id.tsx
+++ b/apps/kpilote-webapp/src/routes/_authenticated/indicateurs/$id.tsx
@@ -117,10 +117,7 @@ function IndicateurDetailComponent() {
 
   const back = (
     <BackLink asChild>
-      <Link
-        to="/indicateurs"
-        search={{ individu: search.individu, referentiel: search.referentiel }}
-      >
+      <Link to="/indicateurs" search={{}}>
         Tableau de bord
       </Link>
     </BackLink>

--- a/apps/kpilote-webapp/src/routes/_authenticated/indicateurs/$id.tsx
+++ b/apps/kpilote-webapp/src/routes/_authenticated/indicateurs/$id.tsx
@@ -1,8 +1,6 @@
 import { indicateurPublicIdSchema } from '@pilote/kpilote-shared/publicIds'
-import { individuPublicIdSchema } from '@pilote/kpilote-shared/individu'
-import { referentielPublicIdSchema } from '@pilote/kpilote-shared/referentiel'
-import { useSuspenseQuery } from '@tanstack/react-query'
-import { createFileRoute, Link, redirect, useNavigate } from '@tanstack/react-router'
+import { useSuspenseQuery, useSuspenseQueries } from '@tanstack/react-query'
+import { createFileRoute, Link, useNavigate } from '@tanstack/react-router'
 import { Upload } from 'lucide-react'
 import { startTransition, useCallback } from 'react'
 import { z } from 'zod'
@@ -11,7 +9,7 @@ import { RouteError } from '@/components/RouteError'
 import { RouteLoading } from '@/components/RouteLoading'
 import { IndicateurMetadonnees } from '@/components/indicateurs/IndicateurMetadonnees'
 import { IndicateurResultatsTab } from '@/components/indicateurs/IndicateurResultatsTab'
-import { FieldIndividuSelect } from '@/components/indicateurs/FieldIndividuSelect'
+import { IndividusSelectorBar } from '@/components/indicateurs/IndividusSelectorBar'
 import { useImportModal } from '@/components/import-valeurs/useImportModal'
 import { usePageFileDrop } from '@/components/import-valeurs/usePageFileDrop'
 import { BackLink } from '@pilote/kpilote-ui/BackLink'
@@ -19,13 +17,24 @@ import { Button } from '@pilote/kpilote-ui/Button'
 import { EmptyState } from '@pilote/kpilote-ui/EmptyState'
 import { Page } from '@pilote/kpilote-ui/Page'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@pilote/kpilote-ui/Tabs'
-import { ensureIndividuReferentielPair } from '@/lib/individus/pair'
+import {
+  buildOrderedNodes,
+  filterGroupsForReferentiels,
+  groupNodesByRootReferentiel,
+  resolveIndividuForIndicateur,
+} from '@/lib/individus/hierarchy'
+import { parseIndividusParam, serializeIndividusParam } from '@/lib/individus/selection'
 import { useRecordVisit } from '@/lib/recentlyVisited'
 import {
   indicateurQueryOptions,
   loadIndicateur,
   prefetchIndicateurValeursForIndividu,
 } from '@/queries/indicateurs'
+import {
+  loadHierarchyFromReferentiels,
+  referentielIndividusQueryOptions,
+  referentielQueryOptions,
+} from '@/queries/referentiels'
 import { useCanWriteIndicateur } from '@/queries/mePermissions'
 
 const paramsSchema = z.object({
@@ -33,8 +42,7 @@ const paramsSchema = z.object({
 })
 
 const searchSchema = z.object({
-  individu: individuPublicIdSchema.optional(),
-  referentiel: referentielPublicIdSchema.optional(),
+  individus: z.string().optional(),
   onglet: z.enum(['resultats', 'metadonnees']).default('resultats'),
   sousOnglet: z.enum(['confiance', 'evolution', 'commentaire']).default('confiance'),
 })
@@ -45,35 +53,26 @@ export const Route = createFileRoute('/_authenticated/indicateurs/$id')({
     stringify: ({ id }) => ({ id }),
   },
   validateSearch: searchSchema,
-  loaderDeps: ({ search }) => ({ individu: search.individu, referentiel: search.referentiel }),
-  loader: async ({ context, params, deps, location }) => {
+  loaderDeps: ({ search }) => ({ individus: search.individus }),
+  loader: async ({ context, params, deps }) => {
     const { queryClient } = context
     const indicateur = await loadIndicateur({ queryClient, indicateurId: params.id })
 
     const referentielIds = indicateur.referentiels.map((configuration) => configuration.id)
-    const pair = await ensureIndividuReferentielPair({
-      queryClient,
-      referentielIds,
-      deps,
-      onMismatch: ({ individu, referentiel }) => {
-        throw redirect({
-          to: '/indicateurs/$id',
-          params,
-          // On préserve le reste du search (onglet, sousOnglet…) : seul le
-          // couple individu/referentiel est corrigé. Sinon un lien profond vers
-          // un sous-onglet (ex. depuis la palette ⌘K) le perdrait au redirect.
-          search: { ...location.search, individu, referentiel },
-          replace: true,
-        })
-      },
+    const nodes = await loadHierarchyFromReferentiels({ queryClient, referentielIds })
+    const groups = filterGroupsForReferentiels(groupNodesByRootReferentiel(nodes), referentielIds)
+    const resolved = resolveIndividuForIndicateur({
+      indicateurReferentielIds: referentielIds,
+      selectedByRoot: parseIndividusParam(deps.individus),
+      groups,
     })
 
-    if (pair) {
+    if (resolved) {
       await prefetchIndicateurValeursForIndividu({
         queryClient,
         indicateurId: params.id,
-        individuId: pair.individu,
-        referentielId: pair.referentiel,
+        individuId: resolved.individu.id,
+        referentielId: resolved.referentiel.id,
       })
     }
 
@@ -95,6 +94,29 @@ function IndicateurDetailComponent() {
   const canWrite = useCanWriteIndicateur(id)
   const { open, target } = useImportModal()
 
+  const referentielIds = indicateur.referentiels.map((c) => c.id)
+  const referentielsData = useSuspenseQueries({
+    queries: referentielIds.map((refId) => referentielQueryOptions(refId)),
+    combine: (results) => results.map((r) => r.data),
+  })
+  const individusByReferentiel = useSuspenseQueries({
+    queries: referentielIds.map((refId) => referentielIndividusQueryOptions(refId)),
+    combine: (results) => results.map((r) => r.data),
+  })
+
+  const referentielsById = new Map(referentielsData.map((r) => [r.id, r] as const))
+  const nodes = buildOrderedNodes(
+    individusByReferentiel.flatMap((batch) => [...batch]),
+    referentielsById,
+  )
+  const groups = filterGroupsForReferentiels(groupNodesByRootReferentiel(nodes), referentielIds)
+  const selected = parseIndividusParam(search.individus)
+  const resolved = resolveIndividuForIndicateur({
+    indicateurReferentielIds: referentielIds,
+    selectedByRoot: selected,
+    groups,
+  })
+
   const onFile = useCallback(
     (file: File) =>
       open({ indicateur: { id: indicateur.id, nom: indicateur.nom }, initialFile: file }),
@@ -103,6 +125,16 @@ function IndicateurDetailComponent() {
   // Désactive le drop de page quand la modale d'import est ouverte : le drop doit
   // viser la dropzone de la modale, pas déclencher un second overlay par-dessus.
   const { isDragging } = usePageFileDrop({ enabled: canWrite && target === null, onFile })
+
+  const onSelect = (rootReferentielId: string, individuId: string) => {
+    const next = new Map(selected)
+    next.set(rootReferentielId, individuId)
+    startTransition(() => {
+      void navigate({
+        search: (prev) => ({ ...prev, individus: serializeIndividusParam(next) }),
+      })
+    })
+  }
 
   const actionsFiche = canWrite ? (
     <Button
@@ -117,7 +149,7 @@ function IndicateurDetailComponent() {
 
   const back = (
     <BackLink asChild>
-      <Link to="/indicateurs" search={{}}>
+      <Link to="/indicateurs" search={{ individus: search.individus }}>
         Tableau de bord
       </Link>
     </BackLink>
@@ -131,7 +163,7 @@ function IndicateurDetailComponent() {
     )
   }
 
-  if (!search.individu || !search.referentiel) {
+  if (!resolved) {
     return (
       <Page title={indicateur.nom} back={back}>
         <EmptyState title="Aucun individu disponible dans les référentiels liés." />
@@ -139,10 +171,9 @@ function IndicateurDetailComponent() {
     )
   }
 
-  const individuId = search.individu
-  const referentielId = search.referentiel
-  const referentielIds = indicateur.referentiels.map((c) => c.id)
-  const referentielNom = indicateur.referentiels.find((c) => c.id === referentielId)?.nom ?? null
+  const individuId = resolved.individu.id
+  const referentielId = resolved.referentiel.id
+  const referentielNom = resolved.referentiel.nom
 
   return (
     <Page title={indicateur.nom} back={back} actions={actionsFiche}>
@@ -161,21 +192,9 @@ function IndicateurDetailComponent() {
 
         <TabsContent value="resultats">
           <div className="flex flex-col gap-8">
-            {/* Sélecteur d'individu propre à l'onglet Résultats : positionné sous la
-                navigation primaire et masqué sur l'onglet Informations. */}
-            <div className="max-w-md">
-              <FieldIndividuSelect
-                referentielIds={referentielIds}
-                value={individuId}
-                onChange={({ individu, referentiel }) => {
-                  startTransition(() => {
-                    void navigate({
-                      search: (prev) => ({ ...prev, individu, referentiel }),
-                    })
-                  })
-                }}
-              />
-            </div>
+            {/* Sélecteur d'individu propre à l'onglet Résultats : un seul ensemble
+                pour un indicateur donné (règle du ticket). */}
+            <IndividusSelectorBar groups={groups} selected={selected} onSelect={onSelect} />
             <IndicateurResultatsTab
               indicateurId={id}
               individuId={individuId}

--- a/apps/kpilote-webapp/src/routes/_authenticated/indicateurs/index.tsx
+++ b/apps/kpilote-webapp/src/routes/_authenticated/indicateurs/index.tsx
@@ -1,7 +1,5 @@
-import { individuPublicIdSchema } from '@pilote/kpilote-shared/individu'
-import { referentielPublicIdSchema } from '@pilote/kpilote-shared/referentiel'
-import { useSuspenseQuery } from '@tanstack/react-query'
-import { createFileRoute, redirect, useNavigate } from '@tanstack/react-router'
+import { useSuspenseQueries, useSuspenseQuery } from '@tanstack/react-query'
+import { createFileRoute, useNavigate } from '@tanstack/react-router'
 import { startTransition } from 'react'
 import { z } from 'zod'
 
@@ -9,43 +7,49 @@ import { DashboardSwitch } from '@/components/DashboardSwitch'
 import { RouteError } from '@/components/RouteError'
 import { RouteLoading } from '@/components/RouteLoading'
 import { IndicateurCard } from '@/components/indicateurs/IndicateurCard'
-import { FieldIndividuSelect } from '@/components/indicateurs/FieldIndividuSelect'
+import { IndividusSelectorBar } from '@/components/indicateurs/IndividusSelectorBar'
 import { CardGrid } from '@pilote/kpilote-ui/CardGrid'
 import { EmptyState } from '@pilote/kpilote-ui/EmptyState'
 import { Page } from '@pilote/kpilote-ui/Page'
 import { Text } from '@pilote/kpilote-ui/Typography'
-import { ensureIndividuReferentielPair } from '@/lib/individus/pair'
+import {
+  buildOrderedNodes,
+  filterGroupsForReferentiels,
+  groupNodesByRootReferentiel,
+  resolveIndividuForIndicateur,
+} from '@/lib/individus/hierarchy'
+import { parseIndividusParam, serializeIndividusParam } from '@/lib/individus/selection'
 import { DEFAULT_PAGE_SIZE_OPTIONS, Pagination } from '@pilote/kpilote-ui/Pagination'
 import { indicateursQueryOptions, loadIndicateurs } from '@/queries/indicateurs'
-import { allReferentielsQueryOptions, loadAllReferentielIds } from '@/queries/referentiels'
+import {
+  pertinentReferentielsQueryOptions,
+  referentielIndividusQueryOptions,
+} from '@/queries/referentiels'
 
 const indicateursSearchSchema = z.object({
   cursor: z.string().optional(),
   pageSize: z.coerce.number().int().min(1).max(100).optional(),
-  individu: individuPublicIdSchema.optional(),
-  referentiel: referentielPublicIdSchema.optional(),
+  individus: z.string().optional(),
 })
+
+const PERTINENT_SCOPE = 'me'
 
 export const Route = createFileRoute('/_authenticated/indicateurs/')({
   validateSearch: indicateursSearchSchema,
   loaderDeps: ({ search }) => search,
   loader: async ({ context, deps }) => {
     const { queryClient } = context
-    const referentielIds = await loadAllReferentielIds({ queryClient })
-    await ensureIndividuReferentielPair({
-      queryClient,
-      referentielIds,
-      deps,
-      onMismatch: ({ individu, referentiel }) => {
-        throw redirect({
-          to: '/indicateurs',
-          search: { ...deps, individu, referentiel },
-          replace: true,
-        })
-      },
-    })
+    const referentiels = await queryClient.ensureQueryData(
+      pertinentReferentielsQueryOptions(PERTINENT_SCOPE),
+    )
+    await Promise.all(
+      referentiels.map((r) => queryClient.ensureQueryData(referentielIndividusQueryOptions(r.id))),
+    )
 
-    return loadIndicateurs({ queryClient, query: deps })
+    return loadIndicateurs({
+      queryClient,
+      query: { cursor: deps.cursor, pageSize: deps.pageSize },
+    })
   },
   pendingComponent: () => <RouteLoading message="Chargement des indicateurs…" />,
   errorComponent: RouteError,
@@ -55,9 +59,35 @@ export const Route = createFileRoute('/_authenticated/indicateurs/')({
 function IndicateursListComponent() {
   const search = Route.useSearch()
   const navigate = useNavigate({ from: Route.fullPath })
-  const { data } = useSuspenseQuery(indicateursQueryOptions(search))
-  const { data: referentiels } = useSuspenseQuery(allReferentielsQueryOptions)
+  const { data } = useSuspenseQuery(
+    indicateursQueryOptions({ cursor: search.cursor, pageSize: search.pageSize }),
+  )
+  const { data: referentiels } = useSuspenseQuery(
+    pertinentReferentielsQueryOptions(PERTINENT_SCOPE),
+  )
   const referentielIds = referentiels.map((r) => r.id)
+  const individusByReferentiel = useSuspenseQueries({
+    queries: referentielIds.map((refId) => referentielIndividusQueryOptions(refId)),
+    combine: (results) => results.map((r) => r.data),
+  })
+
+  const referentielsById = new Map(referentiels.map((r) => [r.id, r] as const))
+  const nodes = buildOrderedNodes(
+    individusByReferentiel.flatMap((batch) => [...batch]),
+    referentielsById,
+  )
+  const groups = filterGroupsForReferentiels(groupNodesByRootReferentiel(nodes), referentielIds)
+  const selected = parseIndividusParam(search.individus)
+
+  const onSelect = (rootReferentielId: string, individuId: string) => {
+    const next = new Map(selected)
+    next.set(rootReferentielId, individuId)
+    startTransition(() => {
+      void navigate({
+        search: (prev) => ({ ...prev, individus: serializeIndividusParam(next) }),
+      })
+    })
+  }
 
   return (
     <Page
@@ -65,23 +95,7 @@ function IndicateursListComponent() {
       description="Consultez et gérez l'ensemble de vos indicateurs par valeur ou par dossier."
       stickybar={
         <>
-          {search.individu ? (
-            <div>
-              <FieldIndividuSelect
-                referentielIds={referentielIds}
-                value={search.individu}
-                onChange={({ individu, referentiel }) => {
-                  startTransition(() => {
-                    void navigate({
-                      search: (prev) => ({ ...prev, individu, referentiel }),
-                    })
-                  })
-                }}
-              />
-            </div>
-          ) : (
-            <div />
-          )}
+          <IndividusSelectorBar groups={groups} selected={selected} onSelect={onSelect} />
           <DashboardSwitch />
         </>
       }
@@ -95,15 +109,27 @@ function IndicateursListComponent() {
           <EmptyState title="Aucun indicateur disponible." />
         ) : (
           <CardGrid>
-            {data.items.map((indicateur) => (
-              <IndicateurCard
-                key={indicateur.id}
-                indicateur={indicateur}
-                {...(search.individu && search.referentiel
-                  ? { context: { individu: search.individu, referentiel: search.referentiel } }
-                  : {})}
-              />
-            ))}
+            {data.items.map((indicateur) => {
+              const resolved = resolveIndividuForIndicateur({
+                indicateurReferentielIds: indicateur.referentiels.map((r) => r.id),
+                selectedByRoot: selected,
+                groups,
+              })
+              return (
+                <IndicateurCard
+                  key={indicateur.id}
+                  indicateur={indicateur}
+                  {...(resolved
+                    ? {
+                        context: {
+                          individu: resolved.individu.id,
+                          referentiel: resolved.referentiel.id,
+                        },
+                      }
+                    : {})}
+                />
+              )
+            })}
           </CardGrid>
         )}
 

--- a/apps/kpilote-webapp/src/routes/_authenticated/indicateurs/index.tsx
+++ b/apps/kpilote-webapp/src/routes/_authenticated/indicateurs/index.tsx
@@ -123,7 +123,7 @@ function IndicateursListComponent() {
                     ? {
                         context: {
                           individu: resolved.individu.id,
-                          referentiel: resolved.referentiel.id,
+                          individus: search.individus,
                         },
                       }
                     : {})}

--- a/apps/kpilote-webapp/src/routes/_authenticated/paniers/$id.tsx
+++ b/apps/kpilote-webapp/src/routes/_authenticated/paniers/$id.tsx
@@ -1,8 +1,6 @@
-import { individuPublicIdSchema } from '@pilote/kpilote-shared/individu'
-import { referentielPublicIdSchema } from '@pilote/kpilote-shared/referentiel'
 import { panierPublicIdSchema } from '@pilote/kpilote-shared/publicIds'
-import { useSuspenseQuery } from '@tanstack/react-query'
-import { createFileRoute, Link, redirect, useNavigate } from '@tanstack/react-router'
+import { useSuspenseQuery, useSuspenseQueries } from '@tanstack/react-query'
+import { createFileRoute, Link, useNavigate } from '@tanstack/react-router'
 import { startTransition, Suspense } from 'react'
 import { z } from 'zod'
 
@@ -10,7 +8,7 @@ import { RouteError } from '@/components/RouteError'
 import { RouteLoading } from '@/components/RouteLoading'
 import { SectionCommentaire } from '@/components/commentaires/SectionCommentaire'
 import { IndicateurCard } from '@/components/indicateurs/IndicateurCard'
-import { FieldIndividuSelect } from '@/components/indicateurs/FieldIndividuSelect'
+import { IndividusSelectorBar } from '@/components/indicateurs/IndividusSelectorBar'
 import { PanierCommentaireConfigProvider } from '@/components/paniers/PanierCommentaireConfigProvider'
 import { PanierGouvernanceTab } from '@/components/paniers/PanierGouvernanceTab'
 import { PanierTauxProgression } from '@/components/paniers/PanierTauxProgression'
@@ -20,7 +18,15 @@ import { EmptyState } from '@pilote/kpilote-ui/EmptyState'
 import { Page } from '@pilote/kpilote-ui/Page'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@pilote/kpilote-ui/Tabs'
 import { Text } from '@pilote/kpilote-ui/Typography'
-import { ensureIndividuReferentielPair } from '@/lib/individus/pair'
+import {
+  buildOrderedNodes,
+  filterGroupsForReferentiels,
+  groupNodesByRootReferentiel,
+  pickRoot,
+  resolveIndividuForIndicateur,
+  type ReferentielGroup,
+} from '@/lib/individus/hierarchy'
+import { parseIndividusParam, serializeIndividusParam } from '@/lib/individus/selection'
 import { useRecordVisit } from '@/lib/recentlyVisited'
 import { indicateursQueryOptions } from '@/queries/indicateurs'
 import {
@@ -28,17 +34,31 @@ import {
   panierQueryOptions,
   panierTauxProgressionQueryOptions,
 } from '@/queries/paniers'
-import { allReferentielsQueryOptions, loadAllReferentielIds } from '@/queries/referentiels'
+import {
+  loadHierarchyFromReferentiels,
+  pertinentReferentielsQueryOptions,
+  referentielIndividusQueryOptions,
+} from '@/queries/referentiels'
 
 const paramsSchema = z.object({
   id: panierPublicIdSchema,
 })
 
 const searchSchema = z.object({
-  individu: individuPublicIdSchema.optional(),
-  referentiel: referentielPublicIdSchema.optional(),
+  individus: z.string().optional(),
   onglet: z.enum(['resultats', 'gouvernance', 'confiance', 'commentaires']).default('resultats'),
 })
+
+// Individu de l'agrégat panier : uniquement défini quand le panier tient dans un
+// seul ensemble (sinon le taux global n'a pas de sens — masqué, cf. PIL-1677).
+const singleEnsembleIndividu = (
+  groups: ReadonlyArray<ReferentielGroup>,
+  selected: ReadonlyMap<string, string>,
+): string | null => {
+  if (groups.length !== 1) return null
+  const group = groups[0]!
+  return selected.get(group.referentiel.id) ?? pickRoot(group.nodes)?.individu.id ?? null
+}
 
 export const Route = createFileRoute('/_authenticated/paniers/$id')({
   params: {
@@ -46,35 +66,25 @@ export const Route = createFileRoute('/_authenticated/paniers/$id')({
     stringify: ({ id }) => ({ id }),
   },
   validateSearch: searchSchema,
-  loaderDeps: ({ search }) => ({ individu: search.individu, referentiel: search.referentiel }),
-  loader: async ({ context, params, deps, location }) => {
+  loaderDeps: ({ search }) => ({ individus: search.individus }),
+  loader: async ({ context, params, deps }) => {
     const { queryClient } = context
     const panier = await loadPanier({ queryClient, panierId: params.id })
     if (panier.indicateurIds.length > 0) {
       await queryClient.ensureQueryData(indicateursQueryOptions({ ids: panier.indicateurIds }))
     }
 
-    const referentielIds = await loadAllReferentielIds({ queryClient })
-    await ensureIndividuReferentielPair({
-      queryClient,
-      referentielIds,
-      deps,
-      onMismatch: ({ individu, referentiel }) => {
-        throw redirect({
-          to: '/paniers/$id',
-          params,
-          // On préserve le reste du search (onglet…) : seul le couple
-          // individu/referentiel est corrigé. Sinon un lien profond vers un
-          // onglet (ex. depuis la palette ⌘K) le perdrait au redirect.
-          search: { ...location.search, individu, referentiel },
-          replace: true,
-        })
-      },
-    })
+    const referentiels = await queryClient.ensureQueryData(
+      pertinentReferentielsQueryOptions(`panier:${params.id}`),
+    )
+    const referentielIds = referentiels.map((r) => r.id)
+    const nodes = await loadHierarchyFromReferentiels({ queryClient, referentielIds })
+    const groups = filterGroupsForReferentiels(groupNodesByRootReferentiel(nodes), referentielIds)
 
-    if (deps.individu) {
+    const individu = singleEnsembleIndividu(groups, parseIndividusParam(deps.individus))
+    if (individu) {
       await queryClient.prefetchQuery(
-        panierTauxProgressionQueryOptions({ panierId: params.id, individu: deps.individu }),
+        panierTauxProgressionQueryOptions({ panierId: params.id, individu }),
       )
     }
 
@@ -94,8 +104,33 @@ function PanierDetailComponent() {
   const { data: indicateurs } = useSuspenseQuery(
     indicateursQueryOptions({ ids: panier.indicateurIds }),
   )
-  const { data: referentiels } = useSuspenseQuery(allReferentielsQueryOptions)
+  const { data: referentiels } = useSuspenseQuery(
+    pertinentReferentielsQueryOptions(`panier:${id}`),
+  )
   const referentielIds = referentiels.map((r) => r.id)
+  const individusByReferentiel = useSuspenseQueries({
+    queries: referentielIds.map((refId) => referentielIndividusQueryOptions(refId)),
+    combine: (results) => results.map((r) => r.data),
+  })
+
+  const referentielsById = new Map(referentiels.map((r) => [r.id, r] as const))
+  const nodes = buildOrderedNodes(
+    individusByReferentiel.flatMap((batch) => [...batch]),
+    referentielsById,
+  )
+  const groups = filterGroupsForReferentiels(groupNodesByRootReferentiel(nodes), referentielIds)
+  const selected = parseIndividusParam(search.individus)
+  const panierIndividu = singleEnsembleIndividu(groups, selected)
+
+  const onSelect = (rootReferentielId: string, individuId: string) => {
+    const next = new Map(selected)
+    next.set(rootReferentielId, individuId)
+    startTransition(() => {
+      void navigate({
+        search: (prev) => ({ ...prev, individus: serializeIndividusParam(next) }),
+      })
+    })
+  }
 
   // Re-tri selon l'ordre du panier : la query indicateurs ne garantit pas
   // l'ordre du filtre `ids`.
@@ -106,16 +141,11 @@ function PanierDetailComponent() {
 
   const back = (
     <BackLink asChild>
-      <Link to="/paniers" search={{ individu: search.individu, referentiel: search.referentiel }}>
+      <Link to="/paniers" search={{}}>
         Tableau de bord
       </Link>
     </BackLink>
   )
-
-  const cardContext =
-    search.individu && search.referentiel
-      ? { individu: search.individu, referentiel: search.referentiel }
-      : undefined
 
   return (
     <Page title={panier.nom} description={panier.description ?? undefined} back={back}>
@@ -136,28 +166,16 @@ function PanierDetailComponent() {
 
         <TabsContent value="resultats">
           <div className="flex flex-col gap-6">
-            {search.individu && (
-              <>
-                {/* Sélecteur d'individu propre à l'onglet Résultats : positionné sous
-                    la navigation primaire et masqué sur les autres onglets. */}
-                <div className="max-w-md">
-                  <FieldIndividuSelect
-                    referentielIds={referentielIds}
-                    value={search.individu}
-                    onChange={({ individu, referentiel }) => {
-                      startTransition(() => {
-                        void navigate({
-                          search: (prev) => ({ ...prev, individu, referentiel }),
-                        })
-                      })
-                    }}
-                  />
-                </div>
-                <div className="max-w-xs">
-                  <PanierTauxProgression panierId={id} individu={search.individu} />
-                </div>
-              </>
-            )}
+            {/* Sélecteur d'individu par ensemble, propre à l'onglet Résultats. */}
+            <IndividusSelectorBar groups={groups} selected={selected} onSelect={onSelect} />
+
+            {/* Taux global du panier : affiché seulement quand le panier tient dans
+                un seul ensemble (un individu applicable non ambigu). */}
+            {panierIndividu ? (
+              <div className="max-w-xs">
+                <PanierTauxProgression panierId={id} individu={panierIndividu} />
+              </div>
+            ) : null}
 
             <Text as="span" variant="kicker" tone="muted">
               {orderedIndicateurs.length} indicateur{orderedIndicateurs.length > 1 ? 's' : ''}
@@ -166,13 +184,22 @@ function PanierDetailComponent() {
               <EmptyState title="Ce panier ne contient aucun indicateur." />
             ) : (
               <CardGrid>
-                {orderedIndicateurs.map((indicateur) => (
-                  <IndicateurCard
-                    key={indicateur.id}
-                    indicateur={indicateur}
-                    {...(cardContext ? { context: cardContext } : {})}
-                  />
-                ))}
+                {orderedIndicateurs.map((indicateur) => {
+                  const resolved = resolveIndividuForIndicateur({
+                    indicateurReferentielIds: indicateur.referentiels.map((r) => r.id),
+                    selectedByRoot: selected,
+                    groups,
+                  })
+                  return (
+                    <IndicateurCard
+                      key={indicateur.id}
+                      indicateur={indicateur}
+                      {...(resolved
+                        ? { context: { individu: resolved.individu.id, individus: search.individus } }
+                        : {})}
+                    />
+                  )
+                })}
               </CardGrid>
             )}
           </div>

--- a/packages/kpilote-shared/src/referentiel.ts
+++ b/packages/kpilote-shared/src/referentiel.ts
@@ -28,7 +28,16 @@ export type ReferentielApiModel = z.infer<typeof referentielApiModelSchema>
 export const referentielListApiModelSchema = createPaginatedApiListSchema(referentielApiModelSchema)
 export type ReferentielListApiModel = z.infer<typeof referentielListApiModelSchema>
 
-export const listReferentielsQuerySchema = listQuerySchema
+export const referentielScopeSchema = z
+  .union([z.literal('me'), z.string().regex(/^panier:.+$/)])
+  .describe(
+    "Restreint aux référentiels reliés à ≥1 indicateur pertinent : `me` (indicateurs lisibles par l'utilisateur) ou `panier:<publicId>` (indicateurs du panier).",
+  )
+export type ReferentielScope = z.infer<typeof referentielScopeSchema>
+
+export const listReferentielsQuerySchema = listQuerySchema.extend({
+  scope: referentielScopeSchema.optional(),
+})
 export type ListReferentielsQuery = z.infer<typeof listReferentielsQuerySchema>
 
 export const upsertReferentielIndividuItemSchema = z.object({

--- a/packages/kpilote-shared/src/referentiel.ts
+++ b/packages/kpilote-shared/src/referentiel.ts
@@ -29,7 +29,8 @@ export const referentielListApiModelSchema = createPaginatedApiListSchema(refere
 export type ReferentielListApiModel = z.infer<typeof referentielListApiModelSchema>
 
 export const referentielScopeSchema = z
-  .union([z.literal('me'), z.string().regex(/^panier:.+$/)])
+  .string()
+  .regex(/^(me|panier:.+)$/)
   .describe(
     "Restreint aux référentiels reliés à ≥1 indicateur pertinent : `me` (indicateurs lisibles par l'utilisateur) ou `panier:<publicId>` (indicateurs du panier).",
   )


### PR DESCRIPTION
## Contexte

[PIL-1677](https://data-ditp.atlassian.net/browse/PIL-1677) — permettre à l'utilisateur de sélectionner l'individu observé **pour chaque ensemble de référentiels** pertinent sur la page consultée (un ensemble = un référentiel racine et son sous-arbre, ex. _France national > Régions > Départements_).

Le concept d'« ensemble » n'est **pas matérialisé en base** : la hiérarchie est reconstruite côté front à partir des individus (`buildOrderedNodes` / `groupNodesByRootReferentiel`), et chaque groupe est nommé par son référentiel racine.

## Ce que fait la PR

**API**
- `GET /referentiels?scope=me|panier:<publicId>` : filtre optionnel renvoyant uniquement les référentiels reliés à ≥1 indicateur pertinent (lisible par l'utilisateur, ou appartenant au panier). Réutilise `withIndicateurReadPermission`. Schéma de retour et pagination inchangés.

**Webapp**
- Helpers purs `filterGroupsForReferentiels` et `resolveIndividuForIndicateur` (résolution de l'individu applicable à une carte, avec fallback quand l'individu sélectionné n'appartient pas à un référentiel de l'indicateur).
- État de sélection dans l'URL (`?individus=REF-FR:DEPT-84,REF-BV:BV-12`, mapping référentiel racine → individu), persisté entre les pages.
- Nouveau composant `EnsembleIndividuSelect` (sélecteur mono-ensemble, extrait de `IndividuSelect`) + `IndividusSelectorBar` (une rangée de sélecteurs, un par ensemble).
- Défaut par ensemble : niveau le plus haut, premier de la liste (`pickRoot`), calculé côté front.
- Pages migrées : **tableau de bord (valeurs)** `/indicateurs`, **collection** `/paniers/$id`, **indicateur** `/indicateurs/$id`.

## Décisions produit (à valider avec le PO)

- **Taux global du panier** (`PanierTauxProgression`) : masqué quand le panier couvre **plusieurs ensembles** (un individu unique n'aurait pas de sens). Affiché uniquement si le panier tient dans un seul ensemble.
- **Liste des paniers** (`/paniers`, face « dossiers » du tableau de bord) : **laissée hors scope** de ce ticket (l'agrégat par carte panier suppose un individu unique et exigerait de connaître les référentiels de chaque panier sur une page liste). Elle reste sur l'ancien modèle ; le `DashboardSwitch` transporte les deux modèles de sélection.

## Tests

- API : `listReferentiels.test.ts` — scope `me` (inclusion/exclusion selon lisibilité), scope `panier`. ✅ 25/25 sur `src/referentiel`.
- Webapp : `hierarchy.test.ts` (filtrage + résolution, dont fallback) et `selection.test.ts` (parse/serialize). ✅ 94/94.
- `tsc` + `eslint` verts sur le périmètre (2 erreurs `tsc` préexistantes hors périmètre : incompat zod/react-hook-form dans `ImportValeursModal`/`EditeurCommentaire`).

## Non couvert

- Vérification manuelle dans le navigateur non effectuée.
- Migration de la liste des paniers au multi-ensemble (US dédiée).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[PIL-1677]: https://data-ditp.atlassian.net/browse/PIL-1677?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ