### PR TITLE
feat(relation): gestion des relations entre individus dans le panel admin

### DIFF
--- a/apps/kpilote-admin/src/api/individus.ts
+++ b/apps/kpilote-admin/src/api/individus.ts
@@ -1,0 +1,17 @@
+import type { IndividuApiModel, IndividuListApiModel } from '@pilote/kpilote-shared/individu'
+import { individuListApiModelSchema } from '@pilote/kpilote-shared/individu'
+
+import { bffClient } from '@/api/client'
+import { fetchAllPages } from '@/lib/fetchAllPages'
+
+export const fetchIndividus = async (
+  params: { cursor?: string | undefined } = {},
+): Promise<IndividuListApiModel> => {
+  const searchParams: Record<string, string> = {}
+  if (params.cursor) searchParams.cursor = params.cursor
+  const json = await bffClient.get('individus', { searchParams }).json()
+  return individuListApiModelSchema.parse(json)
+}
+
+export const fetchAllIndividus = (): Promise<IndividuApiModel[]> =>
+  fetchAllPages((cursor) => fetchIndividus(cursor ? { cursor } : {}))

--- a/apps/kpilote-admin/src/api/relations.ts
+++ b/apps/kpilote-admin/src/api/relations.ts
@@ -1,0 +1,31 @@
+import type {
+  RelationApiModel,
+  RelationListApiModel,
+  UpsertRelationBody,
+} from '@pilote/kpilote-shared/relation'
+import { relationApiModelSchema, relationListApiModelSchema } from '@pilote/kpilote-shared/relation'
+
+import { bffClient } from '@/api/client'
+
+export const fetchRelations = async (
+  params: { recherche?: string | undefined; cursor?: string | undefined } = {},
+): Promise<RelationListApiModel> => {
+  const searchParams: Record<string, string> = {}
+  if (params.recherche) searchParams.recherche = params.recherche
+  if (params.cursor) searchParams.cursor = params.cursor
+  const json = await bffClient.get('relations', { searchParams }).json()
+  return relationListApiModelSchema.parse(json)
+}
+
+export const upsertRelationParent = async (
+  id: string,
+  body: UpsertRelationBody,
+): Promise<RelationApiModel> => {
+  const json = await bffClient.put(`relations/${id}`, { json: body }).json()
+  return relationApiModelSchema.parse(json)
+}
+
+// Pas de `.json()` : la réponse est un 204 sans corps.
+export const supprimerRelation = async (id: string): Promise<void> => {
+  await bffClient.delete(`relations/${id}`)
+}

--- a/apps/kpilote-admin/src/api/relations.ts
+++ b/apps/kpilote-admin/src/api/relations.ts
@@ -6,6 +6,7 @@ import type {
 import { relationApiModelSchema, relationListApiModelSchema } from '@pilote/kpilote-shared/relation'
 
 import { bffClient } from '@/api/client'
+import { fetchAllPages } from '@/lib/fetchAllPages'
 
 export const fetchRelations = async (
   params: { recherche?: string | undefined; cursor?: string | undefined } = {},
@@ -16,6 +17,9 @@ export const fetchRelations = async (
   const json = await bffClient.get('relations', { searchParams }).json()
   return relationListApiModelSchema.parse(json)
 }
+
+export const fetchAllRelations = (): Promise<RelationApiModel[]> =>
+  fetchAllPages((cursor) => fetchRelations(cursor ? { cursor } : {}))
 
 export const upsertRelationParent = async (
   id: string,

--- a/apps/kpilote-admin/src/components/relations/IndividuPicker.tsx
+++ b/apps/kpilote-admin/src/components/relations/IndividuPicker.tsx
@@ -1,0 +1,45 @@
+import type { IndividuApiModel } from '@pilote/kpilote-shared/individu'
+import { useSuspenseQuery } from '@tanstack/react-query'
+
+import { Picker } from '@pilote/kpilote-ui/Picker'
+import { PickerOptionNomId } from '@pilote/kpilote-ui/PickerOptionNomId'
+import { individusAllQueryOptions } from '@/queries/individus'
+
+// Sert à la fois de contrôle d'ajout (sans `value`, le trigger réaffiche son
+// placeholder) et de cellule d'édition du parent (avec `value`).
+export function IndividuPicker({
+  excludedIds,
+  onSelect,
+  value,
+  disabled,
+  placeholder = 'Choisir un individu',
+  filtre,
+}: {
+  excludedIds: string[]
+  onSelect: (id: string) => void
+  value?: string
+  disabled?: boolean
+  placeholder?: string
+  filtre?: (individu: IndividuApiModel) => boolean
+}) {
+  const { data } = useSuspenseQuery(individusAllQueryOptions())
+  const excluded = new Set(excludedIds)
+  const items = data
+    .filter((individu) => !excluded.has(individu.id))
+    .filter((individu) => (filtre ? filtre(individu) : true))
+
+  return (
+    <Picker
+      items={items}
+      onSelect={(individu) => onSelect(individu.id)}
+      getKey={(individu) => individu.id}
+      getSearchText={(individu) => `${individu.id} ${individu.nom} ${individu.referentiel}`}
+      renderItem={(individu) => <PickerOptionNomId nom={individu.nom} id={individu.id} />}
+      triggerLabel={placeholder}
+      searchPlaceholder="Rechercher un individu…"
+      emptyLabel="Aucun individu."
+      disabled={disabled ?? false}
+      {...(value !== undefined ? { value } : {})}
+    />
+  )
+}

--- a/apps/kpilote-admin/src/queries/individus.ts
+++ b/apps/kpilote-admin/src/queries/individus.ts
@@ -1,0 +1,9 @@
+import { queryOptions } from '@tanstack/react-query'
+
+import { fetchAllIndividus } from '@/api/individus'
+
+export const individusAllQueryOptions = () =>
+  queryOptions({
+    queryKey: ['individus', 'all'],
+    queryFn: () => fetchAllIndividus(),
+  })

--- a/apps/kpilote-admin/src/queries/relations.ts
+++ b/apps/kpilote-admin/src/queries/relations.ts
@@ -1,0 +1,13 @@
+import { infiniteQueryOptions } from '@tanstack/react-query'
+
+import { fetchRelations } from '@/api/relations'
+
+export const relationsInfiniteQueryOptions = (recherche: string) =>
+  infiniteQueryOptions({
+    queryKey: ['relations', { recherche }],
+    queryFn: ({ pageParam }) =>
+      fetchRelations({ recherche: recherche || undefined, cursor: pageParam ?? undefined }),
+    initialPageParam: undefined as string | undefined,
+    getNextPageParam: (lastPage) =>
+      lastPage.pagination.hasMore ? (lastPage.pagination.cursor ?? undefined) : undefined,
+  })

--- a/apps/kpilote-admin/src/queries/relations.ts
+++ b/apps/kpilote-admin/src/queries/relations.ts
@@ -1,13 +1,9 @@
-import { infiniteQueryOptions } from '@tanstack/react-query'
+import { queryOptions } from '@tanstack/react-query'
 
-import { fetchRelations } from '@/api/relations'
+import { fetchAllRelations } from '@/api/relations'
 
-export const relationsInfiniteQueryOptions = (recherche: string) =>
-  infiniteQueryOptions({
-    queryKey: ['relations', { recherche }],
-    queryFn: ({ pageParam }) =>
-      fetchRelations({ recherche: recherche || undefined, cursor: pageParam ?? undefined }),
-    initialPageParam: undefined as string | undefined,
-    getNextPageParam: (lastPage) =>
-      lastPage.pagination.hasMore ? (lastPage.pagination.cursor ?? undefined) : undefined,
+export const relationsAllQueryOptions = () =>
+  queryOptions({
+    queryKey: ['relations', 'all'],
+    queryFn: () => fetchAllRelations(),
   })

--- a/apps/kpilote-admin/src/routes/_authed/fonctionnalites.tsx
+++ b/apps/kpilote-admin/src/routes/_authed/fonctionnalites.tsx
@@ -4,6 +4,7 @@ import {
   FolderTree,
   KeyRound,
   LifeBuoy,
+  Network,
   Terminal,
   ToggleLeft,
   Users,
@@ -40,13 +41,21 @@ function FeaturesComponent() {
         </FadeIn>
         <FadeIn delayMs={180}>
           <BarCard
+            icon={Network}
+            title="Gérer les relations"
+            description="Définir le parent de chaque individu dans la hiérarchie des référentiels."
+            onClick={() => void navigate({ to: '/relations' })}
+          />
+        </FadeIn>
+        <FadeIn delayMs={240}>
+          <BarCard
             icon={KeyRound}
             title="Gérer les clés API"
             description="Créer, lister et révoquer les clés API (réservé aux clés ADMIN)."
             onClick={() => void navigate({ to: '/api-keys' })}
           />
         </FadeIn>
-        <FadeIn delayMs={240}>
+        <FadeIn delayMs={300}>
           <BarCard
             icon={Users}
             title="Gérer les utilisateurs"
@@ -54,7 +63,7 @@ function FeaturesComponent() {
             onClick={() => void navigate({ to: '/utilisateurs' })}
           />
         </FadeIn>
-        <FadeIn delayMs={300}>
+        <FadeIn delayMs={360}>
           <BarCard
             icon={Terminal}
             title="Console API"
@@ -62,7 +71,7 @@ function FeaturesComponent() {
             onClick={() => void navigate({ to: '/console' })}
           />
         </FadeIn>
-        <FadeIn delayMs={360}>
+        <FadeIn delayMs={420}>
           <BarCard
             icon={ToggleLeft}
             title="Gérer les features"
@@ -70,7 +79,7 @@ function FeaturesComponent() {
             onClick={() => void navigate({ to: '/features' })}
           />
         </FadeIn>
-        <FadeIn delayMs={420}>
+        <FadeIn delayMs={480}>
           <BarCard
             icon={LifeBuoy}
             title="Centre d’aide"

--- a/apps/kpilote-admin/src/routes/_authed/relations/index.tsx
+++ b/apps/kpilote-admin/src/routes/_authed/relations/index.tsx
@@ -1,0 +1,236 @@
+import {
+  useInfiniteQuery,
+  useMutation,
+  useQueryClient,
+  useSuspenseQuery,
+} from '@tanstack/react-query'
+import { createFileRoute, Link } from '@tanstack/react-router'
+import { Search, Trash2 } from 'lucide-react'
+import { useState } from 'react'
+
+import { supprimerRelation, upsertRelationParent } from '@/api/relations'
+import { Breadcrumb } from '@/components/Breadcrumb'
+import { PageHeading } from '@/components/PageHeading'
+import { IndividuPicker } from '@/components/relations/IndividuPicker'
+import { useAppConfig } from '@/context/AppConfigContext'
+import { extractApiError } from '@/lib/apiError'
+import { useProdEditUnlock } from '@/lib/useProdEditUnlock'
+import { individusAllQueryOptions } from '@/queries/individus'
+import { relationsInfiniteQueryOptions } from '@/queries/relations'
+import { Button } from '@pilote/kpilote-ui/Button'
+import { EmptyState } from '@pilote/kpilote-ui/EmptyState'
+import { Table } from '@pilote/kpilote-ui/Table'
+import { useToast } from '@pilote/kpilote-ui/Toast'
+
+export const Route = createFileRoute('/_authed/relations/')({
+  loader: async ({ context }) => {
+    await context.queryClient.ensureQueryData(individusAllQueryOptions())
+  },
+  component: RelationsComponent,
+})
+
+type LigneEnAttente = { id: string; nom: string; referentiel: string }
+
+function RelationsComponent() {
+  const queryClient = useQueryClient()
+  const toast = useToast()
+  const { isProd, environment } = useAppConfig()
+  const { locked, unlock } = useProdEditUnlock()
+  const [recherche, setRecherche] = useState('')
+  const [enAttente, setEnAttente] = useState<LigneEnAttente[]>([])
+
+  const query = useInfiniteQuery(relationsInfiniteQueryOptions(recherche))
+  const { data: individus } = useSuspenseQuery(individusAllQueryOptions())
+
+  const relations = query.data?.pages.flatMap((page) => page.items) ?? []
+  const total = query.data?.pages[0]?.total ?? 0
+
+  const invalider = async () => {
+    await queryClient.invalidateQueries({ queryKey: ['relations'] })
+    await queryClient.invalidateQueries({ queryKey: ['individus'] })
+  }
+
+  const upsert = useMutation({
+    mutationFn: ({ enfant, parent }: { enfant: string; parent: string }) =>
+      upsertRelationParent(enfant, { parent }),
+    onSuccess: async (_data, variables) => {
+      setEnAttente((lignes) => lignes.filter((ligne) => ligne.id !== variables.enfant))
+      await invalider()
+      toast({ title: 'Relation enregistrée.' })
+    },
+    onError: (error: unknown) => {
+      toast({ title: extractApiError(error), variant: 'error' })
+    },
+  })
+
+  const suppression = useMutation({
+    mutationFn: (enfant: string) => supprimerRelation(enfant),
+    onSuccess: async () => {
+      await invalider()
+      toast({ title: 'Relation supprimée.' })
+    },
+    onError: (error: unknown) => {
+      toast({ title: extractApiError(error), variant: 'error' })
+    },
+  })
+
+  const idsEnAttente = enAttente.map((ligne) => ligne.id)
+  const idsDejaRattaches = relations.map((relation) => relation.enfant.id)
+
+  const ajouterLigne = (id: string) => {
+    const individu = individus.find((candidat) => candidat.id === id)
+    if (!individu) return
+    setEnAttente((lignes) => [
+      { id: individu.id, nom: individu.nom, referentiel: individu.referentiel },
+      ...lignes,
+    ])
+  }
+
+  return (
+    <div>
+      <Breadcrumb>
+        <Link to="/fonctionnalites" className="hover:text-primary">
+          Fonctionnalités
+        </Link>
+        <span className="font-medium text-text">Relations</span>
+      </Breadcrumb>
+      <PageHeading
+        title="Relations"
+        subtitle={
+          <>
+            {total} relation{total > 1 ? 's' : ''} · environnement{' '}
+            <b className={isProd ? 'text-red-marianne' : undefined}>{environment}</b>
+          </>
+        }
+      />
+
+      {locked ? (
+        <div className="mb-6 flex items-center justify-between gap-4 rounded-md border border-red-marianne/30 bg-surface px-4 py-3">
+          <p className="text-sm text-text">
+            Environnement de production : l’édition des relations est verrouillée.
+          </p>
+          <Button variant="secondary" type="button" onClick={unlock}>
+            Déverrouiller
+          </Button>
+        </div>
+      ) : null}
+
+      <div className="mb-6 max-w-md">
+        <p className="mb-1.5 text-xs font-semibold text-text">Ajouter une relation</p>
+        <IndividuPicker
+          excludedIds={[...idsDejaRattaches, ...idsEnAttente]}
+          filtre={(individu) => individu.parents.length === 0}
+          onSelect={ajouterLigne}
+          placeholder="Rechercher un individu…"
+          disabled={locked}
+        />
+      </div>
+
+      <div className="mb-4 flex max-w-sm items-center gap-2 rounded-md border border-border px-3 py-2 text-sm">
+        <Search className="size-4 text-text-subtle" />
+        <input
+          value={recherche}
+          onChange={(event) => setRecherche(event.target.value)}
+          placeholder="Filtrer par nom d’individu…"
+          className="w-full bg-transparent focus:outline-none"
+        />
+      </div>
+
+      {relations.length === 0 && enAttente.length === 0 && !query.isLoading ? (
+        <EmptyState
+          title="Aucune relation"
+          description="Ajoutez un individu ci-dessus pour lui définir un parent."
+        />
+      ) : (
+        <Table>
+          <Table.Head>
+            <Table.Row>
+              <Table.HeaderCell>Individu</Table.HeaderCell>
+              <Table.HeaderCell>Référentiel</Table.HeaderCell>
+              <Table.HeaderCell>Parent</Table.HeaderCell>
+              <Table.HeaderCell />
+            </Table.Row>
+          </Table.Head>
+          <Table.Body>
+            {enAttente.map((ligne) => (
+              <Table.Row key={`attente-${ligne.id}`} className="bg-surface-tinted">
+                <Table.Cell>
+                  <span className="font-semibold">{ligne.nom}</span>{' '}
+                  <span className="font-mono text-xs text-text-muted">{ligne.id}</span>
+                </Table.Cell>
+                <Table.Cell>
+                  <span className="font-mono text-xs text-text-muted">{ligne.referentiel}</span>
+                </Table.Cell>
+                <Table.Cell>
+                  <IndividuPicker
+                    excludedIds={[ligne.id]}
+                    onSelect={(parent) => upsert.mutate({ enfant: ligne.id, parent })}
+                    placeholder="Parent à choisir"
+                    disabled={locked || upsert.isPending}
+                  />
+                </Table.Cell>
+                <Table.Cell align="right">
+                  <button
+                    type="button"
+                    aria-label="Retirer la ligne"
+                    onClick={() =>
+                      setEnAttente((lignes) => lignes.filter((autre) => autre.id !== ligne.id))
+                    }
+                    className="text-text-muted hover:text-red-marianne"
+                  >
+                    <Trash2 className="size-4" />
+                  </button>
+                </Table.Cell>
+              </Table.Row>
+            ))}
+            {relations.map((relation) => (
+              <Table.Row key={relation.enfant.id}>
+                <Table.Cell>
+                  <span className="font-semibold">{relation.enfant.nom}</span>{' '}
+                  <span className="font-mono text-xs text-text-muted">{relation.enfant.id}</span>
+                </Table.Cell>
+                <Table.Cell>
+                  <span className="font-mono text-xs text-text-muted">
+                    {relation.enfant.referentiel}
+                  </span>
+                </Table.Cell>
+                <Table.Cell>
+                  <IndividuPicker
+                    excludedIds={[relation.enfant.id]}
+                    value={relation.parent.id}
+                    onSelect={(parent) => upsert.mutate({ enfant: relation.enfant.id, parent })}
+                    disabled={locked || upsert.isPending}
+                  />
+                </Table.Cell>
+                <Table.Cell align="right">
+                  <button
+                    type="button"
+                    aria-label={`Supprimer la relation de ${relation.enfant.nom}`}
+                    disabled={locked || suppression.isPending}
+                    onClick={() => suppression.mutate(relation.enfant.id)}
+                    className="text-text-muted hover:text-red-marianne disabled:opacity-50"
+                  >
+                    <Trash2 className="size-4" />
+                  </button>
+                </Table.Cell>
+              </Table.Row>
+            ))}
+          </Table.Body>
+        </Table>
+      )}
+
+      {query.hasNextPage ? (
+        <div className="mt-4 flex justify-center">
+          <Button
+            variant="secondary"
+            type="button"
+            disabled={query.isFetchingNextPage}
+            onClick={() => void query.fetchNextPage()}
+          >
+            {query.isFetchingNextPage ? 'Chargement…' : 'Charger plus'}
+          </Button>
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/apps/kpilote-admin/src/routes/_authed/relations/index.tsx
+++ b/apps/kpilote-admin/src/routes/_authed/relations/index.tsx
@@ -1,9 +1,5 @@
-import {
-  useInfiniteQuery,
-  useMutation,
-  useQueryClient,
-  useSuspenseQuery,
-} from '@tanstack/react-query'
+import { searchUnaccent } from '@pilote/kpilote-shared/texte'
+import { useMutation, useQueryClient, useSuspenseQuery } from '@tanstack/react-query'
 import { createFileRoute, Link } from '@tanstack/react-router'
 import { Search, Trash2 } from 'lucide-react'
 import { useState } from 'react'
@@ -16,7 +12,7 @@ import { useAppConfig } from '@/context/AppConfigContext'
 import { extractApiError } from '@/lib/apiError'
 import { useProdEditUnlock } from '@/lib/useProdEditUnlock'
 import { individusAllQueryOptions } from '@/queries/individus'
-import { relationsInfiniteQueryOptions } from '@/queries/relations'
+import { relationsAllQueryOptions } from '@/queries/relations'
 import { Button } from '@pilote/kpilote-ui/Button'
 import { EmptyState } from '@pilote/kpilote-ui/EmptyState'
 import { Table } from '@pilote/kpilote-ui/Table'
@@ -24,7 +20,10 @@ import { useToast } from '@pilote/kpilote-ui/Toast'
 
 export const Route = createFileRoute('/_authed/relations/')({
   loader: async ({ context }) => {
-    await context.queryClient.ensureQueryData(individusAllQueryOptions())
+    await Promise.all([
+      context.queryClient.ensureQueryData(individusAllQueryOptions()),
+      context.queryClient.ensureQueryData(relationsAllQueryOptions()),
+    ])
   },
   component: RelationsComponent,
 })
@@ -39,11 +38,14 @@ function RelationsComponent() {
   const [recherche, setRecherche] = useState('')
   const [enAttente, setEnAttente] = useState<LigneEnAttente[]>([])
 
-  const query = useInfiniteQuery(relationsInfiniteQueryOptions(recherche))
+  const { data: toutesRelations } = useSuspenseQuery(relationsAllQueryOptions())
   const { data: individus } = useSuspenseQuery(individusAllQueryOptions())
 
-  const relations = query.data?.pages.flatMap((page) => page.items) ?? []
-  const total = query.data?.pages[0]?.total ?? 0
+  const terme = searchUnaccent(recherche)
+  const relations = terme
+    ? toutesRelations.filter((relation) => searchUnaccent(relation.enfant.nom).includes(terme))
+    : toutesRelations
+  const total = toutesRelations.length
 
   const invalider = async () => {
     await queryClient.invalidateQueries({ queryKey: ['relations'] })
@@ -75,7 +77,9 @@ function RelationsComponent() {
   })
 
   const idsEnAttente = enAttente.map((ligne) => ligne.id)
-  const idsDejaRattaches = relations.map((relation) => relation.enfant.id)
+  // Sur la liste complète, pas sur la liste filtrée : un individu masqué par le
+  // filtre reste rattaché et ne doit pas réapparaître dans le sélecteur d'ajout.
+  const idsDejaRattaches = toutesRelations.map((relation) => relation.enfant.id)
 
   const ajouterLigne = (id: string) => {
     const individu = individus.find((candidat) => candidat.id === id)
@@ -136,10 +140,14 @@ function RelationsComponent() {
         />
       </div>
 
-      {relations.length === 0 && enAttente.length === 0 && !query.isLoading ? (
+      {relations.length === 0 && enAttente.length === 0 ? (
         <EmptyState
-          title="Aucune relation"
-          description="Ajoutez un individu ci-dessus pour lui définir un parent."
+          title={terme ? 'Aucun résultat' : 'Aucune relation'}
+          description={
+            terme
+              ? 'Aucun individu ne correspond à ce filtre.'
+              : 'Ajoutez un individu ci-dessus pour lui définir un parent.'
+          }
         />
       ) : (
         <Table>
@@ -218,19 +226,6 @@ function RelationsComponent() {
           </Table.Body>
         </Table>
       )}
-
-      {query.hasNextPage ? (
-        <div className="mt-4 flex justify-center">
-          <Button
-            variant="secondary"
-            type="button"
-            disabled={query.isFetchingNextPage}
-            onClick={() => void query.fetchNextPage()}
-          >
-            {query.isFetchingNextPage ? 'Chargement…' : 'Charger plus'}
-          </Button>
-        </div>
-      ) : null}
     </div>
   )
 }

--- a/apps/kpilote-admin/src/server/api/router.ts
+++ b/apps/kpilote-admin/src/server/api/router.ts
@@ -7,7 +7,7 @@ import { readSession } from '@/server/session'
 // Segments sûrs uniquement : une ressource autorisée, puis des segments composés
 // de caractères de public id (alphanum, `_`, `-`). Tout le reste est rejeté.
 const SAFE_PATH =
-  /^(indicateurs|referentiels|individus|api-keys|utilisateurs|collections|permissions|features|centre-aide)(\/[A-Za-z0-9_-]+)*$/
+  /^(indicateurs|referentiels|individus|relations|api-keys|utilisateurs|collections|permissions|features|centre-aide)(\/[A-Za-z0-9_-]+)*$/
 
 // Rejette toute tentative de traversal / d'injection d'URL absolue AVANT de
 // matcher l'allowlist (sinon la normalisation d'URL des `..` permettrait

--- a/apps/kpilote-admin/src/server/api/router.ts
+++ b/apps/kpilote-admin/src/server/api/router.ts
@@ -3,7 +3,7 @@ import { Hono } from 'hono'
 import { kpiloteApiUrlFor } from '@/server/environments'
 import { readSession } from '@/server/session'
 
-// Ressources relayables (lecture + upsert indicateurs/référentiels/individus).
+// Ressources relayables, à tenir à jour avec la regex ci-dessous.
 // Segments sûrs uniquement : une ressource autorisée, puis des segments composés
 // de caractères de public id (alphanum, `_`, `-`). Tout le reste est rejeté.
 const SAFE_PATH =

--- a/apps/kpilote-api/src/app.ts
+++ b/apps/kpilote-api/src/app.ts
@@ -18,6 +18,7 @@ import { meRoutes } from '@/me/routes'
 import { collectionRoutes } from '@/collection/routes'
 import { permissionRoutes } from '@/permission/routes'
 import { referentielRoutes } from '@/referentiel/routes'
+import { relationRoutes } from '@/relation/routes'
 import { objectifIndicateurIndividuRoutes } from '@/objectifIndicateurIndividu/routes'
 import { utilisateurRoutes } from '@/utilisateur/routes'
 import { valeurAvancementRoutes } from '@/valeurAvancement/routes'
@@ -45,6 +46,7 @@ app.route('/', valeurImportRoutes)
 app.route('/', objectifIndicateurIndividuRoutes)
 app.route('/', referentielRoutes)
 app.route('/', individuRoutes)
+app.route('/', relationRoutes)
 app.route('/', collectionRoutes)
 app.route('/', commentaireRoutes)
 app.route('/', centreAideRoutes)

--- a/apps/kpilote-api/src/individu/queries/listIndividus.test.ts
+++ b/apps/kpilote-api/src/individu/queries/listIndividus.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+
+import { listIndividus } from '@/individu/queries/listIndividus'
+import { fixtures } from '@/test/fixtures'
+import { integrationTest } from '@/test/integrationTest'
+import { testDeptIds, testReferentielId, testRegIds } from '@/test/randomIds'
+
+describe.concurrent('listIndividus', () => {
+  it(
+    'trie les individus par nom croissant, tous référentiels confondus',
+    integrationTest(async () => {
+      const refA = testReferentielId()
+      const refB = testReferentielId()
+      const [d1, d2] = testDeptIds(2)
+      const [r1] = testRegIds(1)
+      await fixtures.individu(
+        { publicId: d2, nom: 'Zzbeta', referentiel: { publicId: refA } },
+        { publicId: r1, nom: 'Zzgamma', referentiel: { publicId: refB } },
+        { publicId: d1, nom: 'Zzalpha', referentiel: { publicId: refA } },
+      )
+
+      const result = await listIndividus({ recherche: 'Zz' })
+
+      expect(result._unsafeUnwrap().items.map((individu) => individu.nom)).toEqual([
+        'Zzalpha',
+        'Zzbeta',
+        'Zzgamma',
+      ])
+    }),
+  )
+
+  it(
+    'expose les parents de chaque individu, ce qui permet de repérer ceux déjà rattachés',
+    integrationTest(async () => {
+      const [dept] = testDeptIds(1)
+      const [reg] = testRegIds(1)
+      await fixtures.relation({
+        parent: { publicId: reg, nom: 'Zzparent' },
+        child: { publicId: dept, nom: 'Zzenfant' },
+      })
+
+      const result = await listIndividus({ recherche: 'Zzenfant' })
+
+      expect(result._unsafeUnwrap().items[0]?.parents).toEqual([reg])
+    }),
+  )
+
+  it(
+    'pagine les résultats',
+    integrationTest(async () => {
+      const ref = testReferentielId()
+      const [i1, i2, i3] = testDeptIds(3)
+      await fixtures.individu(
+        { publicId: i1, nom: 'Zzpage0', referentiel: { publicId: ref } },
+        { publicId: i2, nom: 'Zzpage1', referentiel: { publicId: ref } },
+        { publicId: i3, nom: 'Zzpage2', referentiel: { publicId: ref } },
+      )
+
+      const premiere = await listIndividus({ recherche: 'Zzpage', pageSize: 2 })
+      const page1 = premiere._unsafeUnwrap()
+
+      expect(page1.items).toHaveLength(2)
+      expect(page1.pagination.hasMore).toBe(true)
+      expect(page1.total).toBe(3)
+    }),
+  )
+})

--- a/apps/kpilote-api/src/individu/queries/listIndividus.ts
+++ b/apps/kpilote-api/src/individu/queries/listIndividus.ts
@@ -1,0 +1,28 @@
+import { type IndividuListApiModel, type ListIndividusQuery } from '@pilote/kpilote-shared/individu'
+import { ResultAsync } from 'neverthrow'
+
+import { db } from '@/framework/persistence/dbStore'
+import { buildPaginationArgs, toPaginatedResponse } from '@/framework/persistence/paginate'
+import { individuInclude, toIndividuApiModel } from '@/individu/utils'
+
+export const listIndividus = (
+  params: ListIndividusQuery,
+): ResultAsync<IndividuListApiModel, never> => {
+  const where = params.recherche
+    ? { nom: { contains: params.recherche, mode: 'insensitive' as const } }
+    : {}
+
+  const fetchPage = db().individu.findMany({
+    where,
+    // `id` en second critère : le curseur de pagination se positionne dessus,
+    // l'ordre doit donc rester total même quand deux individus sont homonymes.
+    orderBy: [{ nom: 'asc' }, { id: 'asc' }],
+    include: individuInclude,
+    ...buildPaginationArgs(params.cursor, params.pageSize),
+  })
+  const fetchTotal = db().individu.count({ where })
+
+  return ResultAsync.fromSafePromise(Promise.all([fetchPage, fetchTotal])).map(([rows, total]) =>
+    toPaginatedResponse(rows, total, toIndividuApiModel, params.pageSize),
+  )
+}

--- a/apps/kpilote-api/src/individu/routes.ts
+++ b/apps/kpilote-api/src/individu/routes.ts
@@ -1,13 +1,40 @@
 import { createRoute, z } from '@hono/zod-openapi'
-import { individuApiModelSchema, individuPublicIdSchema } from '@pilote/kpilote-shared/individu'
+import {
+  individuApiModelSchema,
+  individuPublicIdSchema,
+  listIndividusQuerySchema,
+} from '@pilote/kpilote-shared/individu'
+import { createPaginatedApiListSchema } from '@pilote/kpilote-shared/pagination'
 
 import { requireAuthentication } from '@/framework/auth/requireAuthentication'
 import { never } from '@/framework/errors/never'
 import { createOpenApiHono } from '@/framework/openapi/createOpenApiHono'
 import { jsonResponseOk } from '@/framework/openapi/jsonResponse'
+import { erreur400 } from '@/framework/openapi/responses'
 import { getIndividuByPublicId } from '@/individu/queries/getIndividuByPublicId'
+import { listIndividus } from '@/individu/queries/listIndividus'
 
 const IndividuApiModelSchema = individuApiModelSchema.openapi('IndividuApiModel')
+const IndividuListApiModelSchema =
+  createPaginatedApiListSchema(individuApiModelSchema).openapi('IndividuListApiModel')
+
+const getIndividusRoute = createRoute({
+  method: 'get',
+  path: '/individus',
+  tags: ['Individu'],
+  summary: 'Lister les individus',
+  description:
+    "Retourne la liste paginée des individus, tous référentiels confondus, triée par nom. Filtre optionnel `recherche` sur le nom. Chaque item inclut `parents`, ce qui permet d'identifier les individus déjà rattachés à un parent. Pagination cursor-based.",
+  middleware: [requireAuthentication],
+  request: { query: listIndividusQuerySchema },
+  responses: {
+    200: {
+      content: { 'application/json': { schema: IndividuListApiModelSchema } },
+      description: 'Liste paginée des individus',
+    },
+    400: erreur400,
+  },
+})
 
 const detailParamsSchema = z.object({
   id: individuPublicIdSchema,
@@ -31,6 +58,21 @@ const getIndividuByIdRoute = createRoute({
 })
 
 export const individuRoutes = createOpenApiHono()
+
+individuRoutes.openapi(getIndividusRoute, async (context) => {
+  const { recherche, cursor, pageSize } = context.req.valid('query')
+
+  return listIndividus({ recherche, cursor, pageSize }).match(
+    (data) =>
+      jsonResponseOk({
+        context,
+        data,
+        schema: IndividuListApiModelSchema,
+        status: 200,
+      }),
+    never,
+  )
+})
 
 individuRoutes.openapi(getIndividuByIdRoute, async (context) => {
   const { id } = context.req.valid('param')

--- a/apps/kpilote-api/src/relation/commands/supprimerRelation.test.ts
+++ b/apps/kpilote-api/src/relation/commands/supprimerRelation.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+
+import { db } from '@/framework/persistence/dbStore'
+import { supprimerRelation } from '@/relation/commands/supprimerRelation'
+import { fixtures } from '@/test/fixtures'
+import { integrationTest } from '@/test/integrationTest'
+import { testDeptIds, testRegIds } from '@/test/randomIds'
+import { runAsAdmin, runAsContributor } from '@/test/runAsPrincipal'
+
+const compteRelations = (publicId: string) =>
+  db().relation.count({ where: { child: { publicId } } })
+
+describe.concurrent('supprimerRelation', () => {
+  it(
+    "supprime la relation de l'individu",
+    integrationTest(async () => {
+      const [dept] = testDeptIds(1)
+      const [reg] = testRegIds(1)
+      await fixtures.relation({ parent: { publicId: reg }, child: { publicId: dept } })
+
+      const result = await runAsAdmin('principal-delete-ok', () => supprimerRelation(dept))
+
+      expect(result.isOk()).toBe(true)
+      expect(await compteRelations(dept)).toBe(0)
+    }),
+  )
+
+  it(
+    "réussit sans rien faire quand l'individu n'a pas de parent",
+    integrationTest(async () => {
+      const [dept] = testDeptIds(1)
+      await fixtures.individu({ publicId: dept })
+
+      const result = await runAsAdmin('principal-delete-idem', () => supprimerRelation(dept))
+
+      expect(result.isOk()).toBe(true)
+      expect(await compteRelations(dept)).toBe(0)
+    }),
+  )
+
+  it(
+    'ne touche pas aux relations des autres individus',
+    integrationTest(async () => {
+      const [cible, voisin] = testDeptIds(2)
+      const [reg] = testRegIds(1)
+      await fixtures.relation(
+        { parent: { publicId: reg }, child: { publicId: cible } },
+        { parent: { publicId: reg }, child: { publicId: voisin } },
+      )
+
+      await runAsAdmin('principal-delete-isolation', () => supprimerRelation(cible))
+
+      expect(await compteRelations(voisin)).toBe(1)
+    }),
+  )
+
+  it(
+    "refuse une clé API qui n'est pas ADMIN",
+    integrationTest(async () => {
+      const [dept] = testDeptIds(1)
+      const [reg] = testRegIds(1)
+      await fixtures.relation({ parent: { publicId: reg }, child: { publicId: dept } })
+
+      await expect(
+        runAsContributor('principal-delete-contributor', () => supprimerRelation(dept)),
+      ).rejects.toThrow('Cette opération requiert un utilisateur OIDC ou une clé API de rôle ADMIN')
+    }),
+  )
+})

--- a/apps/kpilote-api/src/relation/commands/supprimerRelation.test.ts
+++ b/apps/kpilote-api/src/relation/commands/supprimerRelation.test.ts
@@ -5,7 +5,7 @@ import { supprimerRelation } from '@/relation/commands/supprimerRelation'
 import { fixtures } from '@/test/fixtures'
 import { integrationTest } from '@/test/integrationTest'
 import { testDeptIds, testRegIds } from '@/test/randomIds'
-import { runAsAdmin, runAsContributor } from '@/test/runAsPrincipal'
+import { runAsAdmin, runAsContributor, runAsUser } from '@/test/runAsPrincipal'
 
 const compteRelations = (publicId: string) =>
   db().relation.count({ where: { child: { publicId } } })
@@ -63,7 +63,20 @@ describe.concurrent('supprimerRelation', () => {
 
       await expect(
         runAsContributor('principal-delete-contributor', () => supprimerRelation(dept)),
-      ).rejects.toThrow('Cette opération requiert un utilisateur OIDC ou une clé API de rôle ADMIN')
+      ).rejects.toThrow('Cette opération requiert une clé API de rôle ADMIN')
+    }),
+  )
+
+  it(
+    'refuse un utilisateur OIDC : la hiérarchie ne se modifie que par clé ADMIN',
+    integrationTest(async () => {
+      const [dept] = testDeptIds(1)
+      const [reg] = testRegIds(1)
+      await fixtures.relation({ parent: { publicId: reg }, child: { publicId: dept } })
+
+      await expect(
+        runAsUser('utilisateur-delete-oidc', () => supprimerRelation(dept)),
+      ).rejects.toThrow('Cette opération requiert une clé API de rôle ADMIN')
     }),
   )
 })

--- a/apps/kpilote-api/src/relation/commands/supprimerRelation.ts
+++ b/apps/kpilote-api/src/relation/commands/supprimerRelation.ts
@@ -1,0 +1,16 @@
+import { ResultAsync } from 'neverthrow'
+
+import { ensurePrincipal, isApiKeyAdmin, isOidcUser } from '@/framework/auth/principalPredicates'
+import { db } from '@/framework/persistence/dbStore'
+
+const performSuppression = async (enfantPublicId: string): Promise<void> => {
+  ensurePrincipal(
+    (principal) => isApiKeyAdmin(principal) || isOidcUser(principal),
+    'Cette opération requiert un utilisateur OIDC ou une clé API de rôle ADMIN',
+  )
+
+  await db().relation.deleteMany({ where: { child: { publicId: enfantPublicId } } })
+}
+
+export const supprimerRelation = (enfantPublicId: string): ResultAsync<void, never> =>
+  ResultAsync.fromSafePromise(performSuppression(enfantPublicId))

--- a/apps/kpilote-api/src/relation/commands/supprimerRelation.ts
+++ b/apps/kpilote-api/src/relation/commands/supprimerRelation.ts
@@ -1,13 +1,11 @@
 import { ResultAsync } from 'neverthrow'
 
-import { ensurePrincipal, isApiKeyAdmin, isOidcUser } from '@/framework/auth/principalPredicates'
+import { ensurePrincipal, isApiKeyAdmin } from '@/framework/auth/principalPredicates'
 import { db } from '@/framework/persistence/dbStore'
+import { MESSAGE_ADMIN } from '@/relation/utils'
 
 const performSuppression = async (enfantPublicId: string): Promise<void> => {
-  ensurePrincipal(
-    (principal) => isApiKeyAdmin(principal) || isOidcUser(principal),
-    'Cette opération requiert un utilisateur OIDC ou une clé API de rôle ADMIN',
-  )
+  ensurePrincipal(isApiKeyAdmin, MESSAGE_ADMIN)
 
   await db().relation.deleteMany({ where: { child: { publicId: enfantPublicId } } })
 }

--- a/apps/kpilote-api/src/relation/commands/upsertRelationParent.test.ts
+++ b/apps/kpilote-api/src/relation/commands/upsertRelationParent.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from 'vitest'
+
+import { db } from '@/framework/persistence/dbStore'
+import { upsertRelationParent } from '@/relation/commands/upsertRelationParent'
+import { fixtures } from '@/test/fixtures'
+import { integrationTest } from '@/test/integrationTest'
+import { testDeptIds, testRegIds } from '@/test/randomIds'
+import { runAsAdmin, runAsContributor } from '@/test/runAsPrincipal'
+
+const parentsDe = async (publicId: string): Promise<string[]> => {
+  const relations = await db().relation.findMany({
+    where: { child: { publicId } },
+    include: { parent: true },
+  })
+  return relations.map((relation) => relation.parent.publicId).sort()
+}
+
+describe.concurrent('upsertRelationParent', () => {
+  it(
+    "crée la relation quand l'enfant n'a pas de parent",
+    integrationTest(async () => {
+      const [dept] = testDeptIds(1)
+      const [reg] = testRegIds(1)
+      await fixtures.individu({ publicId: dept }, { publicId: reg })
+
+      const result = await runAsAdmin('principal-upsert-creation', () =>
+        upsertRelationParent(dept, { parent: reg }),
+      )
+
+      expect(result.isOk()).toBe(true)
+      expect(await parentsDe(dept)).toEqual([reg])
+    }),
+  )
+
+  it(
+    'remplace le parent existant sans laisser de doublon',
+    integrationTest(async () => {
+      const [dept] = testDeptIds(1)
+      const [ancien, nouveau] = testRegIds(2)
+      await fixtures.relation({ parent: { publicId: ancien }, child: { publicId: dept } })
+      await fixtures.individu({ publicId: nouveau })
+
+      const result = await runAsAdmin('principal-upsert-remplacement', () =>
+        upsertRelationParent(dept, { parent: nouveau }),
+      )
+
+      expect(result.isOk()).toBe(true)
+      expect(await parentsDe(dept)).toEqual([nouveau])
+    }),
+  )
+
+  it(
+    'est idempotent : rejouer la même écriture ne crée pas de seconde relation',
+    integrationTest(async () => {
+      const [dept] = testDeptIds(1)
+      const [reg] = testRegIds(1)
+      await fixtures.individu({ publicId: dept }, { publicId: reg })
+
+      await runAsAdmin('principal-upsert-idem', () => upsertRelationParent(dept, { parent: reg }))
+      await runAsAdmin('principal-upsert-idem', () => upsertRelationParent(dept, { parent: reg }))
+
+      expect(await parentsDe(dept)).toEqual([reg])
+    }),
+  )
+
+  it(
+    "refuse qu'un individu soit son propre parent",
+    integrationTest(async () => {
+      const [dept] = testDeptIds(1)
+      await fixtures.individu({ publicId: dept })
+
+      const result = await runAsAdmin('principal-upsert-auto', () =>
+        upsertRelationParent(dept, { parent: dept }),
+      )
+
+      expect(result._unsafeUnwrapErr()).toEqual({ type: 'AUTO_PARENT' })
+      expect(await parentsDe(dept)).toEqual([])
+    }),
+  )
+
+  it(
+    'refuse un parent qui est un enfant direct de la cible',
+    integrationTest(async () => {
+      const [dept] = testDeptIds(1)
+      const [reg] = testRegIds(1)
+      await fixtures.relation({ parent: { publicId: reg }, child: { publicId: dept } })
+
+      const result = await runAsAdmin('principal-upsert-cycle-court', () =>
+        upsertRelationParent(reg, { parent: dept }),
+      )
+
+      expect(result._unsafeUnwrapErr()).toEqual({ type: 'CYCLE_DETECTE' })
+      expect(await parentsDe(reg)).toEqual([])
+    }),
+  )
+
+  it(
+    'refuse un parent qui est un descendant indirect de la cible',
+    integrationTest(async () => {
+      const [petitEnfant] = testDeptIds(1)
+      const [enfant, racine] = testRegIds(2)
+      await fixtures.relation(
+        { parent: { publicId: racine }, child: { publicId: enfant } },
+        { parent: { publicId: enfant }, child: { publicId: petitEnfant } },
+      )
+
+      const result = await runAsAdmin('principal-upsert-cycle-long', () =>
+        upsertRelationParent(racine, { parent: petitEnfant }),
+      )
+
+      expect(result._unsafeUnwrapErr()).toEqual({ type: 'CYCLE_DETECTE' })
+    }),
+  )
+
+  it(
+    "échoue quand l'individu enfant n'existe pas",
+    integrationTest(async () => {
+      const [reg] = testRegIds(1)
+      await fixtures.individu({ publicId: reg })
+
+      await expect(
+        runAsAdmin('principal-upsert-enfant-inconnu', () =>
+          upsertRelationParent('DEPT-INEXISTANT', { parent: reg }),
+        ),
+      ).rejects.toThrow()
+    }),
+  )
+
+  it(
+    "échoue quand l'individu parent n'existe pas",
+    integrationTest(async () => {
+      const [dept] = testDeptIds(1)
+      await fixtures.individu({ publicId: dept })
+
+      await expect(
+        runAsAdmin('principal-upsert-parent-inconnu', () =>
+          upsertRelationParent(dept, { parent: 'REG-INEXISTANT' }),
+        ),
+      ).rejects.toThrow()
+    }),
+  )
+
+  it(
+    "refuse une clé API qui n'est pas ADMIN",
+    integrationTest(async () => {
+      const [dept] = testDeptIds(1)
+      const [reg] = testRegIds(1)
+      await fixtures.individu({ publicId: dept }, { publicId: reg })
+
+      await expect(
+        runAsContributor('principal-upsert-contributor', () =>
+          upsertRelationParent(dept, { parent: reg }),
+        ),
+      ).rejects.toThrow('Cette opération requiert un utilisateur OIDC ou une clé API de rôle ADMIN')
+    }),
+  )
+})

--- a/apps/kpilote-api/src/relation/commands/upsertRelationParent.test.ts
+++ b/apps/kpilote-api/src/relation/commands/upsertRelationParent.test.ts
@@ -5,7 +5,7 @@ import { upsertRelationParent } from '@/relation/commands/upsertRelationParent'
 import { fixtures } from '@/test/fixtures'
 import { integrationTest } from '@/test/integrationTest'
 import { testDeptIds, testRegIds } from '@/test/randomIds'
-import { runAsAdmin, runAsContributor } from '@/test/runAsPrincipal'
+import { runAsAdmin, runAsContributor, runAsUser } from '@/test/runAsPrincipal'
 
 const parentsDe = async (publicId: string): Promise<string[]> => {
   const relations = await db().relation.findMany({
@@ -151,7 +151,20 @@ describe.concurrent('upsertRelationParent', () => {
         runAsContributor('principal-upsert-contributor', () =>
           upsertRelationParent(dept, { parent: reg }),
         ),
-      ).rejects.toThrow('Cette opération requiert un utilisateur OIDC ou une clé API de rôle ADMIN')
+      ).rejects.toThrow('Cette opération requiert une clé API de rôle ADMIN')
+    }),
+  )
+
+  it(
+    'refuse un utilisateur OIDC : la hiérarchie ne se modifie que par clé ADMIN',
+    integrationTest(async () => {
+      const [dept] = testDeptIds(1)
+      const [reg] = testRegIds(1)
+      await fixtures.individu({ publicId: dept }, { publicId: reg })
+
+      await expect(
+        runAsUser('utilisateur-upsert-oidc', () => upsertRelationParent(dept, { parent: reg })),
+      ).rejects.toThrow('Cette opération requiert une clé API de rôle ADMIN')
     }),
   )
 })

--- a/apps/kpilote-api/src/relation/commands/upsertRelationParent.ts
+++ b/apps/kpilote-api/src/relation/commands/upsertRelationParent.ts
@@ -44,6 +44,13 @@ const performUpsert = async (
     select: { id: true },
   })
 
+  // Verrou sur la ligne de l'enfant pour la durée de la transaction. Sans lui,
+  // et faute de contrainte d'unicité sur `child_id`, deux écritures concurrentes
+  // sur le même enfant intercalent leur deleteMany/create et laissent deux
+  // parents — le cas se produit même sans relation préexistante, puisque
+  // `deleteMany` ne verrouille alors aucune ligne.
+  await db().$executeRaw`SELECT id FROM individu WHERE id = ${enfant.id}::uuid FOR UPDATE`
+
   if (await estDescendant(parent.id, enfant.id)) return err({ type: 'CYCLE_DETECTE' })
 
   await db().relation.deleteMany({ where: { childId: enfant.id } })

--- a/apps/kpilote-api/src/relation/commands/upsertRelationParent.ts
+++ b/apps/kpilote-api/src/relation/commands/upsertRelationParent.ts
@@ -2,8 +2,9 @@ import { type UpsertRelationBody } from '@pilote/kpilote-shared/relation'
 import { err, ok, type Result, ResultAsync } from 'neverthrow'
 import { uuidv7 } from 'uuidv7'
 
-import { ensurePrincipal, isApiKeyAdmin, isOidcUser } from '@/framework/auth/principalPredicates'
+import { ensurePrincipal, isApiKeyAdmin } from '@/framework/auth/principalPredicates'
 import { db } from '@/framework/persistence/dbStore'
+import { MESSAGE_ADMIN } from '@/relation/utils'
 
 export type UpsertRelationParentError = { type: 'AUTO_PARENT' } | { type: 'CYCLE_DETECTE' }
 
@@ -30,10 +31,7 @@ const performUpsert = async (
   enfantPublicId: string,
   body: UpsertRelationBody,
 ): Promise<Result<void, UpsertRelationParentError>> => {
-  ensurePrincipal(
-    (principal) => isApiKeyAdmin(principal) || isOidcUser(principal),
-    'Cette opération requiert un utilisateur OIDC ou une clé API de rôle ADMIN',
-  )
+  ensurePrincipal(isApiKeyAdmin, MESSAGE_ADMIN)
 
   if (enfantPublicId === body.parent) return err({ type: 'AUTO_PARENT' })
 

--- a/apps/kpilote-api/src/relation/commands/upsertRelationParent.ts
+++ b/apps/kpilote-api/src/relation/commands/upsertRelationParent.ts
@@ -1,0 +1,63 @@
+import { type UpsertRelationBody } from '@pilote/kpilote-shared/relation'
+import { err, ok, type Result, ResultAsync } from 'neverthrow'
+import { uuidv7 } from 'uuidv7'
+
+import { ensurePrincipal, isApiKeyAdmin, isOidcUser } from '@/framework/auth/principalPredicates'
+import { db } from '@/framework/persistence/dbStore'
+
+export type UpsertRelationParentError = { type: 'AUTO_PARENT' } | { type: 'CYCLE_DETECTE' }
+
+// Remontée des ancêtres du candidat. Le Set de visités protège des cycles déjà
+// présents en base : les données historiques n'ont pas traversé cette garde.
+const estDescendant = async (candidatId: string, ancetreId: string): Promise<boolean> => {
+  const visites = new Set<string>([candidatId])
+  let courant = [candidatId]
+
+  while (courant.length > 0) {
+    if (courant.includes(ancetreId)) return true
+    const relations = await db().relation.findMany({
+      where: { childId: { in: courant } },
+      select: { parentId: true },
+    })
+    courant = relations.map((relation) => relation.parentId).filter((id) => !visites.has(id))
+    for (const id of courant) visites.add(id)
+  }
+
+  return false
+}
+
+const performUpsert = async (
+  enfantPublicId: string,
+  body: UpsertRelationBody,
+): Promise<Result<void, UpsertRelationParentError>> => {
+  ensurePrincipal(
+    (principal) => isApiKeyAdmin(principal) || isOidcUser(principal),
+    'Cette opération requiert un utilisateur OIDC ou une clé API de rôle ADMIN',
+  )
+
+  if (enfantPublicId === body.parent) return err({ type: 'AUTO_PARENT' })
+
+  const enfant = await db().individu.findUniqueOrThrow({
+    where: { publicId: enfantPublicId },
+    select: { id: true },
+  })
+  const parent = await db().individu.findUniqueOrThrow({
+    where: { publicId: body.parent },
+    select: { id: true },
+  })
+
+  if (await estDescendant(parent.id, enfant.id)) return err({ type: 'CYCLE_DETECTE' })
+
+  await db().relation.deleteMany({ where: { childId: enfant.id } })
+  await db().relation.create({
+    data: { id: uuidv7(), parentId: parent.id, childId: enfant.id },
+  })
+
+  return ok(undefined)
+}
+
+export const upsertRelationParent = (
+  enfantPublicId: string,
+  body: UpsertRelationBody,
+): ResultAsync<void, UpsertRelationParentError> =>
+  ResultAsync.fromSafePromise(performUpsert(enfantPublicId, body)).andThen((result) => result)

--- a/apps/kpilote-api/src/relation/queries/getRelationByEnfant.ts
+++ b/apps/kpilote-api/src/relation/queries/getRelationByEnfant.ts
@@ -1,0 +1,13 @@
+import { type RelationApiModel } from '@pilote/kpilote-shared/relation'
+import { ResultAsync } from 'neverthrow'
+
+import { db } from '@/framework/persistence/dbStore'
+import { relationInclude, toRelationApiModel } from '@/relation/utils'
+
+export const getRelationByEnfant = (enfantPublicId: string): ResultAsync<RelationApiModel, never> =>
+  ResultAsync.fromSafePromise(
+    db().relation.findFirstOrThrow({
+      where: { child: { publicId: enfantPublicId } },
+      include: relationInclude,
+    }),
+  ).map(toRelationApiModel)

--- a/apps/kpilote-api/src/relation/queries/listRelations.test.ts
+++ b/apps/kpilote-api/src/relation/queries/listRelations.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest'
+
+import { listRelations } from '@/relation/queries/listRelations'
+import { fixtures } from '@/test/fixtures'
+import { integrationTest } from '@/test/integrationTest'
+import { testDeptIds, testReferentielId, testRegId } from '@/test/randomIds'
+
+describe.concurrent('listRelations', () => {
+  it(
+    "retourne une liste vide quand aucune relation n'existe",
+    integrationTest(async () => {
+      const result = await listRelations({})
+
+      expect(result._unsafeUnwrap()).toEqual({
+        items: [],
+        pagination: { cursor: null, hasMore: false },
+        total: 0,
+      })
+    }),
+  )
+
+  it(
+    "expose l'enfant et le parent avec leur référentiel",
+    integrationTest(async () => {
+      const refDept = testReferentielId()
+      const refReg = testReferentielId()
+      const [dept] = testDeptIds(1)
+      const reg = testRegId()
+      await fixtures.relation({
+        parent: { publicId: reg, nom: 'Occitanie', referentiel: { publicId: refReg } },
+        child: { publicId: dept, nom: 'Gers', referentiel: { publicId: refDept } },
+      })
+
+      const result = await listRelations({})
+
+      expect(result._unsafeUnwrap().items).toEqual([
+        {
+          enfant: { id: dept, nom: 'Gers', referentiel: refDept },
+          parent: { id: reg, nom: 'Occitanie', referentiel: refReg },
+        },
+      ])
+    }),
+  )
+
+  it(
+    "trie par nom d'enfant croissant",
+    integrationTest(async () => {
+      const refDept = testReferentielId()
+      const [a, b, c] = testDeptIds(3)
+      const reg = testRegId()
+      const parent = { publicId: reg, nom: 'Parent' }
+      await fixtures.relation(
+        {
+          parent,
+          child: { publicId: b, nom: 'Bouches-du-Rhône', referentiel: { publicId: refDept } },
+        },
+        { parent, child: { publicId: c, nom: 'Cantal', referentiel: { publicId: refDept } } },
+        { parent, child: { publicId: a, nom: 'Ain', referentiel: { publicId: refDept } } },
+      )
+
+      const result = await listRelations({})
+
+      expect(result._unsafeUnwrap().items.map((item) => item.enfant.nom)).toEqual([
+        'Ain',
+        'Bouches-du-Rhône',
+        'Cantal',
+      ])
+    }),
+  )
+
+  it(
+    "filtre sur le nom de l'enfant, sans tenir compte de la casse",
+    integrationTest(async () => {
+      const refDept = testReferentielId()
+      const [garsonne, autre] = testDeptIds(2)
+      const reg = testRegId()
+      const parent = { publicId: reg, nom: 'Parent' }
+      await fixtures.relation(
+        {
+          parent,
+          child: { publicId: garsonne, nom: 'Zzgarsonne', referentiel: { publicId: refDept } },
+        },
+        { parent, child: { publicId: autre, nom: 'Zzautre', referentiel: { publicId: refDept } } },
+      )
+
+      const result = await listRelations({ recherche: 'ZZGARS' })
+
+      expect(result._unsafeUnwrap().items.map((item) => item.enfant.id)).toEqual([garsonne])
+    }),
+  )
+
+  it(
+    'pagine de façon stable même quand plusieurs enfants portent le même nom',
+    integrationTest(async () => {
+      const refDept = testReferentielId()
+      const [e1, e2, e3] = testDeptIds(3)
+      const reg = testRegId()
+      const parent = { publicId: reg, nom: 'Parent' }
+      await fixtures.relation(
+        { parent, child: { publicId: e1, nom: 'Homonyme', referentiel: { publicId: refDept } } },
+        { parent, child: { publicId: e2, nom: 'Homonyme', referentiel: { publicId: refDept } } },
+        { parent, child: { publicId: e3, nom: 'Homonyme', referentiel: { publicId: refDept } } },
+      )
+
+      const premiere = await listRelations({ pageSize: 2 })
+      const page1 = premiere._unsafeUnwrap()
+      expect(page1.items).toHaveLength(2)
+      expect(page1.pagination.hasMore).toBe(true)
+
+      const seconde = await listRelations({ pageSize: 2, cursor: page1.pagination.cursor! })
+      const page2 = seconde._unsafeUnwrap()
+
+      const vus = [...page1.items, ...page2.items].map((item) => item.enfant.id)
+      expect(new Set(vus).size).toBe(3)
+    }),
+  )
+})

--- a/apps/kpilote-api/src/relation/queries/listRelations.ts
+++ b/apps/kpilote-api/src/relation/queries/listRelations.ts
@@ -1,0 +1,28 @@
+import { type ListRelationsQuery, type RelationListApiModel } from '@pilote/kpilote-shared/relation'
+import { ResultAsync } from 'neverthrow'
+
+import { db } from '@/framework/persistence/dbStore'
+import { buildPaginationArgs, toPaginatedResponse } from '@/framework/persistence/paginate'
+import { relationInclude, toRelationApiModel } from '@/relation/utils'
+
+export const listRelations = (
+  params: ListRelationsQuery,
+): ResultAsync<RelationListApiModel, never> => {
+  const where = params.recherche
+    ? { child: { nom: { contains: params.recherche, mode: 'insensitive' as const } } }
+    : {}
+
+  const fetchPage = db().relation.findMany({
+    where,
+    // `id` en second critère : le curseur de pagination se positionne dessus,
+    // l'ordre doit donc rester total même quand deux enfants sont homonymes.
+    orderBy: [{ child: { nom: 'asc' } }, { id: 'asc' }],
+    include: relationInclude,
+    ...buildPaginationArgs(params.cursor, params.pageSize),
+  })
+  const fetchTotal = db().relation.count({ where })
+
+  return ResultAsync.fromSafePromise(Promise.all([fetchPage, fetchTotal])).map(([rows, total]) =>
+    toPaginatedResponse(rows, total, toRelationApiModel, params.pageSize),
+  )
+}

--- a/apps/kpilote-api/src/relation/routes.test.ts
+++ b/apps/kpilote-api/src/relation/routes.test.ts
@@ -66,6 +66,13 @@ describe('PUT /relations/{id} — câblage', () => {
     const doc = (await response.json()) as { paths: Record<string, Record<string, unknown>> }
     expect(doc.paths['/relations']?.get).toBeDefined()
     expect(doc.paths['/relations/{id}']?.put).toBeDefined()
+    expect(doc.paths['/relations/{id}']?.delete).toBeDefined()
+  })
+
+  it('renvoie 401 sur une suppression non authentifiée', async () => {
+    const response = await app.request('/relations/DEPT-01', { method: 'DELETE' })
+
+    expect(response.status).toBe(401)
   })
 
   it('renvoie 401 sans authentification', async () => {

--- a/apps/kpilote-api/src/relation/routes.test.ts
+++ b/apps/kpilote-api/src/relation/routes.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+
+import { relationRoutes } from '@/relation/routes'
+import { buildTestApp } from '@/test/buildTestApp'
+import { fixtures } from '@/test/fixtures'
+import { integrationTest } from '@/test/integrationTest'
+import { testApiKeyRawKey, testDeptIds, testReferentielId, testRegId } from '@/test/randomIds'
+
+const buildApp = () => buildTestApp(relationRoutes)
+
+// `testReferentielId()` produit un slug minuscule, refusé par
+// `referentielPublicIdSchema` qui valide la réponse des routes.
+const refId = () => testReferentielId().toUpperCase()
+
+describe.concurrent('GET /relations', () => {
+  it(
+    'retourne les relations avec enfant, parent et référentiels',
+    integrationTest(async () => {
+      const refDept = refId()
+      const refReg = refId()
+      const [dept] = testDeptIds(1)
+      const reg = testRegId()
+      const rawKey = testApiKeyRawKey()
+      await fixtures.relation({
+        parent: { publicId: reg, nom: 'Normandie', referentiel: { publicId: refReg } },
+        child: { publicId: dept, nom: 'Orne', referentiel: { publicId: refDept } },
+      })
+      await fixtures.apiKey({ rawKey })
+
+      const response = await buildApp().request('/relations?recherche=Orne', {
+        headers: { Authorization: `Bearer ${rawKey}` },
+      })
+
+      expect(response.status).toBe(200)
+      const body = (await response.json()) as { items: unknown[] }
+      expect(body.items).toEqual([
+        {
+          enfant: { id: dept, nom: 'Orne', referentiel: refDept },
+          parent: { id: reg, nom: 'Normandie', referentiel: refReg },
+        },
+      ])
+    }),
+  )
+
+  it(
+    'refuse une requête non authentifiée',
+    integrationTest(async () => {
+      const response = await buildApp().request('/relations')
+
+      expect(response.status).toBe(401)
+    }),
+  )
+})

--- a/apps/kpilote-api/src/relation/routes.test.ts
+++ b/apps/kpilote-api/src/relation/routes.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
+import { app } from '../app'
+
 import { relationRoutes } from '@/relation/routes'
 import { buildTestApp } from '@/test/buildTestApp'
 import { fixtures } from '@/test/fixtures'
@@ -48,6 +50,50 @@ describe.concurrent('GET /relations', () => {
       const response = await buildApp().request('/relations')
 
       expect(response.status).toBe(401)
+    }),
+  )
+})
+
+// Les routes d'écriture ouvrent leur propre transaction (`withTransaction`), qui
+// ne voit pas les fixtures de la transaction de test : leur comportement est
+// couvert par les tests de commande. Ici on vérifie le câblage et le mapping
+// d'erreur qui n'a pas besoin de la base.
+describe('PUT /relations/{id} — câblage', () => {
+  it('déclare la route dans le doc OpenAPI', async () => {
+    const response = await app.request('/openapi.json')
+
+    expect(response.status).toBe(200)
+    const doc = (await response.json()) as { paths: Record<string, Record<string, unknown>> }
+    expect(doc.paths['/relations']?.get).toBeDefined()
+    expect(doc.paths['/relations/{id}']?.put).toBeDefined()
+  })
+
+  it('renvoie 401 sans authentification', async () => {
+    const response = await app.request('/relations/DEPT-01', {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ parent: 'REG-93' }),
+    })
+
+    expect(response.status).toBe(401)
+  })
+
+  it(
+    'mappe AUTO_PARENT sur un 400',
+    integrationTest(async () => {
+      const [dept] = testDeptIds(1)
+      const rawKey = testApiKeyRawKey()
+      await fixtures.individu({ publicId: dept })
+      await fixtures.apiKey({ rawKey, role: 'ADMIN' })
+
+      const response = await buildApp().request(`/relations/${dept}`, {
+        method: 'PUT',
+        headers: { Authorization: `Bearer ${rawKey}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ parent: dept }),
+      })
+
+      expect(response.status).toBe(400)
+      expect(await response.json()).toMatchObject({ code: 'AUTO_PARENT' })
     }),
   )
 })

--- a/apps/kpilote-api/src/relation/routes.ts
+++ b/apps/kpilote-api/src/relation/routes.ts
@@ -1,16 +1,30 @@
-import { createRoute } from '@hono/zod-openapi'
+import { createRoute, z } from '@hono/zod-openapi'
 import { createPaginatedApiListSchema } from '@pilote/kpilote-shared/pagination'
-import { listRelationsQuerySchema, relationApiModelSchema } from '@pilote/kpilote-shared/relation'
+import { individuPublicIdSchema } from '@pilote/kpilote-shared/publicIds'
+import {
+  listRelationsQuerySchema,
+  relationApiModelSchema,
+  upsertRelationBodySchema,
+} from '@pilote/kpilote-shared/relation'
 
 import { requireAuthentication } from '@/framework/auth/requireAuthentication'
 import { never } from '@/framework/errors/never'
 import { createOpenApiHono } from '@/framework/openapi/createOpenApiHono'
-import { jsonResponseOk } from '@/framework/openapi/jsonResponse'
-import { erreur400 } from '@/framework/openapi/responses'
+import { jsonResponseError, jsonResponseOk } from '@/framework/openapi/jsonResponse'
+import { ErrorApiModelSchema, erreur400, erreur403, erreur404 } from '@/framework/openapi/responses'
+import { withTransaction } from '@/framework/persistence/withTransaction'
+import { upsertRelationParent } from '@/relation/commands/upsertRelationParent'
+import { getRelationByEnfant } from '@/relation/queries/getRelationByEnfant'
 import { listRelations } from '@/relation/queries/listRelations'
 
+const RelationApiModelSchema = relationApiModelSchema.openapi('RelationApiModel')
 const RelationListApiModelSchema =
   createPaginatedApiListSchema(relationApiModelSchema).openapi('RelationListApiModel')
+const UpsertRelationBodySchema = upsertRelationBodySchema.openapi('UpsertRelationBody')
+
+const detailParamsSchema = z.object({
+  id: individuPublicIdSchema,
+})
 
 // --- GET /relations ----------------------------------------------------------
 
@@ -32,6 +46,40 @@ const getRelationsRoute = createRoute({
   },
 })
 
+// --- PUT /relations/:id ------------------------------------------------------
+
+const upsertRelationRoute = createRoute({
+  method: 'put',
+  path: '/relations/{id}',
+  tags: ['Relation', 'Admin'],
+  summary: "Définir le parent d'un individu",
+  description:
+    "Réservé aux clés API de rôle `ADMIN` (les utilisateurs OIDC authentifiés restent autorisés). `id` est l'identifiant public de l'individu **enfant** : un individu a au plus un parent, l'enfant identifie donc la relation. Crée la relation si l'enfant n'en a pas, remplace son parent sinon. Opération idempotente, exécutée dans une transaction. Rejetée si le parent est l'individu lui-même (`AUTO_PARENT`) ou l'un de ses descendants (`CYCLE_DETECTE`).",
+  middleware: [requireAuthentication],
+  request: {
+    params: detailParamsSchema,
+    body: {
+      content: { 'application/json': { schema: UpsertRelationBodySchema } },
+      required: true,
+    },
+  },
+  responses: {
+    200: {
+      content: { 'application/json': { schema: RelationApiModelSchema } },
+      description: 'Relation créée ou mise à jour',
+    },
+    400: erreur400,
+    403: erreur403,
+    404: erreur404,
+  },
+})
+
+const MESSAGES_ERREUR: Record<'AUTO_PARENT' | 'CYCLE_DETECTE', string> = {
+  AUTO_PARENT: 'Un individu ne peut pas être son propre parent',
+  CYCLE_DETECTE:
+    "Le parent choisi est un descendant de l'individu : la hiérarchie formerait un cycle",
+}
+
 // --- App registration --------------------------------------------------------
 
 export const relationRoutes = createOpenApiHono()
@@ -48,5 +96,31 @@ relationRoutes.openapi(getRelationsRoute, async (context) => {
         status: 200,
       }),
     never,
+  )
+})
+
+relationRoutes.openapi(upsertRelationRoute, async (context) => {
+  const { id } = context.req.valid('param')
+  const body = context.req.valid('json')
+
+  return (
+    await withTransaction(async () =>
+      upsertRelationParent(id, body).andThen(() => getRelationByEnfant(id)),
+    )
+  ).match(
+    (data) =>
+      jsonResponseOk({
+        context,
+        data,
+        schema: RelationApiModelSchema,
+        status: 200,
+      }),
+    (error) =>
+      jsonResponseError({
+        context,
+        error: { code: error.type, message: MESSAGES_ERREUR[error.type] },
+        schema: ErrorApiModelSchema,
+        status: 400,
+      }),
   )
 })

--- a/apps/kpilote-api/src/relation/routes.ts
+++ b/apps/kpilote-api/src/relation/routes.ts
@@ -55,7 +55,7 @@ const upsertRelationRoute = createRoute({
   tags: ['Relation', 'Admin'],
   summary: "Définir le parent d'un individu",
   description:
-    "Réservé aux clés API de rôle `ADMIN` (les utilisateurs OIDC authentifiés restent autorisés). `id` est l'identifiant public de l'individu **enfant** : un individu a au plus un parent, l'enfant identifie donc la relation. Crée la relation si l'enfant n'en a pas, remplace son parent sinon. Opération idempotente, exécutée dans une transaction. Rejetée si le parent est l'individu lui-même (`AUTO_PARENT`) ou l'un de ses descendants (`CYCLE_DETECTE`).",
+    "Réservé aux clés API de rôle `ADMIN`. `id` est l'identifiant public de l'individu **enfant** : un individu a au plus un parent, l'enfant identifie donc la relation. Crée la relation si l'enfant n'en a pas, remplace son parent sinon. Opération idempotente, exécutée dans une transaction. Rejetée si le parent est l'individu lui-même (`AUTO_PARENT`) ou l'un de ses descendants (`CYCLE_DETECTE`).",
   middleware: [requireAuthentication],
   request: {
     params: detailParamsSchema,
@@ -83,7 +83,7 @@ const supprimerRelationRoute = createRoute({
   tags: ['Relation', 'Admin'],
   summary: "Supprimer le parent d'un individu",
   description:
-    "Réservé aux clés API de rôle `ADMIN` (les utilisateurs OIDC authentifiés restent autorisés). `id` est l'identifiant public de l'individu **enfant**. Idempotent : retourne `204` même si l'individu n'avait pas de parent.",
+    "Réservé aux clés API de rôle `ADMIN`. `id` est l'identifiant public de l'individu **enfant**. Idempotent : retourne `204` même si l'individu n'avait pas de parent.",
   middleware: [requireAuthentication],
   request: { params: detailParamsSchema },
   responses: {

--- a/apps/kpilote-api/src/relation/routes.ts
+++ b/apps/kpilote-api/src/relation/routes.ts
@@ -1,0 +1,52 @@
+import { createRoute } from '@hono/zod-openapi'
+import { createPaginatedApiListSchema } from '@pilote/kpilote-shared/pagination'
+import { listRelationsQuerySchema, relationApiModelSchema } from '@pilote/kpilote-shared/relation'
+
+import { requireAuthentication } from '@/framework/auth/requireAuthentication'
+import { never } from '@/framework/errors/never'
+import { createOpenApiHono } from '@/framework/openapi/createOpenApiHono'
+import { jsonResponseOk } from '@/framework/openapi/jsonResponse'
+import { erreur400 } from '@/framework/openapi/responses'
+import { listRelations } from '@/relation/queries/listRelations'
+
+const RelationListApiModelSchema =
+  createPaginatedApiListSchema(relationApiModelSchema).openapi('RelationListApiModel')
+
+// --- GET /relations ----------------------------------------------------------
+
+const getRelationsRoute = createRoute({
+  method: 'get',
+  path: '/relations',
+  tags: ['Relation'],
+  summary: 'Lister les relations parent/enfant entre individus',
+  description:
+    "Retourne la liste paginée des relations hiérarchiques entre individus, triée par nom de l'individu enfant. Un individu a au plus un parent : l'enfant identifie donc la relation. Filtre optionnel `recherche` sur le nom de l'enfant. Pagination cursor-based.",
+  middleware: [requireAuthentication],
+  request: { query: listRelationsQuerySchema },
+  responses: {
+    200: {
+      content: { 'application/json': { schema: RelationListApiModelSchema } },
+      description: 'Liste paginée des relations',
+    },
+    400: erreur400,
+  },
+})
+
+// --- App registration --------------------------------------------------------
+
+export const relationRoutes = createOpenApiHono()
+
+relationRoutes.openapi(getRelationsRoute, async (context) => {
+  const { recherche, cursor, pageSize } = context.req.valid('query')
+
+  return listRelations({ recherche, cursor, pageSize }).match(
+    (data) =>
+      jsonResponseOk({
+        context,
+        data,
+        schema: RelationListApiModelSchema,
+        status: 200,
+      }),
+    never,
+  )
+})

--- a/apps/kpilote-api/src/relation/routes.ts
+++ b/apps/kpilote-api/src/relation/routes.ts
@@ -13,6 +13,7 @@ import { createOpenApiHono } from '@/framework/openapi/createOpenApiHono'
 import { jsonResponseError, jsonResponseOk } from '@/framework/openapi/jsonResponse'
 import { ErrorApiModelSchema, erreur400, erreur403, erreur404 } from '@/framework/openapi/responses'
 import { withTransaction } from '@/framework/persistence/withTransaction'
+import { supprimerRelation } from '@/relation/commands/supprimerRelation'
 import { upsertRelationParent } from '@/relation/commands/upsertRelationParent'
 import { getRelationByEnfant } from '@/relation/queries/getRelationByEnfant'
 import { listRelations } from '@/relation/queries/listRelations'
@@ -74,6 +75,23 @@ const upsertRelationRoute = createRoute({
   },
 })
 
+// --- DELETE /relations/:id ---------------------------------------------------
+
+const supprimerRelationRoute = createRoute({
+  method: 'delete',
+  path: '/relations/{id}',
+  tags: ['Relation', 'Admin'],
+  summary: "Supprimer le parent d'un individu",
+  description:
+    "Réservé aux clés API de rôle `ADMIN` (les utilisateurs OIDC authentifiés restent autorisés). `id` est l'identifiant public de l'individu **enfant**. Idempotent : retourne `204` même si l'individu n'avait pas de parent.",
+  middleware: [requireAuthentication],
+  request: { params: detailParamsSchema },
+  responses: {
+    204: { description: 'Relation supprimée' },
+    403: erreur403,
+  },
+})
+
 const MESSAGES_ERREUR: Record<'AUTO_PARENT' | 'CYCLE_DETECTE', string> = {
   AUTO_PARENT: 'Un individu ne peut pas être son propre parent',
   CYCLE_DETECTE:
@@ -123,4 +141,10 @@ relationRoutes.openapi(upsertRelationRoute, async (context) => {
         status: 400,
       }),
   )
+})
+
+relationRoutes.openapi(supprimerRelationRoute, async (context) => {
+  const { id } = context.req.valid('param')
+
+  return (await supprimerRelation(id)).match(() => context.body(null, 204), never)
 })

--- a/apps/kpilote-api/src/relation/utils.ts
+++ b/apps/kpilote-api/src/relation/utils.ts
@@ -2,6 +2,8 @@ import { type RelationApiModel } from '@pilote/kpilote-shared/relation'
 
 import { type IndividuModel, type RelationModel } from '@/generated/prisma/models'
 
+export const MESSAGE_ADMIN = 'Cette opération requiert une clé API de rôle ADMIN'
+
 type IndividuAvecReferentiel = IndividuModel & { referentiel: { publicId: string } }
 
 export type RelationWithIndividus = RelationModel & {

--- a/apps/kpilote-api/src/relation/utils.ts
+++ b/apps/kpilote-api/src/relation/utils.ts
@@ -1,0 +1,26 @@
+import { type RelationApiModel } from '@pilote/kpilote-shared/relation'
+
+import { type IndividuModel, type RelationModel } from '@/generated/prisma/models'
+
+type IndividuAvecReferentiel = IndividuModel & { referentiel: { publicId: string } }
+
+export type RelationWithIndividus = RelationModel & {
+  parent: IndividuAvecReferentiel
+  child: IndividuAvecReferentiel
+}
+
+export const relationInclude = {
+  parent: { include: { referentiel: true } },
+  child: { include: { referentiel: true } },
+} as const
+
+const toIndividu = (individu: IndividuAvecReferentiel) => ({
+  id: individu.publicId,
+  nom: individu.nom,
+  referentiel: individu.referentiel.publicId,
+})
+
+export const toRelationApiModel = (relation: RelationWithIndividus): RelationApiModel => ({
+  enfant: toIndividu(relation.child),
+  parent: toIndividu(relation.parent),
+})

--- a/apps/kpilote-api/tsconfig.json
+++ b/apps/kpilote-api/tsconfig.json
@@ -24,6 +24,7 @@
       "@/individu/*": ["./src/individu/*"],
       "@/me/*": ["./src/me/*"],
       "@/referentiel/*": ["./src/referentiel/*"],
+      "@/relation/*": ["./src/relation/*"],
       "@/niveauConfiance/*": ["./src/niveauConfiance/*"],
       "@/valeurAvancement/*": ["./src/valeurAvancement/*"],
       "@/valeurImport/*": ["./src/valeurImport/*"],

--- a/packages/kpilote-shared/package.json
+++ b/packages/kpilote-shared/package.json
@@ -76,6 +76,10 @@
       "types": "./src/referentiel.ts",
       "default": "./src/referentiel.ts"
     },
+    "./relation": {
+      "types": "./src/relation.ts",
+      "default": "./src/relation.ts"
+    },
     "./valeurAvancement": {
       "types": "./src/valeurAvancement.ts",
       "default": "./src/valeurAvancement.ts"

--- a/packages/kpilote-shared/src/individu.ts
+++ b/packages/kpilote-shared/src/individu.ts
@@ -32,3 +32,6 @@ export const listIndividusForReferentielQuerySchema = listQuerySchema
 export type ListIndividusForReferentielQuery = z.infer<
   typeof listIndividusForReferentielQuerySchema
 >
+
+export const listIndividusQuerySchema = listQuerySchema
+export type ListIndividusQuery = z.infer<typeof listIndividusQuerySchema>

--- a/packages/kpilote-shared/src/relation.ts
+++ b/packages/kpilote-shared/src/relation.ts
@@ -1,0 +1,29 @@
+import { z } from 'zod'
+
+import { createPaginatedApiListSchema, listQuerySchema } from './pagination'
+import { individuPublicIdSchema, referentielPublicIdSchema } from './publicIds'
+
+const relationIndividuSchema = z.object({
+  id: individuPublicIdSchema,
+  nom: z.string().describe("Nom lisible de l'individu."),
+  referentiel: referentielPublicIdSchema.describe("Référentiel auquel l'individu appartient."),
+})
+
+export const relationApiModelSchema = z.object({
+  enfant: relationIndividuSchema.describe(
+    "Individu enfant. Il identifie la relation : un individu a au plus un parent.",
+  ),
+  parent: relationIndividuSchema.describe('Individu parent.'),
+})
+export type RelationApiModel = z.infer<typeof relationApiModelSchema>
+
+export const relationListApiModelSchema = createPaginatedApiListSchema(relationApiModelSchema)
+export type RelationListApiModel = z.infer<typeof relationListApiModelSchema>
+
+export const listRelationsQuerySchema = listQuerySchema
+export type ListRelationsQuery = z.infer<typeof listRelationsQuerySchema>
+
+export const upsertRelationBodySchema = z.object({
+  parent: individuPublicIdSchema.describe("Identifiant public de l'individu parent."),
+})
+export type UpsertRelationBody = z.infer<typeof upsertRelationBodySchema>

--- a/packages/kpilote-shared/src/relation.ts
+++ b/packages/kpilote-shared/src/relation.ts
@@ -11,7 +11,7 @@ const relationIndividuSchema = z.object({
 
 export const relationApiModelSchema = z.object({
   enfant: relationIndividuSchema.describe(
-    "Individu enfant. Il identifie la relation : un individu a au plus un parent.",
+    'Individu enfant. Il identifie la relation : un individu a au plus un parent.',
   ),
   parent: relationIndividuSchema.describe('Individu parent.'),
 })


### PR DESCRIPTION
## Contexte

La table `relation` porte la hiérarchie parent/enfant des individus. Elle est lue partout — `individuApiModel.parents[]`, `loadSousArbre` pour l'agrégation des indicateurs — mais **aucun endpoint ne permettait de l'écrire** : elle n'était alimentée que par les seeds et la synchronisation ppg.

Cette PR ouvre cette écriture et livre l'écran d'administration qui la consomme.

## Règle métier

**Un individu a au plus un parent.** Le schéma Prisma autorise plusieurs relations pour un même enfant, mais la règle ne le permet pas. Le design fait porter l'invariant par l'API : la relation est identifiée par le public ID de son **enfant**, et l'écriture est un remplacement idempotent, sérialisé par un verrou de ligne sur l'enfant (`SELECT … FOR UPDATE`) pour que deux écritures concurrentes ne laissent pas deux parents.

La garantie reste **applicative, pas structurelle** : il n'y a pas de contrainte d'unicité sur `child_id`. L'ajouter serait plus solide mais demande une migration et un audit des données existantes — le modèle documente explicitement le multi-parents (« commune appartenant à plusieurs EPCI »), donc des lignes en base pourraient la violer. À trancher séparément.

## API

| Endpoint | Comportement |
|---|---|
| `GET /relations?recherche=&cursor=&pageSize=` | Liste paginée, triée par nom d'enfant, référentiel exposé des deux côtés |
| `PUT /relations/{id}` `{ parent }` | `id` = public ID de l'enfant. Crée ou remplace, idempotent, en transaction |
| `DELETE /relations/{id}` | `204`, idempotent |
| `GET /individus?recherche=&cursor=&pageSize=` | Liste paginée triée par nom, expose `parents[]` |

`GET /individus` n'existait pas (seulement `GET /individus/{id}` et `GET /referentiels/{id}/individus`). Il alimente les deux Pickers de l'écran, qui travaillent tous référentiels confondus.

Le champ du body est `parent` et non `parentId` : les modèles API existants exposent les public IDs sans suffixe (`individuApiModel.referentiel`, `individuApiModel.parents[]`), l'UUID interne n'est jamais exposé.

### Garde-fous

| Cas | Réponse |
|---|---|
| `parent` == `id` | `400 AUTO_PARENT` |
| parent visé descendant de l'enfant | `400 CYCLE_DETECTE` |
| enfant ou parent inexistant | `404` |
| principal qui n'est pas une clé API `ADMIN` | `403` |

La hiérarchie sert au calcul d'agrégation : une boucle `A → B → A` ne provoque pas de boucle infinie (`loadSousArbre` garde un Set de visités) mais **fausse silencieusement les agrégats**. Avec la règle mono-parent, la détection est une remontée linéaire des ancêtres du parent visé, bornée par la profondeur de l'arbre.

Autorisation : `ensurePrincipal(isApiKeyAdmin, MESSAGE_ADMIN)` sur les deux écritures, alignée sur `centreAide`. **Les utilisateurs OIDC ne peuvent pas modifier la hiérarchie** — seules les clés API de rôle `ADMIN`, y compris celle que l'admin utilise via son proxy BFF. La lecture reste ouverte à tout principal authentifié.

**Aucune migration Prisma** — la table existe, le client est généré, `schema.prisma` n'est pas touché.

## Écran admin `/relations`

```
Fonctionnalités › Relations

Relations
128 relations · environnement dev

Ajouter une relation
[ 🔍 Rechercher un individu…                    ▾ ]

[🔍 Filtrer par nom d'individu…]

Individu                      Référentiel   Parent
──────────────────────────────────────────────────────────────────────
Ain            DEPT-01        REF-DEPT      [ Auvergne-R.-A.  REG-84 ▾ ]  🗑
Aisne          DEPT-02        REF-DEPT      [ Hauts-de-France REG-32 ▾ ]  🗑
```

- **Ajout** : un `Picker` en contrôle d'ajout, le pattern déjà en place dans `AdminReferentiels` / `AdminResponsables`. `excludedIds` retire les individus qui ont déjà un parent. La sélection insère une ligne en attente en tête de tableau, sur fond distinct, avec son Picker parent ouvert — **rien n'est écrit tant qu'aucun parent n'est choisi**.
- **Cellule parent** : même composant `Picker` (cmdk, recherche par nom ou public ID, insensible aux accents).
- **Sauvegarde immédiate** par ligne, toast de succès ; en cas d'erreur la valeur revient à son état précédent et le message de l'API est repris.
- **Tout est chargé d'un coup** via `fetchAllPages`, comme `referentielsAllQueryOptions` : pas de « Charger plus », le filtre est appliqué côté client (insensible aux accents via `searchUnaccent`). Le paramètre `recherche` de `GET /relations` reste disponible pour les autres consommateurs de l'API.
- **Verrou prod** via `useProdEditUnlock`, comme `PrincipalPermissions` et la console API.
- Entrée `BarCard` « Gérer les relations » dans `/fonctionnalites`.

Les descendants ne sont pas exclus du sélecteur de parent : c'est l'API qui tranche, et le toast affiche « Le parent choisi est un descendant de l'individu ». Maintenant que l'arbre complet est chargé côté client, l'exclusion pourrait aussi se faire dans le `Picker` — je l'ai laissée hors périmètre, la garde serveur restant de toute façon nécessaire.

## Tests

**609 tests verts** sur `kpilote-api` (dont 36 nouveaux), lint à 0 sur `kpilote-api`, `kpilote-admin`, `kpilote-shared` et `kpilote-webapp`.

| Fichier | Couverture |
|---|---|
| `listRelations.test.ts` | tri par nom d'enfant, filtre insensible à la casse, pagination stable avec des homonymes |
| `upsertRelationParent.test.ts` | création, remplacement sans doublon, idempotence, `AUTO_PARENT`, cycle direct **et** indirect, enfant/parent inconnu, refus CONTRIBUTOR **et** refus OIDC |
| `supprimerRelation.test.ts` | suppression, idempotence, isolation des autres individus, refus CONTRIBUTOR **et** refus OIDC |
| `listIndividus.test.ts` | tri par nom tous référentiels confondus, exposition de `parents[]`, pagination |
| `relation/routes.test.ts` | câblage OpenAPI, `401`, mapping `AUTO_PARENT` → `400` |

Pas de tests front, conformément à la convention du projet.

### Pourquoi les routes d'écriture ne sont testées qu'au niveau du câblage

`withTransaction` ouvre systématiquement une transaction **racine** sur `prisma`, sans réutiliser celle du contexte. Le handler ne voit donc jamais les fixtures créées dans la transaction de `integrationTest` — ce que `buildTestApp` documente déjà. C'est la convention du repo : `apiKey/routes.test.ts` teste présence dans le doc OpenAPI + `401`, et le comportement est couvert par les tests de commande. Cette PR s'y aligne.

## Points d'attention pour la revue

**L'écran charge l'intégralité des relations et des individus côté client.** Choix assumé pour un back-office : confortable aux volumes actuels (départements ≈ 101, régions ≈ 18, national = 1). Une population de l'ordre des communes (~35 000) demanderait de repasser à une recherche serveur à la frappe, **sans changement du contrat API** — les endpoints restent paginés et filtrables.

**`DELETE` est idempotent (`204`) plutôt que `404`**, pour suivre la convention déjà appliquée dans `objectifIndicateurIndividu` et `valeurAvancement` (« Idempotent : retourne 204 même si l'objectif n'existait pas »).

**Second critère de tri `id` sur les deux listings.** `buildPaginationArgs` positionne le curseur sur `id` : trier sur `nom` seul rend la pagination instable dès qu'il y a des homonymes. Un test couvre ce cas.

**L'allowlist `SAFE_PATH` du proxy BFF admin** devait inclure `relations`, sinon tous les appels `/api/relations…` partaient en `403` avant d'atteindre l'API.

**Course croisée non couverte.** Le verrou protège les écritures concurrentes sur un même enfant, pas le cas `A→B` et `B→A` en parallèle : chaque transaction verrouille une ligne différente, passe son contrôle de cycle, et le cycle se crée. Fermer ça demanderait du serializable + retry ou un verrou sur le sous-arbre. Écritures réservées aux clés ADMIN via une seule UI, donc jugé hors périmètre — mais c'est un trou connu, pas un oubli.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
