### PR TITLE
fix(indicateur): empêche le scroll vers le haut lors du changement de sous-onglet

### DIFF
--- a/apps/kpilote-webapp/src/routes/_authenticated/indicateurs/$id.tsx
+++ b/apps/kpilote-webapp/src/routes/_authenticated/indicateurs/$id.tsx
@@ -187,7 +187,7 @@ function IndicateurDetailComponent() {
               referentielNom={referentielNom}
               sousOnglet={search.sousOnglet}
               onSousOngletChange={(sousOnglet) => {
-                void navigate({ search: (prev) => ({ ...prev, sousOnglet }) })
+                void navigate({ search: (prev) => ({ ...prev, sousOnglet }), resetScroll: false })
               }}
             />
           </div>


### PR DESCRIPTION
## Résumé

- Ajout de `resetScroll: false` sur l'appel `navigate()` du changement de sous-onglet dans la page indicateur
- Empêche TanStack Router de remonter en haut de page lors du switch entre « Niveaux de confiance », « Evolution et répartition » et « Commentaires »

## Plan de test

- [ ] Scroller sur la page d'un indicateur pour ne plus voir le haut de page
- [ ] Cliquer sur chacun des trois sous-onglets → la page ne doit pas remonter
- [ ] Vérifier que le bouton retour du navigateur fonctionne toujours correctement

🤖 Generated with [Claude Code](https://claude.com/claude-code)