### PR TITLE
refactor(admin): harmonisation des listings et adoption des composants partagés

### DIFF
--- a/apps/kpilote-admin/src/components/CollectionSearchModal.tsx
+++ b/apps/kpilote-admin/src/components/CollectionSearchModal.tsx
@@ -3,6 +3,7 @@ import { Search, X } from 'lucide-react'
 import { useState } from 'react'
 
 import { Button } from '@pilote/kpilote-ui/Button'
+import { IconButton } from '@pilote/kpilote-ui/IconButton'
 import { searchCollectionsInfiniteQueryOptions } from '@/queries/permissions'
 
 export type CollectionHit = { publicId: string; nom: string }
@@ -39,14 +40,9 @@ export function CollectionSearchModal({
       >
         <div className="mb-4 flex items-center justify-between">
           <h2 className="text-lg font-semibold text-text">Ajouter une collection</h2>
-          <button
-            type="button"
-            onClick={onClose}
-            aria-label="Fermer"
-            className="text-text-muted hover:text-text"
-          >
-            <X className="size-5" />
-          </button>
+          <IconButton label="Fermer" onClick={onClose}>
+            <X />
+          </IconButton>
         </div>
 
         <div className="mb-4 space-y-3">

--- a/apps/kpilote-admin/src/components/PrincipalPermissions.tsx
+++ b/apps/kpilote-admin/src/components/PrincipalPermissions.tsx
@@ -16,6 +16,7 @@ import { CollectionSearchModal } from '@/components/CollectionSearchModal'
 import { IndicateurPicker } from '@/components/permissions/IndicateurPicker'
 import { Button } from '@pilote/kpilote-ui/Button'
 import { EmptyState } from '@pilote/kpilote-ui/EmptyState'
+import { IconButton } from '@pilote/kpilote-ui/IconButton'
 import { useToast } from '@pilote/kpilote-ui/Toast'
 import { extractApiError } from '@/lib/apiError'
 import { clsxm } from '@/lib/clsxm'
@@ -129,15 +130,16 @@ export function PrincipalPermissions({ principalId }: { principalId: string }) {
                     >
                       Écriture
                     </button>
-                    <button
-                      type="button"
+                    <IconButton
+                      variant="danger"
+                      size="sm"
+                      label="Retirer la ressource"
                       disabled={disabled}
                       onClick={() => handlers.onRemove(row.publicId)}
-                      className="ml-1 text-text-subtle hover:text-red-marianne disabled:opacity-50"
-                      aria-label="Retirer la ressource"
+                      className="ml-1"
                     >
-                      <Trash2 className="size-4" />
-                    </button>
+                      <Trash2 />
+                    </IconButton>
                   </span>
                 </div>
                 {extra}

--- a/apps/kpilote-admin/src/components/ReferentielForm.tsx
+++ b/apps/kpilote-admin/src/components/ReferentielForm.tsx
@@ -2,6 +2,8 @@ import { Plus, Trash2 } from 'lucide-react'
 import { useState } from 'react'
 
 import { Button } from '@pilote/kpilote-ui/Button'
+import { IconButton } from '@pilote/kpilote-ui/IconButton'
+import { Subtitle } from '@pilote/kpilote-ui/Subtitle'
 import { clsxm } from '@/lib/clsxm'
 
 type IndividuItem = { publicId: string; nom: string }
@@ -100,10 +102,10 @@ export function ReferentielForm({
               <Plus className="size-4" /> Ajouter
             </button>
           </div>
-          <p className="mb-4 text-xs text-text-subtle">
+          <Subtitle className="mb-4">
             Un individu ne peut appartenir qu'à un seul référentiel. En ajouter un déjà rattaché
             ailleurs sera refusé (409).
-          </p>
+          </Subtitle>
           {values.individus.map((item, index) => (
             <div
               key={index}
@@ -123,14 +125,9 @@ export function ReferentielForm({
                 placeholder="Paris"
                 className="flex-[2] rounded-md border border-border bg-surface px-2.5 py-2 text-sm focus:border-primary focus:outline-none"
               />
-              <button
-                type="button"
-                onClick={() => removeIndividu(index)}
-                className="text-red-marianne"
-                aria-label="Retirer"
-              >
-                <Trash2 className="size-4" />
-              </button>
+              <IconButton variant="danger" label="Retirer" onClick={() => removeIndividu(index)}>
+                <Trash2 />
+              </IconButton>
             </div>
           ))}
         </div>

--- a/apps/kpilote-admin/src/components/console/HeadersEditor.tsx
+++ b/apps/kpilote-admin/src/components/console/HeadersEditor.tsx
@@ -2,6 +2,7 @@ import { Plus, Trash2 } from 'lucide-react'
 
 import type { HeaderPair } from '@/api/console'
 import { Button } from '@pilote/kpilote-ui/Button'
+import { IconButton } from '@pilote/kpilote-ui/IconButton'
 
 export function HeadersEditor({
   headers,
@@ -37,14 +38,9 @@ export function HeadersEditor({
             placeholder="application/json"
             className="flex-1 rounded-md border border-border px-3 py-2 text-sm focus:border-primary focus:outline-none"
           />
-          <button
-            type="button"
-            onClick={() => remove(index)}
-            aria-label="Supprimer l'en-tête"
-            className="text-text-muted hover:text-red-marianne"
-          >
-            <Trash2 className="size-4" />
-          </button>
+          <IconButton variant="danger" label="Supprimer l'en-tête" onClick={() => remove(index)}>
+            <Trash2 />
+          </IconButton>
         </div>
       ))}
       <div>

--- a/apps/kpilote-admin/src/components/indicateurs/AdminReferentiels.tsx
+++ b/apps/kpilote-admin/src/components/indicateurs/AdminReferentiels.tsx
@@ -6,6 +6,8 @@ import { ReferentielPicker } from '@/components/indicateurs/ReferentielPicker'
 import { useIndicateurFormContext } from '@/components/indicateurs/indicateurFormContext'
 import { type IndicateurFormValues } from '@/components/indicateurs/indicateurFormSchema'
 import { FieldSelect } from '@pilote/kpilote-ui/FieldSelect'
+import { IconButton } from '@pilote/kpilote-ui/IconButton'
+import { Subtitle } from '@pilote/kpilote-ui/Subtitle'
 import { referentielsAllQueryOptions } from '@/queries/referentiels'
 
 type FonctionAgregation = 'SUM' | 'AVG' | 'NONE'
@@ -28,10 +30,10 @@ export function AdminReferentiels() {
   return (
     <div className="border-t border-border pt-5">
       <span className="mb-1 block text-sm font-bold">Référentiels liés</span>
-      <p className="mb-4 text-xs text-text-subtle">
+      <Subtitle className="mb-4">
         ⚠ Cette liste remplace <b>intégralement</b> l'existant (replace-all). Retirer une ligne
         supprime le lien.
-      </p>
+      </Subtitle>
 
       <ReferentielPicker
         excludedIds={selectedIds}
@@ -84,9 +86,9 @@ function ReferentielRow({
           )}
         />
       </div>
-      <button type="button" onClick={onRemove} className="text-red-marianne" aria-label="Retirer">
-        <Trash2 className="size-4" />
-      </button>
+      <IconButton variant="danger" label="Retirer" onClick={onRemove}>
+        <Trash2 />
+      </IconButton>
     </li>
   )
 }

--- a/apps/kpilote-admin/src/components/indicateurs/AdminResponsables.tsx
+++ b/apps/kpilote-admin/src/components/indicateurs/AdminResponsables.tsx
@@ -3,6 +3,8 @@ import { useFieldArray, useWatch } from 'react-hook-form'
 
 import { useIndicateurFormContext } from '@/components/indicateurs/indicateurFormContext'
 import { UtilisateurPicker } from '@/components/UtilisateurPicker'
+import { IconButton } from '@pilote/kpilote-ui/IconButton'
+import { Subtitle } from '@pilote/kpilote-ui/Subtitle'
 
 export function AdminResponsables() {
   const form = useIndicateurFormContext()
@@ -13,10 +15,10 @@ export function AdminResponsables() {
   return (
     <div className="border-t border-border pt-5">
       <span className="mb-1 block text-sm font-bold">Responsables</span>
-      <p className="mb-4 text-xs text-text-subtle">
+      <Subtitle className="mb-4">
         Utilisateurs désignés responsables de l'indicateur. Cette liste remplace{' '}
         <b>intégralement</b> l'existant à l'enregistrement.
-      </p>
+      </Subtitle>
 
       <UtilisateurPicker
         excludedIds={selectedIds}
@@ -40,14 +42,9 @@ export function AdminResponsables() {
               {responsable.prenom} {responsable.nom}{' '}
               <span className="text-text-subtle">· {responsable.email}</span>
             </span>
-            <button
-              type="button"
-              onClick={() => remove(index)}
-              className="text-red-marianne"
-              aria-label="Retirer"
-            >
-              <Trash2 className="size-4" />
-            </button>
+            <IconButton variant="danger" label="Retirer" onClick={() => remove(index)}>
+              <Trash2 />
+            </IconButton>
           </li>
         ))}
       </ul>

--- a/apps/kpilote-admin/src/routes/_authed/collections/index.tsx
+++ b/apps/kpilote-admin/src/routes/_authed/collections/index.tsx
@@ -1,7 +1,7 @@
 import type { CollectionVisibilite } from '@pilote/kpilote-shared/collection'
 import { useInfiniteQuery } from '@tanstack/react-query'
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router'
-import { Plus, Search } from 'lucide-react'
+import { Plus } from 'lucide-react'
 import { useState, type ComponentProps } from 'react'
 
 import { Breadcrumb } from '@/components/Breadcrumb'
@@ -9,6 +9,7 @@ import { PageHeading } from '@/components/PageHeading'
 import { Button } from '@pilote/kpilote-ui/Button'
 import { EmptyState } from '@pilote/kpilote-ui/EmptyState'
 import { Pill } from '@pilote/kpilote-ui/Pill'
+import { SearchField } from '@pilote/kpilote-ui/SearchField'
 import { Table } from '@pilote/kpilote-ui/Table'
 import { clickableRowProps } from '@/lib/clickableRow'
 import { collectionsInfiniteQueryOptions } from '@/queries/collections'
@@ -58,15 +59,12 @@ function CollectionsListComponent() {
         }
       />
 
-      <div className="mb-4 flex max-w-sm items-center gap-2 rounded-md border border-border px-3 py-2 text-sm">
-        <Search className="size-4 text-text-subtle" />
-        <input
-          type="search"
-          aria-label="Rechercher une collection"
-          value={recherche}
-          onChange={(event) => setRecherche(event.target.value)}
+      <div className="mb-4">
+        <SearchField
+          label="Rechercher une collection"
           placeholder="Rechercher une collection…"
-          className="w-full bg-transparent focus:outline-none"
+          value={recherche}
+          onChange={setRecherche}
         />
       </div>
 

--- a/apps/kpilote-admin/src/routes/_authed/features/$id.tsx
+++ b/apps/kpilote-admin/src/routes/_authed/features/$id.tsx
@@ -7,6 +7,7 @@ import { remplacerUtilisateursAutorises } from '@/api/feature'
 import { Breadcrumb } from '@/components/Breadcrumb'
 import { PageHeading } from '@/components/PageHeading'
 import { UtilisateurPicker } from '@/components/UtilisateurPicker'
+import { IconButton } from '@pilote/kpilote-ui/IconButton'
 import { SegmentedField } from '@pilote/kpilote-ui/SegmentedField'
 import { useToast } from '@pilote/kpilote-ui/Toast'
 import { extractApiError } from '@/lib/apiError'
@@ -135,15 +136,15 @@ function FeatureDetailComponent() {
                       {utilisateur.email}
                     </span>
                   </span>
-                  <button
-                    type="button"
-                    aria-label={`Retirer ${utilisateur.prenom} ${utilisateur.nom}`}
+                  <IconButton
+                    variant="danger"
+                    label={`Retirer ${utilisateur.prenom} ${utilisateur.nom}`}
                     disabled={utilisateursMutation.isPending}
                     onClick={() => retirer(utilisateur.id)}
-                    className="shrink-0 rounded-md p-1.5 text-text-muted hover:bg-red-marianne/10 hover:text-red-marianne disabled:opacity-50"
+                    className="shrink-0"
                   >
-                    <Trash2 className="size-4" />
-                  </button>
+                    <Trash2 />
+                  </IconButton>
                 </li>
               ))}
             </ul>

--- a/apps/kpilote-admin/src/routes/_authed/features/index.tsx
+++ b/apps/kpilote-admin/src/routes/_authed/features/index.tsx
@@ -1,12 +1,12 @@
 import type { FeatureApiModel, FeatureEtat } from '@pilote/kpilote-shared/feature'
 import { useSuspenseQuery } from '@tanstack/react-query'
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router'
-import { Search } from 'lucide-react'
 import { useMemo, useState } from 'react'
 
 import { Breadcrumb } from '@/components/Breadcrumb'
 import { PageHeading } from '@/components/PageHeading'
 import { EmptyState } from '@pilote/kpilote-ui/EmptyState'
+import { SearchField } from '@pilote/kpilote-ui/SearchField'
 import { Table } from '@pilote/kpilote-ui/Table'
 import { useToast } from '@pilote/kpilote-ui/Toast'
 import { extractApiError } from '@/lib/apiError'
@@ -64,13 +64,12 @@ function FeatureListComponent() {
         }
       />
 
-      <div className="mb-4 flex max-w-sm items-center gap-2 rounded-md border border-border px-3 py-2 text-sm">
-        <Search className="size-4 text-text-subtle" />
-        <input
-          value={recherche}
-          onChange={(event) => setRecherche(event.target.value)}
+      <div className="mb-4">
+        <SearchField
+          label="Rechercher une feature"
           placeholder="Rechercher une feature…"
-          className="w-full bg-transparent focus:outline-none"
+          value={recherche}
+          onChange={setRecherche}
         />
       </div>
 

--- a/apps/kpilote-admin/src/routes/_authed/indicateurs/index.tsx
+++ b/apps/kpilote-admin/src/routes/_authed/indicateurs/index.tsx
@@ -1,12 +1,15 @@
+import type { IndicateurVisibilite } from '@pilote/kpilote-shared/indicateur'
 import { useInfiniteQuery } from '@tanstack/react-query'
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router'
-import { Plus, Search } from 'lucide-react'
-import { useState } from 'react'
+import { Plus } from 'lucide-react'
+import { useState, type ComponentProps } from 'react'
 
 import { Breadcrumb } from '@/components/Breadcrumb'
 import { PageHeading } from '@/components/PageHeading'
 import { Button } from '@pilote/kpilote-ui/Button'
 import { EmptyState } from '@pilote/kpilote-ui/EmptyState'
+import { Pill } from '@pilote/kpilote-ui/Pill'
+import { SearchField } from '@pilote/kpilote-ui/SearchField'
 import { Table } from '@pilote/kpilote-ui/Table'
 import { clickableRowProps } from '@/lib/clickableRow'
 import { indicateursInfiniteQueryOptions } from '@/queries/indicateurs'
@@ -16,10 +19,10 @@ export const Route = createFileRoute('/_authed/indicateurs/')({
   component: IndicateursListComponent,
 })
 
-const VISIBILITE_BADGE: Record<string, string> = {
-  PUBLIC: 'bg-[#e8f5ec] text-[#18753c]',
-  PRIVE: 'bg-[#f0eefb] text-[#5246a8]',
-}
+const VISIBILITE_TONE = {
+  PUBLIC: 'success',
+  PRIVE: 'neutral',
+} as const satisfies Record<IndicateurVisibilite, ComponentProps<typeof Pill>['tone']>
 
 function IndicateursListComponent() {
   const navigate = useNavigate()
@@ -56,13 +59,12 @@ function IndicateursListComponent() {
         }
       />
 
-      <div className="mb-4 flex max-w-sm items-center gap-2 rounded-md border border-border px-3 py-2 text-sm">
-        <Search className="size-4 text-text-subtle" />
-        <input
-          value={recherche}
-          onChange={(event) => setRecherche(event.target.value)}
+      <div className="mb-4">
+        <SearchField
+          label="Rechercher un indicateur"
           placeholder="Rechercher un indicateur…"
-          className="w-full bg-transparent focus:outline-none"
+          value={recherche}
+          onChange={setRecherche}
         />
       </div>
 
@@ -95,11 +97,7 @@ function IndicateursListComponent() {
                   <span className="font-semibold">{indicateur.nom}</span>
                 </Table.Cell>
                 <Table.Cell>
-                  <span
-                    className={`rounded-full px-2 py-0.5 text-xs font-semibold ${VISIBILITE_BADGE[indicateur.visibilite]}`}
-                  >
-                    {indicateur.visibilite}
-                  </span>
+                  <Pill tone={VISIBILITE_TONE[indicateur.visibilite]}>{indicateur.visibilite}</Pill>
                 </Table.Cell>
                 <Table.Cell>{indicateur.unite?.libelle ?? '—'}</Table.Cell>
                 <Table.Cell align="center">{indicateur.referentiels.length}</Table.Cell>

--- a/apps/kpilote-admin/src/routes/_authed/referentiels/index.tsx
+++ b/apps/kpilote-admin/src/routes/_authed/referentiels/index.tsx
@@ -1,12 +1,13 @@
 import { useInfiniteQuery } from '@tanstack/react-query'
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router'
-import { Plus, Search } from 'lucide-react'
+import { Plus } from 'lucide-react'
 import { useState } from 'react'
 
 import { Breadcrumb } from '@/components/Breadcrumb'
 import { PageHeading } from '@/components/PageHeading'
 import { Button } from '@pilote/kpilote-ui/Button'
 import { EmptyState } from '@pilote/kpilote-ui/EmptyState'
+import { SearchField } from '@pilote/kpilote-ui/SearchField'
 import { Table } from '@pilote/kpilote-ui/Table'
 import { clickableRowProps } from '@/lib/clickableRow'
 import { referentielsInfiniteQueryOptions } from '@/queries/referentiels'
@@ -49,13 +50,12 @@ function ReferentielsListComponent() {
         }
       />
 
-      <div className="mb-4 flex max-w-sm items-center gap-2 rounded-md border border-border px-3 py-2 text-sm">
-        <Search className="size-4 text-text-subtle" />
-        <input
-          value={recherche}
-          onChange={(event) => setRecherche(event.target.value)}
+      <div className="mb-4">
+        <SearchField
+          label="Rechercher un référentiel"
           placeholder="Rechercher un référentiel…"
-          className="w-full bg-transparent focus:outline-none"
+          value={recherche}
+          onChange={setRecherche}
         />
       </div>
 

--- a/apps/kpilote-admin/src/routes/_authed/relations/index.tsx
+++ b/apps/kpilote-admin/src/routes/_authed/relations/index.tsx
@@ -15,6 +15,7 @@ import { individusAllQueryOptions } from '@/queries/individus'
 import { relationsAllQueryOptions } from '@/queries/relations'
 import { Button } from '@pilote/kpilote-ui/Button'
 import { EmptyState } from '@pilote/kpilote-ui/EmptyState'
+import { IconButton } from '@pilote/kpilote-ui/IconButton'
 import { SearchField } from '@pilote/kpilote-ui/SearchField'
 import { Table } from '@pilote/kpilote-ui/Table'
 import { useToast } from '@pilote/kpilote-ui/Toast'
@@ -178,16 +179,15 @@ function RelationsComponent() {
                   />
                 </Table.Cell>
                 <Table.Cell align="right">
-                  <button
-                    type="button"
-                    aria-label="Retirer la ligne"
+                  <IconButton
+                    variant="danger"
+                    label="Retirer la ligne"
                     onClick={() =>
                       setEnAttente((lignes) => lignes.filter((autre) => autre.id !== ligne.id))
                     }
-                    className="text-text-muted hover:text-red-marianne"
                   >
-                    <Trash2 className="size-4" />
-                  </button>
+                    <Trash2 />
+                  </IconButton>
                 </Table.Cell>
               </Table.Row>
             ))}
@@ -211,15 +211,14 @@ function RelationsComponent() {
                   />
                 </Table.Cell>
                 <Table.Cell align="right">
-                  <button
-                    type="button"
-                    aria-label={`Supprimer la relation de ${relation.enfant.nom}`}
+                  <IconButton
+                    variant="danger"
+                    label={`Supprimer la relation de ${relation.enfant.nom}`}
                     disabled={locked || suppression.isPending}
                     onClick={() => suppression.mutate(relation.enfant.id)}
-                    className="text-text-muted hover:text-red-marianne disabled:opacity-50"
                   >
-                    <Trash2 className="size-4" />
-                  </button>
+                    <Trash2 />
+                  </IconButton>
                 </Table.Cell>
               </Table.Row>
             ))}

--- a/apps/kpilote-admin/src/routes/_authed/relations/index.tsx
+++ b/apps/kpilote-admin/src/routes/_authed/relations/index.tsx
@@ -1,7 +1,7 @@
 import { searchUnaccent } from '@pilote/kpilote-shared/texte'
 import { useMutation, useQueryClient, useSuspenseQuery } from '@tanstack/react-query'
 import { createFileRoute, Link } from '@tanstack/react-router'
-import { Search, Trash2 } from 'lucide-react'
+import { Trash2 } from 'lucide-react'
 import { useState } from 'react'
 
 import { supprimerRelation, upsertRelationParent } from '@/api/relations'
@@ -15,6 +15,7 @@ import { individusAllQueryOptions } from '@/queries/individus'
 import { relationsAllQueryOptions } from '@/queries/relations'
 import { Button } from '@pilote/kpilote-ui/Button'
 import { EmptyState } from '@pilote/kpilote-ui/EmptyState'
+import { SearchField } from '@pilote/kpilote-ui/SearchField'
 import { Table } from '@pilote/kpilote-ui/Table'
 import { useToast } from '@pilote/kpilote-ui/Toast'
 
@@ -130,13 +131,12 @@ function RelationsComponent() {
         />
       </div>
 
-      <div className="mb-4 flex max-w-sm items-center gap-2 rounded-md border border-border px-3 py-2 text-sm">
-        <Search className="size-4 text-text-subtle" />
-        <input
-          value={recherche}
-          onChange={(event) => setRecherche(event.target.value)}
+      <div className="mb-4">
+        <SearchField
+          label="Filtrer par nom d’individu"
           placeholder="Filtrer par nom d’individu…"
-          className="w-full bg-transparent focus:outline-none"
+          value={recherche}
+          onChange={setRecherche}
         />
       </div>
 

--- a/apps/kpilote-admin/src/routes/_authed/utilisateurs/index.tsx
+++ b/apps/kpilote-admin/src/routes/_authed/utilisateurs/index.tsx
@@ -1,15 +1,17 @@
 import { formatDate } from '@pilote/kpilote-shared/formatDate'
 import type { UtilisateurApiModel } from '@pilote/kpilote-shared/utilisateur'
 import { useInfiniteQuery } from '@tanstack/react-query'
-import { createFileRoute, Link } from '@tanstack/react-router'
-import { Plus, Search } from 'lucide-react'
+import { createFileRoute, Link, useNavigate } from '@tanstack/react-router'
+import { Plus } from 'lucide-react'
 import { useState } from 'react'
 
 import { Breadcrumb } from '@/components/Breadcrumb'
 import { PageHeading } from '@/components/PageHeading'
 import { Button } from '@pilote/kpilote-ui/Button'
 import { EmptyState } from '@pilote/kpilote-ui/EmptyState'
+import { SearchField } from '@pilote/kpilote-ui/SearchField'
 import { Table } from '@pilote/kpilote-ui/Table'
+import { clickableRowProps } from '@/lib/clickableRow'
 import { utilisateursInfiniteQueryOptions } from '@/queries/utilisateurs'
 import { session } from '@/session'
 
@@ -36,6 +38,7 @@ const PROVIDER_LABEL: Record<UtilisateurApiModel['providers'][number], string> =
 }
 
 function UtilisateursListComponent() {
+  const navigate = useNavigate()
   const isProd = session.current?.environment === 'prod'
   const [recherche, setRecherche] = useState('')
   const query = useInfiniteQuery(utilisateursInfiniteQueryOptions(recherche))
@@ -69,13 +72,12 @@ function UtilisateursListComponent() {
         }
       />
 
-      <div className="mb-4 flex max-w-sm items-center gap-2 rounded-md border border-border px-3 py-2 text-sm">
-        <Search className="size-4 text-text-subtle" />
-        <input
-          value={recherche}
-          onChange={(event) => setRecherche(event.target.value)}
+      <div className="mb-4">
+        <SearchField
+          label="Rechercher un utilisateur"
           placeholder="Rechercher un utilisateur…"
-          className="w-full bg-transparent focus:outline-none"
+          value={recherche}
+          onChange={setRecherche}
         />
       </div>
 
@@ -95,12 +97,17 @@ function UtilisateursListComponent() {
               <Table.HeaderCell>Statut</Table.HeaderCell>
               <Table.HeaderCell>Providers</Table.HeaderCell>
               <Table.HeaderCell>Créé le</Table.HeaderCell>
-              <Table.HeaderCell align="right" />
+              <Table.HeaderCell />
             </Table.Row>
           </Table.Head>
           <Table.Body>
             {items.map((u) => (
-              <Table.Row key={u.id}>
+              <Table.Row
+                key={u.id}
+                {...clickableRowProps(
+                  () => void navigate({ to: '/utilisateurs/$id', params: { id: u.id } }),
+                )}
+              >
                 <Table.Cell>
                   <span className="font-mono text-sm">{u.email}</span>
                 </Table.Cell>
@@ -134,11 +141,7 @@ function UtilisateursListComponent() {
                   <span className="text-text-muted">{formatDate(u.createdAt)}</span>
                 </Table.Cell>
                 <Table.Cell align="right">
-                  <Button variant="tertiary" size="sm" type="button" asChild>
-                    <Link to="/utilisateurs/$id" params={{ id: u.id }}>
-                      Modifier
-                    </Link>
-                  </Button>
+                  <span className="text-primary">→</span>
                 </Table.Cell>
               </Table.Row>
             ))}

--- a/apps/kpilote-admin/src/routes/cle.$environment.tsx
+++ b/apps/kpilote-admin/src/routes/cle.$environment.tsx
@@ -4,6 +4,7 @@ import { KeyRound } from 'lucide-react'
 import { useState } from 'react'
 
 import { Button } from '@pilote/kpilote-ui/Button'
+import { Subtitle } from '@pilote/kpilote-ui/Subtitle'
 import { type Environment, session } from '@/session'
 
 const ENV_LABEL: Record<Environment, string> = { local: 'Local', dev: 'Dev', prod: 'Prod' }
@@ -139,9 +140,9 @@ function KeyComponent() {
           </div>
         ) : null}
 
-        <p className="text-xs text-text-subtle">
+        <Subtitle>
           🔒 La clé est validée puis stockée chiffrée côté serveur, jamais exposée au navigateur.
-        </p>
+        </Subtitle>
       </div>
     </div>
   )


### PR DESCRIPTION
## Contexte

Le listing des utilisateurs du panel admin kpilote sortait du design des autres listings : un bouton **« Modifier »** en variant `tertiary` dans la dernière cellule, là où `collections`, `indicateurs`, `referentiels` et `features` utilisent la **ligne entière cliquable + chevron `→`**. En tirant le fil, plusieurs composants de `kpilote-ui` se sont avérés soit inutilisés, soit cantonnés au dernier lot livré pendant que le reste des pages recopiait leur markup à la main.

Deux commits.

---

## Commit 1 — Harmonisation des listings

### Ligne cliquable sur `utilisateurs`

Le bouton « Modifier » est remplacé par `clickableRowProps` + chevron, comme les quatre autres listings. Aucune régression d'accessibilité : `clickableRowProps` pose `role="button"`, `tabIndex={0}` et gère Enter/Espace.

### Adoption de `SearchField` sur les 6 listings

Les six listings recopiaient à l'identique ce bloc :

```tsx
<div className="mb-4 flex max-w-sm items-center gap-2 rounded-md border border-border px-3 py-2 text-sm">
  <Search className="size-4 text-text-subtle" />
  <input value={recherche} onChange={…} placeholder="…" className="w-full bg-transparent focus:outline-none" />
</div>
```

`SearchField` existait déjà dans `kpilote-ui` **mais n'était importé nulle part** — écrit puis jamais branché. Il est maintenant utilisé partout, et apporte `type="search"` + un `<label class="sr-only">` (via `useId`) que la version recopiée n'avait pas.

### `Pill` au lieu de couleurs hex sur `indicateurs`

Le badge de visibilité utilisait `bg-[#e8f5ec] text-[#18753c]` / `bg-[#f0eefb] text-[#5246a8]` en dur. Il passe sur `<Pill tone=…>` avec le même `as const satisfies Record<IndicateurVisibilite, …>` que `collections`.

---

## Commit 2 — Adoption de `Subtitle` et `IconButton`

Ces deux composants ne servaient que dans `components/collections/`, le dernier lot livré. Les pages antérieures recopiaient leur markup.

### `Subtitle` — 4 sites

`<p className="text-xs text-text-subtle">` à l'identique dans `ReferentielForm`, `AdminResponsables`, `AdminReferentiels`, `cle.$environment`.

### `IconButton` — 9 sites

| Fichier | Icône | Variante |
|---|---|---|
| `ReferentielForm`, `AdminResponsables`, `AdminReferentiels` | `Trash2` | `danger` |
| `HeadersEditor`, `relations` (×2), `features/$id` | `Trash2` | `danger` |
| `PrincipalPermissions` | `Trash2` | `danger` + `size="sm"` pour rester compact dans sa ligne inline |
| `CollectionSearchModal` | `X` | `ghost` |

Au-delà du style, ils gagnent une **cible de clic de 36 px** là où seule l'icône de 16 px était cliquable, un **`focus-visible:outline`** qu'aucun n'avait, et une infobulle native via `title`.

### Écartés volontairement

- Les chevrons déplier/replier de `ArbreCentreAide` et `AccordeonExtension`, et le drag-handle dnd-kit — glyphes inline dans des lignes denses alignées sur des spacers `w-3.5` ; une boîte `size-9` avec fond au survol casserait la grille.
- Les mentions `🔒 non modifiable` de `ReferentielForm` et `IndicateurForm` : imbriquées dans un badge `<span>` inline, où le `<p>` de `Subtitle` serait invalide.

---

## Deltas visuels à valider à l'œil

Purement présentation, aucun changement d'API ni de requête, mais trois choses se voient :

1. **Champ de recherche** — loupe en position absolue au lieu d'inline, `py-2.5` au lieu de `py-2`, ajout de `focus:ring-2 focus:ring-primary/15` + `hover:border-border-strong`.
2. **Croix de `CollectionSearchModal`** — passe de 20 à 16 px.
3. **`features/$id`** — troque `hover:bg-red-marianne/10` contre le token `hover:bg-red-marianne-tinted`.

## Vérification

`pnpm lint` passe sur `kpilote-admin` (tsr generate + eslint + tsc --noEmit + prettier).