### PR TITLE
fix(chantier): calcule la tendance du TA sur les valeurs entières

### DIFF
--- a/apps/pilote-ppg-data-management/models/exposition/chantier/chantier_territoire.sql
+++ b/apps/pilote-ppg-data-management/models/exposition/chantier/chantier_territoire.sql
@@ -97,13 +97,13 @@ SELECT
             THEN NULL::TYPE_TENDANCE
         WHEN
             ta_ch_prev_month.tag_ch IS NULL
-            OR ta_ch_today.tag_ch = ta_ch_prev_month.tag_ch
+            OR ROUND(ta_ch_today.tag_ch) = ROUND(ta_ch_prev_month.tag_ch)
             THEN 'STAGNATION'::TYPE_TENDANCE
         WHEN
-            ta_ch_today.tag_ch > ta_ch_prev_month.tag_ch
+            ROUND(ta_ch_today.tag_ch) > ROUND(ta_ch_prev_month.tag_ch)
             THEN 'HAUSSE'::TYPE_TENDANCE
         WHEN
-            ta_ch_today.tag_ch < ta_ch_prev_month.tag_ch
+            ROUND(ta_ch_today.tag_ch) < ROUND(ta_ch_prev_month.tag_ch)
             THEN 'BAISSE'::TYPE_TENDANCE
     END AS tendance,
     CASE


### PR DESCRIPTION
## Problème

Le taux d'avancement (TA) est affiché arrondi à l'entier en front-end. Cependant, la tendance (HAUSSE/BAISSE/STAGNATION) était calculée en comparant les valeurs décimales brutes stockées en base.

Cela créait une confusion : un TA à 60,20 comparé à 60,35 affichait une **BAISSE** alors que l'utilisateur voyait **60** des deux côtés.

## Solution

Calcul de la tendance sur `ROUND(tag_ch)` plutôt que sur `tag_ch` brut, ce qui aligne la logique de comparaison avec ce que l'utilisateur voit à l'écran.

## Conséquences

- Si les deux TA affichés sont identiques → STAGNATION (cohérent avec l'affichage)
- Si le TA affiché augmente → HAUSSE
- Si le TA affiché diminue → BAISSE
- La précision décimale reste intacte en base (utile pour d'autres calculs comme l'écart à la médiane)

🤖 Generated with [Claude Code](https://claude.com/claude-code)