### PR TITLE
feature(PIL-1653): objet mailto support, title KPilote & pagination par défaut à 100

### DIFF
--- a/apps/kpilote-webapp/index.html
+++ b/apps/kpilote-webapp/index.html
@@ -13,7 +13,7 @@
       href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <title>Pilote - Piloter l'action publique par les résultats</title>
+    <title>KPilote - Piloter l'action publique par les résultats</title>
   </head>
   <body>
     <div id="root"></div>

--- a/apps/kpilote-webapp/src/components/ContacterEquipe.tsx
+++ b/apps/kpilote-webapp/src/components/ContacterEquipe.tsx
@@ -3,7 +3,7 @@ import { Mail } from 'lucide-react'
 export function ContacterEquipe() {
   return (
     <a
-      href="mailto:pilote.ditp@modernisation.gouv.fr"
+      href="mailto:pilote.ditp@modernisation.gouv.fr?subject=Support%20KPILOTE"
       className="hidden items-center gap-2 rounded-md px-3 py-2 text-sm font-semibold text-primary transition-colors hover:bg-surface-tinted sm:inline-flex"
     >
       <Mail className="size-5" />

--- a/apps/kpilote-webapp/src/routes/_authenticated/collections/index.tsx
+++ b/apps/kpilote-webapp/src/routes/_authenticated/collections/index.tsx
@@ -13,7 +13,7 @@ import { FieldIndividuSelect } from '@/components/indicateurs/FieldIndividuSelec
 import { CardGrid } from '@pilote/kpilote-ui/CardGrid'
 import { EmptyState } from '@pilote/kpilote-ui/EmptyState'
 import { Page } from '@pilote/kpilote-ui/Page'
-import { DEFAULT_PAGE_SIZE_OPTIONS, Pagination } from '@pilote/kpilote-ui/Pagination'
+import { DEFAULT_PAGE_SIZE, Pagination } from '@pilote/kpilote-ui/Pagination'
 import { Text } from '@pilote/kpilote-ui/Typography'
 import { ensureIndividuReferentielPair } from '@/lib/individus/pair'
 import { loadCollections, collectionsQueryOptions } from '@/queries/collections'
@@ -47,7 +47,7 @@ export const Route = createFileRoute('/_authenticated/collections/')({
 
     return loadCollections({
       queryClient,
-      query: { cursor: deps.cursor, pageSize: deps.pageSize },
+      query: { cursor: deps.cursor, pageSize: deps.pageSize ?? DEFAULT_PAGE_SIZE },
     })
   },
   pendingComponent: () => <RouteLoading message="Chargement des collections…" />,
@@ -59,7 +59,10 @@ function CollectionsListComponent() {
   const search = Route.useSearch()
   const navigate = useNavigate({ from: Route.fullPath })
   const { data } = useSuspenseQuery(
-    collectionsQueryOptions({ cursor: search.cursor, pageSize: search.pageSize }),
+    collectionsQueryOptions({
+      cursor: search.cursor,
+      pageSize: search.pageSize ?? DEFAULT_PAGE_SIZE,
+    }),
   )
   const { data: referentiels } = useSuspenseQuery(allReferentielsQueryOptions)
   const referentielIds = referentiels.map((r) => r.id)
@@ -117,7 +120,7 @@ function CollectionsListComponent() {
             const next = data.pagination.cursor
             if (next) void navigate({ search: (prev) => ({ ...prev, cursor: next }) })
           }}
-          pageSize={search.pageSize ?? DEFAULT_PAGE_SIZE_OPTIONS[0]}
+          pageSize={search.pageSize ?? DEFAULT_PAGE_SIZE}
           onPageSizeChange={(pageSize) => {
             void navigate({ search: (prev) => ({ ...prev, pageSize, cursor: undefined }) })
           }}

--- a/apps/kpilote-webapp/src/routes/_authenticated/indicateurs/index.tsx
+++ b/apps/kpilote-webapp/src/routes/_authenticated/indicateurs/index.tsx
@@ -15,7 +15,7 @@ import { EmptyState } from '@pilote/kpilote-ui/EmptyState'
 import { Page } from '@pilote/kpilote-ui/Page'
 import { Text } from '@pilote/kpilote-ui/Typography'
 import { ensureIndividuReferentielPair } from '@/lib/individus/pair'
-import { DEFAULT_PAGE_SIZE_OPTIONS, Pagination } from '@pilote/kpilote-ui/Pagination'
+import { DEFAULT_PAGE_SIZE, Pagination } from '@pilote/kpilote-ui/Pagination'
 import { indicateursQueryOptions, loadIndicateurs } from '@/queries/indicateurs'
 import { allReferentielsQueryOptions, loadAllReferentielIds } from '@/queries/referentiels'
 
@@ -24,6 +24,13 @@ const indicateursSearchSchema = z.object({
   pageSize: z.coerce.number().int().min(1).max(100).optional(),
   individu: individuPublicIdSchema.optional(),
   referentiel: referentielPublicIdSchema.optional(),
+})
+
+type IndicateursSearch = z.infer<typeof indicateursSearchSchema>
+
+const toIndicateursQuery = (search: IndicateursSearch) => ({
+  ...search,
+  pageSize: search.pageSize ?? DEFAULT_PAGE_SIZE,
 })
 
 export const Route = createFileRoute('/_authenticated/indicateurs/')({
@@ -45,7 +52,7 @@ export const Route = createFileRoute('/_authenticated/indicateurs/')({
       },
     })
 
-    return loadIndicateurs({ queryClient, query: deps })
+    return loadIndicateurs({ queryClient, query: toIndicateursQuery(deps) })
   },
   pendingComponent: () => <RouteLoading message="Chargement des indicateurs…" />,
   errorComponent: RouteError,
@@ -55,7 +62,7 @@ export const Route = createFileRoute('/_authenticated/indicateurs/')({
 function IndicateursListComponent() {
   const search = Route.useSearch()
   const navigate = useNavigate({ from: Route.fullPath })
-  const { data } = useSuspenseQuery(indicateursQueryOptions(search))
+  const { data } = useSuspenseQuery(indicateursQueryOptions(toIndicateursQuery(search)))
   const { data: referentiels } = useSuspenseQuery(allReferentielsQueryOptions)
   const referentielIds = referentiels.map((r) => r.id)
 
@@ -113,7 +120,7 @@ function IndicateursListComponent() {
             const next = data.pagination.cursor
             if (next) void navigate({ search: (prev) => ({ ...prev, cursor: next }) })
           }}
-          pageSize={search.pageSize ?? DEFAULT_PAGE_SIZE_OPTIONS[0]}
+          pageSize={search.pageSize ?? DEFAULT_PAGE_SIZE}
           onPageSizeChange={(pageSize) => {
             void navigate({ search: (prev) => ({ ...prev, pageSize, cursor: undefined }) })
           }}

--- a/packages/kpilote-ui/src/Pagination.tsx
+++ b/packages/kpilote-ui/src/Pagination.tsx
@@ -6,6 +6,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '.
 import { clsxm } from './clsxm'
 
 export const DEFAULT_PAGE_SIZE_OPTIONS = [20, 50, 100] as const
+export const DEFAULT_PAGE_SIZE = 100
 
 export interface PaginationProps {
   hasPrevious?: boolean

--- a/packages/kpilote-ui/src/Pagination.tsx
+++ b/packages/kpilote-ui/src/Pagination.tsx
@@ -6,7 +6,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '.
 import { clsxm } from './clsxm'
 
 export const DEFAULT_PAGE_SIZE_OPTIONS = [20, 50, 100] as const
-export const DEFAULT_PAGE_SIZE = 100
+export const DEFAULT_PAGE_SIZE = 100 satisfies (typeof DEFAULT_PAGE_SIZE_OPTIONS)[number]
 
 export interface PaginationProps {
   hasPrevious?: boolean


### PR DESCRIPTION
## Contexte

Retours de [PIL-1653 — \[MEP\]\[Accueil\] Tableau de bord](https://data-ditp.atlassian.net/browse/PIL-1653) (mise à jour des maquettes par Jean-François).

Après revue du ticket point par point, l'essentiel était déjà livré (renommage KPILOTE dans le header, suppression du bouton tableau de bord, placeholder de la command palette, lien « Contacter l'équipe », conservation de « Mon espace », ombre header ↔ body, switch sous la description, suppression de la barre de recherche, structure du footer, pages légales). Cette PR traite les 3 points restants.

## Changements

**1. Objet du mailto support** — le ticket demande `objet: Support KPILOTE`, le lien n'avait pas de `subject`.

**2. Titre de l'onglet** — `index.html` affichait encore « Pilote », passé à « KPilote » au titre du renommage PILOTE → KPILOTE.

**3. Pagination par défaut 20 → 100** sur les listings indicateurs et collections.

Sur ce dernier point, afficher la valeur dans le sélecteur ne suffisait pas : quand aucun `pageSize` n'est présent en URL, la webapp n'en envoyait aucun et c'est le défaut serveur (`DEFAULT_PAGE_SIZE = 20` dans `kpilote-api`) qui s'appliquait — le sélecteur aurait affiché 100 en ne ramenant que 20 lignes. La valeur est donc injectée explicitement dans le loader **et** dans la query des deux routes.

La constante `DEFAULT_PAGE_SIZE` est volontairement séparée de `DEFAULT_PAGE_SIZE_OPTIONS` plutôt que d'être un index dans ce tableau : ajouter ou réordonner une option (75, par ex.) changerait sinon silencieusement le défaut.

Le défaut de l'API reste à 20, inchangé pour ses autres consommateurs (admin, sync ppg).

## Hors périmètre

- **Texte du footer** : toujours `À DÉFINIR — Lorem ipsum` dans `__root.tsx`, en attente du contenu définitif côté DITP.
- **Vocabulaire « dossier »** : le ticket parle de « dossiers », mais le terme retenu depuis est « collection » (cf. renommage panier → collection). Confirmé, rien à changer.
- **Sélecteur d'individu** : renvoyé à son US dédiée par le ticket lui-même.

## Vérifications

- ESLint et Prettier OK sur les fichiers touchés.
- `routing.test.tsx` : 4 tests passent.
- ⚠️ `pnpm lint` sur `@pilote/kpilote-webapp` échoue sur des erreurs `tsc` **pré-existantes sur `dev`** dans `src/scripts/svgVersGeoJson.ts` (`number | undefined`), vérifiées en stashant les modifs de cette PR. Aucune erreur sur les fichiers touchés ici, mais ça bloque la chaîne de lint du package — à traiter à part.