### PR TITLE
chore(ssl): désactive temporairement l'upload du cert sur Scalingo

### DIFF
--- a/.github/workflows/renouvellement-ssl.yml
+++ b/.github/workflows/renouvellement-ssl.yml
@@ -174,23 +174,26 @@ jobs:
           fi
           echo "domain_id=$DOMAIN_ID" >> "$GITHUB_OUTPUT"
 
-      - name: Pousser le certificat sur Scalingo
-        if: steps.cible.outputs.skip == 'false'
-        run: |
-          DOMAIN="${{ steps.cible.outputs.domaine }}"
-          LIVE="$GITHUB_WORKSPACE/.certbot/config/live/$DOMAIN"
-          CERT=$(cat "$LIVE/fullchain.pem")
-          KEY=$(cat "$LIVE/privkey.pem")
-          RESP=$(mktemp)
-          HTTP_CODE=$(jq -n --arg cert "$CERT" --arg key "$KEY" \
-            '{domain: {tlscert: $cert, tlskey: $key}}' \
-            | curl -sS -X PATCH -o "$RESP" -w "%{http_code}" \
-              -H "Authorization: Bearer ${{ steps.scalingo-auth.outputs.jwt }}" \
-              -H "Content-Type: application/json" \
-              --data-binary @- \
-              "${SCALINGO_API_BASE}/v1/apps/${{ steps.cible.outputs.scalingo_app }}/domains/${{ steps.scalingo-domain.outputs.domain_id }}")
-          echo "HTTP $HTTP_CODE"
-          cat "$RESP"; echo ""
-          if [ "$HTTP_CODE" -lt 200 ] || [ "$HTTP_CODE" -ge 300 ]; then
-            exit 1
-          fi
+      # Upload du certificat désactivé temporairement : on émet + vérifie le
+      # cert et on valide l'accès à l'API Scalingo (JWT + domain ID), mais on ne
+      # remplace pas encore le cert en place. Décommenter pour réactiver le push.
+      # - name: Pousser le certificat sur Scalingo
+      #   if: steps.cible.outputs.skip == 'false'
+      #   run: |
+      #     DOMAIN="${{ steps.cible.outputs.domaine }}"
+      #     LIVE="$GITHUB_WORKSPACE/.certbot/config/live/$DOMAIN"
+      #     CERT=$(cat "$LIVE/fullchain.pem")
+      #     KEY=$(cat "$LIVE/privkey.pem")
+      #     RESP=$(mktemp)
+      #     HTTP_CODE=$(jq -n --arg cert "$CERT" --arg key "$KEY" \
+      #       '{domain: {tlscert: $cert, tlskey: $key}}' \
+      #       | curl -sS -X PATCH -o "$RESP" -w "%{http_code}" \
+      #         -H "Authorization: Bearer ${{ steps.scalingo-auth.outputs.jwt }}" \
+      #         -H "Content-Type: application/json" \
+      #         --data-binary @- \
+      #         "${SCALINGO_API_BASE}/v1/apps/${{ steps.cible.outputs.scalingo_app }}/domains/${{ steps.scalingo-domain.outputs.domain_id }}")
+      #     echo "HTTP $HTTP_CODE"
+      #     cat "$RESP"; echo ""
+      #     if [ "$HTTP_CODE" -lt 200 ] || [ "$HTTP_CODE" -ge 300 ]; then
+      #       exit 1
+      #     fi


### PR DESCRIPTION
## Contexte

Le workflow de renouvellement SSL (`.github/workflows/renouvellement-ssl.yml`) émet les certificats via certbot (HTTP-01), les vérifie, puis les **pousse sur Scalingo** (PATCH du domaine) pour remplacer le cert en place.

On souhaite pouvoir faire tourner le renouvellement **sans remplacer** encore le certificat en place, le temps de valider le flow de bout en bout.

## Changement

Commente **uniquement** le step « Pousser le certificat sur Scalingo ».

Ce qui reste actif :
- émission du certificat (certbot HTTP-01 via hooks)
- vérification du certificat (chaîne, cohérence clé/cert)
- échange du token Scalingo → JWT et recherche du domain ID (l'accès API Scalingo reste donc validé)

Ce qui est désactivé :
- le `PATCH .../domains/{id}` qui remplace le cert en place

Pour réactiver : décommenter le bloc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)