### PR TITLE
refactor(permissions): scinde PermissionAction en deux enums par domaine

### DIFF
--- a/apps/kpilote-admin/src/api/permissions.ts
+++ b/apps/kpilote-admin/src/api/permissions.ts
@@ -1,7 +1,8 @@
 import type {
+  CollectionPermissionActionValue,
   GrantCollectionPermissionBody,
   GrantIndicateurPermissionBody,
-  PermissionActionValue,
+  IndicateurPermissionActionValue,
   PrincipalPermissionsApiModel,
 } from '@pilote/kpilote-shared/permission'
 import { principalPermissionsApiModelSchema } from '@pilote/kpilote-shared/permission'
@@ -27,7 +28,7 @@ export const grantIndicateurPermission = async (
 export const revokeIndicateurPermission = async (params: {
   principalId: string
   indicateurPublicId: string
-  action?: PermissionActionValue
+  action?: IndicateurPermissionActionValue
 }): Promise<PrincipalPermissionsApiModel> => {
   const searchParams: Record<string, string> = {
     principalId: params.principalId,
@@ -50,7 +51,7 @@ export const grantCollectionPermission = async (
 export const revokeCollectionPermission = async (params: {
   principalId: string
   collectionPublicId: string
-  action?: PermissionActionValue
+  action?: CollectionPermissionActionValue
 }): Promise<PrincipalPermissionsApiModel> => {
   const searchParams: Record<string, string> = {
     principalId: params.principalId,

--- a/apps/kpilote-admin/src/components/PrincipalPermissions.tsx
+++ b/apps/kpilote-admin/src/components/PrincipalPermissions.tsx
@@ -61,11 +61,16 @@ export function PrincipalPermissions({ principalId }: { principalId: string }) {
   // Indicateurs — appels directs, aucune factorisation avec les collections.
   const addIndicateur = (indicateurPublicId: string) => {
     run(() =>
-      grantIndicateurPermission({ principalId, indicateurPublicId, action: IndicateurPermissionAction.READ }),
+      grantIndicateurPermission({
+        principalId,
+        indicateurPublicId,
+        action: IndicateurPermissionAction.READ,
+      }),
     )
   }
   const toggleIndicateurWrite =
-    (action: IndicateurPermissionWriteActionValue) => (indicateurPublicId: string, active: boolean) =>
+    (action: IndicateurPermissionWriteActionValue) =>
+    (indicateurPublicId: string, active: boolean) =>
       run(() =>
         active
           ? revokeIndicateurPermission({ principalId, indicateurPublicId, action })
@@ -78,7 +83,11 @@ export function PrincipalPermissions({ principalId }: { principalId: string }) {
   const addCollection = (collectionPublicId: string) => {
     setModal(null)
     run(() =>
-      grantCollectionPermission({ principalId, collectionPublicId, action: CollectionPermissionAction.READ }),
+      grantCollectionPermission({
+        principalId,
+        collectionPublicId,
+        action: CollectionPermissionAction.READ,
+      }),
     )
   }
   const toggleCollectionWriteComment = (collectionPublicId: string, active: boolean) =>
@@ -118,7 +127,9 @@ export function PrincipalPermissions({ principalId }: { principalId: string }) {
         <ul className="divide-y divide-border rounded-lg border border-border">
           {rows.map((row) => {
             const writeDataActive = row.actions.includes(IndicateurPermissionAction.WRITE_DATA)
-            const writeCommentActive = row.actions.includes(IndicateurPermissionAction.WRITE_COMMENT)
+            const writeCommentActive = row.actions.includes(
+              IndicateurPermissionAction.WRITE_COMMENT,
+            )
             const extra = extraForRow?.(row.publicId)
             return (
               <li key={row.publicId} className="px-3 py-2.5">

--- a/apps/kpilote-admin/src/components/PrincipalPermissions.tsx
+++ b/apps/kpilote-admin/src/components/PrincipalPermissions.tsx
@@ -1,7 +1,8 @@
 import {
-  PermissionAction,
-  type PermissionActionValue,
-  type PermissionWriteActionValue,
+  CollectionPermissionAction,
+  IndicateurPermissionAction,
+  type IndicateurPermissionActionValue,
+  type IndicateurPermissionWriteActionValue,
   type PrincipalPermissionsApiModel,
 } from '@pilote/kpilote-shared/permission'
 import { useMutation, useQueryClient, useSuspenseQuery } from '@tanstack/react-query'
@@ -25,7 +26,7 @@ import { clsxm } from '@/lib/clsxm'
 import { useProdEditUnlock } from '@/lib/useProdEditUnlock'
 import { principalPermissionsQueryOptions } from '@/queries/permissions'
 
-type DirectRow = { publicId: string; nom: string; actions: PermissionActionValue[] }
+type DirectRow = { publicId: string; nom: string; actions: IndicateurPermissionActionValue[] }
 
 type SectionHandlers = {
   onToggleWriteData?: (publicId: string, active: boolean) => void
@@ -60,11 +61,11 @@ export function PrincipalPermissions({ principalId }: { principalId: string }) {
   // Indicateurs — appels directs, aucune factorisation avec les collections.
   const addIndicateur = (indicateurPublicId: string) => {
     run(() =>
-      grantIndicateurPermission({ principalId, indicateurPublicId, action: PermissionAction.READ }),
+      grantIndicateurPermission({ principalId, indicateurPublicId, action: IndicateurPermissionAction.READ }),
     )
   }
   const toggleIndicateurWrite =
-    (action: PermissionWriteActionValue) => (indicateurPublicId: string, active: boolean) =>
+    (action: IndicateurPermissionWriteActionValue) => (indicateurPublicId: string, active: boolean) =>
       run(() =>
         active
           ? revokeIndicateurPermission({ principalId, indicateurPublicId, action })
@@ -77,7 +78,7 @@ export function PrincipalPermissions({ principalId }: { principalId: string }) {
   const addCollection = (collectionPublicId: string) => {
     setModal(null)
     run(() =>
-      grantCollectionPermission({ principalId, collectionPublicId, action: PermissionAction.READ }),
+      grantCollectionPermission({ principalId, collectionPublicId, action: CollectionPermissionAction.READ }),
     )
   }
   const toggleCollectionWriteComment = (collectionPublicId: string, active: boolean) =>
@@ -86,12 +87,12 @@ export function PrincipalPermissions({ principalId }: { principalId: string }) {
         ? revokeCollectionPermission({
             principalId,
             collectionPublicId,
-            action: PermissionAction.WRITE_COMMENT,
+            action: CollectionPermissionAction.WRITE_COMMENT,
           })
         : grantCollectionPermission({
             principalId,
             collectionPublicId,
-            action: PermissionAction.WRITE_COMMENT,
+            action: CollectionPermissionAction.WRITE_COMMENT,
           }),
     )
   const removeCollection = (collectionPublicId: string) =>
@@ -116,8 +117,8 @@ export function PrincipalPermissions({ principalId }: { principalId: string }) {
       ) : (
         <ul className="divide-y divide-border rounded-lg border border-border">
           {rows.map((row) => {
-            const writeDataActive = row.actions.includes(PermissionAction.WRITE_DATA)
-            const writeCommentActive = row.actions.includes(PermissionAction.WRITE_COMMENT)
+            const writeDataActive = row.actions.includes(IndicateurPermissionAction.WRITE_DATA)
+            const writeCommentActive = row.actions.includes(IndicateurPermissionAction.WRITE_COMMENT)
             const extra = extraForRow?.(row.publicId)
             return (
               <li key={row.publicId} className="px-3 py-2.5">
@@ -278,8 +279,8 @@ export function PrincipalPermissions({ principalId }: { principalId: string }) {
           disabled={disabled}
         />,
         {
-          onToggleWriteData: toggleIndicateurWrite(PermissionAction.WRITE_DATA),
-          onToggleWriteComment: toggleIndicateurWrite(PermissionAction.WRITE_COMMENT),
+          onToggleWriteData: toggleIndicateurWrite(IndicateurPermissionAction.WRITE_DATA),
+          onToggleWriteComment: toggleIndicateurWrite(IndicateurPermissionAction.WRITE_COMMENT),
           onRemove: removeIndicateur,
         },
       )}

--- a/apps/kpilote-admin/src/components/collections/CollectionAcces.tsx
+++ b/apps/kpilote-admin/src/components/collections/CollectionAcces.tsx
@@ -1,5 +1,5 @@
 import {
-  PermissionAction,
+  CollectionPermissionAction,
   type PrincipalPermissionsApiModel,
 } from '@pilote/kpilote-shared/permission'
 import { useMutation, useQueryClient, useSuspenseQuery } from '@tanstack/react-query'
@@ -51,7 +51,7 @@ export function CollectionAcces({ collectionId }: { collectionId: string }) {
             grantCollectionPermission({
               principalId: utilisateur.id,
               collectionPublicId: collectionId,
-              action: PermissionAction.READ,
+              action: CollectionPermissionAction.READ,
             }),
           )
         }
@@ -67,7 +67,7 @@ export function CollectionAcces({ collectionId }: { collectionId: string }) {
       ) : (
         <ul className="divide-y divide-border rounded-lg border border-border">
           {permissions.items.map((item) => {
-            const ecritureActive = item.actions.includes(PermissionAction.WRITE_COMMENT)
+            const ecritureActive = item.actions.includes(CollectionPermissionAction.WRITE_COMMENT)
             return (
               <li key={item.principalId} className="flex items-center gap-3 px-3 py-2.5">
                 <span className="min-w-0 flex-1">
@@ -93,12 +93,12 @@ export function CollectionAcces({ collectionId }: { collectionId: string }) {
                         ? revokeCollectionPermission({
                             principalId: item.principalId,
                             collectionPublicId: collectionId,
-                            action: PermissionAction.WRITE_COMMENT,
+                            action: CollectionPermissionAction.WRITE_COMMENT,
                           })
                         : grantCollectionPermission({
                             principalId: item.principalId,
                             collectionPublicId: collectionId,
-                            action: PermissionAction.WRITE_COMMENT,
+                            action: CollectionPermissionAction.WRITE_COMMENT,
                           }),
                     )
                   }

--- a/apps/kpilote-api/docs/architecture/permissions-design.md
+++ b/apps/kpilote-api/docs/architecture/permissions-design.md
@@ -70,7 +70,7 @@ PermissionAction ∈ { READ, WRITE }
   n'implique pas READ par la sémantique de l'enum**, mais par convention, les
   helpers `with*ReadPermission` acceptent les deux actions comme valant un
   READ (un principal qui peut écrire peut lire). Voir constantes
-  `INDICATEUR_READ_PERMISSIONS` / `COLLECTION_READ_PERMISSIONS`.
+  `INDICATEUR_PERMISSIONS_GRANTING_READ` / `COLLECTION_PERMISSIONS_GRANTING_READ`.
 
 ## Helpers
 

--- a/apps/kpilote-api/prisma/migrations/20260803000000_split_permission_action_enum/migration.sql
+++ b/apps/kpilote-api/prisma/migrations/20260803000000_split_permission_action_enum/migration.sql
@@ -1,0 +1,30 @@
+-- Étape 1 : retirer les PKs (incluent la colonne action, de type enum)
+ALTER TABLE "indicateur_permission" DROP CONSTRAINT "indicateur_permission_pkey";
+ALTER TABLE "collection_permission" DROP CONSTRAINT "collection_permission_pkey";
+
+-- Étape 2 : convertir les colonnes action en text (libère la dépendance sur le type enum)
+ALTER TABLE "indicateur_permission" ALTER COLUMN "action" TYPE text;
+ALTER TABLE "collection_permission" ALTER COLUMN "action" TYPE text;
+
+-- Étape 3 : supprimer l'ancien enum
+DROP TYPE "permission_action_enum";
+
+-- Étape 4 : créer les deux nouveaux enums
+CREATE TYPE "indicateur_permission_action_enum" AS ENUM ('READ', 'WRITE_DATA', 'WRITE_COMMENT');
+CREATE TYPE "collection_permission_action_enum" AS ENUM ('READ', 'WRITE_COMMENT');
+
+-- Étape 5 : recaster les colonnes vers les nouveaux enums
+ALTER TABLE "indicateur_permission"
+  ALTER COLUMN "action" TYPE "indicateur_permission_action_enum"
+  USING "action"::"indicateur_permission_action_enum";
+
+ALTER TABLE "collection_permission"
+  ALTER COLUMN "action" TYPE "collection_permission_action_enum"
+  USING "action"::"collection_permission_action_enum";
+
+-- Étape 6 : recréer les PKs
+ALTER TABLE "indicateur_permission"
+  ADD CONSTRAINT "indicateur_permission_pkey" PRIMARY KEY (principal_id, indicateur_id, action);
+
+ALTER TABLE "collection_permission"
+  ADD CONSTRAINT "collection_permission_pkey" PRIMARY KEY (principal_id, collection_id, action);

--- a/apps/kpilote-api/prisma/schema.prisma
+++ b/apps/kpilote-api/prisma/schema.prisma
@@ -211,19 +211,26 @@ model IndicateurReferentiel {
   @@map("indicateur_referentiel")
 }
 
-enum PermissionAction {
+enum IndicateurPermissionAction {
   READ
   WRITE_DATA
   WRITE_COMMENT
 
-  @@map("permission_action_enum")
+  @@map("indicateur_permission_action_enum")
+}
+
+enum CollectionPermissionAction {
+  READ
+  WRITE_COMMENT
+
+  @@map("collection_permission_action_enum")
 }
 
 model IndicateurPermission {
-  principalId  String           @map("principal_id") @db.Uuid
-  indicateurId String           @map("indicateur_id") @db.Uuid
-  action       PermissionAction
-  createdAt    DateTime         @default(now()) @map("created_at")
+  principalId  String                    @map("principal_id") @db.Uuid
+  indicateurId String                    @map("indicateur_id") @db.Uuid
+  action       IndicateurPermissionAction
+  createdAt    DateTime                  @default(now()) @map("created_at")
 
   principal  Principal  @relation(fields: [principalId], references: [id], onDelete: Cascade)
   indicateur Indicateur @relation(fields: [indicateurId], references: [id], onDelete: Cascade)
@@ -364,10 +371,10 @@ model Collection {
 }
 
 model CollectionPermission {
-  principalId  String           @map("principal_id") @db.Uuid
-  collectionId String           @map("collection_id") @db.Uuid
-  action       PermissionAction
-  createdAt    DateTime         @default(now()) @map("created_at")
+  principalId  String                     @map("principal_id") @db.Uuid
+  collectionId String                     @map("collection_id") @db.Uuid
+  action       CollectionPermissionAction
+  createdAt    DateTime                   @default(now()) @map("created_at")
 
   principal  Principal  @relation(fields: [principalId], references: [id], onDelete: Cascade)
   collection Collection @relation(fields: [collectionId], references: [id], onDelete: Cascade)

--- a/apps/kpilote-api/prisma/seed.ts
+++ b/apps/kpilote-api/prisma/seed.ts
@@ -8,11 +8,11 @@ import {
 } from '@pilote/kpilote-shared/indicateur'
 
 import { Prisma, PrismaClient } from '../src/generated/prisma/client.js'
-import { type FonctionAgregation } from '../src/generated/prisma/enums.js'
 import {
+  type FonctionAgregation,
   CollectionPermissionAction,
   IndicateurPermissionAction,
-} from '@pilote/kpilote-shared/permission'
+} from '../src/generated/prisma/enums.js'
 
 import {
   buildObjectifsPourIndicateur,

--- a/apps/kpilote-api/prisma/seed.ts
+++ b/apps/kpilote-api/prisma/seed.ts
@@ -8,7 +8,11 @@ import {
 } from '@pilote/kpilote-shared/indicateur'
 
 import { Prisma, PrismaClient } from '../src/generated/prisma/client.js'
-import { type FonctionAgregation, PermissionAction } from '../src/generated/prisma/enums.js'
+import { type FonctionAgregation } from '../src/generated/prisma/enums.js'
+import {
+  CollectionPermissionAction,
+  IndicateurPermissionAction,
+} from '@pilote/kpilote-shared/permission'
 
 import {
   buildObjectifsPourIndicateur,
@@ -354,9 +358,9 @@ const main = async () => {
       select: { id: true },
     })
     for (const action of [
-      PermissionAction.READ,
-      PermissionAction.WRITE_DATA,
-      PermissionAction.WRITE_COMMENT,
+      IndicateurPermissionAction.READ,
+      IndicateurPermissionAction.WRITE_DATA,
+      IndicateurPermissionAction.WRITE_COMMENT,
     ]) {
       await prisma.indicateurPermission.upsert({
         where: {
@@ -828,7 +832,10 @@ const main = async () => {
   // (cf. boucle indicateursSeed.slice(0, 8) plus haut), la propagation
   // n'apporte rien ici en pratique pour ditp.admin — c'est volontaire : la
   // démo de propagation reste vérifiée en tests d'intégration.
-  for (const action of [PermissionAction.READ, PermissionAction.WRITE_COMMENT]) {
+  for (const action of [
+    CollectionPermissionAction.READ,
+    CollectionPermissionAction.WRITE_COMMENT,
+  ]) {
     const collection = collectionsByPublicId.get('COL-005')
     if (!collection) continue
     await prisma.collectionPermission.upsert({

--- a/apps/kpilote-api/src/collection/permissions.test.ts
+++ b/apps/kpilote-api/src/collection/permissions.test.ts
@@ -1,4 +1,4 @@
-import { PermissionAction } from '@/generated/prisma/enums'
+import { CollectionPermissionAction } from '@/generated/prisma/enums'
 import { describe, expect, it } from 'vitest'
 
 import { db } from '@/framework/persistence/dbStore'
@@ -51,7 +51,7 @@ describe.concurrent('withCollectionReadPermission', () => {
       await fixtures.collection({ publicId: colPriRead, visibilite: 'PRIVE' })
       const apiKey = await fixtures.apiKey({
         collectionPermissions: [
-          { collection: { publicId: colPriRead }, action: PermissionAction.READ },
+          { collection: { publicId: colPriRead }, action: CollectionPermissionAction.READ },
         ],
       })
 
@@ -68,7 +68,7 @@ describe.concurrent('withCollectionReadPermission', () => {
       await fixtures.collection({ publicId: colPriWrite, visibilite: 'PRIVE' })
       const apiKey = await fixtures.apiKey({
         collectionPermissions: [
-          { collection: { publicId: colPriWrite }, action: PermissionAction.WRITE_COMMENT },
+          { collection: { publicId: colPriWrite }, action: CollectionPermissionAction.WRITE_COMMENT },
         ],
       })
 
@@ -86,7 +86,7 @@ describe.concurrent('withCollectionReadPermission', () => {
       const [a, b] = await fixtures.apiKey(
         {
           collectionPermissions: [
-            { collection: { publicId: colIso }, action: PermissionAction.READ },
+            { collection: { publicId: colIso }, action: CollectionPermissionAction.READ },
           ],
         },
         {},
@@ -129,7 +129,7 @@ describe.concurrent('ensureCollectionWriteCommentPermission', () => {
       const collection = await fixtures.collection({ publicId: colEwOk, visibilite: 'PRIVE' })
       const apiKey = await fixtures.apiKey({
         collectionPermissions: [
-          { collection: { publicId: colEwOk }, action: PermissionAction.WRITE_COMMENT },
+          { collection: { publicId: colEwOk }, action: CollectionPermissionAction.WRITE_COMMENT },
         ],
       })
 
@@ -165,7 +165,7 @@ describe.concurrent('ensureCollectionWriteCommentPermission', () => {
       const collection = await fixtures.collection({ publicId: colEwRonly, visibilite: 'PRIVE' })
       const apiKey = await fixtures.apiKey({
         collectionPermissions: [
-          { collection: { publicId: colEwRonly }, action: PermissionAction.READ },
+          { collection: { publicId: colEwRonly }, action: CollectionPermissionAction.READ },
         ],
       })
 

--- a/apps/kpilote-api/src/collection/permissions.test.ts
+++ b/apps/kpilote-api/src/collection/permissions.test.ts
@@ -68,7 +68,10 @@ describe.concurrent('withCollectionReadPermission', () => {
       await fixtures.collection({ publicId: colPriWrite, visibilite: 'PRIVE' })
       const apiKey = await fixtures.apiKey({
         collectionPermissions: [
-          { collection: { publicId: colPriWrite }, action: CollectionPermissionAction.WRITE_COMMENT },
+          {
+            collection: { publicId: colPriWrite },
+            action: CollectionPermissionAction.WRITE_COMMENT,
+          },
         ],
       })
 

--- a/apps/kpilote-api/src/collection/permissions.ts
+++ b/apps/kpilote-api/src/collection/permissions.ts
@@ -5,7 +5,7 @@ import { db } from '@/framework/persistence/dbStore'
 import { Prisma } from '@/generated/prisma/client'
 import { CollectionPermissionAction, Visibilite } from '@/generated/prisma/enums'
 
-export const COLLECTION_READ_PERMISSIONS: CollectionPermissionAction[] = [
+export const COLLECTION_PERMISSIONS_GRANTING_READ: CollectionPermissionAction[] = [
   CollectionPermissionAction.READ,
   CollectionPermissionAction.WRITE_COMMENT,
 ]
@@ -19,7 +19,11 @@ export const withCollectionReadPermission = (
     {
       OR: [
         { visibilite: Visibilite.PUBLIC },
-        { permissions: { some: { principalId, action: { in: COLLECTION_READ_PERMISSIONS } } } },
+        {
+          permissions: {
+            some: { principalId, action: { in: COLLECTION_PERMISSIONS_GRANTING_READ } },
+          },
+        },
       ],
     },
   ],

--- a/apps/kpilote-api/src/collection/permissions.ts
+++ b/apps/kpilote-api/src/collection/permissions.ts
@@ -3,11 +3,11 @@ import { ResultAsync } from 'neverthrow'
 import { ForbiddenError } from '@/framework/errors/AppError'
 import { db } from '@/framework/persistence/dbStore'
 import { Prisma } from '@/generated/prisma/client'
-import { PermissionAction, Visibilite } from '@/generated/prisma/enums'
+import { CollectionPermissionAction, Visibilite } from '@/generated/prisma/enums'
 
-export const COLLECTION_READ_PERMISSIONS: PermissionAction[] = [
-  PermissionAction.READ,
-  PermissionAction.WRITE_COMMENT,
+export const COLLECTION_READ_PERMISSIONS: CollectionPermissionAction[] = [
+  CollectionPermissionAction.READ,
+  CollectionPermissionAction.WRITE_COMMENT,
 ]
 
 export const withCollectionReadPermission = (
@@ -39,7 +39,7 @@ export const ensureCollectionWriteCommentPermission = ({
           principalId_collectionId_action: {
             principalId,
             collectionId,
-            action: PermissionAction.WRITE_COMMENT,
+            action: CollectionPermissionAction.WRITE_COMMENT,
           },
         },
       })

--- a/apps/kpilote-api/src/collection/queries/getCollectionByPublicId.test.ts
+++ b/apps/kpilote-api/src/collection/queries/getCollectionByPublicId.test.ts
@@ -1,4 +1,4 @@
-import { PermissionAction } from '@/generated/prisma/enums'
+import { CollectionPermissionAction } from '@/generated/prisma/enums'
 import { describe, expect, it } from 'vitest'
 
 import { getCollectionByPublicId } from '@/collection/queries/getCollectionByPublicId'
@@ -70,7 +70,7 @@ describe.concurrent('getCollectionByPublicId', () => {
       await fixtures.collection({ publicId: colPriv, visibilite: 'PRIVE' })
       const apiKey = await fixtures.apiKey({
         collectionPermissions: [
-          { collection: { publicId: colPriv }, action: PermissionAction.READ },
+          { collection: { publicId: colPriv }, action: CollectionPermissionAction.READ },
         ],
       })
 

--- a/apps/kpilote-api/src/collection/queries/getCollectionTauxProgression.test.ts
+++ b/apps/kpilote-api/src/collection/queries/getCollectionTauxProgression.test.ts
@@ -1,4 +1,4 @@
-import { PermissionAction } from '@/generated/prisma/enums'
+import { CollectionPermissionAction } from '@/generated/prisma/enums'
 import { describe, expect, it } from 'vitest'
 
 import { getCollectionTauxProgression } from '@/collection/queries/getCollectionTauxProgression'
@@ -374,7 +374,7 @@ describe.concurrent('getCollectionTauxProgression', () => {
       })
       const apiKey = await fixtures.apiKey({
         collectionPermissions: [
-          { collection: { publicId: 'COL-PROG-PRIV-OK' }, action: PermissionAction.READ },
+          { collection: { publicId: 'COL-PROG-PRIV-OK' }, action: CollectionPermissionAction.READ },
         ],
       })
 

--- a/apps/kpilote-api/src/collection/queries/listCollectionPermissions.test.ts
+++ b/apps/kpilote-api/src/collection/queries/listCollectionPermissions.test.ts
@@ -55,11 +55,15 @@ describe.concurrent('listCollectionPermissions', () => {
       const email = testEmail()
       const cle = await fixtures.apiKey({
         label: 'sync-ppg',
-        collectionPermissions: [{ collection: { publicId }, action: CollectionPermissionAction.READ }],
+        collectionPermissions: [
+          { collection: { publicId }, action: CollectionPermissionAction.READ },
+        ],
       })
       const utilisateur = await fixtures.utilisateur({
         email,
-        collectionPermissions: [{ collection: { publicId }, action: CollectionPermissionAction.READ }],
+        collectionPermissions: [
+          { collection: { publicId }, action: CollectionPermissionAction.READ },
+        ],
       })
       const admin = await fixtures.apiKey({ role: 'ADMIN' })
 
@@ -89,7 +93,9 @@ describe.concurrent('listCollectionPermissions', () => {
       await fixtures.collection({ publicId })
       await fixtures.utilisateur({
         email: testEmail(),
-        collectionPermissions: [{ collection: { publicId }, action: CollectionPermissionAction.READ }],
+        collectionPermissions: [
+          { collection: { publicId }, action: CollectionPermissionAction.READ },
+        ],
       })
       const apiKey = await fixtures.apiKey()
 

--- a/apps/kpilote-api/src/collection/queries/listCollectionPermissions.test.ts
+++ b/apps/kpilote-api/src/collection/queries/listCollectionPermissions.test.ts
@@ -1,4 +1,4 @@
-import { PermissionAction } from '@/generated/prisma/enums'
+import { CollectionPermissionAction } from '@/generated/prisma/enums'
 import { describe, expect, it } from 'vitest'
 
 import { listCollectionPermissions } from '@/collection/queries/listCollectionPermissions'
@@ -29,8 +29,8 @@ describe.concurrent('listCollectionPermissions', () => {
       const utilisateur = await fixtures.utilisateur({
         email,
         collectionPermissions: [
-          { collection: { publicId }, action: PermissionAction.WRITE_COMMENT },
-          { collection: { publicId }, action: PermissionAction.READ },
+          { collection: { publicId }, action: CollectionPermissionAction.WRITE_COMMENT },
+          { collection: { publicId }, action: CollectionPermissionAction.READ },
         ],
       })
       const apiKey = await fixtures.apiKey({ role: 'ADMIN' })
@@ -42,7 +42,7 @@ describe.concurrent('listCollectionPermissions', () => {
           principalId: utilisateur.id,
           type: 'UTILISATEUR',
           libelle: email,
-          actions: [PermissionAction.READ, PermissionAction.WRITE_COMMENT],
+          actions: [CollectionPermissionAction.READ, CollectionPermissionAction.WRITE_COMMENT],
         },
       ])
     }),
@@ -55,11 +55,11 @@ describe.concurrent('listCollectionPermissions', () => {
       const email = testEmail()
       const cle = await fixtures.apiKey({
         label: 'sync-ppg',
-        collectionPermissions: [{ collection: { publicId }, action: PermissionAction.READ }],
+        collectionPermissions: [{ collection: { publicId }, action: CollectionPermissionAction.READ }],
       })
       const utilisateur = await fixtures.utilisateur({
         email,
-        collectionPermissions: [{ collection: { publicId }, action: PermissionAction.READ }],
+        collectionPermissions: [{ collection: { publicId }, action: CollectionPermissionAction.READ }],
       })
       const admin = await fixtures.apiKey({ role: 'ADMIN' })
 
@@ -70,13 +70,13 @@ describe.concurrent('listCollectionPermissions', () => {
           principalId: cle.id,
           type: 'API_KEY',
           libelle: 'sync-ppg',
-          actions: [PermissionAction.READ],
+          actions: [CollectionPermissionAction.READ],
         },
         {
           principalId: utilisateur.id,
           type: 'UTILISATEUR',
           libelle: email,
-          actions: [PermissionAction.READ],
+          actions: [CollectionPermissionAction.READ],
         },
       ])
     }),
@@ -89,7 +89,7 @@ describe.concurrent('listCollectionPermissions', () => {
       await fixtures.collection({ publicId })
       await fixtures.utilisateur({
         email: testEmail(),
-        collectionPermissions: [{ collection: { publicId }, action: PermissionAction.READ }],
+        collectionPermissions: [{ collection: { publicId }, action: CollectionPermissionAction.READ }],
       })
       const apiKey = await fixtures.apiKey()
 

--- a/apps/kpilote-api/src/collection/queries/listCollectionPermissions.ts
+++ b/apps/kpilote-api/src/collection/queries/listCollectionPermissions.ts
@@ -1,19 +1,20 @@
 import {
   type CollectionPermissionsApiModel,
-  type PermissionActionValue,
+  type CollectionPermissionActionValue,
+  CollectionPermissionAction,
 } from '@pilote/kpilote-shared/permission'
 import { ResultAsync } from 'neverthrow'
 
 import { ensurePrincipal, isApiKeyAdmin } from '@/framework/auth/principalPredicates'
 import { db } from '@/framework/persistence/dbStore'
 import { MESSAGE_ADMIN } from '@/collection/utils'
-import { PermissionAction } from '@/generated/prisma/enums'
+import { sortByOrder } from '@/permission/utils'
 
 type Entree = CollectionPermissionsApiModel['items'][number]
 
-const ORDRE_ACTIONS: PermissionActionValue[] = [
-  PermissionAction.READ,
-  PermissionAction.WRITE_COMMENT,
+const ORDRE_ACTIONS: CollectionPermissionActionValue[] = [
+  CollectionPermissionAction.READ,
+  CollectionPermissionAction.WRITE_COMMENT,
 ]
 
 const performList = async (publicId: string): Promise<CollectionPermissionsApiModel> => {
@@ -42,7 +43,7 @@ const performList = async (publicId: string): Promise<CollectionPermissionsApiMo
   const items = [...parPrincipal.values()]
     .map((entree) => ({
       ...entree,
-      actions: ORDRE_ACTIONS.filter((action) => entree.actions.includes(action)),
+      actions: sortByOrder(entree.actions, ORDRE_ACTIONS),
     }))
     .sort((a, b) => a.type.localeCompare(b.type) || a.libelle.localeCompare(b.libelle))
 

--- a/apps/kpilote-api/src/collection/queries/listCollectionPermissions.ts
+++ b/apps/kpilote-api/src/collection/queries/listCollectionPermissions.ts
@@ -8,7 +8,7 @@ import { ResultAsync } from 'neverthrow'
 import { ensurePrincipal, isApiKeyAdmin } from '@/framework/auth/principalPredicates'
 import { db } from '@/framework/persistence/dbStore'
 import { MESSAGE_ADMIN } from '@/collection/utils'
-import { sortByOrder } from '@/permission/utils'
+import { sortByOrder } from '@/permission/order'
 
 type Entree = CollectionPermissionsApiModel['items'][number]
 

--- a/apps/kpilote-api/src/collection/queries/listCollections.test.ts
+++ b/apps/kpilote-api/src/collection/queries/listCollections.test.ts
@@ -1,4 +1,4 @@
-import { PermissionAction } from '@/generated/prisma/enums'
+import { CollectionPermissionAction } from '@/generated/prisma/enums'
 import { describe, expect, it } from 'vitest'
 
 import { encodeCursor } from '@/framework/persistence/paginate'
@@ -58,7 +58,7 @@ describe.concurrent('listCollections', () => {
       )
       const apiKey = await fixtures.apiKey({
         collectionPermissions: [
-          { collection: { publicId: colPermAcc }, action: PermissionAction.READ },
+          { collection: { publicId: colPermAcc }, action: CollectionPermissionAction.READ },
         ],
       })
 

--- a/apps/kpilote-api/src/commentaire/commands/creerCommentaire.test.ts
+++ b/apps/kpilote-api/src/commentaire/commands/creerCommentaire.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest'
 import { creerCommentaire } from '@/commentaire/commands/creerCommentaire'
 import { indicateurIndividuConfig } from '@/indicateur/commands/creerIndicateurIndividuCommentaire'
 import { db } from '@/framework/persistence/dbStore'
-import { PermissionAction } from '@/generated/prisma/enums'
+import { IndicateurPermissionAction } from '@/generated/prisma/enums'
 import { fixtures } from '@/test/fixtures'
 import { integrationTest } from '@/test/integrationTest'
 import { testIndicateurId, testIndividuId } from '@/test/randomIds'
@@ -18,7 +18,7 @@ describe.concurrent('creerCommentaire', () => {
       const indicateur = await fixtures.indicateur({ publicId: indId })
       await fixtures.individu({ publicId: indivId })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.WRITE_COMMENT }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_COMMENT }],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>
@@ -69,7 +69,7 @@ describe.concurrent('creerCommentaire', () => {
       await fixtures.indicateur({ publicId: indId })
       await fixtures.individu({ publicId: indivId })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.WRITE_COMMENT }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_COMMENT }],
       })
       const creerBrouillon = () =>
         runAsPrincipal(apiKey.id, () =>

--- a/apps/kpilote-api/src/commentaire/commands/creerCommentaire.test.ts
+++ b/apps/kpilote-api/src/commentaire/commands/creerCommentaire.test.ts
@@ -18,7 +18,9 @@ describe.concurrent('creerCommentaire', () => {
       const indicateur = await fixtures.indicateur({ publicId: indId })
       await fixtures.individu({ publicId: indivId })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_COMMENT }],
+        permissions: [
+          { indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_COMMENT },
+        ],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>
@@ -69,7 +71,9 @@ describe.concurrent('creerCommentaire', () => {
       await fixtures.indicateur({ publicId: indId })
       await fixtures.individu({ publicId: indivId })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_COMMENT }],
+        permissions: [
+          { indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_COMMENT },
+        ],
       })
       const creerBrouillon = () =>
         runAsPrincipal(apiKey.id, () =>

--- a/apps/kpilote-api/src/commentaire/commands/modifierCommentaire.test.ts
+++ b/apps/kpilote-api/src/commentaire/commands/modifierCommentaire.test.ts
@@ -14,7 +14,9 @@ describe.concurrent('modifierCommentaire', () => {
     integrationTest(async () => {
       const indId = testIndicateurId()
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_COMMENT }],
+        permissions: [
+          { indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_COMMENT },
+        ],
       })
       const c = await fixtures.commentaire({
         indicateur: { publicId: indId },
@@ -39,10 +41,14 @@ describe.concurrent('modifierCommentaire', () => {
     integrationTest(async () => {
       const indId = testIndicateurId()
       const auteur = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_COMMENT }],
+        permissions: [
+          { indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_COMMENT },
+        ],
       })
       const autre = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_COMMENT }],
+        permissions: [
+          { indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_COMMENT },
+        ],
       })
       const c = await fixtures.commentaire({
         indicateur: { publicId: indId },

--- a/apps/kpilote-api/src/commentaire/commands/modifierCommentaire.test.ts
+++ b/apps/kpilote-api/src/commentaire/commands/modifierCommentaire.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import { modifierCommentaire } from '@/commentaire/commands/modifierCommentaire'
 import { db } from '@/framework/persistence/dbStore'
-import { PermissionAction } from '@/generated/prisma/enums'
+import { IndicateurPermissionAction } from '@/generated/prisma/enums'
 import { fixtures } from '@/test/fixtures'
 import { integrationTest } from '@/test/integrationTest'
 import { testIndicateurId, testIndividuId } from '@/test/randomIds'
@@ -14,7 +14,7 @@ describe.concurrent('modifierCommentaire', () => {
     integrationTest(async () => {
       const indId = testIndicateurId()
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.WRITE_COMMENT }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_COMMENT }],
       })
       const c = await fixtures.commentaire({
         indicateur: { publicId: indId },
@@ -39,10 +39,10 @@ describe.concurrent('modifierCommentaire', () => {
     integrationTest(async () => {
       const indId = testIndicateurId()
       const auteur = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.WRITE_COMMENT }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_COMMENT }],
       })
       const autre = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.WRITE_COMMENT }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_COMMENT }],
       })
       const c = await fixtures.commentaire({
         indicateur: { publicId: indId },

--- a/apps/kpilote-api/src/commentaire/commands/supprimerCommentaire.test.ts
+++ b/apps/kpilote-api/src/commentaire/commands/supprimerCommentaire.test.ts
@@ -14,7 +14,9 @@ describe.concurrent('supprimerCommentaire', () => {
     integrationTest(async () => {
       const indId = testIndicateurId()
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_COMMENT }],
+        permissions: [
+          { indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_COMMENT },
+        ],
       })
       const c = await fixtures.commentaire({
         indicateur: { publicId: indId },

--- a/apps/kpilote-api/src/commentaire/commands/supprimerCommentaire.test.ts
+++ b/apps/kpilote-api/src/commentaire/commands/supprimerCommentaire.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import { supprimerCommentaire } from '@/commentaire/commands/supprimerCommentaire'
 import { db } from '@/framework/persistence/dbStore'
-import { PermissionAction } from '@/generated/prisma/enums'
+import { IndicateurPermissionAction } from '@/generated/prisma/enums'
 import { fixtures } from '@/test/fixtures'
 import { integrationTest } from '@/test/integrationTest'
 import { testIndicateurId, testIndividuId } from '@/test/randomIds'
@@ -14,7 +14,7 @@ describe.concurrent('supprimerCommentaire', () => {
     integrationTest(async () => {
       const indId = testIndicateurId()
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.WRITE_COMMENT }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_COMMENT }],
       })
       const c = await fixtures.commentaire({
         indicateur: { publicId: indId },

--- a/apps/kpilote-api/src/commentaire/queries/getDernierBrouillon.test.ts
+++ b/apps/kpilote-api/src/commentaire/queries/getDernierBrouillon.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import { getDernierBrouillon } from '@/commentaire/queries/getDernierBrouillon'
 import { indicateurIndividuConfig } from '@/indicateur/commands/creerIndicateurIndividuCommentaire'
-import { PermissionAction } from '@/generated/prisma/enums'
+import { IndicateurPermissionAction } from '@/generated/prisma/enums'
 import { fixtures } from '@/test/fixtures'
 import { integrationTest } from '@/test/integrationTest'
 import { testIndicateurId, testIndividuId } from '@/test/randomIds'
@@ -17,7 +17,7 @@ describe.concurrent('getDernierBrouillon', () => {
       await fixtures.indicateur({ publicId: indId })
       await fixtures.individu({ publicId: indivId })
       const moi = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.READ }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.READ }],
       })
       const autre = await fixtures.apiKey({ permissions: [] })
       const scope = { indicateur: { publicId: indId }, individu: { publicId: indivId } }
@@ -56,7 +56,7 @@ describe.concurrent('getDernierBrouillon', () => {
       await fixtures.indicateur({ publicId: indId })
       await fixtures.individu({ publicId: indivId })
       const moi = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.READ }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.READ }],
       })
       await fixtures.commentaire({
         indicateur: { publicId: indId },

--- a/apps/kpilote-api/src/commentaire/queries/listerCommentaires.test.ts
+++ b/apps/kpilote-api/src/commentaire/queries/listerCommentaires.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import { listerCommentaires } from '@/commentaire/queries/listerCommentaires'
 import { indicateurIndividuConfig } from '@/indicateur/commands/creerIndicateurIndividuCommentaire'
-import { PermissionAction } from '@/generated/prisma/enums'
+import { IndicateurPermissionAction } from '@/generated/prisma/enums'
 import { fixtures } from '@/test/fixtures'
 import { integrationTest } from '@/test/integrationTest'
 import { testIndicateurId, testIndividuId } from '@/test/randomIds'
@@ -17,7 +17,7 @@ describe.concurrent('listerCommentaires', () => {
       await fixtures.indicateur({ publicId: indId })
       await fixtures.individu({ publicId: indivId })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.READ }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.READ }],
       })
       await fixtures.commentaire({
         indicateur: { publicId: indId },
@@ -58,7 +58,7 @@ describe.concurrent('listerCommentaires', () => {
       await fixtures.indicateur({ publicId: indId })
       await fixtures.individu({ publicId: indivId })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.READ }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.READ }],
       })
       await fixtures.commentaire({
         indicateur: { publicId: indId },
@@ -94,7 +94,7 @@ describe.concurrent('listerCommentaires', () => {
       await fixtures.indicateur({ publicId: indId })
       await fixtures.individu({ publicId: indivId })
       const moi = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.READ }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.READ }],
       })
       const scope = { indicateur: { publicId: indId }, individu: { publicId: indivId } }
       await fixtures.commentaire({ ...scope, createdBy: moi.id, type: 'DEFAUT', statut: 'PUBLIE' })

--- a/apps/kpilote-api/src/indicateur/commands/upsertIndicateur.test.ts
+++ b/apps/kpilote-api/src/indicateur/commands/upsertIndicateur.test.ts
@@ -1,4 +1,4 @@
-import { PermissionAction } from '@/generated/prisma/enums'
+import { IndicateurPermissionAction } from '@/generated/prisma/enums'
 import { describe, expect, it } from 'vitest'
 import { uuidv7 } from 'uuidv7'
 
@@ -124,9 +124,9 @@ describe.concurrent('upsertIndicateur', () => {
         orderBy: { action: 'asc' },
       })
       expect(grants.map((g) => g.action)).toEqual([
-        PermissionAction.READ,
-        PermissionAction.WRITE_DATA,
-        PermissionAction.WRITE_COMMENT,
+        IndicateurPermissionAction.READ,
+        IndicateurPermissionAction.WRITE_DATA,
+        IndicateurPermissionAction.WRITE_COMMENT,
       ])
     }),
   )
@@ -256,7 +256,7 @@ describe.concurrent('upsertIndicateur', () => {
       const indId = testIndicateurId()
       await fixtures.indicateur({ publicId: indId, visibilite: 'PRIVE' })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.WRITE_DATA }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_DATA }],
       })
 
       await runAsAdmin(apiKey.id, () =>
@@ -420,7 +420,7 @@ describe.concurrent('upsertIndicateur', () => {
       const indId = testIndicateurId()
       await fixtures.indicateur({ publicId: indId, nom: 'Ancien' })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.READ }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.READ }],
       })
 
       await expect(
@@ -653,7 +653,7 @@ describe.concurrent('upsertIndicateur — garde ADMIN', () => {
     integrationTest(async () => {
       const indId = testIndicateurId()
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.WRITE_DATA }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_DATA }],
       })
 
       await expect(

--- a/apps/kpilote-api/src/indicateur/commands/upsertIndicateur.test.ts
+++ b/apps/kpilote-api/src/indicateur/commands/upsertIndicateur.test.ts
@@ -256,7 +256,9 @@ describe.concurrent('upsertIndicateur', () => {
       const indId = testIndicateurId()
       await fixtures.indicateur({ publicId: indId, visibilite: 'PRIVE' })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_DATA }],
+        permissions: [
+          { indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_DATA },
+        ],
       })
 
       await runAsAdmin(apiKey.id, () =>
@@ -653,7 +655,9 @@ describe.concurrent('upsertIndicateur — garde ADMIN', () => {
     integrationTest(async () => {
       const indId = testIndicateurId()
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_DATA }],
+        permissions: [
+          { indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_DATA },
+        ],
       })
 
       await expect(

--- a/apps/kpilote-api/src/indicateur/commands/upsertIndicateur.ts
+++ b/apps/kpilote-api/src/indicateur/commands/upsertIndicateur.ts
@@ -9,7 +9,7 @@ import { ensurePrincipal, isApiKeyAdmin, isOidcUser } from '@/framework/auth/pri
 import { requireCurrentPrincipalId } from '@/framework/auth/userContext'
 import { ForbiddenError, ValidationError } from '@/framework/errors/AppError'
 import { db } from '@/framework/persistence/dbStore'
-import { type FonctionAgregation, PermissionAction } from '@/generated/prisma/enums'
+import { type FonctionAgregation, IndicateurPermissionAction } from '@/generated/prisma/enums'
 
 type ConfigurationResolue = {
   referentielId: string
@@ -139,7 +139,7 @@ const assertWritePermission = async (indicateurId: string, principalId: string):
       principalId_indicateurId_action: {
         principalId,
         indicateurId,
-        action: PermissionAction.WRITE_DATA,
+        action: IndicateurPermissionAction.WRITE_DATA,
       },
     },
   })
@@ -191,9 +191,9 @@ const updateIndicateurExistant = async (
 const grantOwnerPermissions = async (principalId: string, indicateurId: string): Promise<void> => {
   await db().indicateurPermission.createMany({
     data: [
-      { principalId, indicateurId, action: PermissionAction.READ },
-      { principalId, indicateurId, action: PermissionAction.WRITE_DATA },
-      { principalId, indicateurId, action: PermissionAction.WRITE_COMMENT },
+      { principalId, indicateurId, action: IndicateurPermissionAction.READ },
+      { principalId, indicateurId, action: IndicateurPermissionAction.WRITE_DATA },
+      { principalId, indicateurId, action: IndicateurPermissionAction.WRITE_COMMENT },
     ],
   })
 }

--- a/apps/kpilote-api/src/indicateur/permissions.test.ts
+++ b/apps/kpilote-api/src/indicateur/permissions.test.ts
@@ -1,4 +1,4 @@
-import { PermissionAction } from '@/generated/prisma/enums'
+import { CollectionPermissionAction, IndicateurPermissionAction } from '@/generated/prisma/enums'
 import { describe, expect, it } from 'vitest'
 
 import { db } from '@/framework/persistence/dbStore'
@@ -51,7 +51,7 @@ describe.concurrent('withIndicateurReadPermission', () => {
       const [priv] = testIndicateurIds(1)
       await fixtures.indicateur({ publicId: priv, visibilite: 'PRIVE' })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: priv }, action: PermissionAction.READ }],
+        permissions: [{ indicateur: { publicId: priv }, action: IndicateurPermissionAction.READ }],
       })
 
       const rows = await listIndicateursWithReadPermission(apiKey.id)
@@ -66,7 +66,7 @@ describe.concurrent('withIndicateurReadPermission', () => {
       const [priv] = testIndicateurIds(1)
       await fixtures.indicateur({ publicId: priv, visibilite: 'PRIVE' })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: priv }, action: PermissionAction.WRITE_DATA }],
+        permissions: [{ indicateur: { publicId: priv }, action: IndicateurPermissionAction.WRITE_DATA }],
       })
 
       const rows = await listIndicateursWithReadPermission(apiKey.id)
@@ -81,7 +81,7 @@ describe.concurrent('withIndicateurReadPermission', () => {
       const [priv] = testIndicateurIds(1)
       await fixtures.indicateur({ publicId: priv, visibilite: 'PRIVE' })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: priv }, action: PermissionAction.WRITE_COMMENT }],
+        permissions: [{ indicateur: { publicId: priv }, action: IndicateurPermissionAction.WRITE_COMMENT }],
       })
 
       const rows = await listIndicateursWithReadPermission(apiKey.id)
@@ -103,7 +103,7 @@ describe.concurrent('withIndicateurReadPermission', () => {
       })
       const apiKey = await fixtures.apiKey({
         collectionPermissions: [
-          { collection: { publicId: colRpropR }, action: PermissionAction.READ },
+          { collection: { publicId: colRpropR }, action: CollectionPermissionAction.READ },
         ],
       })
 
@@ -126,7 +126,7 @@ describe.concurrent('withIndicateurReadPermission', () => {
       })
       const apiKey = await fixtures.apiKey({
         collectionPermissions: [
-          { collection: { publicId: colRpropW }, action: PermissionAction.WRITE_COMMENT },
+          { collection: { publicId: colRpropW }, action: CollectionPermissionAction.WRITE_COMMENT },
         ],
       })
 
@@ -195,7 +195,7 @@ describe.concurrent('ensureIndicateurWriteDataPermission', () => {
       const [pub] = testIndicateurIds(1)
       const indicateur = await fixtures.indicateur({ publicId: pub, visibilite: 'PRIVE' })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: pub }, action: PermissionAction.WRITE_DATA }],
+        permissions: [{ indicateur: { publicId: pub }, action: IndicateurPermissionAction.WRITE_DATA }],
       })
 
       const result = await ensureIndicateurWriteDataPermission({
@@ -213,7 +213,7 @@ describe.concurrent('ensureIndicateurWriteDataPermission', () => {
       const [pub] = testIndicateurIds(1)
       const indicateur = await fixtures.indicateur({ publicId: pub, visibilite: 'PRIVE' })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: pub }, action: PermissionAction.READ }],
+        permissions: [{ indicateur: { publicId: pub }, action: IndicateurPermissionAction.READ }],
       })
 
       await expect(
@@ -231,7 +231,7 @@ describe.concurrent('ensureIndicateurWriteDataPermission', () => {
       const [pub] = testIndicateurIds(1)
       const indicateur = await fixtures.indicateur({ publicId: pub, visibilite: 'PRIVE' })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: pub }, action: PermissionAction.WRITE_COMMENT }],
+        permissions: [{ indicateur: { publicId: pub }, action: IndicateurPermissionAction.WRITE_COMMENT }],
       })
 
       await expect(
@@ -272,7 +272,7 @@ describe.concurrent('ensureIndicateurWriteDataPermission', () => {
       })
       const apiKey = await fixtures.apiKey({
         collectionPermissions: [
-          { collection: { publicId: colWpropNo }, action: PermissionAction.WRITE_COMMENT },
+          { collection: { publicId: colWpropNo }, action: CollectionPermissionAction.WRITE_COMMENT },
         ],
       })
 
@@ -293,7 +293,7 @@ describe.concurrent('ensureIndicateurWriteCommentPermission', () => {
       const [pub] = testIndicateurIds(1)
       const indicateur = await fixtures.indicateur({ publicId: pub, visibilite: 'PRIVE' })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: pub }, action: PermissionAction.WRITE_COMMENT }],
+        permissions: [{ indicateur: { publicId: pub }, action: IndicateurPermissionAction.WRITE_COMMENT }],
       })
 
       const result = await ensureIndicateurWriteCommentPermission({
@@ -311,7 +311,7 @@ describe.concurrent('ensureIndicateurWriteCommentPermission', () => {
       const [pub] = testIndicateurIds(1)
       const indicateur = await fixtures.indicateur({ publicId: pub, visibilite: 'PRIVE' })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: pub }, action: PermissionAction.READ }],
+        permissions: [{ indicateur: { publicId: pub }, action: IndicateurPermissionAction.READ }],
       })
 
       await expect(
@@ -329,7 +329,7 @@ describe.concurrent('ensureIndicateurWriteCommentPermission', () => {
       const [pub] = testIndicateurIds(1)
       const indicateur = await fixtures.indicateur({ publicId: pub, visibilite: 'PRIVE' })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: pub }, action: PermissionAction.WRITE_DATA }],
+        permissions: [{ indicateur: { publicId: pub }, action: IndicateurPermissionAction.WRITE_DATA }],
       })
 
       await expect(
@@ -370,7 +370,7 @@ describe.concurrent('ensureIndicateurWriteCommentPermission', () => {
       })
       const apiKey = await fixtures.apiKey({
         collectionPermissions: [
-          { collection: { publicId: colWpropNo }, action: PermissionAction.WRITE_COMMENT },
+          { collection: { publicId: colWpropNo }, action: CollectionPermissionAction.WRITE_COMMENT },
         ],
       })
 

--- a/apps/kpilote-api/src/indicateur/permissions.test.ts
+++ b/apps/kpilote-api/src/indicateur/permissions.test.ts
@@ -66,7 +66,9 @@ describe.concurrent('withIndicateurReadPermission', () => {
       const [priv] = testIndicateurIds(1)
       await fixtures.indicateur({ publicId: priv, visibilite: 'PRIVE' })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: priv }, action: IndicateurPermissionAction.WRITE_DATA }],
+        permissions: [
+          { indicateur: { publicId: priv }, action: IndicateurPermissionAction.WRITE_DATA },
+        ],
       })
 
       const rows = await listIndicateursWithReadPermission(apiKey.id)
@@ -81,7 +83,9 @@ describe.concurrent('withIndicateurReadPermission', () => {
       const [priv] = testIndicateurIds(1)
       await fixtures.indicateur({ publicId: priv, visibilite: 'PRIVE' })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: priv }, action: IndicateurPermissionAction.WRITE_COMMENT }],
+        permissions: [
+          { indicateur: { publicId: priv }, action: IndicateurPermissionAction.WRITE_COMMENT },
+        ],
       })
 
       const rows = await listIndicateursWithReadPermission(apiKey.id)
@@ -195,7 +199,9 @@ describe.concurrent('ensureIndicateurWriteDataPermission', () => {
       const [pub] = testIndicateurIds(1)
       const indicateur = await fixtures.indicateur({ publicId: pub, visibilite: 'PRIVE' })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: pub }, action: IndicateurPermissionAction.WRITE_DATA }],
+        permissions: [
+          { indicateur: { publicId: pub }, action: IndicateurPermissionAction.WRITE_DATA },
+        ],
       })
 
       const result = await ensureIndicateurWriteDataPermission({
@@ -231,7 +237,9 @@ describe.concurrent('ensureIndicateurWriteDataPermission', () => {
       const [pub] = testIndicateurIds(1)
       const indicateur = await fixtures.indicateur({ publicId: pub, visibilite: 'PRIVE' })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: pub }, action: IndicateurPermissionAction.WRITE_COMMENT }],
+        permissions: [
+          { indicateur: { publicId: pub }, action: IndicateurPermissionAction.WRITE_COMMENT },
+        ],
       })
 
       await expect(
@@ -272,7 +280,10 @@ describe.concurrent('ensureIndicateurWriteDataPermission', () => {
       })
       const apiKey = await fixtures.apiKey({
         collectionPermissions: [
-          { collection: { publicId: colWpropNo }, action: CollectionPermissionAction.WRITE_COMMENT },
+          {
+            collection: { publicId: colWpropNo },
+            action: CollectionPermissionAction.WRITE_COMMENT,
+          },
         ],
       })
 
@@ -293,7 +304,9 @@ describe.concurrent('ensureIndicateurWriteCommentPermission', () => {
       const [pub] = testIndicateurIds(1)
       const indicateur = await fixtures.indicateur({ publicId: pub, visibilite: 'PRIVE' })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: pub }, action: IndicateurPermissionAction.WRITE_COMMENT }],
+        permissions: [
+          { indicateur: { publicId: pub }, action: IndicateurPermissionAction.WRITE_COMMENT },
+        ],
       })
 
       const result = await ensureIndicateurWriteCommentPermission({
@@ -329,7 +342,9 @@ describe.concurrent('ensureIndicateurWriteCommentPermission', () => {
       const [pub] = testIndicateurIds(1)
       const indicateur = await fixtures.indicateur({ publicId: pub, visibilite: 'PRIVE' })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: pub }, action: IndicateurPermissionAction.WRITE_DATA }],
+        permissions: [
+          { indicateur: { publicId: pub }, action: IndicateurPermissionAction.WRITE_DATA },
+        ],
       })
 
       await expect(
@@ -370,7 +385,10 @@ describe.concurrent('ensureIndicateurWriteCommentPermission', () => {
       })
       const apiKey = await fixtures.apiKey({
         collectionPermissions: [
-          { collection: { publicId: colWpropNo }, action: CollectionPermissionAction.WRITE_COMMENT },
+          {
+            collection: { publicId: colWpropNo },
+            action: CollectionPermissionAction.WRITE_COMMENT,
+          },
         ],
       })
 

--- a/apps/kpilote-api/src/indicateur/permissions.ts
+++ b/apps/kpilote-api/src/indicateur/permissions.ts
@@ -4,9 +4,9 @@ import { ForbiddenError } from '@/framework/errors/AppError'
 import { db } from '@/framework/persistence/dbStore'
 import { Prisma } from '@/generated/prisma/client'
 import { IndicateurPermissionAction, Visibilite } from '@/generated/prisma/enums'
-import { COLLECTION_READ_PERMISSIONS } from '@/collection/permissions'
+import { COLLECTION_PERMISSIONS_GRANTING_READ } from '@/collection/permissions'
 
-const INDICATEUR_READ_PERMISSIONS: IndicateurPermissionAction[] = [
+const INDICATEUR_PERMISSIONS_GRANTING_READ: IndicateurPermissionAction[] = [
   IndicateurPermissionAction.READ,
   IndicateurPermissionAction.WRITE_DATA,
   IndicateurPermissionAction.WRITE_COMMENT,
@@ -33,13 +33,17 @@ export const withIndicateurReadPermission = (
       {
         OR: [
           { visibilite: Visibilite.PUBLIC },
-          { permissions: { some: { principalId, action: { in: INDICATEUR_READ_PERMISSIONS } } } },
+          {
+            permissions: {
+              some: { principalId, action: { in: INDICATEUR_PERMISSIONS_GRANTING_READ } },
+            },
+          },
           {
             collections: {
               some: {
                 collection: {
                   permissions: {
-                    some: { principalId, action: { in: COLLECTION_READ_PERMISSIONS } },
+                    some: { principalId, action: { in: COLLECTION_PERMISSIONS_GRANTING_READ } },
                   },
                 },
               },

--- a/apps/kpilote-api/src/indicateur/permissions.ts
+++ b/apps/kpilote-api/src/indicateur/permissions.ts
@@ -3,13 +3,13 @@ import { ResultAsync } from 'neverthrow'
 import { ForbiddenError } from '@/framework/errors/AppError'
 import { db } from '@/framework/persistence/dbStore'
 import { Prisma } from '@/generated/prisma/client'
-import { PermissionAction, Visibilite } from '@/generated/prisma/enums'
+import { IndicateurPermissionAction, Visibilite } from '@/generated/prisma/enums'
 import { COLLECTION_READ_PERMISSIONS } from '@/collection/permissions'
 
-const INDICATEUR_READ_PERMISSIONS: PermissionAction[] = [
-  PermissionAction.READ,
-  PermissionAction.WRITE_DATA,
-  PermissionAction.WRITE_COMMENT,
+const INDICATEUR_READ_PERMISSIONS: IndicateurPermissionAction[] = [
+  IndicateurPermissionAction.READ,
+  IndicateurPermissionAction.WRITE_DATA,
+  IndicateurPermissionAction.WRITE_COMMENT,
 ]
 
 // La permission de lecture sur un indicateur est accordée si :
@@ -65,7 +65,7 @@ export const ensureIndicateurWriteDataPermission = ({
           principalId_indicateurId_action: {
             principalId,
             indicateurId,
-            action: PermissionAction.WRITE_DATA,
+            action: IndicateurPermissionAction.WRITE_DATA,
           },
         },
       })
@@ -92,7 +92,7 @@ export const ensureIndicateurWriteCommentPermission = ({
           principalId_indicateurId_action: {
             principalId,
             indicateurId,
-            action: PermissionAction.WRITE_COMMENT,
+            action: IndicateurPermissionAction.WRITE_COMMENT,
           },
         },
       })

--- a/apps/kpilote-api/src/indicateur/queries/getIndicateurByPublicId.test.ts
+++ b/apps/kpilote-api/src/indicateur/queries/getIndicateurByPublicId.test.ts
@@ -207,7 +207,9 @@ describe.concurrent('getIndicateurByPublicId', () => {
       const indId = testIndicateurId()
       await fixtures.indicateur({ publicId: indId })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_DATA }],
+        permissions: [
+          { indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_DATA },
+        ],
       })
 
       const result = await runAsPrincipal(apiKey.id, () => getIndicateurByPublicId(indId))
@@ -318,7 +320,9 @@ describe.concurrent('getIndicateurByPublicId', () => {
       })
       await fixtures.collection({ publicId: colId, indicateurs: [{ publicId: indId }] })
       const apiKey = await fixtures.apiKey({
-        collectionPermissions: [{ collection: { publicId: colId }, action: CollectionPermissionAction.READ }],
+        collectionPermissions: [
+          { collection: { publicId: colId }, action: CollectionPermissionAction.READ },
+        ],
       })
 
       const result = await runAsPrincipal(apiKey.id, () => getIndicateurByPublicId(indId))

--- a/apps/kpilote-api/src/indicateur/queries/getIndicateurByPublicId.test.ts
+++ b/apps/kpilote-api/src/indicateur/queries/getIndicateurByPublicId.test.ts
@@ -1,4 +1,4 @@
-import { PermissionAction } from '@/generated/prisma/enums'
+import { CollectionPermissionAction, IndicateurPermissionAction } from '@/generated/prisma/enums'
 import { describe, expect, it } from 'vitest'
 
 import { db } from '@/framework/persistence/dbStore'
@@ -27,7 +27,7 @@ describe.concurrent('getIndicateurByPublicId', () => {
         ],
       })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.READ }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.READ }],
       })
 
       const result = await runAsPrincipal(apiKey.id, () => getIndicateurByPublicId(indId))
@@ -75,7 +75,7 @@ describe.concurrent('getIndicateurByPublicId', () => {
       const indId = testIndicateurId()
       await fixtures.indicateur({ publicId: indId, unite: 'POURCENTAGE' })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.READ }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.READ }],
       })
 
       const result = await runAsPrincipal(apiKey.id, () => getIndicateurByPublicId(indId))
@@ -102,7 +102,7 @@ describe.concurrent('getIndicateurByPublicId', () => {
         jourMiseAJour: 15,
       })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.READ }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.READ }],
       })
 
       const result = await runAsPrincipal(apiKey.id, () => getIndicateurByPublicId(indId))
@@ -141,7 +141,7 @@ describe.concurrent('getIndicateurByPublicId', () => {
         },
       )
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.READ }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.READ }],
       })
 
       const result = await runAsPrincipal(apiKey.id, () => getIndicateurByPublicId(indId))
@@ -172,7 +172,7 @@ describe.concurrent('getIndicateurByPublicId', () => {
         },
       })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.READ }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.READ }],
       })
 
       const result = await runAsPrincipal(apiKey.id, () => getIndicateurByPublicId(indId))
@@ -207,7 +207,7 @@ describe.concurrent('getIndicateurByPublicId', () => {
       const indId = testIndicateurId()
       await fixtures.indicateur({ publicId: indId })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.WRITE_DATA }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_DATA }],
       })
 
       const result = await runAsPrincipal(apiKey.id, () => getIndicateurByPublicId(indId))
@@ -318,7 +318,7 @@ describe.concurrent('getIndicateurByPublicId', () => {
       })
       await fixtures.collection({ publicId: colId, indicateurs: [{ publicId: indId }] })
       const apiKey = await fixtures.apiKey({
-        collectionPermissions: [{ collection: { publicId: colId }, action: PermissionAction.READ }],
+        collectionPermissions: [{ collection: { publicId: colId }, action: CollectionPermissionAction.READ }],
       })
 
       const result = await runAsPrincipal(apiKey.id, () => getIndicateurByPublicId(indId))

--- a/apps/kpilote-api/src/indicateur/queries/listIndicateurs.test.ts
+++ b/apps/kpilote-api/src/indicateur/queries/listIndicateurs.test.ts
@@ -1,4 +1,4 @@
-import { PermissionAction } from '@/generated/prisma/enums'
+import { CollectionPermissionAction, IndicateurPermissionAction } from '@/generated/prisma/enums'
 import { describe, expect, it } from 'vitest'
 
 import { db } from '@/framework/persistence/dbStore'
@@ -31,7 +31,7 @@ describe.concurrent('listIndicateurs', () => {
       const [accessible, hidden] = testIndicateurIds(2)
       await fixtures.indicateur({ publicId: accessible }, { publicId: hidden })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: accessible }, action: PermissionAction.READ }],
+        permissions: [{ indicateur: { publicId: accessible }, action: IndicateurPermissionAction.READ }],
       })
 
       const result = await runAsPrincipal(apiKey.id, () => listIndicateurs({}))
@@ -76,7 +76,7 @@ describe.concurrent('listIndicateurs', () => {
       })
       const apiKey = await fixtures.apiKey({
         collectionPermissions: [
-          { collection: { publicId: colPropag }, action: PermissionAction.READ },
+          { collection: { publicId: colPropag }, action: CollectionPermissionAction.READ },
         ],
       })
 
@@ -101,7 +101,7 @@ describe.concurrent('listIndicateurs', () => {
       })
       const apiKey = await fixtures.apiKey({
         collectionPermissions: [
-          { collection: { publicId: colPropag }, action: PermissionAction.WRITE_COMMENT },
+          { collection: { publicId: colPropag }, action: CollectionPermissionAction.WRITE_COMMENT },
         ],
       })
 
@@ -123,9 +123,9 @@ describe.concurrent('listIndicateurs', () => {
       )
       const apiKey = await fixtures.apiKey({
         permissions: [
-          { indicateur: { publicId: ind1 }, action: PermissionAction.READ },
-          { indicateur: { publicId: ind2 }, action: PermissionAction.READ },
-          { indicateur: { publicId: ind3 }, action: PermissionAction.READ },
+          { indicateur: { publicId: ind1 }, action: IndicateurPermissionAction.READ },
+          { indicateur: { publicId: ind2 }, action: IndicateurPermissionAction.READ },
+          { indicateur: { publicId: ind3 }, action: IndicateurPermissionAction.READ },
         ],
       })
 
@@ -153,7 +153,7 @@ describe.concurrent('listIndicateurs', () => {
       const apiKey = await fixtures.apiKey({
         permissions: ids.map((publicId) => ({
           indicateur: { publicId },
-          action: PermissionAction.READ,
+          action: IndicateurPermissionAction.READ,
         })),
       })
 
@@ -181,7 +181,7 @@ describe.concurrent('listIndicateurs', () => {
       const apiKey = await fixtures.apiKey({
         permissions: ids.map((publicId) => ({
           indicateur: { publicId },
-          action: PermissionAction.READ,
+          action: IndicateurPermissionAction.READ,
         })),
       })
 
@@ -207,9 +207,9 @@ describe.concurrent('listIndicateurs', () => {
       )
       const apiKey = await fixtures.apiKey({
         permissions: [
-          { indicateur: { publicId: ind1 }, action: PermissionAction.READ },
-          { indicateur: { publicId: ind2 }, action: PermissionAction.READ },
-          { indicateur: { publicId: ind3 }, action: PermissionAction.READ },
+          { indicateur: { publicId: ind1 }, action: IndicateurPermissionAction.READ },
+          { indicateur: { publicId: ind2 }, action: IndicateurPermissionAction.READ },
+          { indicateur: { publicId: ind3 }, action: IndicateurPermissionAction.READ },
         ],
       })
 
@@ -240,7 +240,7 @@ describe.concurrent('listIndicateurs', () => {
       const apiKey = await fixtures.apiKey({
         permissions: ids.map((publicId) => ({
           indicateur: { publicId },
-          action: PermissionAction.READ,
+          action: IndicateurPermissionAction.READ,
         })),
       })
 
@@ -262,9 +262,9 @@ describe.concurrent('listIndicateurs', () => {
       await fixtures.indicateur({ publicId: ind1 }, { publicId: ind2 }, { publicId: ind3 })
       const apiKey = await fixtures.apiKey({
         permissions: [
-          { indicateur: { publicId: ind1 }, action: PermissionAction.READ },
-          { indicateur: { publicId: ind2 }, action: PermissionAction.READ },
-          { indicateur: { publicId: ind3 }, action: PermissionAction.READ },
+          { indicateur: { publicId: ind1 }, action: IndicateurPermissionAction.READ },
+          { indicateur: { publicId: ind2 }, action: IndicateurPermissionAction.READ },
+          { indicateur: { publicId: ind3 }, action: IndicateurPermissionAction.READ },
         ],
       })
 
@@ -282,7 +282,7 @@ describe.concurrent('listIndicateurs', () => {
       const [accessible, hidden] = testIndicateurIds(2)
       await fixtures.indicateur({ publicId: accessible }, { publicId: hidden })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: accessible }, action: PermissionAction.READ }],
+        permissions: [{ indicateur: { publicId: accessible }, action: IndicateurPermissionAction.READ }],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>
@@ -313,7 +313,7 @@ describe.concurrent('listIndicateurs', () => {
         ],
       })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: accessible }, action: PermissionAction.READ }],
+        permissions: [{ indicateur: { publicId: accessible }, action: IndicateurPermissionAction.READ }],
       })
 
       const result = await runAsPrincipal(apiKey.id, () => listIndicateurs({}))

--- a/apps/kpilote-api/src/indicateur/queries/listIndicateurs.test.ts
+++ b/apps/kpilote-api/src/indicateur/queries/listIndicateurs.test.ts
@@ -31,7 +31,9 @@ describe.concurrent('listIndicateurs', () => {
       const [accessible, hidden] = testIndicateurIds(2)
       await fixtures.indicateur({ publicId: accessible }, { publicId: hidden })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: accessible }, action: IndicateurPermissionAction.READ }],
+        permissions: [
+          { indicateur: { publicId: accessible }, action: IndicateurPermissionAction.READ },
+        ],
       })
 
       const result = await runAsPrincipal(apiKey.id, () => listIndicateurs({}))
@@ -282,7 +284,9 @@ describe.concurrent('listIndicateurs', () => {
       const [accessible, hidden] = testIndicateurIds(2)
       await fixtures.indicateur({ publicId: accessible }, { publicId: hidden })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: accessible }, action: IndicateurPermissionAction.READ }],
+        permissions: [
+          { indicateur: { publicId: accessible }, action: IndicateurPermissionAction.READ },
+        ],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>
@@ -313,7 +317,9 @@ describe.concurrent('listIndicateurs', () => {
         ],
       })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: accessible }, action: IndicateurPermissionAction.READ }],
+        permissions: [
+          { indicateur: { publicId: accessible }, action: IndicateurPermissionAction.READ },
+        ],
       })
 
       const result = await runAsPrincipal(apiKey.id, () => listIndicateurs({}))

--- a/apps/kpilote-api/src/indicateur/resolveIndicateurAndIndividuForWriteData.test.ts
+++ b/apps/kpilote-api/src/indicateur/resolveIndicateurAndIndividuForWriteData.test.ts
@@ -1,4 +1,4 @@
-import { PermissionAction } from '@/generated/prisma/enums'
+import { IndicateurPermissionAction } from '@/generated/prisma/enums'
 import { describe, expect, it } from 'vitest'
 
 import { ForbiddenError } from '@/framework/errors/AppError'
@@ -25,7 +25,7 @@ describe.concurrent('resolveIndicateurAndIndividuForWriteData', () => {
         referentiel: { publicId: refId },
       })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.WRITE_DATA }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_DATA }],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>
@@ -79,7 +79,7 @@ describe.concurrent('resolveIndicateurAndIndividuForWriteData', () => {
       })
       await fixtures.individu({ publicId: individuId, referentiel: { publicId: refId } })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.READ }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.READ }],
       })
 
       await expect(
@@ -103,7 +103,7 @@ describe.concurrent('resolveIndicateurAndIndividuForWriteData', () => {
         referentiel: { publicId: refId },
       })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.WRITE_DATA }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_DATA }],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>
@@ -131,7 +131,7 @@ describe.concurrent('resolveIndicateurAndIndividuForWriteData', () => {
       })
       await fixtures.individu({ publicId: individuId, referentiel: { publicId: refOrphelin } })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.WRITE_DATA }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_DATA }],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>

--- a/apps/kpilote-api/src/indicateur/resolveIndicateurAndIndividuForWriteData.test.ts
+++ b/apps/kpilote-api/src/indicateur/resolveIndicateurAndIndividuForWriteData.test.ts
@@ -25,7 +25,9 @@ describe.concurrent('resolveIndicateurAndIndividuForWriteData', () => {
         referentiel: { publicId: refId },
       })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_DATA }],
+        permissions: [
+          { indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_DATA },
+        ],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>
@@ -103,7 +105,9 @@ describe.concurrent('resolveIndicateurAndIndividuForWriteData', () => {
         referentiel: { publicId: refId },
       })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_DATA }],
+        permissions: [
+          { indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_DATA },
+        ],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>
@@ -131,7 +135,9 @@ describe.concurrent('resolveIndicateurAndIndividuForWriteData', () => {
       })
       await fixtures.individu({ publicId: individuId, referentiel: { publicId: refOrphelin } })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_DATA }],
+        permissions: [
+          { indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_DATA },
+        ],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>

--- a/apps/kpilote-api/src/me/queries/listerMesPermissions.test.ts
+++ b/apps/kpilote-api/src/me/queries/listerMesPermissions.test.ts
@@ -32,7 +32,10 @@ describe.concurrent('listerMesPermissions', () => {
       })
       const apiKey = await fixtures.apiKey({
         collectionPermissions: [
-          { collection: { publicId: collectionId }, action: CollectionPermissionAction.WRITE_COMMENT },
+          {
+            collection: { publicId: collectionId },
+            action: CollectionPermissionAction.WRITE_COMMENT,
+          },
         ],
       })
 
@@ -78,7 +81,10 @@ describe.concurrent('listerMesPermissions', () => {
       await fixtures.collection({ publicId: collectionId })
       const apiKey = await fixtures.apiKey({
         collectionPermissions: [
-          { collection: { publicId: collectionId }, action: CollectionPermissionAction.WRITE_COMMENT },
+          {
+            collection: { publicId: collectionId },
+            action: CollectionPermissionAction.WRITE_COMMENT,
+          },
           { collection: { publicId: collectionId }, action: CollectionPermissionAction.READ },
         ],
       })
@@ -86,7 +92,10 @@ describe.concurrent('listerMesPermissions', () => {
       const result = await runAsPrincipal(apiKey.id, () => listerMesPermissions())
 
       expect(result._unsafeUnwrap().collections).toEqual([
-        { id: collectionId, actions: [CollectionPermissionAction.READ, CollectionPermissionAction.WRITE_COMMENT] },
+        {
+          id: collectionId,
+          actions: [CollectionPermissionAction.READ, CollectionPermissionAction.WRITE_COMMENT],
+        },
       ])
     }),
   )
@@ -106,7 +115,10 @@ describe.concurrent('listerMesPermissions', () => {
       )
       const apiKey = await fixtures.apiKey({
         collectionPermissions: [
-          { collection: { publicId: collectionWriteId }, action: CollectionPermissionAction.WRITE_COMMENT },
+          {
+            collection: { publicId: collectionWriteId },
+            action: CollectionPermissionAction.WRITE_COMMENT,
+          },
           { collection: { publicId: collectionReadId }, action: CollectionPermissionAction.READ },
         ],
       })
@@ -136,9 +148,14 @@ describe.concurrent('listerMesPermissions', () => {
       })
       const apiKey = await fixtures.apiKey({
         collectionPermissions: [
-          { collection: { publicId: collectionId }, action: CollectionPermissionAction.WRITE_COMMENT },
+          {
+            collection: { publicId: collectionId },
+            action: CollectionPermissionAction.WRITE_COMMENT,
+          },
         ],
-        permissions: [{ indicateur: { publicId: indicateurId }, action: IndicateurPermissionAction.READ }],
+        permissions: [
+          { indicateur: { publicId: indicateurId }, action: IndicateurPermissionAction.READ },
+        ],
       })
 
       const result = await runAsPrincipal(apiKey.id, () => listerMesPermissions())
@@ -171,7 +188,10 @@ describe.concurrent('listerMesPermissions', () => {
       const result = await runAsPrincipal(apiKey.id, () => listerMesPermissions())
 
       expect(result._unsafeUnwrap().indicateurs).toEqual([
-        { id: indicateurId, actions: [IndicateurPermissionAction.READ, IndicateurPermissionAction.WRITE_DATA] },
+        {
+          id: indicateurId,
+          actions: [IndicateurPermissionAction.READ, IndicateurPermissionAction.WRITE_DATA],
+        },
       ])
     }),
   )
@@ -198,9 +218,18 @@ describe.concurrent('listerMesPermissions', () => {
           { collection: { publicId: collections[1]! }, action: CollectionPermissionAction.READ },
         ],
         permissions: [
-          { indicateur: { publicId: indicateurs[2] }, action: IndicateurPermissionAction.WRITE_DATA },
-          { indicateur: { publicId: indicateurs[0] }, action: IndicateurPermissionAction.WRITE_DATA },
-          { indicateur: { publicId: indicateurs[1] }, action: IndicateurPermissionAction.WRITE_DATA },
+          {
+            indicateur: { publicId: indicateurs[2] },
+            action: IndicateurPermissionAction.WRITE_DATA,
+          },
+          {
+            indicateur: { publicId: indicateurs[0] },
+            action: IndicateurPermissionAction.WRITE_DATA,
+          },
+          {
+            indicateur: { publicId: indicateurs[1] },
+            action: IndicateurPermissionAction.WRITE_DATA,
+          },
         ],
       })
 

--- a/apps/kpilote-api/src/me/queries/listerMesPermissions.test.ts
+++ b/apps/kpilote-api/src/me/queries/listerMesPermissions.test.ts
@@ -1,4 +1,4 @@
-import { PermissionAction } from '@/generated/prisma/enums'
+import { CollectionPermissionAction, IndicateurPermissionAction } from '@/generated/prisma/enums'
 import { describe, expect, it } from 'vitest'
 
 import { listerMesPermissions } from '@/me/queries/listerMesPermissions'
@@ -32,7 +32,7 @@ describe.concurrent('listerMesPermissions', () => {
       })
       const apiKey = await fixtures.apiKey({
         collectionPermissions: [
-          { collection: { publicId: collectionId }, action: PermissionAction.WRITE_COMMENT },
+          { collection: { publicId: collectionId }, action: CollectionPermissionAction.WRITE_COMMENT },
         ],
       })
 
@@ -55,18 +55,18 @@ describe.concurrent('listerMesPermissions', () => {
       await fixtures.indicateur({ publicId: indicateurId })
       const apiKey = await fixtures.apiKey({
         collectionPermissions: [
-          { collection: { publicId: collectionId }, action: PermissionAction.READ },
+          { collection: { publicId: collectionId }, action: CollectionPermissionAction.READ },
         ],
         permissions: [
-          { indicateur: { publicId: indicateurId }, action: PermissionAction.WRITE_DATA },
+          { indicateur: { publicId: indicateurId }, action: IndicateurPermissionAction.WRITE_DATA },
         ],
       })
 
       const result = await runAsPrincipal(apiKey.id, () => listerMesPermissions())
 
       expect(result._unsafeUnwrap()).toEqual({
-        collections: [{ id: collectionId, actions: [PermissionAction.READ] }],
-        indicateurs: [{ id: indicateurId, actions: [PermissionAction.WRITE_DATA] }],
+        collections: [{ id: collectionId, actions: [CollectionPermissionAction.READ] }],
+        indicateurs: [{ id: indicateurId, actions: [IndicateurPermissionAction.WRITE_DATA] }],
       })
     }),
   )
@@ -78,15 +78,15 @@ describe.concurrent('listerMesPermissions', () => {
       await fixtures.collection({ publicId: collectionId })
       const apiKey = await fixtures.apiKey({
         collectionPermissions: [
-          { collection: { publicId: collectionId }, action: PermissionAction.WRITE_COMMENT },
-          { collection: { publicId: collectionId }, action: PermissionAction.READ },
+          { collection: { publicId: collectionId }, action: CollectionPermissionAction.WRITE_COMMENT },
+          { collection: { publicId: collectionId }, action: CollectionPermissionAction.READ },
         ],
       })
 
       const result = await runAsPrincipal(apiKey.id, () => listerMesPermissions())
 
       expect(result._unsafeUnwrap().collections).toEqual([
-        { id: collectionId, actions: [PermissionAction.READ, PermissionAction.WRITE_COMMENT] },
+        { id: collectionId, actions: [CollectionPermissionAction.READ, CollectionPermissionAction.WRITE_COMMENT] },
       ])
     }),
   )
@@ -106,8 +106,8 @@ describe.concurrent('listerMesPermissions', () => {
       )
       const apiKey = await fixtures.apiKey({
         collectionPermissions: [
-          { collection: { publicId: collectionWriteId }, action: PermissionAction.WRITE_COMMENT },
-          { collection: { publicId: collectionReadId }, action: PermissionAction.READ },
+          { collection: { publicId: collectionWriteId }, action: CollectionPermissionAction.WRITE_COMMENT },
+          { collection: { publicId: collectionReadId }, action: CollectionPermissionAction.READ },
         ],
       })
 
@@ -117,9 +117,9 @@ describe.concurrent('listerMesPermissions', () => {
       const indicateurs = result._unsafeUnwrap().indicateurs
       expect(indicateurs).toEqual(
         [
-          { id: indWrite1, actions: [PermissionAction.READ] },
-          { id: indWrite2, actions: [PermissionAction.READ] },
-          { id: indRead, actions: [PermissionAction.READ] },
+          { id: indWrite1, actions: [IndicateurPermissionAction.READ] },
+          { id: indWrite2, actions: [IndicateurPermissionAction.READ] },
+          { id: indRead, actions: [IndicateurPermissionAction.READ] },
         ].sort((a, b) => a.id.localeCompare(b.id)),
       )
     }),
@@ -136,16 +136,16 @@ describe.concurrent('listerMesPermissions', () => {
       })
       const apiKey = await fixtures.apiKey({
         collectionPermissions: [
-          { collection: { publicId: collectionId }, action: PermissionAction.WRITE_COMMENT },
+          { collection: { publicId: collectionId }, action: CollectionPermissionAction.WRITE_COMMENT },
         ],
-        permissions: [{ indicateur: { publicId: indicateurId }, action: PermissionAction.READ }],
+        permissions: [{ indicateur: { publicId: indicateurId }, action: IndicateurPermissionAction.READ }],
       })
 
       const result = await runAsPrincipal(apiKey.id, () => listerMesPermissions())
 
       // READ direct + READ propagé via collectionWriteComment → une seule entrée, pas de doublon.
       expect(result._unsafeUnwrap().indicateurs).toEqual([
-        { id: indicateurId, actions: [PermissionAction.READ] },
+        { id: indicateurId, actions: [IndicateurPermissionAction.READ] },
       ])
     }),
   )
@@ -161,17 +161,17 @@ describe.concurrent('listerMesPermissions', () => {
       })
       const apiKey = await fixtures.apiKey({
         collectionPermissions: [
-          { collection: { publicId: collectionId }, action: PermissionAction.READ },
+          { collection: { publicId: collectionId }, action: CollectionPermissionAction.READ },
         ],
         permissions: [
-          { indicateur: { publicId: indicateurId }, action: PermissionAction.WRITE_DATA },
+          { indicateur: { publicId: indicateurId }, action: IndicateurPermissionAction.WRITE_DATA },
         ],
       })
 
       const result = await runAsPrincipal(apiKey.id, () => listerMesPermissions())
 
       expect(result._unsafeUnwrap().indicateurs).toEqual([
-        { id: indicateurId, actions: [PermissionAction.READ, PermissionAction.WRITE_DATA] },
+        { id: indicateurId, actions: [IndicateurPermissionAction.READ, IndicateurPermissionAction.WRITE_DATA] },
       ])
     }),
   )
@@ -193,14 +193,14 @@ describe.concurrent('listerMesPermissions', () => {
       )
       const apiKey = await fixtures.apiKey({
         collectionPermissions: [
-          { collection: { publicId: collections[2]! }, action: PermissionAction.READ },
-          { collection: { publicId: collections[0]! }, action: PermissionAction.READ },
-          { collection: { publicId: collections[1]! }, action: PermissionAction.READ },
+          { collection: { publicId: collections[2]! }, action: CollectionPermissionAction.READ },
+          { collection: { publicId: collections[0]! }, action: CollectionPermissionAction.READ },
+          { collection: { publicId: collections[1]! }, action: CollectionPermissionAction.READ },
         ],
         permissions: [
-          { indicateur: { publicId: indicateurs[2] }, action: PermissionAction.WRITE_DATA },
-          { indicateur: { publicId: indicateurs[0] }, action: PermissionAction.WRITE_DATA },
-          { indicateur: { publicId: indicateurs[1] }, action: PermissionAction.WRITE_DATA },
+          { indicateur: { publicId: indicateurs[2] }, action: IndicateurPermissionAction.WRITE_DATA },
+          { indicateur: { publicId: indicateurs[0] }, action: IndicateurPermissionAction.WRITE_DATA },
+          { indicateur: { publicId: indicateurs[1] }, action: IndicateurPermissionAction.WRITE_DATA },
         ],
       })
 

--- a/apps/kpilote-api/src/me/queries/listerMesPermissions.ts
+++ b/apps/kpilote-api/src/me/queries/listerMesPermissions.ts
@@ -3,15 +3,22 @@ import { okAsync, ResultAsync } from 'neverthrow'
 
 import { isAdminPrincipal, requireCurrentPrincipalId } from '@/framework/auth/userContext'
 import { db } from '@/framework/persistence/dbStore'
-import { PermissionAction } from '@/generated/prisma/enums'
+import {
+  CollectionPermissionAction,
+  IndicateurPermissionAction,
+} from '@/generated/prisma/enums'
+import { sortByOrder } from '@/permission/utils'
 
-type PermissionEntry = MePermissionsApiModel['collections'][number]
+const INDICATEUR_ACTION_ORDER = [
+  IndicateurPermissionAction.READ,
+  IndicateurPermissionAction.WRITE_DATA,
+  IndicateurPermissionAction.WRITE_COMMENT,
+] as const
 
-const ACTION_ORDER: PermissionAction[] = [
-  PermissionAction.READ,
-  PermissionAction.WRITE_DATA,
-  PermissionAction.WRITE_COMMENT,
-]
+const COLLECTION_ACTION_ORDER = [
+  CollectionPermissionAction.READ,
+  CollectionPermissionAction.WRITE_COMMENT,
+] as const
 
 // READ collection (direct ou WRITE_COMMENT) propage en READ sur les indicateurs de la collection.
 // WRITE_DATA et WRITE_COMMENT restent strictement directs — cf. permissions-design.md.
@@ -47,14 +54,14 @@ const loadPermissions = (principalId: string) =>
 type LoadResult = Awaited<ReturnType<typeof loadPermissions>>
 
 const buildResponse = ([collectionPerms, indicateurPerms]: LoadResult): MePermissionsApiModel => {
-  const collectionsActions = new Map<string, Set<PermissionAction>>()
-  const indicateursActions = new Map<string, Set<PermissionAction>>()
+  const collectionsActions = new Map<string, Set<CollectionPermissionAction>>()
+  const indicateursActions = new Map<string, Set<IndicateurPermissionAction>>()
 
   for (const perm of collectionPerms) {
     addAction(collectionsActions, perm.collection.publicId, perm.action)
     // Propagation : READ ou WRITE collection → READ sur chaque indicateur lié.
     for (const link of perm.collection.indicateurs) {
-      addAction(indicateursActions, link.indicateur.publicId, PermissionAction.READ)
+      addAction(indicateursActions, link.indicateur.publicId, IndicateurPermissionAction.READ)
     }
   }
   for (const perm of indicateurPerms) {
@@ -62,25 +69,21 @@ const buildResponse = ([collectionPerms, indicateurPerms]: LoadResult): MePermis
   }
 
   return {
-    collections: serialize(collectionsActions),
-    indicateurs: serialize(indicateursActions),
+    collections: serializeMap(collectionsActions, COLLECTION_ACTION_ORDER),
+    indicateurs: serializeMap(indicateursActions, INDICATEUR_ACTION_ORDER),
   }
 }
 
-const addAction = (
-  map: Map<string, Set<PermissionAction>>,
-  publicId: string,
-  action: PermissionAction,
-): void => {
-  const set = map.get(publicId) ?? new Set<PermissionAction>()
+const addAction = <T>(map: Map<string, Set<T>>, publicId: string, action: T): void => {
+  const set = map.get(publicId) ?? new Set<T>()
   set.add(action)
   map.set(publicId, set)
 }
 
-const serialize = (map: Map<string, Set<PermissionAction>>): PermissionEntry[] =>
+const serializeMap = <T>(map: Map<string, Set<T>>, order: readonly T[]) =>
   Array.from(map.entries())
     .map(([id, actions]) => ({
       id,
-      actions: ACTION_ORDER.filter((a) => actions.has(a)),
+      actions: sortByOrder([...actions], order),
     }))
     .sort((a, b) => a.id.localeCompare(b.id))

--- a/apps/kpilote-api/src/me/queries/listerMesPermissions.ts
+++ b/apps/kpilote-api/src/me/queries/listerMesPermissions.ts
@@ -4,18 +4,7 @@ import { okAsync, ResultAsync } from 'neverthrow'
 import { isAdminPrincipal, requireCurrentPrincipalId } from '@/framework/auth/userContext'
 import { db } from '@/framework/persistence/dbStore'
 import { CollectionPermissionAction, IndicateurPermissionAction } from '@/generated/prisma/enums'
-import { sortByOrder } from '@/permission/utils'
-
-const INDICATEUR_ACTION_ORDER = [
-  IndicateurPermissionAction.READ,
-  IndicateurPermissionAction.WRITE_DATA,
-  IndicateurPermissionAction.WRITE_COMMENT,
-] as const
-
-const COLLECTION_ACTION_ORDER = [
-  CollectionPermissionAction.READ,
-  CollectionPermissionAction.WRITE_COMMENT,
-] as const
+import { COLLECTION_ACTION_ORDER, INDICATEUR_ACTION_ORDER, sortByOrder } from '@/permission/order'
 
 // READ collection (direct ou WRITE_COMMENT) propage en READ sur les indicateurs de la collection.
 // WRITE_DATA et WRITE_COMMENT restent strictement directs — cf. permissions-design.md.

--- a/apps/kpilote-api/src/me/queries/listerMesPermissions.ts
+++ b/apps/kpilote-api/src/me/queries/listerMesPermissions.ts
@@ -3,10 +3,7 @@ import { okAsync, ResultAsync } from 'neverthrow'
 
 import { isAdminPrincipal, requireCurrentPrincipalId } from '@/framework/auth/userContext'
 import { db } from '@/framework/persistence/dbStore'
-import {
-  CollectionPermissionAction,
-  IndicateurPermissionAction,
-} from '@/generated/prisma/enums'
+import { CollectionPermissionAction, IndicateurPermissionAction } from '@/generated/prisma/enums'
 import { sortByOrder } from '@/permission/utils'
 
 const INDICATEUR_ACTION_ORDER = [

--- a/apps/kpilote-api/src/me/routes.test.ts
+++ b/apps/kpilote-api/src/me/routes.test.ts
@@ -22,7 +22,10 @@ describe.concurrent('GET /me/permissions', () => {
       await fixtures.apiKey({
         rawKey: 'pilote_live_meperms_principal_with_perms',
         collectionPermissions: [
-          { collection: { publicId: collectionId }, action: CollectionPermissionAction.WRITE_COMMENT },
+          {
+            collection: { publicId: collectionId },
+            action: CollectionPermissionAction.WRITE_COMMENT,
+          },
         ],
       })
 

--- a/apps/kpilote-api/src/me/routes.test.ts
+++ b/apps/kpilote-api/src/me/routes.test.ts
@@ -1,4 +1,4 @@
-import { PermissionAction } from '@/generated/prisma/enums'
+import { CollectionPermissionAction, IndicateurPermissionAction } from '@/generated/prisma/enums'
 import { describe, expect, it } from 'vitest'
 
 import { meRoutes } from '@/me/routes'
@@ -22,7 +22,7 @@ describe.concurrent('GET /me/permissions', () => {
       await fixtures.apiKey({
         rawKey: 'pilote_live_meperms_principal_with_perms',
         collectionPermissions: [
-          { collection: { publicId: collectionId }, action: PermissionAction.WRITE_COMMENT },
+          { collection: { publicId: collectionId }, action: CollectionPermissionAction.WRITE_COMMENT },
         ],
       })
 
@@ -32,8 +32,8 @@ describe.concurrent('GET /me/permissions', () => {
 
       expect(response.status).toBe(200)
       expect(await response.json()).toEqual({
-        collections: [{ id: collectionId, actions: [PermissionAction.WRITE_COMMENT] }],
-        indicateurs: [{ id: indicateurId, actions: [PermissionAction.READ] }],
+        collections: [{ id: collectionId, actions: [CollectionPermissionAction.WRITE_COMMENT] }],
+        indicateurs: [{ id: indicateurId, actions: [IndicateurPermissionAction.READ] }],
       })
     }),
   )

--- a/apps/kpilote-api/src/niveauConfiance/commands/creerNiveauConfiance.test.ts
+++ b/apps/kpilote-api/src/niveauConfiance/commands/creerNiveauConfiance.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import { creerIndicateurIndividuCommentaire } from '@/indicateur/commands/creerIndicateurIndividuCommentaire'
-import { PermissionAction } from '@/generated/prisma/enums'
+import { IndicateurPermissionAction } from '@/generated/prisma/enums'
 import { creerNiveauConfiance } from '@/niveauConfiance/commands/creerNiveauConfiance'
 import { fixtures } from '@/test/fixtures'
 import { integrationTest } from '@/test/integrationTest'
@@ -17,7 +17,7 @@ describe.concurrent('creerNiveauConfiance', () => {
       await fixtures.indicateur({ publicId: indId })
       await fixtures.individu({ publicId: indivId })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.WRITE_COMMENT }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_COMMENT }],
       })
       const params = { indicateurId: indId, individuId: indivId }
       const commentaire = await runAsPrincipal(apiKey.id, () =>
@@ -50,7 +50,7 @@ describe.concurrent('creerNiveauConfiance', () => {
       await fixtures.indicateur({ publicId: indId })
       await fixtures.individu({ publicId: indivId })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.WRITE_COMMENT }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_COMMENT }],
       })
       const commentaire = await runAsPrincipal(apiKey.id, () =>
         creerIndicateurIndividuCommentaire({
@@ -78,7 +78,7 @@ describe.concurrent('creerNiveauConfiance', () => {
       await fixtures.indicateur({ publicId: indId })
       await fixtures.individu({ publicId: indivId })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.WRITE_COMMENT }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_COMMENT }],
       })
       const commentaire = await runAsPrincipal(apiKey.id, () =>
         creerIndicateurIndividuCommentaire({

--- a/apps/kpilote-api/src/niveauConfiance/commands/creerNiveauConfiance.test.ts
+++ b/apps/kpilote-api/src/niveauConfiance/commands/creerNiveauConfiance.test.ts
@@ -17,7 +17,9 @@ describe.concurrent('creerNiveauConfiance', () => {
       await fixtures.indicateur({ publicId: indId })
       await fixtures.individu({ publicId: indivId })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_COMMENT }],
+        permissions: [
+          { indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_COMMENT },
+        ],
       })
       const params = { indicateurId: indId, individuId: indivId }
       const commentaire = await runAsPrincipal(apiKey.id, () =>
@@ -50,7 +52,9 @@ describe.concurrent('creerNiveauConfiance', () => {
       await fixtures.indicateur({ publicId: indId })
       await fixtures.individu({ publicId: indivId })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_COMMENT }],
+        permissions: [
+          { indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_COMMENT },
+        ],
       })
       const commentaire = await runAsPrincipal(apiKey.id, () =>
         creerIndicateurIndividuCommentaire({
@@ -78,7 +82,9 @@ describe.concurrent('creerNiveauConfiance', () => {
       await fixtures.indicateur({ publicId: indId })
       await fixtures.individu({ publicId: indivId })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_COMMENT }],
+        permissions: [
+          { indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_COMMENT },
+        ],
       })
       const commentaire = await runAsPrincipal(apiKey.id, () =>
         creerIndicateurIndividuCommentaire({

--- a/apps/kpilote-api/src/niveauConfiance/commands/modifierNiveauConfiance.test.ts
+++ b/apps/kpilote-api/src/niveauConfiance/commands/modifierNiveauConfiance.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import { creerIndicateurIndividuCommentaire } from '@/indicateur/commands/creerIndicateurIndividuCommentaire'
-import { PermissionAction } from '@/generated/prisma/enums'
+import { IndicateurPermissionAction } from '@/generated/prisma/enums'
 import { creerNiveauConfiance } from '@/niveauConfiance/commands/creerNiveauConfiance'
 import { modifierNiveauConfiance } from '@/niveauConfiance/commands/modifierNiveauConfiance'
 import { fixtures } from '@/test/fixtures'
@@ -41,7 +41,7 @@ describe.concurrent('modifierNiveauConfiance', () => {
       await fixtures.indicateur({ publicId: indId })
       await fixtures.individu({ publicId: indivId })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.WRITE_COMMENT }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_COMMENT }],
       })
       const cree = await creerNcSur({
         apiKeyId: apiKey.id,
@@ -68,10 +68,10 @@ describe.concurrent('modifierNiveauConfiance', () => {
       await fixtures.indicateur({ publicId: indId })
       await fixtures.individu({ publicId: indivId })
       const auteur = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.WRITE_COMMENT }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_COMMENT }],
       })
       const autre = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.WRITE_COMMENT }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_COMMENT }],
       })
       const cree = await creerNcSur({
         apiKeyId: auteur.id,

--- a/apps/kpilote-api/src/niveauConfiance/commands/modifierNiveauConfiance.test.ts
+++ b/apps/kpilote-api/src/niveauConfiance/commands/modifierNiveauConfiance.test.ts
@@ -41,7 +41,9 @@ describe.concurrent('modifierNiveauConfiance', () => {
       await fixtures.indicateur({ publicId: indId })
       await fixtures.individu({ publicId: indivId })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_COMMENT }],
+        permissions: [
+          { indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_COMMENT },
+        ],
       })
       const cree = await creerNcSur({
         apiKeyId: apiKey.id,
@@ -68,10 +70,14 @@ describe.concurrent('modifierNiveauConfiance', () => {
       await fixtures.indicateur({ publicId: indId })
       await fixtures.individu({ publicId: indivId })
       const auteur = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_COMMENT }],
+        permissions: [
+          { indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_COMMENT },
+        ],
       })
       const autre = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_COMMENT }],
+        permissions: [
+          { indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_COMMENT },
+        ],
       })
       const cree = await creerNcSur({
         apiKeyId: auteur.id,

--- a/apps/kpilote-api/src/niveauConfiance/queries/listerNiveauxParCommentaires.test.ts
+++ b/apps/kpilote-api/src/niveauConfiance/queries/listerNiveauxParCommentaires.test.ts
@@ -5,7 +5,7 @@ import {
   creerIndicateurIndividuCommentaire,
   indicateurIndividuConfig,
 } from '@/indicateur/commands/creerIndicateurIndividuCommentaire'
-import { PermissionAction } from '@/generated/prisma/enums'
+import { IndicateurPermissionAction } from '@/generated/prisma/enums'
 import { creerNiveauConfiance } from '@/niveauConfiance/commands/creerNiveauConfiance'
 import { listerNiveauxParCommentaires } from '@/niveauConfiance/queries/listerNiveauxParCommentaires'
 import { fixtures } from '@/test/fixtures'
@@ -39,7 +39,7 @@ describe.concurrent('listerNiveauxParCommentaires', () => {
       await fixtures.indicateur({ publicId: indId })
       await fixtures.individu({ publicId: indivId })
       const moi = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.WRITE_COMMENT }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_COMMENT }],
       })
       const params = { indicateurId: indId, individuId: indivId }
       const idA = await creerCommentaireAvecNiveau(moi.id, params, 'OBJECTIF_SECURISE')
@@ -66,10 +66,10 @@ describe.concurrent('listerNiveauxParCommentaires', () => {
       await fixtures.indicateur({ publicId: indId })
       await fixtures.individu({ publicId: indivId })
       const moi = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.WRITE_COMMENT }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_COMMENT }],
       })
       const autre = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.WRITE_COMMENT }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_COMMENT }],
       })
       const params = { indicateurId: indId, individuId: indivId }
       const idAutre = await creerCommentaireAvecNiveau(
@@ -98,7 +98,7 @@ describe.concurrent('listerNiveauxParCommentaires', () => {
       await fixtures.indicateur({ publicId: indId })
       await fixtures.individu({ publicId: indivId })
       const moi = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.READ }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.READ }],
       })
 
       const result = await runAsPrincipal(moi.id, () =>

--- a/apps/kpilote-api/src/niveauConfiance/queries/listerNiveauxParCommentaires.test.ts
+++ b/apps/kpilote-api/src/niveauConfiance/queries/listerNiveauxParCommentaires.test.ts
@@ -39,7 +39,9 @@ describe.concurrent('listerNiveauxParCommentaires', () => {
       await fixtures.indicateur({ publicId: indId })
       await fixtures.individu({ publicId: indivId })
       const moi = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_COMMENT }],
+        permissions: [
+          { indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_COMMENT },
+        ],
       })
       const params = { indicateurId: indId, individuId: indivId }
       const idA = await creerCommentaireAvecNiveau(moi.id, params, 'OBJECTIF_SECURISE')
@@ -66,10 +68,14 @@ describe.concurrent('listerNiveauxParCommentaires', () => {
       await fixtures.indicateur({ publicId: indId })
       await fixtures.individu({ publicId: indivId })
       const moi = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_COMMENT }],
+        permissions: [
+          { indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_COMMENT },
+        ],
       })
       const autre = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_COMMENT }],
+        permissions: [
+          { indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_COMMENT },
+        ],
       })
       const params = { indicateurId: indId, individuId: indivId }
       const idAutre = await creerCommentaireAvecNiveau(

--- a/apps/kpilote-api/src/objectifIndicateurIndividu/commands/deleteObjectifIndicateurIndividu.test.ts
+++ b/apps/kpilote-api/src/objectifIndicateurIndividu/commands/deleteObjectifIndicateurIndividu.test.ts
@@ -1,4 +1,4 @@
-import { PermissionAction } from '@/generated/prisma/enums'
+import { IndicateurPermissionAction } from '@/generated/prisma/enums'
 import { describe, expect, it } from 'vitest'
 
 import { ForbiddenError } from '@/framework/errors/AppError'
@@ -32,7 +32,7 @@ describe.concurrent('deleteObjectifIndicateurIndividu', () => {
         valeurCible: 100,
       })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.WRITE_DATA }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_DATA }],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>
@@ -69,7 +69,7 @@ describe.concurrent('deleteObjectifIndicateurIndividu', () => {
         referentiel: { publicId: refId },
       })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.WRITE_DATA }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_DATA }],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>
@@ -110,7 +110,7 @@ describe.concurrent('deleteObjectifIndicateurIndividu', () => {
         valeurCible: 100,
       })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.WRITE_DATA }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_DATA }],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>
@@ -165,7 +165,7 @@ describe.concurrent('deleteObjectifIndicateurIndividu', () => {
       })
       await fixtures.individu({ publicId: individuId, referentiel: { publicId: refId } })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.READ }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.READ }],
       })
 
       await expect(
@@ -189,7 +189,7 @@ describe.concurrent('deleteObjectifIndicateurIndividu', () => {
         referentiel: { publicId: refId },
       })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.WRITE_DATA }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_DATA }],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>
@@ -220,7 +220,7 @@ describe.concurrent('deleteObjectifIndicateurIndividu', () => {
       })
       await fixtures.individu({ publicId: individuId, referentiel: { publicId: refOrphelin } })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.WRITE_DATA }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_DATA }],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>

--- a/apps/kpilote-api/src/objectifIndicateurIndividu/commands/deleteObjectifIndicateurIndividu.test.ts
+++ b/apps/kpilote-api/src/objectifIndicateurIndividu/commands/deleteObjectifIndicateurIndividu.test.ts
@@ -32,7 +32,9 @@ describe.concurrent('deleteObjectifIndicateurIndividu', () => {
         valeurCible: 100,
       })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_DATA }],
+        permissions: [
+          { indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_DATA },
+        ],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>
@@ -69,7 +71,9 @@ describe.concurrent('deleteObjectifIndicateurIndividu', () => {
         referentiel: { publicId: refId },
       })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_DATA }],
+        permissions: [
+          { indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_DATA },
+        ],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>
@@ -110,7 +114,9 @@ describe.concurrent('deleteObjectifIndicateurIndividu', () => {
         valeurCible: 100,
       })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_DATA }],
+        permissions: [
+          { indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_DATA },
+        ],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>
@@ -189,7 +195,9 @@ describe.concurrent('deleteObjectifIndicateurIndividu', () => {
         referentiel: { publicId: refId },
       })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_DATA }],
+        permissions: [
+          { indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_DATA },
+        ],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>
@@ -220,7 +228,9 @@ describe.concurrent('deleteObjectifIndicateurIndividu', () => {
       })
       await fixtures.individu({ publicId: individuId, referentiel: { publicId: refOrphelin } })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_DATA }],
+        permissions: [
+          { indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_DATA },
+        ],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>

--- a/apps/kpilote-api/src/objectifIndicateurIndividu/commands/upsertObjectifIndicateurIndividu.test.ts
+++ b/apps/kpilote-api/src/objectifIndicateurIndividu/commands/upsertObjectifIndicateurIndividu.test.ts
@@ -1,4 +1,4 @@
-import { PermissionAction } from '@/generated/prisma/enums'
+import { IndicateurPermissionAction } from '@/generated/prisma/enums'
 import { describe, expect, it } from 'vitest'
 
 import { ForbiddenError } from '@/framework/errors/AppError'
@@ -26,7 +26,7 @@ describe.concurrent('upsertObjectifIndicateurIndividu', () => {
         referentiel: { publicId: refId },
       })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.WRITE_DATA }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_DATA }],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>
@@ -76,7 +76,7 @@ describe.concurrent('upsertObjectifIndicateurIndividu', () => {
         valeurCible: 50,
       })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.WRITE_DATA }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_DATA }],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>
@@ -135,7 +135,7 @@ describe.concurrent('upsertObjectifIndicateurIndividu', () => {
       })
       await fixtures.individu({ publicId: individuId, referentiel: { publicId: refId } })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.READ }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.READ }],
       })
 
       await expect(
@@ -159,7 +159,7 @@ describe.concurrent('upsertObjectifIndicateurIndividu', () => {
         referentiel: { publicId: refId },
       })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.WRITE_DATA }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_DATA }],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>
@@ -190,7 +190,7 @@ describe.concurrent('upsertObjectifIndicateurIndividu', () => {
       })
       await fixtures.individu({ publicId: individuId, referentiel: { publicId: refOrphelin } })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.WRITE_DATA }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_DATA }],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>

--- a/apps/kpilote-api/src/objectifIndicateurIndividu/commands/upsertObjectifIndicateurIndividu.test.ts
+++ b/apps/kpilote-api/src/objectifIndicateurIndividu/commands/upsertObjectifIndicateurIndividu.test.ts
@@ -26,7 +26,9 @@ describe.concurrent('upsertObjectifIndicateurIndividu', () => {
         referentiel: { publicId: refId },
       })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_DATA }],
+        permissions: [
+          { indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_DATA },
+        ],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>
@@ -76,7 +78,9 @@ describe.concurrent('upsertObjectifIndicateurIndividu', () => {
         valeurCible: 50,
       })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_DATA }],
+        permissions: [
+          { indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_DATA },
+        ],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>
@@ -159,7 +163,9 @@ describe.concurrent('upsertObjectifIndicateurIndividu', () => {
         referentiel: { publicId: refId },
       })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_DATA }],
+        permissions: [
+          { indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_DATA },
+        ],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>
@@ -190,7 +196,9 @@ describe.concurrent('upsertObjectifIndicateurIndividu', () => {
       })
       await fixtures.individu({ publicId: individuId, referentiel: { publicId: refOrphelin } })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_DATA }],
+        permissions: [
+          { indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_DATA },
+        ],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>

--- a/apps/kpilote-api/src/objectifIndicateurIndividu/queries/listObjectifsForIndicateur.test.ts
+++ b/apps/kpilote-api/src/objectifIndicateurIndividu/queries/listObjectifsForIndicateur.test.ts
@@ -1,4 +1,4 @@
-import { PermissionAction } from '@/generated/prisma/enums'
+import { IndicateurPermissionAction } from '@/generated/prisma/enums'
 import { assert, describe, expect, it } from 'vitest'
 
 import { listObjectifsForIndicateur } from '@/objectifIndicateurIndividu/queries/listObjectifsForIndicateur'
@@ -44,7 +44,7 @@ describe.concurrent('listObjectifsForIndicateur', () => {
         },
       )
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.READ }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.READ }],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>
@@ -97,7 +97,7 @@ describe.concurrent('listObjectifsForIndicateur', () => {
         },
       )
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.READ }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.READ }],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>
@@ -125,7 +125,7 @@ describe.concurrent('listObjectifsForIndicateur', () => {
       })
       await fixtures.individu({ publicId: deptId, referentiel: { publicId: refId } })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.READ }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.READ }],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>
@@ -153,7 +153,7 @@ describe.concurrent('listObjectifsForIndicateur', () => {
         valeurCible: 50,
       })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.READ }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.READ }],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>
@@ -195,7 +195,7 @@ describe.concurrent('listObjectifsForIndicateur', () => {
         },
       )
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.READ }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.READ }],
       })
 
       // dateTrunc=year → les deux tombent dans le bucket '2025-01-01', on retient le plus récent
@@ -266,7 +266,7 @@ describe.concurrent('listObjectifsForIndicateur', () => {
         },
       )
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.READ }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.READ }],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>
@@ -340,7 +340,7 @@ describe.concurrent('listObjectifsForIndicateur', () => {
         },
       )
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.READ }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.READ }],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>
@@ -420,7 +420,7 @@ describe.concurrent('listObjectifsForIndicateur', () => {
         },
       )
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.READ }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.READ }],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>
@@ -489,7 +489,7 @@ describe.concurrent('listObjectifsForIndicateur', () => {
         valeurCible: 50,
       })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.READ }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.READ }],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>
@@ -535,7 +535,7 @@ describe.concurrent('listObjectifsForIndicateur', () => {
         valeurCible: 200,
       })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.READ }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.READ }],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>
@@ -601,7 +601,7 @@ describe.concurrent('listObjectifsForIndicateur', () => {
         },
       )
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.READ }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.READ }],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>

--- a/apps/kpilote-api/src/permission/commands/grantCollectionPermission.test.ts
+++ b/apps/kpilote-api/src/permission/commands/grantCollectionPermission.test.ts
@@ -1,4 +1,4 @@
-import { PermissionAction } from '@/generated/prisma/enums'
+import { CollectionPermissionAction } from '@/generated/prisma/enums'
 import { describe, expect, it } from 'vitest'
 
 import { grantCollectionPermission } from '@/permission/commands/grantCollectionPermission'
@@ -23,13 +23,13 @@ describe.concurrent('grantCollectionPermission', () => {
         grantCollectionPermission({
           principalId: target.id,
           collectionPublicId: dos.publicId,
-          action: PermissionAction.READ,
+          action: CollectionPermissionAction.READ,
         }),
       )
       const model = result._unsafeUnwrap()
 
       expect(model.collections).toEqual([
-        { publicId: dos.publicId, nom: 'Mon collection', actions: [PermissionAction.READ] },
+        { publicId: dos.publicId, nom: 'Mon collection', actions: [CollectionPermissionAction.READ] },
       ])
       expect(model.indicateursHerites).toEqual([
         {
@@ -51,7 +51,7 @@ describe.concurrent('grantCollectionPermission', () => {
           grantCollectionPermission({
             principalId: target.id,
             collectionPublicId: 'COL-INEXISTANT',
-            action: PermissionAction.READ,
+            action: CollectionPermissionAction.READ,
           }),
         ),
       ).rejects.toThrow()

--- a/apps/kpilote-api/src/permission/commands/grantCollectionPermission.test.ts
+++ b/apps/kpilote-api/src/permission/commands/grantCollectionPermission.test.ts
@@ -29,7 +29,11 @@ describe.concurrent('grantCollectionPermission', () => {
       const model = result._unsafeUnwrap()
 
       expect(model.collections).toEqual([
-        { publicId: dos.publicId, nom: 'Mon collection', actions: [CollectionPermissionAction.READ] },
+        {
+          publicId: dos.publicId,
+          nom: 'Mon collection',
+          actions: [CollectionPermissionAction.READ],
+        },
       ])
       expect(model.indicateursHerites).toEqual([
         {

--- a/apps/kpilote-api/src/permission/commands/grantIndicateurPermission.test.ts
+++ b/apps/kpilote-api/src/permission/commands/grantIndicateurPermission.test.ts
@@ -1,4 +1,4 @@
-import { PermissionAction } from '@/generated/prisma/enums'
+import { IndicateurPermissionAction } from '@/generated/prisma/enums'
 import { describe, expect, it } from 'vitest'
 
 import { ForbiddenError } from '@/framework/errors/AppError'
@@ -21,12 +21,12 @@ describe.concurrent('grantIndicateurPermission', () => {
         grantIndicateurPermission({
           principalId: target.id,
           indicateurPublicId: ind.publicId,
-          action: PermissionAction.READ,
+          action: IndicateurPermissionAction.READ,
         }),
       )
 
       expect(result._unsafeUnwrap().indicateurs).toEqual([
-        { publicId: ind.publicId, nom: 'Mon indic', actions: [PermissionAction.READ] },
+        { publicId: ind.publicId, nom: 'Mon indic', actions: [IndicateurPermissionAction.READ] },
       ])
     }),
   )
@@ -39,7 +39,7 @@ describe.concurrent('grantIndicateurPermission', () => {
       const body = {
         principalId: target.id,
         indicateurPublicId: ind.publicId,
-        action: PermissionAction.READ,
+        action: IndicateurPermissionAction.READ,
       }
 
       await runAsAdmin(CALLER_ID, () => grantIndicateurPermission(body))
@@ -59,7 +59,7 @@ describe.concurrent('grantIndicateurPermission', () => {
           grantIndicateurPermission({
             principalId: target.id,
             indicateurPublicId: 'IND-INEXISTANT',
-            action: PermissionAction.READ,
+            action: IndicateurPermissionAction.READ,
           }),
         ),
       ).rejects.toThrow()
@@ -76,7 +76,7 @@ describe.concurrent('grantIndicateurPermission', () => {
           grantIndicateurPermission({
             principalId: target.id,
             indicateurPublicId: ind.publicId,
-            action: PermissionAction.READ,
+            action: IndicateurPermissionAction.READ,
           }),
         ),
       ).rejects.toBeInstanceOf(ForbiddenError)

--- a/apps/kpilote-api/src/permission/commands/revokeCollectionPermission.test.ts
+++ b/apps/kpilote-api/src/permission/commands/revokeCollectionPermission.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import { ForbiddenError } from '@/framework/errors/AppError'
-import { PermissionAction } from '@/generated/prisma/enums'
+import { CollectionPermissionAction } from '@/generated/prisma/enums'
 import { revokeCollectionPermission } from '@/permission/commands/revokeCollectionPermission'
 import { fixtures } from '@/test/fixtures'
 import { integrationTest } from '@/test/integrationTest'
@@ -18,7 +18,7 @@ describe.concurrent('revokeCollectionPermission', () => {
       await fixtures.collectionPermission({
         principalId: target.id,
         collection: { publicId: dos.publicId },
-        action: PermissionAction.READ,
+        action: CollectionPermissionAction.READ,
       })
 
       const result = await runAsAdmin(CALLER_ID, () =>
@@ -39,7 +39,7 @@ describe.concurrent('revokeCollectionPermission', () => {
           revokeCollectionPermission({
             principalId: target.id,
             collectionPublicId: dos.publicId,
-            action: PermissionAction.READ,
+            action: CollectionPermissionAction.READ,
           }),
         ),
       ).rejects.toBeInstanceOf(ForbiddenError)

--- a/apps/kpilote-api/src/permission/commands/revokeIndicateurPermission.test.ts
+++ b/apps/kpilote-api/src/permission/commands/revokeIndicateurPermission.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { PermissionAction } from '@/generated/prisma/enums'
+import { IndicateurPermissionAction } from '@/generated/prisma/enums'
 import { revokeIndicateurPermission } from '@/permission/commands/revokeIndicateurPermission'
 import { fixtures } from '@/test/fixtures'
 import { integrationTest } from '@/test/integrationTest'
@@ -12,12 +12,12 @@ const grantReadWrite = async (principalId: string, indicateurPublicId: string) =
   await fixtures.indicateurPermission({
     principalId,
     indicateur: { publicId: indicateurPublicId },
-    action: PermissionAction.READ,
+    action: IndicateurPermissionAction.READ,
   })
   await fixtures.indicateurPermission({
     principalId,
     indicateur: { publicId: indicateurPublicId },
-    action: PermissionAction.WRITE_DATA,
+    action: IndicateurPermissionAction.WRITE_DATA,
   })
 }
 
@@ -33,12 +33,12 @@ describe.concurrent('revokeIndicateurPermission', () => {
         revokeIndicateurPermission({
           principalId: target.id,
           indicateurPublicId: ind.publicId,
-          action: PermissionAction.WRITE_DATA,
+          action: IndicateurPermissionAction.WRITE_DATA,
         }),
       )
 
       expect(result._unsafeUnwrap().indicateurs).toEqual([
-        { publicId: ind.publicId, nom: 'Indic', actions: [PermissionAction.READ] },
+        { publicId: ind.publicId, nom: 'Indic', actions: [IndicateurPermissionAction.READ] },
       ])
     }),
   )

--- a/apps/kpilote-api/src/permission/order.ts
+++ b/apps/kpilote-api/src/permission/order.ts
@@ -1,0 +1,15 @@
+import { CollectionPermissionAction, IndicateurPermissionAction } from '@/generated/prisma/enums'
+
+export const INDICATEUR_ACTION_ORDER = [
+  IndicateurPermissionAction.READ,
+  IndicateurPermissionAction.WRITE_DATA,
+  IndicateurPermissionAction.WRITE_COMMENT,
+] as const
+
+export const COLLECTION_ACTION_ORDER = [
+  CollectionPermissionAction.READ,
+  CollectionPermissionAction.WRITE_COMMENT,
+] as const
+
+export const sortByOrder = <T>(items: T[], order: readonly T[]): T[] =>
+  [...items].sort((a, b) => order.indexOf(a) - order.indexOf(b))

--- a/apps/kpilote-api/src/permission/queries/getPrincipalPermissions.test.ts
+++ b/apps/kpilote-api/src/permission/queries/getPrincipalPermissions.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 import { uuidv7 } from 'uuidv7'
 
 import { ForbiddenError } from '@/framework/errors/AppError'
-import { PermissionAction } from '@/generated/prisma/enums'
+import { CollectionPermissionAction, IndicateurPermissionAction } from '@/generated/prisma/enums'
 import { getPrincipalPermissions } from '@/permission/queries/getPrincipalPermissions'
 import { fixtures } from '@/test/fixtures'
 import { integrationTest } from '@/test/integrationTest'
@@ -24,22 +24,22 @@ describe.concurrent('getPrincipalPermissions', () => {
       await fixtures.indicateurPermission({
         principalId: target.id,
         indicateur: { publicId: ind1.publicId },
-        action: PermissionAction.WRITE_DATA,
+        action: IndicateurPermissionAction.WRITE_DATA,
       })
       await fixtures.collectionPermission({
         principalId: target.id,
         collection: { publicId: dos.publicId },
-        action: PermissionAction.READ,
+        action: CollectionPermissionAction.READ,
       })
 
       const result = await runAsAdmin(CALLER_ID, () => getPrincipalPermissions(target.id))
       const model = result._unsafeUnwrap()
 
       expect(model.collections).toEqual([
-        { publicId: dos.publicId, nom: 'Collection', actions: [PermissionAction.READ] },
+        { publicId: dos.publicId, nom: 'Collection', actions: [CollectionPermissionAction.READ] },
       ])
       expect(model.indicateurs).toEqual([
-        { publicId: ind1.publicId, nom: 'Indic 1', actions: [PermissionAction.WRITE_DATA] },
+        { publicId: ind1.publicId, nom: 'Indic 1', actions: [IndicateurPermissionAction.WRITE_DATA] },
       ])
       expect(model.indicateursHerites).toEqual([
         {
@@ -61,12 +61,12 @@ describe.concurrent('getPrincipalPermissions', () => {
       await fixtures.collectionPermission({
         principalId: target.id,
         collection: { publicId: dos.publicId },
-        action: PermissionAction.READ,
+        action: CollectionPermissionAction.READ,
       })
       await fixtures.indicateurPermission({
         principalId: target.id,
         indicateur: { publicId: ind.publicId },
-        action: PermissionAction.WRITE_DATA,
+        action: IndicateurPermissionAction.WRITE_DATA,
       })
 
       const result = await runAsAdmin(CALLER_ID, () => getPrincipalPermissions(target.id))
@@ -76,7 +76,7 @@ describe.concurrent('getPrincipalPermissions', () => {
         {
           publicId: ind.publicId,
           nom: 'Direct et dans collection',
-          actions: [PermissionAction.WRITE_DATA],
+          actions: [IndicateurPermissionAction.WRITE_DATA],
         },
       ])
       expect(model.indicateursHerites).toEqual([])

--- a/apps/kpilote-api/src/permission/queries/getPrincipalPermissions.test.ts
+++ b/apps/kpilote-api/src/permission/queries/getPrincipalPermissions.test.ts
@@ -39,7 +39,11 @@ describe.concurrent('getPrincipalPermissions', () => {
         { publicId: dos.publicId, nom: 'Collection', actions: [CollectionPermissionAction.READ] },
       ])
       expect(model.indicateurs).toEqual([
-        { publicId: ind1.publicId, nom: 'Indic 1', actions: [IndicateurPermissionAction.WRITE_DATA] },
+        {
+          publicId: ind1.publicId,
+          nom: 'Indic 1',
+          actions: [IndicateurPermissionAction.WRITE_DATA],
+        },
       ])
       expect(model.indicateursHerites).toEqual([
         {

--- a/apps/kpilote-api/src/permission/queries/loadPrincipalPermissions.ts
+++ b/apps/kpilote-api/src/permission/queries/loadPrincipalPermissions.ts
@@ -1,22 +1,41 @@
 import { type PrincipalPermissionsApiModel } from '@pilote/kpilote-shared/permission'
 
 import { db } from '@/framework/persistence/dbStore'
-import { PermissionAction } from '@/generated/prisma/enums'
+import {
+  CollectionPermissionAction,
+  IndicateurPermissionAction,
+} from '@/generated/prisma/enums'
+import { sortByOrder } from '@/permission/utils'
 
-const ACTION_ORDER: PermissionAction[] = [
-  PermissionAction.READ,
-  PermissionAction.WRITE_DATA,
-  PermissionAction.WRITE_COMMENT,
-]
+const INDICATEUR_ACTION_ORDER = [
+  IndicateurPermissionAction.READ,
+  IndicateurPermissionAction.WRITE_DATA,
+  IndicateurPermissionAction.WRITE_COMMENT,
+] as const
 
-type DirectEntry = { publicId: string; nom: string; actions: Set<PermissionAction> }
+const COLLECTION_ACTION_ORDER = [
+  CollectionPermissionAction.READ,
+  CollectionPermissionAction.WRITE_COMMENT,
+] as const
 
-const serializeDirect = (map: Map<string, DirectEntry>) =>
+type IndicateurEntry = { publicId: string; nom: string; actions: Set<IndicateurPermissionAction> }
+type CollectionEntry = { publicId: string; nom: string; actions: Set<CollectionPermissionAction> }
+
+const serializeIndicateurs = (map: Map<string, IndicateurEntry>) =>
   Array.from(map.values())
     .map((e) => ({
       publicId: e.publicId,
       nom: e.nom,
-      actions: ACTION_ORDER.filter((a) => e.actions.has(a)),
+      actions: sortByOrder([...e.actions], INDICATEUR_ACTION_ORDER),
+    }))
+    .sort((a, b) => a.publicId.localeCompare(b.publicId))
+
+const serializeCollections = (map: Map<string, CollectionEntry>) =>
+  Array.from(map.values())
+    .map((e) => ({
+      publicId: e.publicId,
+      nom: e.nom,
+      actions: sortByOrder([...e.actions], COLLECTION_ACTION_ORDER),
     }))
     .sort((a, b) => a.publicId.localeCompare(b.publicId))
 
@@ -45,23 +64,23 @@ export const loadPrincipalPermissions = async (
     }),
   ])
 
-  const collectionsMap = new Map<string, DirectEntry>()
+  const collectionsMap = new Map<string, CollectionEntry>()
   for (const p of collectionPerms) {
     const entry = collectionsMap.get(p.collection.publicId) ?? {
       publicId: p.collection.publicId,
       nom: p.collection.nom,
-      actions: new Set<PermissionAction>(),
+      actions: new Set<CollectionPermissionAction>(),
     }
     entry.actions.add(p.action)
     collectionsMap.set(p.collection.publicId, entry)
   }
 
-  const indicateursMap = new Map<string, DirectEntry>()
+  const indicateursMap = new Map<string, IndicateurEntry>()
   for (const i of indicateurPerms) {
     const entry = indicateursMap.get(i.indicateur.publicId) ?? {
       publicId: i.indicateur.publicId,
       nom: i.indicateur.nom,
-      actions: new Set<PermissionAction>(),
+      actions: new Set<IndicateurPermissionAction>(),
     }
     entry.actions.add(i.action)
     indicateursMap.set(i.indicateur.publicId, entry)
@@ -85,8 +104,8 @@ export const loadPrincipalPermissions = async (
   }
 
   return {
-    collections: serializeDirect(collectionsMap),
-    indicateurs: serializeDirect(indicateursMap),
+    collections: serializeCollections(collectionsMap),
+    indicateurs: serializeIndicateurs(indicateursMap),
     indicateursHerites: Array.from(heritesMap.values()).sort((a, b) =>
       a.publicId.localeCompare(b.publicId),
     ),

--- a/apps/kpilote-api/src/permission/queries/loadPrincipalPermissions.ts
+++ b/apps/kpilote-api/src/permission/queries/loadPrincipalPermissions.ts
@@ -2,18 +2,7 @@ import { type PrincipalPermissionsApiModel } from '@pilote/kpilote-shared/permis
 
 import { db } from '@/framework/persistence/dbStore'
 import { CollectionPermissionAction, IndicateurPermissionAction } from '@/generated/prisma/enums'
-import { sortByOrder } from '@/permission/utils'
-
-const INDICATEUR_ACTION_ORDER = [
-  IndicateurPermissionAction.READ,
-  IndicateurPermissionAction.WRITE_DATA,
-  IndicateurPermissionAction.WRITE_COMMENT,
-] as const
-
-const COLLECTION_ACTION_ORDER = [
-  CollectionPermissionAction.READ,
-  CollectionPermissionAction.WRITE_COMMENT,
-] as const
+import { COLLECTION_ACTION_ORDER, INDICATEUR_ACTION_ORDER, sortByOrder } from '@/permission/order'
 
 type IndicateurEntry = { publicId: string; nom: string; actions: Set<IndicateurPermissionAction> }
 type CollectionEntry = { publicId: string; nom: string; actions: Set<CollectionPermissionAction> }

--- a/apps/kpilote-api/src/permission/queries/loadPrincipalPermissions.ts
+++ b/apps/kpilote-api/src/permission/queries/loadPrincipalPermissions.ts
@@ -7,21 +7,15 @@ import { COLLECTION_ACTION_ORDER, INDICATEUR_ACTION_ORDER, sortByOrder } from '@
 type IndicateurEntry = { publicId: string; nom: string; actions: Set<IndicateurPermissionAction> }
 type CollectionEntry = { publicId: string; nom: string; actions: Set<CollectionPermissionAction> }
 
-const serializeIndicateurs = (map: Map<string, IndicateurEntry>) =>
+const serializeMap = <T>(
+  map: Map<string, { publicId: string; nom: string; actions: Set<T> }>,
+  order: readonly T[],
+) =>
   Array.from(map.values())
     .map((e) => ({
       publicId: e.publicId,
       nom: e.nom,
-      actions: sortByOrder([...e.actions], INDICATEUR_ACTION_ORDER),
-    }))
-    .sort((a, b) => a.publicId.localeCompare(b.publicId))
-
-const serializeCollections = (map: Map<string, CollectionEntry>) =>
-  Array.from(map.values())
-    .map((e) => ({
-      publicId: e.publicId,
-      nom: e.nom,
-      actions: sortByOrder([...e.actions], COLLECTION_ACTION_ORDER),
+      actions: sortByOrder([...e.actions], order),
     }))
     .sort((a, b) => a.publicId.localeCompare(b.publicId))
 
@@ -90,8 +84,8 @@ export const loadPrincipalPermissions = async (
   }
 
   return {
-    collections: serializeCollections(collectionsMap),
-    indicateurs: serializeIndicateurs(indicateursMap),
+    collections: serializeMap(collectionsMap, COLLECTION_ACTION_ORDER),
+    indicateurs: serializeMap(indicateursMap, INDICATEUR_ACTION_ORDER),
     indicateursHerites: Array.from(heritesMap.values()).sort((a, b) =>
       a.publicId.localeCompare(b.publicId),
     ),

--- a/apps/kpilote-api/src/permission/queries/loadPrincipalPermissions.ts
+++ b/apps/kpilote-api/src/permission/queries/loadPrincipalPermissions.ts
@@ -1,10 +1,7 @@
 import { type PrincipalPermissionsApiModel } from '@pilote/kpilote-shared/permission'
 
 import { db } from '@/framework/persistence/dbStore'
-import {
-  CollectionPermissionAction,
-  IndicateurPermissionAction,
-} from '@/generated/prisma/enums'
+import { CollectionPermissionAction, IndicateurPermissionAction } from '@/generated/prisma/enums'
 import { sortByOrder } from '@/permission/utils'
 
 const INDICATEUR_ACTION_ORDER = [

--- a/apps/kpilote-api/src/permission/utils.ts
+++ b/apps/kpilote-api/src/permission/utils.ts
@@ -1,2 +1,0 @@
-export const sortByOrder = <T>(items: T[], order: readonly T[]): T[] =>
-  [...items].sort((a, b) => order.indexOf(a) - order.indexOf(b))

--- a/apps/kpilote-api/src/permission/utils.ts
+++ b/apps/kpilote-api/src/permission/utils.ts
@@ -1,0 +1,2 @@
+export const sortByOrder = <T>(items: T[], order: readonly T[]): T[] =>
+  [...items].sort((a, b) => order.indexOf(a) - order.indexOf(b))

--- a/apps/kpilote-api/src/test/fixtures.ts
+++ b/apps/kpilote-api/src/test/fixtures.ts
@@ -37,7 +37,8 @@ import {
 } from '@/generated/prisma/models'
 import {
   ApiKeyRole,
-  PermissionAction,
+  CollectionPermissionAction,
+  IndicateurPermissionAction,
   ProviderType,
   Visibilite,
   type FeatureEtat,
@@ -535,12 +536,12 @@ async function collection(
 
 type PrincipalIndicateurPermissionOverrides = {
   indicateur: IndicateurOverrides
-  action: PermissionAction
+  action: IndicateurPermissionAction
 }
 
 type PrincipalCollectionPermissionOverrides = {
   collection: CollectionOverrides
-  action: PermissionAction
+  action: CollectionPermissionAction
 }
 
 type ApiKeyOverrides = Partial<{
@@ -687,7 +688,7 @@ async function utilisateur(
 type IndicateurPermissionOverrides = {
   principalId: string
   indicateur: IndicateurOverrides
-  action: PermissionAction
+  action: IndicateurPermissionAction
 }
 
 const upsertIndicateurPermission = async (o: IndicateurPermissionOverrides) => {
@@ -731,7 +732,7 @@ async function indicateurPermission(
 type CollectionPermissionOverrides = {
   principalId: string
   collection: CollectionOverrides
-  action: PermissionAction
+  action: CollectionPermissionAction
 }
 
 const upsertCollectionPermission = async (o: CollectionPermissionOverrides) => {

--- a/apps/kpilote-api/src/valeurAvancement/commands/deleteValeurAvancement.test.ts
+++ b/apps/kpilote-api/src/valeurAvancement/commands/deleteValeurAvancement.test.ts
@@ -32,7 +32,9 @@ describe.concurrent('deleteValeurAvancement', () => {
         valeur: 12.34,
       })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_DATA }],
+        permissions: [
+          { indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_DATA },
+        ],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>
@@ -81,7 +83,9 @@ describe.concurrent('deleteValeurAvancement', () => {
         valeur: 20,
       })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_DATA }],
+        permissions: [
+          { indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_DATA },
+        ],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>
@@ -116,7 +120,9 @@ describe.concurrent('deleteValeurAvancement', () => {
         referentiel: { publicId: refId },
       })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_DATA }],
+        permissions: [
+          { indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_DATA },
+        ],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>
@@ -225,7 +231,9 @@ describe.concurrent('deleteValeurAvancement', () => {
         referentiel: { publicId: refId },
       })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_DATA }],
+        permissions: [
+          { indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_DATA },
+        ],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>
@@ -259,7 +267,9 @@ describe.concurrent('deleteValeurAvancement', () => {
         referentiel: { publicId: refOrphelin },
       })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_DATA }],
+        permissions: [
+          { indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_DATA },
+        ],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>

--- a/apps/kpilote-api/src/valeurAvancement/commands/deleteValeurAvancement.test.ts
+++ b/apps/kpilote-api/src/valeurAvancement/commands/deleteValeurAvancement.test.ts
@@ -1,4 +1,4 @@
-import { PermissionAction } from '@/generated/prisma/enums'
+import { IndicateurPermissionAction } from '@/generated/prisma/enums'
 import { describe, expect, it } from 'vitest'
 
 import { ForbiddenError } from '@/framework/errors/AppError'
@@ -32,7 +32,7 @@ describe.concurrent('deleteValeurAvancement', () => {
         valeur: 12.34,
       })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.WRITE_DATA }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_DATA }],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>
@@ -81,7 +81,7 @@ describe.concurrent('deleteValeurAvancement', () => {
         valeur: 20,
       })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.WRITE_DATA }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_DATA }],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>
@@ -116,7 +116,7 @@ describe.concurrent('deleteValeurAvancement', () => {
         referentiel: { publicId: refId },
       })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.WRITE_DATA }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_DATA }],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>
@@ -201,7 +201,7 @@ describe.concurrent('deleteValeurAvancement', () => {
         referentiel: { publicId: refId },
       })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.READ }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.READ }],
       })
 
       await expect(
@@ -225,7 +225,7 @@ describe.concurrent('deleteValeurAvancement', () => {
         referentiel: { publicId: refId },
       })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.WRITE_DATA }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_DATA }],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>
@@ -259,7 +259,7 @@ describe.concurrent('deleteValeurAvancement', () => {
         referentiel: { publicId: refOrphelin },
       })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.WRITE_DATA }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_DATA }],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>

--- a/apps/kpilote-api/src/valeurAvancement/commands/upsertValeurAvancement.test.ts
+++ b/apps/kpilote-api/src/valeurAvancement/commands/upsertValeurAvancement.test.ts
@@ -1,4 +1,4 @@
-import { PermissionAction } from '@/generated/prisma/enums'
+import { IndicateurPermissionAction } from '@/generated/prisma/enums'
 import { describe, expect, it } from 'vitest'
 
 import { ForbiddenError } from '@/framework/errors/AppError'
@@ -26,7 +26,7 @@ describe.concurrent('upsertValeurAvancement', () => {
         referentiel: { publicId: refId },
       })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.WRITE_DATA }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_DATA }],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>
@@ -76,7 +76,7 @@ describe.concurrent('upsertValeurAvancement', () => {
         valeur: 5,
       })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.WRITE_DATA }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_DATA }],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>
@@ -171,7 +171,7 @@ describe.concurrent('upsertValeurAvancement', () => {
         referentiel: { publicId: refId },
       })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.READ }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.READ }],
       })
 
       await expect(
@@ -195,7 +195,7 @@ describe.concurrent('upsertValeurAvancement', () => {
         referentiel: { publicId: refId },
       })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.WRITE_DATA }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_DATA }],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>
@@ -229,7 +229,7 @@ describe.concurrent('upsertValeurAvancement', () => {
         referentiel: { publicId: refOrphelin },
       })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.WRITE_DATA }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_DATA }],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>

--- a/apps/kpilote-api/src/valeurAvancement/commands/upsertValeurAvancement.test.ts
+++ b/apps/kpilote-api/src/valeurAvancement/commands/upsertValeurAvancement.test.ts
@@ -26,7 +26,9 @@ describe.concurrent('upsertValeurAvancement', () => {
         referentiel: { publicId: refId },
       })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_DATA }],
+        permissions: [
+          { indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_DATA },
+        ],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>
@@ -76,7 +78,9 @@ describe.concurrent('upsertValeurAvancement', () => {
         valeur: 5,
       })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_DATA }],
+        permissions: [
+          { indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_DATA },
+        ],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>
@@ -195,7 +199,9 @@ describe.concurrent('upsertValeurAvancement', () => {
         referentiel: { publicId: refId },
       })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_DATA }],
+        permissions: [
+          { indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_DATA },
+        ],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>
@@ -229,7 +235,9 @@ describe.concurrent('upsertValeurAvancement', () => {
         referentiel: { publicId: refOrphelin },
       })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_DATA }],
+        permissions: [
+          { indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_DATA },
+        ],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>

--- a/apps/kpilote-api/src/valeurAvancement/commands/upsertValeursAvancementBatch.test.ts
+++ b/apps/kpilote-api/src/valeurAvancement/commands/upsertValeursAvancementBatch.test.ts
@@ -33,7 +33,9 @@ describe.concurrent('upsertValeursAvancementBatch', () => {
         valeur: 1,
       })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_DATA }],
+        permissions: [
+          { indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_DATA },
+        ],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>
@@ -80,7 +82,9 @@ describe.concurrent('upsertValeursAvancementBatch', () => {
         { publicId: deptB, referentiel: { publicId: refId } },
       )
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_DATA }],
+        permissions: [
+          { indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_DATA },
+        ],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>
@@ -126,7 +130,9 @@ describe.concurrent('upsertValeursAvancementBatch', () => {
         referentiel: { publicId: refNonLieAIndicateur },
       })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_DATA }],
+        permissions: [
+          { indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_DATA },
+        ],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>
@@ -173,7 +179,9 @@ describe.concurrent('upsertValeursAvancementBatch', () => {
         { publicId: deptB, referentiel: { publicId: refId } },
       )
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_DATA }],
+        permissions: [
+          { indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_DATA },
+        ],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>
@@ -273,7 +281,9 @@ describe.concurrent('upsertValeursAvancementBatch', () => {
         valeur: 2,
       })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_DATA }],
+        permissions: [
+          { indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_DATA },
+        ],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>

--- a/apps/kpilote-api/src/valeurAvancement/commands/upsertValeursAvancementBatch.test.ts
+++ b/apps/kpilote-api/src/valeurAvancement/commands/upsertValeursAvancementBatch.test.ts
@@ -1,4 +1,4 @@
-import { PermissionAction } from '@/generated/prisma/enums'
+import { IndicateurPermissionAction } from '@/generated/prisma/enums'
 import { describe, expect, it } from 'vitest'
 
 import { ForbiddenError } from '@/framework/errors/AppError'
@@ -33,7 +33,7 @@ describe.concurrent('upsertValeursAvancementBatch', () => {
         valeur: 1,
       })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.WRITE_DATA }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_DATA }],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>
@@ -80,7 +80,7 @@ describe.concurrent('upsertValeursAvancementBatch', () => {
         { publicId: deptB, referentiel: { publicId: refId } },
       )
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.WRITE_DATA }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_DATA }],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>
@@ -126,7 +126,7 @@ describe.concurrent('upsertValeursAvancementBatch', () => {
         referentiel: { publicId: refNonLieAIndicateur },
       })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.WRITE_DATA }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_DATA }],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>
@@ -173,7 +173,7 @@ describe.concurrent('upsertValeursAvancementBatch', () => {
         { publicId: deptB, referentiel: { publicId: refId } },
       )
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.WRITE_DATA }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_DATA }],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>
@@ -233,7 +233,7 @@ describe.concurrent('upsertValeursAvancementBatch', () => {
       })
       await fixtures.individu({ publicId: deptA, referentiel: { publicId: refId } })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.READ }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.READ }],
       })
 
       await expect(
@@ -273,7 +273,7 @@ describe.concurrent('upsertValeursAvancementBatch', () => {
         valeur: 2,
       })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.WRITE_DATA }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.WRITE_DATA }],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>

--- a/apps/kpilote-api/src/valeurAvancement/queries/listIndividusWithValeurs.test.ts
+++ b/apps/kpilote-api/src/valeurAvancement/queries/listIndividusWithValeurs.test.ts
@@ -1,4 +1,4 @@
-import { PermissionAction } from '@/generated/prisma/enums'
+import { IndicateurPermissionAction } from '@/generated/prisma/enums'
 import { describe, expect, it } from 'vitest'
 
 import { fixtures } from '@/test/fixtures'
@@ -58,7 +58,7 @@ describe.concurrent('listIndividusWithValeurs', () => {
         },
       )
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.READ }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.READ }],
       })
 
       const result = await runAsPrincipal(apiKey.id, () => listIndividusWithValeurs(indId, {}))
@@ -133,7 +133,7 @@ describe.concurrent('listIndividusWithValeurs', () => {
         },
       )
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.READ }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.READ }],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>
@@ -184,7 +184,7 @@ describe.concurrent('listIndividusWithValeurs', () => {
       const indId = testIndicateurId()
       await fixtures.indicateur({ publicId: indId, nom: 'T' })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.READ }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.READ }],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>

--- a/apps/kpilote-api/src/valeurAvancement/queries/listTauxProgressionForIndicateur.test.ts
+++ b/apps/kpilote-api/src/valeurAvancement/queries/listTauxProgressionForIndicateur.test.ts
@@ -1004,7 +1004,9 @@ describe.concurrent('listTauxProgressionForIndicateur', () => {
       const deptId = testDeptId()
       // clé sans permission sur indId
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: autreIndId }, action: IndicateurPermissionAction.READ }],
+        permissions: [
+          { indicateur: { publicId: autreIndId }, action: IndicateurPermissionAction.READ },
+        ],
       })
 
       await expect(

--- a/apps/kpilote-api/src/valeurAvancement/queries/listTauxProgressionForIndicateur.test.ts
+++ b/apps/kpilote-api/src/valeurAvancement/queries/listTauxProgressionForIndicateur.test.ts
@@ -1,4 +1,4 @@
-import { PermissionAction } from '@/generated/prisma/enums'
+import { IndicateurPermissionAction } from '@/generated/prisma/enums'
 import { describe, expect, it } from 'vitest'
 
 import { listTauxProgressionForIndicateur } from '@/valeurAvancement/queries/listTauxProgressionForIndicateur'
@@ -23,7 +23,7 @@ describe.concurrent('listTauxProgressionForIndicateur', () => {
     integrationTest(async () => {
       const indId = testIndicateurId()
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.READ }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.READ }],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>
@@ -47,7 +47,7 @@ describe.concurrent('listTauxProgressionForIndicateur', () => {
         valeur: 50,
       })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.READ }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.READ }],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>
@@ -81,7 +81,7 @@ describe.concurrent('listTauxProgressionForIndicateur', () => {
         valeurCible: 100,
       })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.READ }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.READ }],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>
@@ -127,7 +127,7 @@ describe.concurrent('listTauxProgressionForIndicateur', () => {
         valeurCible: 100,
       })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.READ }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.READ }],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>
@@ -164,7 +164,7 @@ describe.concurrent('listTauxProgressionForIndicateur', () => {
         valeurCible: 3,
       })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.READ }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.READ }],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>
@@ -213,7 +213,7 @@ describe.concurrent('listTauxProgressionForIndicateur', () => {
         },
       )
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.READ }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.READ }],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>
@@ -265,7 +265,7 @@ describe.concurrent('listTauxProgressionForIndicateur', () => {
         },
       )
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.READ }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.READ }],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>
@@ -319,7 +319,7 @@ describe.concurrent('listTauxProgressionForIndicateur', () => {
         },
       )
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.READ }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.READ }],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>
@@ -373,7 +373,7 @@ describe.concurrent('listTauxProgressionForIndicateur', () => {
         },
       )
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.READ }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.READ }],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>
@@ -431,7 +431,7 @@ describe.concurrent('listTauxProgressionForIndicateur', () => {
         valeurCible: 100,
       })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.READ }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.READ }],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>
@@ -491,7 +491,7 @@ describe.concurrent('listTauxProgressionForIndicateur', () => {
         },
       )
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.READ }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.READ }],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>
@@ -539,7 +539,7 @@ describe.concurrent('listTauxProgressionForIndicateur', () => {
         valeurCible: 60,
       })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.READ }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.READ }],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>
@@ -624,7 +624,7 @@ describe.concurrent('listTauxProgressionForIndicateur', () => {
         },
       )
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.READ }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.READ }],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>
@@ -680,7 +680,7 @@ describe.concurrent('listTauxProgressionForIndicateur', () => {
       })
       // Aucun objectif ni sur la région ni sur le département
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.READ }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.READ }],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>
@@ -756,7 +756,7 @@ describe.concurrent('listTauxProgressionForIndicateur', () => {
         },
       )
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.READ }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.READ }],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>
@@ -851,7 +851,7 @@ describe.concurrent('listTauxProgressionForIndicateur', () => {
         },
       )
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.READ }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.READ }],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>
@@ -913,7 +913,7 @@ describe.concurrent('listTauxProgressionForIndicateur', () => {
         valeurCible: 100,
       })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.READ }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.READ }],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>
@@ -970,7 +970,7 @@ describe.concurrent('listTauxProgressionForIndicateur', () => {
         },
       )
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.READ }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.READ }],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>
@@ -1004,7 +1004,7 @@ describe.concurrent('listTauxProgressionForIndicateur', () => {
       const deptId = testDeptId()
       // clé sans permission sur indId
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: autreIndId }, action: PermissionAction.READ }],
+        permissions: [{ indicateur: { publicId: autreIndId }, action: IndicateurPermissionAction.READ }],
       })
 
       await expect(

--- a/apps/kpilote-api/src/valeurAvancement/queries/listValeursForIndicateur.test.ts
+++ b/apps/kpilote-api/src/valeurAvancement/queries/listValeursForIndicateur.test.ts
@@ -1,4 +1,4 @@
-import { PermissionAction } from '@/generated/prisma/enums'
+import { IndicateurPermissionAction } from '@/generated/prisma/enums'
 import { describe, expect, it } from 'vitest'
 
 import { fixtures } from '@/test/fixtures'
@@ -34,7 +34,7 @@ describe.concurrent('listValeursForIndicateur', () => {
         },
       )
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.READ }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.READ }],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>
@@ -75,7 +75,7 @@ describe.concurrent('listValeursForIndicateur', () => {
         },
       )
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.READ }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.READ }],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>
@@ -122,7 +122,7 @@ describe.concurrent('listValeursForIndicateur', () => {
         },
       )
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.READ }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.READ }],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>
@@ -147,7 +147,7 @@ describe.concurrent('listValeursForIndicateur', () => {
       await fixtures.indicateur({ publicId: indId, nom: 'T' })
       await fixtures.individu({ publicId: deptId, nom: 'Vaucluse' })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.READ }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.READ }],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>
@@ -236,7 +236,7 @@ describe.concurrent('listValeursForIndicateur', () => {
         },
       )
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.READ }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.READ }],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>
@@ -312,7 +312,7 @@ describe.concurrent('listValeursForIndicateur', () => {
         },
       )
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.READ }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.READ }],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>
@@ -420,7 +420,7 @@ describe.concurrent('listValeursForIndicateur', () => {
         },
       )
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.READ }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.READ }],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>
@@ -474,7 +474,7 @@ describe.concurrent('listValeursForIndicateur', () => {
         },
       )
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.READ }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.READ }],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>
@@ -529,7 +529,7 @@ describe.concurrent('listValeursForIndicateur', () => {
         },
       )
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.READ }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.READ }],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>
@@ -589,7 +589,7 @@ describe.concurrent('listValeursForIndicateur', () => {
         },
       )
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.READ }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.READ }],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>

--- a/apps/kpilote-api/src/valeurAvancement/queries/listValeursRemarquablesForIndicateur.test.ts
+++ b/apps/kpilote-api/src/valeurAvancement/queries/listValeursRemarquablesForIndicateur.test.ts
@@ -1,4 +1,4 @@
-import { PermissionAction } from '@/generated/prisma/enums'
+import { IndicateurPermissionAction } from '@/generated/prisma/enums'
 import { describe, expect, it } from 'vitest'
 
 import { fixtures } from '@/test/fixtures'
@@ -800,7 +800,7 @@ describe.concurrent('listValeursRemarquablesForIndicateur', () => {
       await fixtures.indicateur({ publicId: indId, nom: 'T', visibilite: 'PRIVE' })
       await fixtures.referentiel({ publicId: refId, nom: 'A' })
       const apiKey = await fixtures.apiKey({
-        permissions: [{ indicateur: { publicId: indId }, action: PermissionAction.READ }],
+        permissions: [{ indicateur: { publicId: indId }, action: IndicateurPermissionAction.READ }],
       })
 
       const result = await runAsPrincipal(apiKey.id, () =>

--- a/apps/kpilote-webapp/src/queries/mePermissions.test.ts
+++ b/apps/kpilote-webapp/src/queries/mePermissions.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from 'vitest'
 
 import type { MePermissionsApiModel } from '@pilote/kpilote-shared/mePermissions'
-import { PermissionAction } from '@pilote/kpilote-shared/permission'
+import {
+  CollectionPermissionAction,
+  IndicateurPermissionAction,
+} from '@pilote/kpilote-shared/permission'
 
 import {
   canWriteDataIndicateur,
@@ -21,7 +24,7 @@ describe('canWriteDataIndicateur', () => {
   it("autorise si une entrée WRITE_DATA existe pour l'indicateur", () => {
     const permissions: MePermissionsApiModel = {
       ...base,
-      indicateurs: [{ id: 'IND-1', actions: [PermissionAction.WRITE_DATA] }],
+      indicateurs: [{ id: 'IND-1', actions: [IndicateurPermissionAction.WRITE_DATA] }],
     }
     expect(canWriteDataIndicateur({ permissions, indicateurId: 'IND-1' })).toBe(true)
   })
@@ -29,7 +32,7 @@ describe('canWriteDataIndicateur', () => {
   it('refuse avec seulement READ', () => {
     const permissions: MePermissionsApiModel = {
       ...base,
-      indicateurs: [{ id: 'IND-1', actions: [PermissionAction.READ] }],
+      indicateurs: [{ id: 'IND-1', actions: [IndicateurPermissionAction.READ] }],
     }
     expect(canWriteDataIndicateur({ permissions, indicateurId: 'IND-1' })).toBe(false)
   })
@@ -37,7 +40,7 @@ describe('canWriteDataIndicateur', () => {
   it('refuse avec seulement WRITE_COMMENT (WRITE_COMMENT ne donne pas WRITE_DATA)', () => {
     const permissions: MePermissionsApiModel = {
       ...base,
-      indicateurs: [{ id: 'IND-1', actions: [PermissionAction.WRITE_COMMENT] }],
+      indicateurs: [{ id: 'IND-1', actions: [IndicateurPermissionAction.WRITE_COMMENT] }],
     }
     expect(canWriteDataIndicateur({ permissions, indicateurId: 'IND-1' })).toBe(false)
   })
@@ -53,7 +56,7 @@ describe('canWriteCommentIndicateur', () => {
   it("autorise si une entrée WRITE_COMMENT existe pour l'indicateur", () => {
     const permissions: MePermissionsApiModel = {
       ...base,
-      indicateurs: [{ id: 'IND-1', actions: [PermissionAction.WRITE_COMMENT] }],
+      indicateurs: [{ id: 'IND-1', actions: [IndicateurPermissionAction.WRITE_COMMENT] }],
     }
     expect(canWriteCommentIndicateur({ permissions, indicateurId: 'IND-1' })).toBe(true)
   })
@@ -61,7 +64,7 @@ describe('canWriteCommentIndicateur', () => {
   it('refuse avec seulement READ', () => {
     const permissions: MePermissionsApiModel = {
       ...base,
-      indicateurs: [{ id: 'IND-1', actions: [PermissionAction.READ] }],
+      indicateurs: [{ id: 'IND-1', actions: [IndicateurPermissionAction.READ] }],
     }
     expect(canWriteCommentIndicateur({ permissions, indicateurId: 'IND-1' })).toBe(false)
   })
@@ -69,7 +72,7 @@ describe('canWriteCommentIndicateur', () => {
   it('refuse avec seulement WRITE_DATA (WRITE_DATA ne donne pas WRITE_COMMENT)', () => {
     const permissions: MePermissionsApiModel = {
       ...base,
-      indicateurs: [{ id: 'IND-1', actions: [PermissionAction.WRITE_DATA] }],
+      indicateurs: [{ id: 'IND-1', actions: [IndicateurPermissionAction.WRITE_DATA] }],
     }
     expect(canWriteCommentIndicateur({ permissions, indicateurId: 'IND-1' })).toBe(false)
   })
@@ -85,7 +88,7 @@ describe('canWriteCommentCollection', () => {
   it('autorise si une entrée WRITE_COMMENT existe pour la collection', () => {
     const permissions: MePermissionsApiModel = {
       ...base,
-      collections: [{ id: 'COL-1', actions: [PermissionAction.WRITE_COMMENT] }],
+      collections: [{ id: 'COL-1', actions: [CollectionPermissionAction.WRITE_COMMENT] }],
     }
     expect(canWriteCommentCollection({ permissions, collectionId: 'COL-1' })).toBe(true)
   })
@@ -93,7 +96,7 @@ describe('canWriteCommentCollection', () => {
   it('refuse avec seulement READ', () => {
     const permissions: MePermissionsApiModel = {
       ...base,
-      collections: [{ id: 'COL-1', actions: [PermissionAction.READ] }],
+      collections: [{ id: 'COL-1', actions: [CollectionPermissionAction.READ] }],
     }
     expect(canWriteCommentCollection({ permissions, collectionId: 'COL-1' })).toBe(false)
   })
@@ -101,7 +104,7 @@ describe('canWriteCommentCollection', () => {
   it("refuse si la collection n'est pas dans les permissions", () => {
     const permissions: MePermissionsApiModel = {
       ...base,
-      collections: [{ id: 'COL-2', actions: [PermissionAction.WRITE_COMMENT] }],
+      collections: [{ id: 'COL-2', actions: [CollectionPermissionAction.WRITE_COMMENT] }],
     }
     expect(canWriteCommentCollection({ permissions, collectionId: 'COL-1' })).toBe(false)
   })

--- a/apps/kpilote-webapp/src/queries/mePermissions.ts
+++ b/apps/kpilote-webapp/src/queries/mePermissions.ts
@@ -35,7 +35,7 @@ const hasCollectionAction =
   (entries: CollectionPermissionEntryApiModel[], publicId: string): boolean =>
     entries.some((entry) => entry.id === publicId && entry.actions.includes(action))
 
-const hasWriteData = hasIndicateurAction(IndicateurPermissionAction.WRITE_DATA)
+const hasIndicateurWriteData = hasIndicateurAction(IndicateurPermissionAction.WRITE_DATA)
 const hasIndicateurWriteComment = hasIndicateurAction(IndicateurPermissionAction.WRITE_COMMENT)
 const hasCollectionWriteComment = hasCollectionAction(CollectionPermissionAction.WRITE_COMMENT)
 
@@ -45,7 +45,8 @@ export const canWriteDataIndicateur = ({
 }: {
   permissions: MePermissionsApiModel
   indicateurId: string
-}): boolean => permissions.isAdmin === true || hasWriteData(permissions.indicateurs, indicateurId)
+}): boolean =>
+  permissions.isAdmin === true || hasIndicateurWriteData(permissions.indicateurs, indicateurId)
 
 export const canWriteCommentIndicateur = ({
   permissions,

--- a/apps/kpilote-webapp/src/queries/mePermissions.ts
+++ b/apps/kpilote-webapp/src/queries/mePermissions.ts
@@ -1,8 +1,14 @@
 import {
   type MePermissionsApiModel,
-  type PermissionEntryApiModel,
+  type CollectionPermissionEntryApiModel,
+  type IndicateurPermissionEntryApiModel,
 } from '@pilote/kpilote-shared/mePermissions'
-import { PermissionAction, type PermissionActionValue } from '@pilote/kpilote-shared/permission'
+import {
+  CollectionPermissionAction,
+  IndicateurPermissionAction,
+  type CollectionPermissionActionValue,
+  type IndicateurPermissionActionValue,
+} from '@pilote/kpilote-shared/permission'
 import { type QueryClient, queryOptions, useSuspenseQuery } from '@tanstack/react-query'
 
 import { fetchMePermissions } from '@/api/mePermissions'
@@ -19,13 +25,19 @@ export const mePermissionsQueryOptions = () =>
 export const loadMePermissions = ({ queryClient }: { queryClient: QueryClient }) =>
   queryClient.ensureQueryData(mePermissionsQueryOptions())
 
-const hasAction =
-  (action: PermissionActionValue) =>
-  (entries: PermissionEntryApiModel[], publicId: string): boolean =>
+const hasIndicateurAction =
+  (action: IndicateurPermissionActionValue) =>
+  (entries: IndicateurPermissionEntryApiModel[], publicId: string): boolean =>
     entries.some((entry) => entry.id === publicId && entry.actions.includes(action))
 
-const hasWriteData = hasAction(PermissionAction.WRITE_DATA)
-const hasWriteComment = hasAction(PermissionAction.WRITE_COMMENT)
+const hasCollectionAction =
+  (action: CollectionPermissionActionValue) =>
+  (entries: CollectionPermissionEntryApiModel[], publicId: string): boolean =>
+    entries.some((entry) => entry.id === publicId && entry.actions.includes(action))
+
+const hasWriteData = hasIndicateurAction(IndicateurPermissionAction.WRITE_DATA)
+const hasIndicateurWriteComment = hasIndicateurAction(IndicateurPermissionAction.WRITE_COMMENT)
+const hasCollectionWriteComment = hasCollectionAction(CollectionPermissionAction.WRITE_COMMENT)
 
 export const canWriteDataIndicateur = ({
   permissions,
@@ -42,7 +54,7 @@ export const canWriteCommentIndicateur = ({
   permissions: MePermissionsApiModel
   indicateurId: string
 }): boolean =>
-  permissions.isAdmin === true || hasWriteComment(permissions.indicateurs, indicateurId)
+  permissions.isAdmin === true || hasIndicateurWriteComment(permissions.indicateurs, indicateurId)
 
 // WRITE_COMMENT collection reste strictement direct (jamais propagé) — cf. me-permissions-design.md.
 export const canWriteCommentCollection = ({
@@ -52,7 +64,7 @@ export const canWriteCommentCollection = ({
   permissions: MePermissionsApiModel
   collectionId: string
 }): boolean =>
-  permissions.isAdmin === true || hasWriteComment(permissions.collections, collectionId)
+  permissions.isAdmin === true || hasCollectionWriteComment(permissions.collections, collectionId)
 
 export const useCanWriteDataIndicateur = (indicateurId: string): boolean => {
   const { data } = useSuspenseQuery(mePermissionsQueryOptions())

--- a/packages/kpilote-shared/src/mePermissions.ts
+++ b/packages/kpilote-shared/src/mePermissions.ts
@@ -1,18 +1,26 @@
 import { z } from 'zod'
 
-import { permissionActionSchema } from './permission'
+import { collectionPermissionActionSchema, indicateurPermissionActionSchema } from './permission'
 
-const permissionEntrySchema = z.object({
+const collectionPermissionEntrySchema = z.object({
   id: z
     .string()
-    .describe(
-      'Identifiant public de la ressource (`COL-…` pour une collection, `IND-…` pour un indicateur).',
-    ),
+    .describe("Identifiant public de la collection (`COL-…`)."),
   actions: z
-    .array(permissionActionSchema)
+    .array(collectionPermissionActionSchema)
+    .min(1)
+    .describe('Actions accordées. Triées `READ` avant `WRITE_COMMENT`.'),
+})
+
+const indicateurPermissionEntrySchema = z.object({
+  id: z
+    .string()
+    .describe("Identifiant public de l'indicateur (`IND-…`)."),
+  actions: z
+    .array(indicateurPermissionActionSchema)
     .min(1)
     .describe(
-      'Actions accordées au principal courant sur cette ressource. Trié `READ` avant `WRITE_DATA` avant `WRITE_COMMENT`.',
+      'Actions accordées. Triées `READ` avant `WRITE_DATA` avant `WRITE_COMMENT`.',
     ),
 })
 
@@ -26,13 +34,13 @@ export const mePermissionsApiModelSchema = z.object({
         '(retournés vides). Pour les principals standards, ce champ est absent.',
     ),
   collections: z
-    .array(permissionEntrySchema)
+    .array(collectionPermissionEntrySchema)
     .describe(
       "Permissions explicites du principal sur les collections, triées par `id` ASC. N'inclut PAS " +
         'le READ implicite des collections `PUBLIC` (le client le sait en affichant la collection).',
     ),
   indicateurs: z
-    .array(permissionEntrySchema)
+    .array(indicateurPermissionEntrySchema)
     .describe(
       'Permissions du principal sur les indicateurs, triées par `id` ASC. Inclut les permissions ' +
         'directes et le READ dans le cas où le principal possède READ ou WRITE_COMMENT sur une ' +
@@ -44,5 +52,5 @@ export const mePermissionsApiModelSchema = z.object({
 
 export type MePermissionsApiModel = z.infer<typeof mePermissionsApiModelSchema>
 
-// Entrée de permission (id + actions), partagée par `collections` et `indicateurs`.
-export type PermissionEntryApiModel = z.infer<typeof permissionEntrySchema>
+export type CollectionPermissionEntryApiModel = z.infer<typeof collectionPermissionEntrySchema>
+export type IndicateurPermissionEntryApiModel = z.infer<typeof indicateurPermissionEntrySchema>

--- a/packages/kpilote-shared/src/mePermissions.ts
+++ b/packages/kpilote-shared/src/mePermissions.ts
@@ -3,9 +3,7 @@ import { z } from 'zod'
 import { collectionPermissionActionSchema, indicateurPermissionActionSchema } from './permission'
 
 const collectionPermissionEntrySchema = z.object({
-  id: z
-    .string()
-    .describe("Identifiant public de la collection (`COL-…`)."),
+  id: z.string().describe('Identifiant public de la collection (`COL-…`).'),
   actions: z
     .array(collectionPermissionActionSchema)
     .min(1)
@@ -13,15 +11,11 @@ const collectionPermissionEntrySchema = z.object({
 })
 
 const indicateurPermissionEntrySchema = z.object({
-  id: z
-    .string()
-    .describe("Identifiant public de l'indicateur (`IND-…`)."),
+  id: z.string().describe("Identifiant public de l'indicateur (`IND-…`)."),
   actions: z
     .array(indicateurPermissionActionSchema)
     .min(1)
-    .describe(
-      'Actions accordées. Triées `READ` avant `WRITE_DATA` avant `WRITE_COMMENT`.',
-    ),
+    .describe('Actions accordées. Triées `READ` avant `WRITE_DATA` avant `WRITE_COMMENT`.'),
 })
 
 export const mePermissionsApiModelSchema = z.object({

--- a/packages/kpilote-shared/src/permission.ts
+++ b/packages/kpilote-shared/src/permission.ts
@@ -12,7 +12,6 @@ export type IndicateurPermissionWriteActionValue = Exclude<IndicateurPermissionA
 export const collectionPermissionActionSchema = z.enum(['READ', 'WRITE_COMMENT'])
 export type CollectionPermissionActionValue = z.infer<typeof collectionPermissionActionSchema>
 export const CollectionPermissionAction = collectionPermissionActionSchema.enum
-export type CollectionPermissionWriteActionValue = Exclude<CollectionPermissionActionValue, 'READ'>
 
 // --- Commun ------------------------------------------------------------------
 

--- a/packages/kpilote-shared/src/permission.ts
+++ b/packages/kpilote-shared/src/permission.ts
@@ -1,22 +1,42 @@
 import { z } from 'zod'
 
-export const permissionActionSchema = z.enum(['READ', 'WRITE_DATA', 'WRITE_COMMENT'])
-export type PermissionActionValue = z.infer<typeof permissionActionSchema>
-export const PermissionAction = permissionActionSchema.enum
-export type PermissionWriteActionValue = Exclude<PermissionActionValue, 'READ'>
+// --- Indicateur --------------------------------------------------------------
+
+export const indicateurPermissionActionSchema = z.enum(['READ', 'WRITE_DATA', 'WRITE_COMMENT'])
+export type IndicateurPermissionActionValue = z.infer<typeof indicateurPermissionActionSchema>
+export const IndicateurPermissionAction = indicateurPermissionActionSchema.enum
+export type IndicateurPermissionWriteActionValue = Exclude<IndicateurPermissionActionValue, 'READ'>
+
+// --- Collection --------------------------------------------------------------
+
+export const collectionPermissionActionSchema = z.enum(['READ', 'WRITE_COMMENT'])
+export type CollectionPermissionActionValue = z.infer<typeof collectionPermissionActionSchema>
+export const CollectionPermissionAction = collectionPermissionActionSchema.enum
+export type CollectionPermissionWriteActionValue = Exclude<CollectionPermissionActionValue, 'READ'>
+
+// --- Commun ------------------------------------------------------------------
 
 export const permissionResourceTypeSchema = z.enum(['COLLECTION', 'INDICATEUR'])
 export type PermissionResourceType = z.infer<typeof permissionResourceTypeSchema>
 
-const directPermissionSchema = z.object({
-  publicId: z.string().describe('Identifiant public de la ressource (`COL-…` / `IND-…`).'),
+const directIndicateurPermissionSchema = z.object({
+  publicId: z.string().describe('Identifiant public de la ressource (`IND-…`).'),
   nom: z.string().describe('Nom lisible de la ressource.'),
   actions: z
-    .array(permissionActionSchema)
+    .array(indicateurPermissionActionSchema)
     .min(1)
     .describe(
       'Actions directes accordées, triées `READ` avant `WRITE_DATA` avant `WRITE_COMMENT`.',
     ),
+})
+
+const directCollectionPermissionSchema = z.object({
+  publicId: z.string().describe('Identifiant public de la ressource (`COL-…`).'),
+  nom: z.string().describe('Nom lisible de la ressource.'),
+  actions: z
+    .array(collectionPermissionActionSchema)
+    .min(1)
+    .describe('Actions directes accordées, triées `READ` avant `WRITE_COMMENT`.'),
 })
 
 const indicateurHeriteSchema = z.object({
@@ -28,10 +48,10 @@ const indicateurHeriteSchema = z.object({
 
 export const principalPermissionsApiModelSchema = z.object({
   collections: z
-    .array(directPermissionSchema)
+    .array(directCollectionPermissionSchema)
     .describe('Permissions directes sur les collections, triées par `publicId` ASC.'),
   indicateurs: z
-    .array(directPermissionSchema)
+    .array(directIndicateurPermissionSchema)
     .describe('Permissions directes sur les indicateurs, triées par `publicId` ASC.'),
   indicateursHerites: z
     .array(indicateurHeriteSchema)
@@ -47,30 +67,30 @@ export const listPrincipalPermissionsQuerySchema = z.object({
 })
 export type ListPrincipalPermissionsQuery = z.infer<typeof listPrincipalPermissionsQuerySchema>
 
-// --- Indicateur --------------------------------------------------------------
+// --- Requêtes indicateur -----------------------------------------------------
 
 export const grantIndicateurPermissionBodySchema = z.object({
   principalId: z.string().uuid().describe('Principal (UUID) à qui accorder le droit.'),
   indicateurPublicId: z.string().describe("Identifiant public de l'indicateur (`IND-…`)."),
-  action: permissionActionSchema,
+  action: indicateurPermissionActionSchema,
 })
 export type GrantIndicateurPermissionBody = z.infer<typeof grantIndicateurPermissionBodySchema>
 
 export const revokeIndicateurPermissionQuerySchema = z.object({
   principalId: z.string().uuid(),
   indicateurPublicId: z.string(),
-  action: permissionActionSchema
+  action: indicateurPermissionActionSchema
     .optional()
     .describe("Action à retirer. Si absent, retire toutes les actions de l'indicateur."),
 })
 export type RevokeIndicateurPermissionQuery = z.infer<typeof revokeIndicateurPermissionQuerySchema>
 
-// --- Collection -----------------------------------------------------------------
+// --- Requêtes collection -----------------------------------------------------
 
 export const grantCollectionPermissionBodySchema = z.object({
   principalId: z.string().uuid().describe('Principal (UUID) à qui accorder le droit.'),
   collectionPublicId: z.string().describe('Identifiant public de la collection (`COL-…`).'),
-  action: permissionActionSchema,
+  action: collectionPermissionActionSchema,
 })
 export type GrantCollectionPermissionBody = z.infer<typeof grantCollectionPermissionBodySchema>
 
@@ -89,13 +109,13 @@ export const collectionPermissionsApiModelSchema = z.object({
           .string()
           .describe("Email de l'utilisateur, ou libellé de la clé API selon le `type`."),
         actions: z
-          .array(permissionActionSchema)
+          .array(collectionPermissionActionSchema)
           .min(1)
           .describe('Triées `READ` avant `WRITE_COMMENT`.'),
       }),
     )
     .describe(
-      'Principals disposant d’une permission directe sur la collection, triés par `type` puis `libelle`.',
+      "Principals disposant d'une permission directe sur la collection, triés par `type` puis `libelle`.",
     ),
 })
 export type CollectionPermissionsApiModel = z.infer<typeof collectionPermissionsApiModelSchema>
@@ -103,7 +123,7 @@ export type CollectionPermissionsApiModel = z.infer<typeof collectionPermissions
 export const revokeCollectionPermissionQuerySchema = z.object({
   principalId: z.string().uuid(),
   collectionPublicId: z.string(),
-  action: permissionActionSchema
+  action: collectionPermissionActionSchema
     .optional()
     .describe('Action à retirer. Si absent, retire toutes les actions de la collection.'),
 })


### PR DESCRIPTION
## Summary

- **Nouveau schéma Prisma** : `PermissionAction` (enum unique) → `IndicateurPermissionAction` (`READ`, `WRITE_DATA`, `WRITE_COMMENT`) + `CollectionPermissionAction` (`READ`, `WRITE_COMMENT`), appliqué via migration SQL avec cast text intermédiaire
- **Shared package** : deux schemas Zod distincts, deux sets de types/valeurs d'enum, propagés dans `mePermissions.ts` (entrées typées par domaine)
- **Backend** : logique de permission, fixtures de test, et seed migrent vers les enums appropriés selon le domaine (indicateur vs collection)
- **Frontend** : `kpilote-admin` (PrincipalPermissions, CollectionAcces, api/permissions) et `kpilote-webapp` (mePermissions) utilisent les types stricts — `WRITE_DATA` sur une collection devient une erreur TypeScript

## Test plan

- [ ] `prisma migrate deploy` passe sans erreur sur la base de données de dev
- [ ] `pnpm -F kpilote-api test` — suites de tests API vertes
- [ ] `pnpm -F kpilote-webapp test` — tests `mePermissions.test.ts` verts
- [ ] `grep -r "\\bPermissionAction\\b" apps/ packages/ --include="*.ts" --include="*.tsx"` → zéro résultat hors fichiers de migration
- [ ] Interface admin : ajout/retrait de permissions indicateur et collection fonctionne en PROD et en edit déverrouillé

🤖 Generated with [Claude Code](https://claude.com/claude-code)