### PR TITLE
feat(albert): liens cliquables vers les pages chantiers dans les réponses Albert

### DIFF
--- a/apps/pilote-ppg/src/server/albert/tools/getChantiers.ts
+++ b/apps/pilote-ppg/src/server/albert/tools/getChantiers.ts
@@ -62,6 +62,9 @@ export type GetChantiersOutput = {
 const NON_APPLICABLE_EN_RETARD_NAT_FR =
   "L'analyse des chantiers en retard ne peut pas être réalisée au niveau national.\n\nEn effet, cet indicateur repose sur une comparaison entre le taux d'avancement d'un chantier pour un territoire donné et la valeur médiane observée sur l'ensemble des autres territoires.";
 
+const LIEN_MARKDOWN_INSTRUCTION =
+  "Chaque chantier dans les résultats dispose d'un champ `page_url`. Quand tu affiches l'identifiant (CH-XXX) ou le nom d'un chantier, utilise systématiquement un lien Markdown vers ce champ, par exemple : `[CH-001 – Nom du chantier](page_url)`.";
+
 function getOutputInstructions(
   input: GetChantiersInput,
   resultats: GetChantiersResult[],
@@ -87,12 +90,12 @@ function getOutputInstructions(
     .map((r) => r.territoire_code)
     .filter((code) => !territoiresAccessibles.includes(code));
 
-  if (codesRestreints.length === 0) return base;
+  const restrictionPrefix =
+    codesRestreints.length > 0
+      ? `⚠️ Restriction d'accès — territoires ${codesRestreints.join(", ")} : seuls le taux d'avancement, la météo et l'écart à la médiane sont disponibles. Les champs tendance et synthèse (commentaire) sont null par restriction d'accès, et non par absence de données. Tu DOIS le mentionner explicitement dans ta réponse quand ces champs sont retournés.\n\n`
+      : "";
 
-  return (
-    `⚠️ Restriction d'accès — territoires ${codesRestreints.join(", ")} : seuls le taux d'avancement, la météo et l'écart à la médiane sont disponibles. Les champs tendance et synthèse (commentaire) sont null par restriction d'accès, et non par absence de données. Tu DOIS le mentionner explicitement dans ta réponse quand ces champs sont retournés.\n\n` +
-    base
-  );
+  return `${restrictionPrefix}${base}\n\n${LIEN_MARKDOWN_INSTRUCTION}`;
 }
 
 function toQueryParams(

--- a/apps/pilote-ppg/src/server/chantiers/__tests__/query/GetChantiersEnRetardQuery.integration.test.ts
+++ b/apps/pilote-ppg/src/server/chantiers/__tests__/query/GetChantiersEnRetardQuery.integration.test.ts
@@ -60,6 +60,7 @@ describe("GetChantiersQuery — view en_retard", () => {
             ppg: "PPG 1",
             ministeres: ["MIN-01"],
           },
+          page_url: "/chantier/CH-001/NAT-FR?jalon=2025",
           ecart: -15,
           taux_avancement: 30,
           meteo: "NON_RENSEIGNEE",

--- a/apps/pilote-ppg/src/server/chantiers/query/GetChantiersQuery.ts
+++ b/apps/pilote-ppg/src/server/chantiers/query/GetChantiersQuery.ts
@@ -23,6 +23,7 @@ type CommentaireResult = {
 
 export type ChantierResult = {
   chantier: ChantierIdentite;
+  page_url: string;
   meteo: string | null;
   tendance: string | null;
   ecart: number | null;
@@ -111,6 +112,7 @@ export class GetChantiersQuery {
           ppg: ct.chantier_identite.ppg,
           ministeres: ct.chantier_identite.ministeres_acronymes,
         },
+        page_url: `/chantier/${ct.chantier_identite.id}/${params.territoireCode}?jalon=${params.jalon}`,
         meteo: ct.meteo,
         tendance: ct.tendance,
         ecart,


### PR DESCRIPTION
## Summary

- Ajoute un champ `page_url` dans `ChantierResult` (construit par `GetChantiersQuery` à partir de l'id chantier, du territoire code et du jalon)
- Instruite le modèle Albert à systématiquement afficher l'id ou le nom d'un chantier sous forme de lien Markdown vers cette URL

## Test plan

- [ ] Demander à Albert des chantiers sur un territoire donné et vérifier que chaque chantier est affiché avec un lien cliquable
- [ ] Vérifier que le lien pointe vers `/chantier/{id}/{territoire_code}?jalon={jalon}`
- [ ] Vérifier que le comportement est identique avec `include_sous_territoires=true` (les sous-territoires ont leur propre `page_url`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)