### PR TITLE
feat(ppg-metadata): ajoute created_at et updated_at sur les 8 tables metadata

### DIFF
--- a/apps/pilote-ppg/src/database/prisma/migrations/20260805072404_ajoute_tables_ppg_metadata/migration.sql
+++ b/apps/pilote-ppg/src/database/prisma/migrations/20260805072404_ajoute_tables_ppg_metadata/migration.sql
@@ -6,6 +6,8 @@ CREATE TABLE "raw_data"."metadata_zones" (
     "zone_code" TEXT NOT NULL,
     "zone_type" TEXT NOT NULL,
     "zone_parent" TEXT,
+    "created_at" TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    "updated_at" TIMESTAMPTZ NOT NULL DEFAULT NOW(),
 
     CONSTRAINT "metadata_zones_pkey" PRIMARY KEY ("zone_id")
 );
@@ -31,6 +33,8 @@ CREATE TABLE "raw_data"."metadata_chantiers" (
     "replicate_val_nat_to" TEXT,
     "ch_cible_attendue" BOOLEAN NOT NULL,
     "conseiller_mail" TEXT,
+    "created_at" TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    "updated_at" TIMESTAMPTZ NOT NULL DEFAULT NOW(),
 
     CONSTRAINT "metadata_chantiers_pkey" PRIMARY KEY ("chantier_id")
 );
@@ -42,6 +46,8 @@ CREATE TABLE "raw_data"."metadata_ppgs" (
     "ppg_nom" TEXT NOT NULL,
     "ppg_desc" TEXT,
     "ppg_axe" TEXT,
+    "created_at" TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    "updated_at" TIMESTAMPTZ NOT NULL DEFAULT NOW(),
 
     CONSTRAINT "metadata_ppgs_pkey" PRIMARY KEY ("ppg_id")
 );
@@ -58,6 +64,8 @@ CREATE TABLE "raw_data"."metadata_porteurs" (
     "porteur_directeur" TEXT,
     "porteur_name_short" TEXT,
     "porteur_picto" TEXT,
+    "created_at" TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    "updated_at" TIMESTAMPTZ NOT NULL DEFAULT NOW(),
 
     CONSTRAINT "metadata_porteurs_pkey" PRIMARY KEY ("porteur_id")
 );
@@ -69,6 +77,8 @@ CREATE TABLE "raw_data"."metadata_perimetres" (
     "per_nom" TEXT NOT NULL,
     "per_porteur_id" TEXT,
     "per_porteur_name_short" TEXT,
+    "created_at" TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    "updated_at" TIMESTAMPTZ NOT NULL DEFAULT NOW(),
 
     CONSTRAINT "metadata_perimetres_pkey" PRIMARY KEY ("perimetre_id")
 );
@@ -79,6 +89,8 @@ CREATE TABLE "raw_data"."metadata_axes" (
     "axe_id" TEXT NOT NULL,
     "axe_name" TEXT NOT NULL,
     "axe_desc" TEXT,
+    "created_at" TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    "updated_at" TIMESTAMPTZ NOT NULL DEFAULT NOW(),
 
     CONSTRAINT "metadata_axes_pkey" PRIMARY KEY ("axe_id")
 );
@@ -89,6 +101,8 @@ CREATE TABLE "raw_data"."metadata_engagement" (
     "engagement_id" TEXT NOT NULL,
     "engagement_short" TEXT NOT NULL,
     "engagement_name" TEXT NOT NULL,
+    "created_at" TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    "updated_at" TIMESTAMPTZ NOT NULL DEFAULT NOW(),
 
     CONSTRAINT "metadata_engagement_pkey" PRIMARY KEY ("engagement_id")
 );
@@ -100,6 +114,8 @@ CREATE TABLE "raw_data"."metadata_zonegroup" (
     "zg_name" TEXT,
     "zg_desc" TEXT,
     "zg_zones" TEXT NOT NULL,
+    "created_at" TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    "updated_at" TIMESTAMPTZ NOT NULL DEFAULT NOW(),
 
     CONSTRAINT "metadata_zonegroup_pkey" PRIMARY KEY ("zone_group_id")
 );

--- a/apps/pilote-ppg/src/database/prisma/schema.prisma
+++ b/apps/pilote-ppg/src/database/prisma/schema.prisma
@@ -496,6 +496,8 @@ model metadata_zones {
   zone_code   String
   zone_type   String
   zone_parent String?
+  created_at  DateTime @default(now()) @db.Timestamptz
+  updated_at  DateTime @default(now()) @updatedAt @db.Timestamptz
 
   @@schema("raw_data")
 }
@@ -519,21 +521,25 @@ model metadata_chantiers {
   replicate_val_nat_to String?
   ch_cible_attendue    Boolean
   conseiller_mail      String?
+  created_at           DateTime    @default(now()) @db.Timestamptz
+  updated_at           DateTime    @default(now()) @updatedAt @db.Timestamptz
 
   @@schema("raw_data")
 }
 
 model metadata_ppgs {
-  ppg_id   String  @id
-  ppg_nom  String
-  ppg_desc String?
-  ppg_axe  String?
+  ppg_id     String   @id
+  ppg_nom    String
+  ppg_desc   String?
+  ppg_axe    String?
+  created_at DateTime @default(now()) @db.Timestamptz
+  updated_at DateTime @default(now()) @updatedAt @db.Timestamptz
 
   @@schema("raw_data")
 }
 
 model metadata_porteurs {
-  porteur_id         String  @id
+  porteur_id         String   @id
   porteur_short      String
   porteur_name       String
   porteur_desc       String?
@@ -542,42 +548,52 @@ model metadata_porteurs {
   porteur_directeur  String?
   porteur_name_short String?
   porteur_picto      String?
+  created_at         DateTime @default(now()) @db.Timestamptz
+  updated_at         DateTime @default(now()) @updatedAt @db.Timestamptz
 
   @@schema("raw_data")
 }
 
 model metadata_perimetres {
-  perimetre_id           String  @id
+  perimetre_id           String   @id
   per_nom                String
   per_porteur_id         String?
   per_porteur_name_short String?
+  created_at             DateTime @default(now()) @db.Timestamptz
+  updated_at             DateTime @default(now()) @updatedAt @db.Timestamptz
 
   @@schema("raw_data")
 }
 
 model metadata_axes {
-  axe_id   String  @id
-  axe_name String
-  axe_desc String?
+  axe_id     String   @id
+  axe_name   String
+  axe_desc   String?
+  created_at DateTime @default(now()) @db.Timestamptz
+  updated_at DateTime @default(now()) @updatedAt @db.Timestamptz
 
   @@schema("raw_data")
 }
 
 // Utilisé uniquement par les modèles baromètre (baro_meta_engagement, baro_meta_chantiers) côté datajobs — à supprimer lors du décommissionnement du baromètre
 model metadata_engagement {
-  engagement_id    String @id
+  engagement_id    String   @id
   engagement_short String
   engagement_name  String
+  created_at       DateTime @default(now()) @db.Timestamptz
+  updated_at       DateTime @default(now()) @updatedAt @db.Timestamptz
 
   @@schema("raw_data")
 }
 
 
 model metadata_zonegroup {
-  zone_group_id String  @id
+  zone_group_id String   @id
   zg_name       String?
   zg_desc       String?
   zg_zones      String
+  created_at    DateTime @default(now()) @db.Timestamptz
+  updated_at    DateTime @default(now()) @updatedAt @db.Timestamptz
 
   @@schema("raw_data")
 }


### PR DESCRIPTION
## Summary

- Ajoute les colonnes `created_at` et `updated_at` (`TIMESTAMPTZ NOT NULL DEFAULT NOW()`) sur les 8 tables PPG metadata dans le schéma `raw_data`
- Met à jour la migration existante `20260805072404_ajoute_tables_ppg_metadata` (pas de nouvelle migration)
- Met à jour les modèles Prisma correspondants avec `@default(now()) @db.Timestamptz` et `@updatedAt`

**Tables concernées :** `metadata_zones`, `metadata_chantiers`, `metadata_ppgs`, `metadata_porteurs`, `metadata_perimetres`, `metadata_axes`, `metadata_engagement`, `metadata_zonegroup`

## Test plan

- [ ] Re-jouer la migration en dev : `pnpm database:migration`
- [ ] Re-jouer le seed PPG metadata : `scripts/migration/20260805-seed-ppg-metadata.sql`
- [ ] Vérifier que les 8 tables ont bien les colonnes `created_at` et `updated_at` avec les bonnes valeurs par défaut

🤖 Generated with [Claude Code](https://claude.com/claude-code)