### PR TITLE
feat(albert): expose la maille de pilotage des chantiers

### DIFF
--- a/apps/pilote-ppg/tests/seed/seed.sh
+++ b/apps/pilote-ppg/tests/seed/seed.sh
@@ -18,15 +18,15 @@ psql -q -d "$DATABASE_URL" -f "$SCRIPT_DIR/utilisateurs-test.sql"
 psql -q -d "$DATABASE_URL" -f "$SCRIPT_DIR/seed-metadata-indicateur.sql"
 
 # Tables sans dependances
-psql -q -d "$DATABASE_URL" -c "\COPY raw_data.metadata_axes FROM '$SCRIPT_DIR/$RAW_DATA_SEED_DIR/metadata_axes.csv' WITH (FORMAT csv, HEADER true)"
-psql -q -d "$DATABASE_URL" -c "\COPY raw_data.metadata_ppgs FROM '$SCRIPT_DIR/$RAW_DATA_SEED_DIR/metadata_ppgs.csv' WITH (FORMAT csv, HEADER true)"
+psql -q -d "$DATABASE_URL" -c "\COPY raw_data.metadata_axes (axe_id, axe_name, axe_desc) FROM '$SCRIPT_DIR/$RAW_DATA_SEED_DIR/metadata_axes.csv' WITH (FORMAT csv, HEADER true)"
+psql -q -d "$DATABASE_URL" -c "\COPY raw_data.metadata_ppgs (ppg_id, ppg_nom, ppg_desc, ppg_axe) FROM '$SCRIPT_DIR/$RAW_DATA_SEED_DIR/metadata_ppgs.csv' WITH (FORMAT csv, HEADER true)"
 psql -q -d "$DATABASE_URL" -c "\COPY raw_data.metadata_chantier_meteos FROM '$SCRIPT_DIR/$RAW_DATA_SEED_DIR/metadata_chantier_meteos.csv' WITH (FORMAT csv, HEADER true)"
-psql -q -d "$DATABASE_URL" -c "\COPY raw_data.metadata_chantiers FROM '$SCRIPT_DIR/$RAW_DATA_SEED_DIR/metadata_chantiers.csv' WITH (FORMAT csv, HEADER true)"
-psql -q -d "$DATABASE_URL" -c "\COPY raw_data.metadata_engagement FROM '$SCRIPT_DIR/$RAW_DATA_SEED_DIR/metadata_engagement.csv' WITH (FORMAT csv, HEADER true)"
-psql -q -d "$DATABASE_URL" -c "\COPY raw_data.metadata_perimetres FROM '$SCRIPT_DIR/$RAW_DATA_SEED_DIR/metadata_perimetres.csv' WITH (FORMAT csv, HEADER true)"
-psql -q -d "$DATABASE_URL" -c "\COPY raw_data.metadata_porteurs FROM '$SCRIPT_DIR/$RAW_DATA_SEED_DIR/metadata_porteurs.csv' WITH (FORMAT csv, HEADER true)"
-psql -q -d "$DATABASE_URL" -c "\COPY raw_data.metadata_zonegroup FROM '$SCRIPT_DIR/$RAW_DATA_SEED_DIR/metadata_zonegroup.csv' WITH (FORMAT csv, HEADER true)"
-psql -q -d "$DATABASE_URL" -c "\COPY raw_data.metadata_zones FROM '$SCRIPT_DIR/$RAW_DATA_SEED_DIR/metadata_zones.csv' WITH (FORMAT csv, HEADER true)"
+psql -q -d "$DATABASE_URL" -c "\COPY raw_data.metadata_chantiers (chantier_id, ch_nom, ch_descr, ch_ppg, ch_territo, engagement_short, ch_hidden_pilote, ch_saisie_ate, ch_state, zg_applicable, \"porteur_ids_noDAC\", \"porteur_ids_DAC\", ch_per, maille_applicable, replicate_val_reg_to, replicate_val_nat_to, ch_cible_attendue, conseiller_mail) FROM '$SCRIPT_DIR/$RAW_DATA_SEED_DIR/metadata_chantiers.csv' WITH (FORMAT csv, HEADER true)"
+psql -q -d "$DATABASE_URL" -c "\COPY raw_data.metadata_engagement (engagement_id, engagement_short, engagement_name) FROM '$SCRIPT_DIR/$RAW_DATA_SEED_DIR/metadata_engagement.csv' WITH (FORMAT csv, HEADER true)"
+psql -q -d "$DATABASE_URL" -c "\COPY raw_data.metadata_perimetres (perimetre_id, per_nom, per_porteur_id, per_porteur_name_short) FROM '$SCRIPT_DIR/$RAW_DATA_SEED_DIR/metadata_perimetres.csv' WITH (FORMAT csv, HEADER true)"
+psql -q -d "$DATABASE_URL" -c "\COPY raw_data.metadata_porteurs (porteur_id, porteur_short, porteur_name, porteur_desc, porteur_type_id, porteur_type_short, porteur_directeur, porteur_name_short, porteur_picto) FROM '$SCRIPT_DIR/$RAW_DATA_SEED_DIR/metadata_porteurs.csv' WITH (FORMAT csv, HEADER true)"
+psql -q -d "$DATABASE_URL" -c "\COPY raw_data.metadata_zonegroup (zone_group_id, zg_name, zg_desc, zg_zones) FROM '$SCRIPT_DIR/$RAW_DATA_SEED_DIR/metadata_zonegroup.csv' WITH (FORMAT csv, HEADER true)"
+psql -q -d "$DATABASE_URL" -c "\COPY raw_data.metadata_zones (zone_id, nom, zone_code, zone_type, zone_parent) FROM '$SCRIPT_DIR/$RAW_DATA_SEED_DIR/metadata_zones.csv' WITH (FORMAT csv, HEADER true)"
 
 # Tables avec dependance sur indicateurs (ordre important)
 psql -q -d "$DATABASE_URL" -c "\COPY raw_data.metadata_indicateurs FROM '$SCRIPT_DIR/$RAW_DATA_SEED_DIR/metadata_indicateurs.csv' WITH (FORMAT csv, HEADER true)"


### PR DESCRIPTION
## Summary

- Ajoute `mailles_applicables: string[]` dans `ChantierResult.chantier` (mappé depuis `chantier_identite.mailles_applicables`, déjà inclus via l'include Prisma existant — aucun JOIN supplémentaire)
- Ajoute une section `## Maille de pilotage` dans le system prompt d'Albert : règle de dérivation (maille la plus fine), libellés utilisateur (nationale / régionale / départementale), synonymes reconnus, et distinctions avec le territoire interrogé et la maille indicateur

## Test plan

- [ ] Demander à Albert "à quelle maille est piloté CH-XXX ?" — réponse en langage naturel sans codes NAT/REG/DEPT ni mention de `mailles_applicables`
- [ ] Vérifier qu'un chantier avec `["NAT", "REG", "DEPT"]` est décrit "jusqu'à la maille départementale"
- [ ] Vérifier qu'un chantier avec `["NAT"]` est décrit "à la maille nationale uniquement"
- [ ] Vérifier qu'Albert distingue la maille du chantier du territoire interrogé

🤖 Generated with [Claude Code](https://claude.com/claude-code)