### PR TITLE
feat(albert): expose la maille de pilotage des chantiers

### DIFF
--- a/apps/pilote-ppg/src/server/albert/systemPrompt.ts
+++ b/apps/pilote-ppg/src/server/albert/systemPrompt.ts
@@ -314,6 +314,34 @@ La tendance indique l'évolution récente du taux d'avancement d'un chantier sur
 - **BAISSE** — Le taux d'avancement régresse
 - **STAGNATION** — Le taux d'avancement est stable
 
+## Maille de pilotage
+
+La maille de pilotage d'un chantier est la maille territoriale la plus fine jusqu'à laquelle il est décliné et suivi dans PILOTE.
+
+Chaque chantier retourné par \`get_chantiers\` expose \`chantier.mailles_applicables\` : un tableau de codes (\`"NAT"\`, \`"REG"\`, \`"DEPT"\`).
+
+**Dérivation** — la maille de pilotage est la plus fine présente dans le tableau :
+- \`"DEPT"\` présent → piloté jusqu'à la **maille départementale**
+- \`"REG"\` présent (sans \`"DEPT"\`) → piloté jusqu'à la **maille régionale**
+- \`"NAT"\` uniquement → piloté à la **maille nationale uniquement**
+
+"Jusqu'à" signifie que le suivi existe aussi aux mailles parentes. Ex. : un chantier piloté jusqu'au département est aussi suivi au niveau régional et national, sous réserve de l'applicabilité sur chaque territoire et des droits de l'utilisateur.
+
+**Libellés à utiliser** (jamais les codes bruts, jamais le nom du champ \`mailles_applicables\`) :
+- \`"NAT"\` → "nationale"
+- \`"REG"\` → "régionale"
+- \`"DEPT"\` → "départementale"
+
+N'utilise jamais les codes internes (\`NAT\`, \`REG\`, \`DEPT\`) ni le nom du champ (\`mailles_applicables\`) dans tes réponses. Exprime-toi uniquement avec les libellés ci-dessus et en langage naturel.
+
+**Synonymes reconnus** : "à quelle maille est-il piloté / suivi ?", "niveau de pilotage", "niveau de suivi", "maille de suivi", "jusqu'à quelle maille", "est-ce suivi au niveau régional / départemental ?"
+
+**Distinctions importantes** :
+- Maille de pilotage du chantier ≠ territoire interrogé (un chantier piloté jusqu'au département peut être interrogé au niveau national).
+- Maille de pilotage du chantier ≠ maille de pilotage d'un indicateur (les indicateurs ont leur propre maille, distincte).
+
+Si \`mailles_applicables\` est absent ou vide, indique que tu ne peux pas déterminer la maille de pilotage au lieu d'inférer.
+
 ## Synthèse des résultats
 Pour chaque couple (chantier, territoire), une synthèse peut être disponible avec :
 - La météo (voir échelle ci-dessus)

--- a/apps/pilote-ppg/src/server/chantiers/__tests__/query/GetChantiersEnRetardQuery.integration.test.ts
+++ b/apps/pilote-ppg/src/server/chantiers/__tests__/query/GetChantiersEnRetardQuery.integration.test.ts
@@ -59,6 +59,7 @@ describe("GetChantiersQuery — view en_retard", () => {
             axe: "Axe 1",
             ppg: "PPG 1",
             ministeres: ["MIN-01"],
+            mailles_applicables: [],
           },
           ecart: -15,
           taux_avancement: 30,

--- a/apps/pilote-ppg/src/server/chantiers/query/GetChantiersQuery.ts
+++ b/apps/pilote-ppg/src/server/chantiers/query/GetChantiersQuery.ts
@@ -7,6 +7,7 @@ type ChantierIdentite = {
   axe: string;
   ppg: string;
   ministeres: string[];
+  mailles_applicables: string[];
 };
 
 type SyntheseResultat = {
@@ -110,6 +111,7 @@ export class GetChantiersQuery {
           axe: ct.chantier_identite.axe,
           ppg: ct.chantier_identite.ppg,
           ministeres: ct.chantier_identite.ministeres_acronymes,
+          mailles_applicables: ct.chantier_identite.mailles_applicables,
         },
         meteo: ct.meteo,
         tendance: ct.tendance,


### PR DESCRIPTION
## Summary

- Ajoute `mailles_applicables: string[]` dans `ChantierResult.chantier` (mappé depuis `chantier_identite.mailles_applicables`, déjà inclus via l'include Prisma existant — aucun JOIN supplémentaire)
- Ajoute une section `## Maille de pilotage` dans le system prompt d'Albert : règle de dérivation (maille la plus fine), libellés utilisateur (nationale / régionale / départementale), synonymes reconnus, et distinctions avec le territoire interrogé et la maille indicateur

## Test plan

- [ ] Demander à Albert "à quelle maille est piloté CH-XXX ?" — réponse en langage naturel sans codes NAT/REG/DEPT ni mention de `mailles_applicables`
- [ ] Vérifier qu'un chantier avec `["NAT", "REG", "DEPT"]` est décrit "jusqu'à la maille départementale"
- [ ] Vérifier qu'un chantier avec `["NAT"]` est décrit "à la maille nationale uniquement"
- [ ] Vérifier qu'Albert distingue la maille du chantier du territoire interrogé

🤖 Generated with [Claude Code](https://claude.com/claude-code)